### PR TITLE
reorder initialization to perform better during boot

### DIFF
--- a/drivers/gpu/drm/adi_axi_hdmi/axi_hdmi_drv.c
+++ b/drivers/gpu/drm/adi_axi_hdmi/axi_hdmi_drv.c
@@ -66,9 +66,6 @@ static int axi_hdmi_load(struct drm_device *dev, unsigned long flags)
 
 	drm_mode_config_init(dev);
 
-	/* init kms poll for handling hpd */
-	drm_kms_helper_poll_init(dev);
-
 	axi_hdmi_mode_config_init(dev);
 
 	private->crtc = axi_hdmi_crtc_create(dev);
@@ -89,6 +86,9 @@ static int axi_hdmi_load(struct drm_device *dev, unsigned long flags)
 		ret = PTR_ERR(private->fbdev);
 		goto err_crtc;
 	}
+
+	/* init kms poll for handling hpd */
+	drm_kms_helper_poll_init(dev);
 
 	return 0;
 


### PR DESCRIPTION
If HDMI cable is connected while the device is booting, the axi hdmi driver does not initialize the display since hot plug event happens before the driver is fully initialized. By moving drm_kms_helper_poll_init down in the axi_hdmi_load() allows driver to initialize the display properly.