### PR TITLE
arm: dts: zynq-mini-itx-adv7511: Disable axi_hdmi RGB output

### DIFF
--- a/arch/arm/boot/dts/zynq-mini-itx-adv7511.dtsi
+++ b/arch/arm/boot/dts/zynq-mini-itx-adv7511.dtsi
@@ -98,7 +98,6 @@
 			dmas = <&axi_vdma_0 0>;
 			dma-names = "video";
 			clocks = <&hdmi_clock>;
-			adi,is-rgb;
 
 			port {
 				axi_hdmi_out: endpoint {


### PR DESCRIPTION
The FPGA should send YUV data to ADV7511 for the Mini-ITX.

Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>