### PR TITLE
iio: Fix IIO_VAL_FRACTIONAL_LOG2 newline termination

### DIFF
--- a/drivers/iio/industrialio-core.c
+++ b/drivers/iio/industrialio-core.c
@@ -621,9 +621,9 @@ static ssize_t __iio_format_value(char *buf, size_t len, unsigned int type,
 		tmp1 = vals[1];
 		tmp0 = div_s64_rem(stmp, 1000000000LL, &tmp1);
 		if (vals[1] < 0)
-			return snprintf(buf, len, "-%d.%09u\n", abs(tmp0), -tmp1);
+			return snprintf(buf, len, "-%d.%09u", abs(tmp0), -tmp1);
 		else
-			return snprintf(buf, len,  "%d.%09u\n", tmp0, tmp1);
+			return snprintf(buf, len,  "%d.%09u", tmp0, tmp1);
 	case IIO_VAL_INT_MULTIPLE:
 	{
 		int i;


### PR DESCRIPTION
Currently two newline characters are appended at the end of
IIO_VAL_FRACTIONAL_LOG2 values when preparing them for displaying in sysfs.
One is added in __iio_format_value() the other in iio_format_value().

This is unintended behavior and can confuse userspace tools. Remove the
newline that is added in __iio_format_value().

Fixes: 4320b0914a5e ("iio:core: add a callback to allow drivers to provide _available attributes")
Signed-off-by: Lars-Peter Clausen <lars@metafoo.de>