### PR TITLE
Compile fixes for xcomm_zynq

### DIFF
--- a/drivers/iio/accel/st_accel_buffer.c
+++ b/drivers/iio/accel/st_accel_buffer.c
@@ -84,7 +84,7 @@ static const struct iio_buffer_setup_ops st_accel_buffer_setup_ops = {
 int st_accel_allocate_ring(struct iio_dev *indio_dev)
 {
 	return iio_triggered_buffer_setup(indio_dev, &iio_pollfunc_store_time,
-		&st_sensors_trigger_handler);
+		&st_sensors_trigger_handler, &st_accel_buffer_setup_ops);
 }
 
 void st_accel_deallocate_ring(struct iio_dev *indio_dev)

--- a/drivers/iio/adc/ad7923.c
+++ b/drivers/iio/adc/ad7923.c
@@ -315,7 +315,7 @@ static int ad7923_probe(struct spi_device *spi)
 		return ret;
 
 	ret = iio_triggered_buffer_setup(indio_dev, NULL,
-			&ad7923_trigger_handler);
+			&ad7923_trigger_handler, NULL);
 	if (ret)
 		goto error_disable_reg;
 

--- a/drivers/iio/gyro/itg3200_buffer.c
+++ b/drivers/iio/gyro/itg3200_buffer.c
@@ -66,7 +66,7 @@ error_ret:
 int itg3200_buffer_configure(struct iio_dev *indio_dev)
 {
 	return iio_triggered_buffer_setup(indio_dev, &iio_pollfunc_store_time,
-		itg3200_trigger_handler);
+		itg3200_trigger_handler, NULL);
 }
 
 void itg3200_buffer_unconfigure(struct iio_dev *indio_dev)

--- a/drivers/iio/gyro/st_gyro_buffer.c
+++ b/drivers/iio/gyro/st_gyro_buffer.c
@@ -84,7 +84,7 @@ static const struct iio_buffer_setup_ops st_gyro_buffer_setup_ops = {
 int st_gyro_allocate_ring(struct iio_dev *indio_dev)
 {
 	return iio_triggered_buffer_setup(indio_dev, &iio_pollfunc_store_time,
-		&st_sensors_trigger_handler);
+		&st_sensors_trigger_handler, &st_gyro_buffer_setup_ops);
 }
 
 void st_gyro_deallocate_ring(struct iio_dev *indio_dev)

--- a/drivers/iio/imu/inv_mpu6050/inv_mpu_core.c
+++ b/drivers/iio/imu/inv_mpu6050/inv_mpu_core.c
@@ -821,7 +821,8 @@ static int inv_mpu_probe(struct i2c_client *client,
 
 	result = iio_triggered_buffer_setup(indio_dev,
 					    inv_mpu6050_irq_handler,
-					    inv_mpu6050_read_fifo
+					    inv_mpu6050_read_fifo,
+					    NULL
 					    );
 	if (result) {
 		dev_err(&st->client->dev, "configure buffer fail %d\n",

--- a/drivers/iio/magnetometer/st_magn_buffer.c
+++ b/drivers/iio/magnetometer/st_magn_buffer.c
@@ -66,7 +66,7 @@ static const struct iio_buffer_setup_ops st_magn_buffer_setup_ops = {
 int st_magn_allocate_ring(struct iio_dev *indio_dev)
 {
 	return iio_triggered_buffer_setup(indio_dev, &iio_pollfunc_store_time,
-		&st_sensors_trigger_handler);
+		&st_sensors_trigger_handler, &st_magn_buffer_setup_ops);
 }
 
 void st_magn_deallocate_ring(struct iio_dev *indio_dev)

--- a/drivers/iio/pressure/st_pressure_buffer.c
+++ b/drivers/iio/pressure/st_pressure_buffer.c
@@ -53,7 +53,7 @@ static int st_press_buffer_predisable(struct iio_dev *indio_dev)
 
 	err = st_sensors_set_enable(indio_dev, false);
 
-	kfree(pdata->buffer_data);
+	kfree(press_data->buffer_data);
 	return err;
 }
 

--- a/include/drm/drm_edid.h
+++ b/include/drm/drm_edid.h
@@ -24,6 +24,7 @@
 #define __DRM_EDID_H__
 
 #include <linux/types.h>
+#include <drm/drm_crtc.h>
 
 #define EDID_LENGTH 128
 #define DDC_ADDR 0x50


### PR DESCRIPTION
Fix compilation issues with iio_triggered_buffer_setup usage and
st_press_buffer_predisable.