### PR TITLE
 net: ethernet: xilinx: fix internal phy initialization

### DIFF
--- a/drivers/net/ethernet/xilinx/xilinx_axienet.h
+++ b/drivers/net/ethernet/xilinx/xilinx_axienet.h
@@ -636,7 +636,7 @@ struct axienet_local {
 	struct device *dev;
 
 	/* Connection to PHY device */
-	struct phy_device *phy_dev, *phy_dev_int;/* Pointer to PHY device */
+	struct phy_device *phy_dev_int; /* Pointer to internal PHY device */
 	struct device_node *phy_node, *phy_node_int;
 
 	/* MDIO bus data */

--- a/drivers/net/ethernet/xilinx/xilinx_axienet_main.c
+++ b/drivers/net/ethernet/xilinx/xilinx_axienet_main.c
@@ -2322,7 +2322,10 @@ err_ptp_rx_irq:
 #endif
 	if (phydev)
 		phy_disconnect(phydev);
+	if (lp->phy_dev_int)
+		phy_disconnect(lp->phy_dev_int);
 	phydev = NULL;
+	lp->phy_dev_int = NULL;
 	for_each_dma_queue(lp, i)
 		tasklet_kill(&lp->dma_err_tasklet[i]);
 	dev_err(lp->dev, "request_irq() failed\n");
@@ -2381,6 +2384,11 @@ static int axienet_stop(struct net_device *ndev)
 
 	if (ndev->phydev)
 		phy_disconnect(ndev->phydev);
+
+	if (lp->phy_dev_int)
+		phy_disconnect(lp->phy_dev_int);
+
+	lp->phy_dev_int = NULL;
 
 	if (lp->temac_no != XAE_TEMAC2)
 		axienet_dma_bd_release(ndev);

--- a/drivers/net/ethernet/xilinx/xilinx_axienet_main.c
+++ b/drivers/net/ethernet/xilinx/xilinx_axienet_main.c
@@ -2200,7 +2200,7 @@ static int axienet_open(struct net_device *ndev)
 		} else if ((lp->axienet_config->mactype == XAXIENET_1G) ||
 			     (lp->axienet_config->mactype == XAXIENET_2_5G)) {
 			/**
-			 * No need to start the internal PHY, applying the fixup
+			 * No need to start the internal PHY, initializing the internal PHY,
 			 * is enough for SGMII operation. `lp->phy_node_int` should
 			 * be non-NULL only for SGMII mode.
 			 */
@@ -3753,18 +3753,6 @@ static const struct attribute_group mcdma_attributes = {
 #endif
 
 /**
- * axienet_pma_phy_fixup - PCS/PMA Internal PHY fixup.
- * @phy: the pointer to the phy device
- *
- * The internal PHY powers up with BMCR_ISOLATE beeing set, clear it.
- */
-
-static int axienet_pma_phy_fixup(struct phy_device *phy)
-{
-	return phy_write(phy, MII_BMCR, BMCR_ANENABLE | BMCR_FULLDPLX);
-}
-
-/**
  * axienet_probe - Axi Ethernet probe function.
  * @pdev:	Pointer to platform device structure.
  *
@@ -4048,9 +4036,6 @@ static int axienet_probe(struct platform_device *pdev)
 	if (lp->phy_type == XAE_PHY_TYPE_SGMII) {
 		lp->phy_node_int = of_parse_phandle(pdev->dev.of_node,
 						    "phy-handle", 1);
-		if (lp->phy_node_int)
-			phy_register_fixup_for_uid(0, 0xffffffff,
-						   axienet_pma_phy_fixup);
 	}
 
 #ifdef CONFIG_AXIENET_HAS_MCDMA

--- a/drivers/net/ethernet/xilinx/xilinx_axienet_main.c
+++ b/drivers/net/ethernet/xilinx/xilinx_axienet_main.c
@@ -2199,23 +2199,20 @@ static int axienet_open(struct net_device *ndev)
 						PHY_INTERFACE_MODE_RGMII_ID);
 		} else if ((lp->axienet_config->mactype == XAXIENET_1G) ||
 			     (lp->axienet_config->mactype == XAXIENET_2_5G)) {
-			phydev = of_phy_connect(lp->ndev, lp->phy_node,
-						axienet_adjust_link,
-						lp->phy_flags,
-						lp->phy_interface);
-		} else {
 			/**
 			 * No need to start the internal PHY, applying the fixup
-			 * is enough for SGMII operation
+			 * is enough for SGMII operation. `lp->phy_node_int` should
+			 * be non-NULL only for SGMII mode.
 			 */
 			if (lp->phy_node_int)
 				lp->phy_dev_int = of_phy_connect(lp->ndev,
 					lp->phy_node_int, NULL, 0,
 					PHY_INTERFACE_MODE_GMII);
 
-			lp->phy_dev = of_phy_connect(lp->ndev, lp->phy_node,
-					     axienet_adjust_link, 0,
-					     PHY_INTERFACE_MODE_SGMII);
+			phydev = of_phy_connect(lp->ndev, lp->phy_node,
+						axienet_adjust_link,
+						lp->phy_flags,
+						lp->phy_interface);
 		}
 
 		if (!phydev)


### PR DESCRIPTION
The main fix is commit bf25c79be5571a5f231e8629a0847c51bf81463c which moves the init of the internal PHY before the init of the external one.
Also, the external PHY was being initialized inside this else block
```
 		} else if ((lp->axienet_config->mactype == XAXIENET_1G) ||
 			     (lp->axienet_config->mactype == XAXIENET_2_5G)) {
```

I've removed the fixup routine.
It does not seem to be run.

And finally, added code to cleanup the internal after each [external] PHY cleanup.

Tested successfully on VC707 & KCU105

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>