### PR TITLE
[AD9361] Add a DT property to set 0x106[D6:D4]

### DIFF
--- a/arch/arm/boot/dts/adi-fmcomms2.dtsi
+++ b/arch/arm/boot/dts/adi-fmcomms2.dtsi
@@ -148,7 +148,8 @@
 
 		adi,agc-adc-small-overload-exceed-counter = <10>; /* 0..15 */
 		adi,agc-adc-large-overload-exceed-counter = <10>; /* 0..15 */
-		adi,agc-adc-large-overload-inc-steps = <2>; /* 0..15 */
+		adi,agc-adc-large-overload-inc-steps = <5>; /* 0..15 */
+		adi,agc-any-large-overload-inc-steps = <2>; /* 0..7 */
 		//adi,agc-adc-lmt-small-overload-prevent-gain-inc-enable;
 		adi,agc-lmt-overload-large-exceed-counter = <10>; /* 0..15 */
 		adi,agc-lmt-overload-small-exceed-counter = <10>; /* 0..15 */

--- a/drivers/iio/adc/ad9361.c
+++ b/drivers/iio/adc/ad9361.c
@@ -3219,8 +3219,9 @@ static int ad9361_gc_setup(struct ad9361_rf_phy *phy, struct gain_control *ctrl)
 		SMALL_ADC_OVERLOAD_EXED_COUNTER(ctrl->adc_small_overload_exceed_counter);
 	ad9361_spi_write(spi, REG_ADC_OVERLOAD_COUNTERS, reg);
 
-	ad9361_spi_writef(spi, REG_GAIN_STP_CONFIG_2, LARGE_LPF_GAIN_STEP(~0),
-			 LARGE_LPF_GAIN_STEP(ctrl->adc_large_overload_inc_steps));
+	reg = DECREMENT_STP_SIZE_FOR_SMALL_LPF_GAIN_CHANGE(ctrl->agc_any_large_overload_inc_steps) |
+		LARGE_LPF_GAIN_STEP(ctrl->adc_large_overload_inc_steps);
+	ad9361_spi_write(spi, REG_GAIN_STP_CONFIG_2, reg);
 
 	reg = LARGE_LMT_OVERLOAD_EXED_COUNTER(ctrl->lmt_overload_large_exceed_counter) |
 		SMALL_LMT_OVERLOAD_EXED_COUNTER(ctrl->lmt_overload_small_exceed_counter);
@@ -8228,8 +8229,10 @@ static struct ad9361_phy_platform_data
 			  &pdata->gain_ctrl.adc_small_overload_exceed_counter);
 	ad9361_of_get_u32(iodev, np, "adi,agc-adc-large-overload-exceed-counter", 10,
 			  &pdata->gain_ctrl.adc_large_overload_exceed_counter);
-	ad9361_of_get_u32(iodev, np, "adi,agc-adc-large-overload-inc-steps", 2,
+	ad9361_of_get_u32(iodev, np, "adi,agc-adc-large-overload-inc-steps", 5,
 			  &pdata->gain_ctrl.adc_large_overload_inc_steps);
+	ad9361_of_get_u32(iodev, np, "adi,agc-any-large-overload-inc-steps", 2,
+			  &pdata->gain_ctrl.agc_any_large_overload_inc_steps);
 	ad9361_of_get_bool(iodev, np, "adi,agc-adc-lmt-small-overload-prevent-gain-inc-enable",
 			   &pdata->gain_ctrl.adc_lmt_small_overload_prevent_gain_inc);
 	ad9361_of_get_u32(iodev, np, "adi,agc-lmt-overload-large-exceed-counter", 10,

--- a/drivers/iio/adc/ad9361.h
+++ b/drivers/iio/adc/ad9361.h
@@ -2899,6 +2899,7 @@ struct gain_control {
 	u8 adc_small_overload_exceed_counter; /* 0..15, 0x122 */
 	u8 adc_large_overload_exceed_counter; /* 0..15, 0x122 */
 	u8 adc_large_overload_inc_steps; /* 0..15, 0x106 */
+	u8 agc_any_large_overload_inc_steps; /* 0..7, 0x106 */
 
 	bool adc_lmt_small_overload_prevent_gain_inc; /* 0x120 */
 


### PR DESCRIPTION
Just a small PR to be able to set bits 6 to 4 of register 0x106 from DTSI files. I'm not sure about the property name though.

Also, the default value of 0x106[D3:D0] (`adi,agc-adc-large-overload-inc-steps` property) was set to 2 while the default value is 5 in the register map reference manual (Table 42, rev0), so this PR sets it back to 5.