### PR TITLE
media: i2c: adv7511: Fix use with DT

### DIFF
--- a/drivers/media/i2c/adv7511.c
+++ b/drivers/media/i2c/adv7511.c
@@ -1751,6 +1751,14 @@ static void adv7511_get_ofdt_config(struct i2c_client *client,
 	if (prop)
 		state->pdata.i2c_edid = (uint8_t)be32_to_cpup(prop);
 
+	prop = of_get_property(dn, "pktmem-addr", &size);
+	if (prop)
+		state->pdata.i2c_pktmem = (uint8_t)be32_to_cpup(prop);
+
+	prop = of_get_property(dn, "cec-addr", &size);
+	if (prop)
+		state->pdata.i2c_cec = (uint8_t)be32_to_cpup(prop);
+
 	np = of_find_node_by_name(dn, "video-input");
 	if (np) {
 		prop = of_get_property(np, "input-id", &size);


### PR DESCRIPTION
The DT bindings added by b983a5a3 were added before support for
infoframes (b4dbad8f). With the infoframes added, DT based use of the
driver will fail to find the pktmem I2C device and fail to load.

Add a pktmem-addr device tree binding (similar to the edid-addr)
binding to enable this address to be specified.

Add a cec-addr device tree binding as well, for future use.

Signed-off-by: Matthew Fornero <mfornero@mathworks.com>