### PR TITLE
[media] adv7604: remove duplicate reset code of gpios

### DIFF
--- a/drivers/media/i2c/adv7604.c
+++ b/drivers/media/i2c/adv7604.c
@@ -3436,13 +3436,6 @@ static int adv76xx_probe(struct i2c_client *client,
 
 	adv76xx_reset(state);
 
-	state->reset_gpio = devm_gpiod_get_optional(&client->dev, "reset",
-								GPIOD_OUT_HIGH);
-	if (IS_ERR(state->reset_gpio))
-		return PTR_ERR(state->reset_gpio);
-
-	adv76xx_reset(state);
-
 	state->timings = cea640x480;
 	state->format = adv76xx_format_info(state, MEDIA_BUS_FMT_YUYV8_2X8);
 


### PR DESCRIPTION
Seems this was left-over from a merge commit.
Probably this commit 41d036b3795606 (Merge remote-tracking branch
'xilinx/master' into xcomm_zynq_4_9)

Remove it, since it's a duplicate reset.

The duplicate code is viewable in right above this patch/change.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>