### PR TITLE
adi_axi_hdmi: reduce adv7511 private API dependancy and make it work with mainline

### DIFF
--- a/drivers/gpu/drm/adi_axi_hdmi/axi_hdmi_drv.c
+++ b/drivers/gpu/drm/adi_axi_hdmi/axi_hdmi_drv.c
@@ -188,7 +188,7 @@ static int axi_hdmi_platform_probe(struct platform_device *pdev)
 	if (private->version == AXI_HDMI_LEGACY &&
 		of_property_read_bool(np, "adi,embedded-sync"))
 		private->version = AXI_HDMI_LEGACY_ES;
-	
+
 	private->encoder_slave = of_find_i2c_device_by_node(slave_node);
 	of_node_put(slave_node);
 

--- a/drivers/gpu/drm/adi_axi_hdmi/axi_hdmi_encoder.c
+++ b/drivers/gpu/drm/adi_axi_hdmi/axi_hdmi_encoder.c
@@ -19,6 +19,7 @@
 #include <drm/drmP.h>
 #include <drm/drm_crtc_helper.h>
 #include <drm/drm_encoder_slave.h>
+#include <drm/drm_edid.h>
 
 #include "axi_hdmi_drv.h"
 
@@ -265,10 +266,10 @@ static void axi_hdmi_encoder_dpms(struct drm_encoder *encoder, int mode)
 		else
 			writel(AXI_HDMI_LEGACY_CTRL_ENABLE, private->base + AXI_HDMI_LEGACY_REG_CTRL);
 
-		if ((!connector) || (!connector->edid_blob_ptr))
+		if (!connector)
 			edid = NULL;
 		else
-			edid = (struct edid *)connector->edid_blob_ptr->data;
+			edid = drm_connector_get_edid(connector);
 
 		if (edid) {
 			config.hdmi_mode = drm_detect_hdmi_monitor(edid);

--- a/drivers/gpu/drm/adi_axi_hdmi/axi_hdmi_encoder.c
+++ b/drivers/gpu/drm/adi_axi_hdmi/axi_hdmi_encoder.c
@@ -296,8 +296,8 @@ static void axi_hdmi_encoder_dpms(struct drm_encoder *encoder, int mode)
 				config.avi_infoframe.colorspace = HDMI_COLORSPACE_RGB;
 			}
 		}
-
-		sfuncs->set_config(encoder, &config);
+		if (sfuncs && sfuncs->set_config)
+			sfuncs->set_config(encoder, &config);
 		break;
 	default:
 		if (private->version == AXI_HDMI)

--- a/drivers/gpu/drm/adi_axi_hdmi/axi_hdmi_encoder.c
+++ b/drivers/gpu/drm/adi_axi_hdmi/axi_hdmi_encoder.c
@@ -264,10 +264,14 @@ static void axi_hdmi_encoder_dpms(struct drm_encoder *encoder, int mode)
 			writel(AXI_HDMI_RESET_ENABLE, private->base + AXI_HDMI_REG_RESET);
 		else
 			writel(AXI_HDMI_LEGACY_CTRL_ENABLE, private->base + AXI_HDMI_LEGACY_REG_CTRL);
-		edid = adv7511_get_edid(encoder);
+
+		if ((!connector) || (!connector->edid_blob_ptr))
+			edid = NULL;
+		else
+			edid = (struct edid *)connector->edid_blob_ptr->data;
+
 		if (edid) {
 			config.hdmi_mode = drm_detect_hdmi_monitor(edid);
-			kfree(edid);
 		} else {
 			config.hdmi_mode = false;
 		}
