### PR TITLE
iio:dac:ad5683r:fix the write command operation for AD5681R/82R/83/83…

### DIFF
--- a/drivers/iio/dac/ad5686-spi.c
+++ b/drivers/iio/dac/ad5686-spi.c
@@ -19,17 +19,28 @@ static int ad5686_spi_write(struct ad5686_state *st,
 	struct spi_device *spi = to_spi_device(st->dev);
 	u8 tx_len, *buf;
 
-	if (st->chip_info->regmap_type == AD5310_REGMAP) {
+	switch (st->chip_info->regmap_type) {
+	case AD5310_REGMAP:
 		st->data[0].d16 = cpu_to_be16(AD5310_CMD(cmd) |
 					      val);
 		buf = &st->data[0].d8[0];
 		tx_len = 2;
-	} else {
+		break;
+	case AD5683_REGMAP:
+		st->data[0].d32 = cpu_to_be32(AD5686_CMD(cmd) |
+					      AD5683_DATA(val));
+		buf = &st->data[0].d8[1];
+		tx_len = 3;
+		break;
+	case AD5686_REGMAP:
 		st->data[0].d32 = cpu_to_be32(AD5686_CMD(cmd) |
 					      AD5686_ADDR(addr) |
 					      val);
 		buf = &st->data[0].d8[1];
 		tx_len = 3;
+		break;
+	default:
+		return -EINVAL;
 	}
 
 	return spi_write(spi, buf, tx_len);

--- a/drivers/iio/dac/ad5686.c
+++ b/drivers/iio/dac/ad5686.c
@@ -100,7 +100,7 @@ static ssize_t ad5686_write_dac_powerdown(struct iio_dev *indio_dev,
 		ref_bit_msk = AD5310_REF_BIT_MSK;
 		break;
 	case AD5683_REGMAP:
-		shift = 17;
+		shift = 13;
 		ref_bit_msk = AD5683_REF_BIT_MSK;
 		break;
 	case AD5686_REGMAP:

--- a/drivers/iio/dac/ad5686.h
+++ b/drivers/iio/dac/ad5686.h
@@ -8,6 +8,8 @@
 
 #define AD5310_CMD(x)				((x) << 12)
 
+#define AD5683_DATA(x)				((x) << 4)
+
 #define AD5686_ADDR(x)				((x) << 16)
 #define AD5686_CMD(x)				((x) << 20)
 
@@ -34,7 +36,7 @@
 #define AD5686_CMD_READBACK_ENABLE_V2		0x5
 
 #define AD5310_REF_BIT_MSK			BIT(8)
-#define AD5683_REF_BIT_MSK			BIT(16)
+#define AD5683_REF_BIT_MSK			BIT(12)
 #define AD5693_REF_BIT_MSK			BIT(12)
 
 /**


### PR DESCRIPTION
…R devices

For AD5681R/82R/83/83R devices the shift register is 24 bits wide.
The first four bits are the command bits followed by the data bits.
As the data comprises of 20-bit, 18-bit or 16-bit input code, this
means that 4 LSB bits are don't care. This is why the data needs to
be shifted on the left with four bits. In order to fix this, AD5683_REGMAP
is checked inside a switch case inside the ad5686_spi_write() function.
Also AD5683_REF_BIT_MSK had to be modified.

This is different from other similar devices such as AD5693R family,
which have the 4 MSB command bits followed by 4 don't care bits.

Signed-off-by: Stefan Popa <stefan.popa@analog.com>