### PR TITLE
Fix RFPLL frequency calculation

### DIFF
--- a/drivers/iio/adc/ad9361.c
+++ b/drivers/iio/adc/ad9361.c
@@ -5062,8 +5062,8 @@ static unsigned long ad9361_rfpll_recalc_rate(struct clk_hw *hw,
 		vco_div = ad9361_spi_readf(clk_priv->spi, REG_RFPLL_DIVIDERS, div_mask);
 	}
 
-	fract = (buf[0] << 16) | (buf[1] << 8) | buf[2];
-	integer = buf[3] << 8 | buf[4];
+	fract = ((buf[0] & 0x7F) << 16) | (buf[1] << 8) | buf[2];
+	integer = (buf[3] & 0x7) << 8 | buf[4];
 
 	return ad9361_to_clk(ad9361_calc_rfpll_freq(parent_rate, integer,
 					      fract, vco_div));
@@ -5121,12 +5121,14 @@ static int ad9361_rfpll_set_rate(struct clk_hw *hw, unsigned long rate,
 					   true);
 
 	ad9361_rfpll_vco_init(phy, div_mask == TX_VCO_DIVIDER(~0),
-			      vco, parent_rate);
+		      	vco, parent_rate);
 
-	buf[0] = fract >> 16;
-	buf[1] = fract >> 8;
+	ad9361_spi_readm(clk_priv->spi, reg, buf, 5);
+
+	buf[0] = (fract >> 16) & 0xFF | (buf[0] & 0x80);
+	buf[1] = (fract >> 8) & 0xFF;
 	buf[2] = fract & 0xFF;
-	buf[3] = integer >> 8;
+	buf[3] = ((integer >> 8) & 0xFF) | (buf[3] & 0xF8);
 	buf[4] = integer & 0xFF;
 
 	ad9361_spi_writem(clk_priv->spi, reg, buf, 5);


### PR DESCRIPTION
Fix ad9361_rfpll_recalc_rate and ad9361_rfpll_set_rate.
After this fix, these methods may return or set correct value even when
user use SDM Bypass or SDM PD (0x232[7:6] or 0x272[7:6]).

This request is same as [No-OS one](https://github.com/analogdevicesinc/no-OS/pull/4).