### PR TITLE
iio: ad6676: Assign values from division

### DIFF
--- a/drivers/iio/adc/ad6676.c
+++ b/drivers/iio/adc/ad6676.c
@@ -222,8 +222,8 @@ static u32 ad6676_get_fif(struct axiadc_converter *conv)
 	mix1 = mix1 * pdata->base.f_adc_hz;
 	mix2 = mix2 * pdata->base.f_adc_hz;
 
-	div_s64(mix1, 64);
-	div_s64(mix2, phy->m);
+	mix1 = div_s64(mix1, 64);
+	mix2 = div_s64(mix2, phy->m);
 
 	return mix1 + mix2;
 }


### PR DESCRIPTION
Fixes commit 8cd9482bf: `drivers/iio/adc/ad6676: Fix compiler warnings`

`do_div` is a macro that passes the result to the
first parameter via reference.

Whereas `div_s64` is function whose return value must be assigned.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>