@@ -338,7 +342,7 @@ static void axi_hdmi_encoder_mode_set(struct drm_encoder *encoder,
 	h_de_max = h_de_min + mode->hdisplay;
 	v_de_min = mode->vtotal - mode->vsync_start;
 	v_de_max = v_de_min + mode->vdisplay;
-	
+
 	switch (private->version) {
 	case AXI_HDMI:
 		val = (mode->hdisplay << 16) | mode->htotal;

--- a/drivers/gpu/drm/i2c/adv7511.h
+++ b/drivers/gpu/drm/i2c/adv7511.h
@@ -372,7 +372,7 @@ struct adv7511_link_config {
 
 /**
 	adi,input-style = 1|2|3;
-	adi,input-id = 
+	adi,input-id =
 		"24-bit-rgb444-ycbcr444",
 		"16-20-24-bit-ycbcr422-separate-sync" |
 		"16-20-24-bit-ycbcr422-embedded-sync" |

--- a/drivers/gpu/drm/i2c/adv7511.h
+++ b/drivers/gpu/drm/i2c/adv7511.h
@@ -451,6 +451,4 @@ struct adv7511 {
 	int gpio_pd;
 };
 
-struct edid *adv7511_get_edid(struct drm_encoder *encoder);
-
 #endif

--- a/drivers/gpu/drm/i2c/adv7511_core.c
+++ b/drivers/gpu/drm/i2c/adv7511_core.c
@@ -680,8 +680,8 @@ static const struct regmap_config adv7511_regmap_config = {
 };
 
 /*
-	adi,input-id - 
-		0x00: 
+	adi,input-id -
+		0x00:
 		0x01:
 		0x02:
 		0x03:
@@ -696,7 +696,7 @@ static const struct regmap_config adv7511_regmap_config = {
 		0x00: Evently
 		0x01: Right
 		0x02: Left
-	adi,up-conversion - 
+	adi,up-conversion -
 		0x00: zero-order up conversion
 		0x01: first-order up conversion
 	adi,timing-generation-sequence -
@@ -725,7 +725,7 @@ static const struct regmap_config adv7511_regmap_config = {
 		0x02: Use input style 1
 		0x01: Use input style 2
 		0x03: Use Input style 3
-	adi,input-color-depth - Selects the input format color depth 
+	adi,input-color-depth - Selects the input format color depth
 		0x03: 8-bit per channel
 		0x01: 10-bit per channel
 		0x02: 12-bit per channel

--- a/drivers/gpu/drm/i2c/adv7511_core.c
+++ b/drivers/gpu/drm/i2c/adv7511_core.c
@@ -472,18 +472,6 @@ static int adv7511_get_modes(struct drm_encoder *encoder,
 	return count;
 }
 
-struct edid *adv7511_get_edid(struct drm_encoder *encoder)
-{
-	struct adv7511 *adv7511 = encoder_to_adv7511(encoder);
-
-	if (!adv7511->edid)
-		return NULL;
-
-	return kmemdup(adv7511->edid, sizeof(*adv7511->edid) +
-		       adv7511->edid->extensions * 128, GFP_KERNEL);
-}
-EXPORT_SYMBOL_GPL(adv7511_get_edid);
-
 static void adv7511_encoder_dpms(struct drm_encoder *encoder, int mode)
 {
 	struct adv7511 *adv7511 = encoder_to_adv7511(encoder);

--- a/include/drm/drm_edid.h
+++ b/include/drm/drm_edid.h
@@ -383,6 +383,21 @@ static inline int drm_eld_size(const uint8_t *eld)
 	return DRM_ELD_HEADER_BLOCK_SIZE + eld[DRM_ELD_BASELINE_ELD_LEN] * 4;
 }
 
+/**
+ * drm_connector_get_edid - Get current EDID from the given connector
+ * @connector: pointer to the connector stucture
+ *
+ * This is a helper for accessing the drm blob buffered in the connector
+ * struct (if any)
+ */
+static inline struct edid *drm_connector_get_edid(struct drm_connector *connector)
+{
+	if (!connector->edid_blob_ptr)
+		return NULL;
+
+	return (struct edid *)connector->edid_blob_ptr->data;
+}
+
 struct edid *drm_do_get_edid(struct drm_connector *connector,
 	int (*get_edid_block)(void *data, u8 *buf, unsigned int block,
 			      size_t len),


### PR DESCRIPTION
I have removed a custom API for accessing EDID data, using instead a DRM-layer internal structure. It seemed pointless to me (otherwise please RFC). Tegra driver seems to do this way.. I added also an extra check to avoid calling a potential null helper function.

With  this changes, the adi_axi_hdmi driver works also with the mainline version of the ADV7511(provided that the DT is changed accordingly), and it shouldn't break anything with the ADV7511 in the analogdevicesinc tree.

I don't know if there is any plan to merge the ADV7511 driver in the analogdeviceinc tree with the mainline version, but IMHO my changes should make sense either way.

BTW at this point the adi_axi_hdmi should work with the mainline tree without touching anything else (except for my one-line-patch fixing VDMA not setting the INTERLEAVE bit in cap_mask, that wouldn't even necessary if we would drop support for old VDMA driver). So, I'm wondering whether at this point it would be possible pushing adi_axi_hdmi driver for mainlining :)