### PR TITLE
iio: admc_adc: use axiadc_unconfigure_ring_stream() in remove function

### DIFF
--- a/drivers/iio/adc/admc_adc.c
+++ b/drivers/iio/adc/admc_adc.c
@@ -166,7 +166,7 @@ static int axiadc_remove(struct platform_device *pdev)
 	struct iio_dev *indio_dev = platform_get_drvdata(pdev);
 
 	iio_device_unregister(indio_dev);
-	axiadc_unconfigure_ring(indio_dev);
+	axiadc_unconfigure_ring_stream(indio_dev);
 
 	return 0;
 }


### PR DESCRIPTION
When you try to remove the admc_adc module from the kernel, it segfaults.

The reason is that the probe function calls "axiadc_configure_ring_stream" and the remove function currently calls "axiadc_unconfigure_ring". The bug is fixed by modifying the remove function to call "axiadc_unconfigure_ring_stream" instead.