### PR TITLE
Rpi 4.9.y adxl372 fifo

### DIFF
--- a/arch/arm/boot/dts/overlays/rpi-adxl372-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-adxl372-overlay.dts
@@ -15,6 +15,8 @@
 				compatible = "adi,adxl372";
 				reg = <0>;
 				spi-max-frequency = <1000000>;
+				interrupts = <25 2>;
+				interrupt-parent = <&gpio>;
 			};
 		};
 	};

--- a/drivers/iio/accel/adxl372.c
+++ b/drivers/iio/accel/adxl372.c
@@ -11,9 +11,18 @@
 #include <linux/spi/spi.h>
 #include <linux/regmap.h>
 #include <linux/bitops.h>
+#include <linux/gpio/consumer.h>
+#include <linux/interrupt.h>
+#include <linux/irq.h>
 
 #include <linux/iio/iio.h>
 #include <linux/iio/sysfs.h>
+
+#include <linux/iio/buffer.h>
+#include <linux/iio/events.h>
+#include <linux/iio/trigger.h>
+#include <linux/iio/trigger_consumer.h>
+#include <linux/iio/triggered_buffer.h>
 
 /*
  * ADXL372 registers definition
@@ -166,6 +175,8 @@
 #define ADXL372_INT2_MAP_LOW_MSK		BIT(7)
 #define ADXL372_INT2_MAP_LOW_MODE(x)		(((x) & 0x1) << 7)
 
+#define ADXL372_FIFO_SIZE			512
+
 /*
  * At +/- 200g with 12-bit resolution, scale is computed as:
  * (200 + 200) * 9.81 / (2^12 - 1) = 0.958241
@@ -223,6 +234,24 @@ enum adxl372_bandwidth {
 	ADXL372_BW_3200HZ,
 };
 
+enum adxl372_fifo_format {
+	ADXL372_XYZ_FIFO,
+	ADXL372_X_FIFO,
+	ADXL372_Y_FIFO,
+	ADXL372_XY_FIFO,
+	ADXL372_Z_FIFO,
+	ADXL372_XZ_FIFO,
+	ADXL372_YZ_FIFO,
+	ADXL372_XYZ_PEAK_FIFO,
+};
+
+enum adxl372_fifo_mode {
+	ADXL372_FIFO_BYPASSED,
+	ADXL372_FIFO_STREAMED,
+	ADXL372_FIFO_TRIGGERED,
+	ADXL372_FIFO_OLD_SAVED
+};
+
 #define ADXL372_ACCEL_CHANNEL(index, reg, axis) {			\
 	.type = IIO_ACCEL,						\
 	.address = reg,							\
@@ -251,10 +280,17 @@ static const struct iio_chan_spec adxl372_channels[] = {
 struct adxl372_state {
 	struct spi_device		*spi;
 	struct regmap			*regmap;
+	struct iio_trigger		*dready_trig;
+	enum adxl372_fifo_mode		fifo_mode;
+	enum adxl372_fifo_format	fifo_format;
 	enum adxl372_op_mode		op_mode;
 	enum adxl372_act_proc_mode	act_proc_mode;
 	enum adxl372_odr		odr;
 	enum adxl372_bandwidth		bw;
+	u8				fifo_set_size;
+	u8				int1_bitmask;
+	u8				int2_bitmask;
+	u16				watermark;
 
 	/*
 	 * DMA (thus cache coherency maintenance) requires the
@@ -262,7 +298,7 @@ struct adxl372_state {
 	 */
 	union {
 		__le16 regval;
-		u8 d8[512];
+		u8 d8[1024];
 	} data ____cacheline_aligned;
 };
 
@@ -285,6 +321,20 @@ static int adxl372_spi_write_mask(struct adxl372_state *st,
 			   st->data.regval);
 
 	return ret;
+}
+
+static int adxl372_read_fifo(struct adxl372_state *st, u16 fifo_entries)
+{
+	int ret;
+
+	ret = regmap_bulk_read(st->regmap, ADXL372_REG_READ(ADXL372_FIFO_DATA),
+			       &st->data.d8[0], fifo_entries * 2);
+	if (ret < 0) {
+		dev_err(&st->spi->dev, "Failed to read fifo\n");
+		return ret;
+	}
+
+	return 0;
 }
 
 static int adxl372_read_axis(struct adxl372_state *st, u8 addr)
@@ -422,6 +472,126 @@ static int adxl372_set_activity_threshold(struct adxl372_state *st,
 	return ret;
 }
 
+static int adxl372_set_interrupts(struct adxl372_state *st,
+				  u8 int1_bitmask,
+				  u8 int2_bitmask)
+{
+	int ret;
+
+	st->data.d8[0] = int1_bitmask;
+	st->data.d8[1] = int2_bitmask;
+
+
+	/* INT1_MAP and INT2_MAP are adjacent registers */
+	ret = regmap_bulk_write(st->regmap,
+				ADXL372_REG_WRITE(ADXL372_INT1_MAP),
+				&st->data.d8[0], 2);
+
+	if (ret < 0) {
+		dev_err(&st->spi->dev,
+			"Error setting interrupts\n");
+		return ret;
+	}
+
+	st->int1_bitmask = int1_bitmask;
+	st->int2_bitmask = int2_bitmask;
+
+	return ret;
+}
+
+static int adxl372_configure_fifo(struct adxl372_state *st)
+{
+	int ret;
+
+	/* FIFO must be configured while in standby mode */
+	ret = adxl372_set_op_mode(st, ADXL372_STANDBY);
+	if (ret < 0)
+		return ret;
+
+	st->data.d8[0] = (st->watermark & 0xFF);
+	st->data.d8[1] = (ADXL372_FIFO_CTL_FORMAT_MODE(st->fifo_format) |
+			  ADXL372_FIFO_CTL_MODE_MODE(st->fifo_mode) |
+			  ADXL372_FIFO_CTL_SAMPLES_MODE(st->watermark));
+
+	/* FIFO_SAMPLES and FIFO_CTL are adjacent registers */
+	ret = regmap_bulk_write(st->regmap,
+				ADXL372_REG_WRITE(ADXL372_FIFO_SAMPLES),
+				&st->data.d8[0], 2);
+
+	if (ret < 0) {
+		dev_err(&st->spi->dev,
+			"Error configuring fifo\n");
+		return ret;
+	}
+
+	ret = adxl372_set_op_mode(st, ADXL372_FULL_BW_MEASUREMENT);
+
+	return ret;
+}
+
+static int adxl372_get_status(struct adxl372_state *st,
+			      u8 *status1, u8 *status2,
+			      u16 *fifo_entries)
+{
+	int ret;
+
+	/* STATUS, STATUS2, FIFO_ENTRIES2 and FIFO_ENTRIES are adjacent regs */
+	ret = regmap_bulk_read(st->regmap, ADXL372_REG_READ(ADXL372_STATUS_1),
+			       &st->data.d8[0], 4);
+	if (ret < 0) {
+		dev_err(&st->spi->dev,
+			"Error reading status register\n");
+		return ret;
+	}
+
+	*status1 = st->data.d8[0];
+	*status2 = st->data.d8[1];
+	/*
+	 * FIFO_ENTRIES contains the least significant byte, and FIFO_ENTRIES2
+	 * contains the two most significant bits
+	 */
+	*fifo_entries = ((st->data.d8[2] & 0x3) << 8) | st->data.d8[3];
+
+	return ret;
+}
+
+static irqreturn_t adxl372_trigger_handler(int irq, void  *p)
+{
+	struct iio_poll_func *pf = p;
+	struct iio_dev *indio_dev = pf->indio_dev;
+	struct adxl372_state *st = iio_priv(indio_dev);
+	u8 status1, status2;
+	u16 fifo_entries, i;
+	int ret;
+
+	ret = adxl372_get_status(st, &status1, &status2, &fifo_entries);
+	if (ret < 0)
+		goto err;
+
+	if ((st->fifo_mode != ADXL372_FIFO_BYPASSED) &&
+	    (ADXL372_STATUS_1_FIFO_FULL(status1))) {
+		/*
+		 * When reading data from multiple axes from the FIFO,
+		 * to ensure that data is not overwritten and stored out
+		 * of order at least one sample set must be left in the
+		 * FIFO after every read.
+		 */
+		fifo_entries -= st->fifo_set_size;
+
+		ret = adxl372_read_fifo(st, fifo_entries);
+		if (ret < 0)
+			goto err;
+
+		for (i = 0; i < fifo_entries * 2; i += st->fifo_set_size * 2)
+			iio_push_to_buffers_with_timestamp(indio_dev,
+						&st->data.d8[i],
+						iio_get_time_ns(indio_dev));
+	}
+err:
+	iio_trigger_notify_done(indio_dev->trig);
+	return IRQ_HANDLED;
+}
+
 static int adxl372_setup(struct adxl372_state *st)
 {
 	int ret;
@@ -518,8 +688,10 @@ static int adxl372_raw(struct iio_dev *indio_dev,
 
 	switch (info) {
 	case IIO_CHAN_INFO_RAW:
-		ret = adxl372_read_axis(st, chan->address);
+		if (iio_buffer_enabled(indio_dev))
+			return -EBUSY;
 
+		ret = adxl372_read_axis(st, chan->address);
 		if (ret < 0)
 			return ret;
 
@@ -527,6 +699,7 @@ static int adxl372_raw(struct iio_dev *indio_dev,
 				     chan->scan_type.realbits - 1);
 
 		return IIO_VAL_INT;
+
 	case IIO_CHAN_INFO_SCALE:
 		*val = 0;
 		*val2 = ADXL372_USCALE;
@@ -537,10 +710,160 @@ static int adxl372_raw(struct iio_dev *indio_dev,
 	return -EINVAL;
 }
 
+static ssize_t adxl372_get_fifo_enabled(struct device *dev,
+					  struct device_attribute *attr,
+					  char *buf)
+{
+	struct iio_dev *indio_dev = dev_to_iio_dev(dev);
+	struct adxl372_state *st = iio_priv(indio_dev);
+
+	return sprintf(buf, "%d\n", st->fifo_mode);
+}
+
+static ssize_t adxl372_get_fifo_watermark(struct device *dev,
+					  struct device_attribute *attr,
+					  char *buf)
+{
+	struct iio_dev *indio_dev = dev_to_iio_dev(dev);
+	struct adxl372_state *st = iio_priv(indio_dev);
+
+	return sprintf(buf, "%d\n", st->watermark);
+}
+
+static IIO_CONST_ATTR(hwfifo_watermark_min, "1");
+static IIO_CONST_ATTR(hwfifo_watermark_max,
+		      __stringify(ADXL372_FIFO_SIZE));
+static IIO_DEVICE_ATTR(hwfifo_watermark, 0444,
+		       adxl372_get_fifo_watermark, NULL, 0);
+static IIO_DEVICE_ATTR(hwfifo_enabled, 0444,
+		       adxl372_get_fifo_enabled, NULL, 0);
+
+static const struct attribute *adxl372_fifo_attributes[] = {
+	&iio_const_attr_hwfifo_watermark_min.dev_attr.attr,
+	&iio_const_attr_hwfifo_watermark_max.dev_attr.attr,
+	&iio_dev_attr_hwfifo_watermark.dev_attr.attr,
+	&iio_dev_attr_hwfifo_enabled.dev_attr.attr,
+	NULL,
+};
+
+static int adxl372_set_watermark(struct iio_dev *indio_dev, unsigned int val)
+{
+	struct adxl372_state *st  = iio_priv(indio_dev);
+
+	if (val > ADXL372_FIFO_SIZE)
+		val = ADXL372_FIFO_SIZE;
+
+	st->watermark = val;
+
+	return 0;
+}
+
+static int adxl372_buffer_postenable(struct iio_dev *indio_dev)
+{
+	struct adxl372_state *st = iio_priv(indio_dev);
+	u8 fifo_set_size, accel_axis_en;
+	int bit, ret;
+
+	if (!st->watermark)
+		return -EINVAL;
+
+	ret = adxl372_set_interrupts(st,
+				     ADXL372_INT1_MAP_FIFO_FULL_MSK,
+				     0);
+	if (ret < 0)
+		return ret;
+
+	fifo_set_size = 0;
+	accel_axis_en = 0;
+	for_each_set_bit(bit, indio_dev->active_scan_mask,
+			 indio_dev->masklength) {
+		accel_axis_en |= bit;
+		fifo_set_size++;
+	}
+
+	switch (accel_axis_en) {
+	case 0:
+		st->fifo_format = ADXL372_X_FIFO;
+		break;
+	case 1:
+		st->fifo_format = ((fifo_set_size == 1) ?
+				   ADXL372_Y_FIFO : ADXL372_XY_FIFO);
+		break;
+	case 2:
+		st->fifo_format = ((fifo_set_size == 1) ?
+				   ADXL372_Z_FIFO : ADXL372_XZ_FIFO);
+		break;
+	case 3:
+		st->fifo_format = ((fifo_set_size == 3) ?
+				   ADXL372_XYZ_PEAK_FIFO : ADXL372_YZ_FIFO);
+		break;
+	}
+
+	/*
+	 * The 512 FIFO samples can be allotted in several ways, such as:
+	 * 170 sample sets of concurrent 3-axis data
+	 * 256 sample sets of concurrent 2-axis data (user selectable)
+	 * 512 sample sets of single-axis data
+	 */
+	if ((st->watermark * fifo_set_size) > ADXL372_FIFO_SIZE)
+		st->watermark = (ADXL372_FIFO_SIZE  / fifo_set_size);
+
+	st->fifo_set_size = fifo_set_size;
+	st->fifo_mode = ADXL372_FIFO_STREAMED;
+
+	ret = adxl372_configure_fifo(st);
+	if (ret < 0) {
+		st->fifo_mode = ADXL372_FIFO_BYPASSED;
+		adxl372_set_interrupts(st, 0, 0);
+	}
+
+	return ret;
+}
+
+static int adxl372_buffer_predisable(struct iio_dev *indio_dev)
+{
+	struct adxl372_state *st = iio_priv(indio_dev);
+
+	adxl372_set_interrupts(st, 0, 0);
+	st->fifo_mode = ADXL372_FIFO_BYPASSED;
+	adxl372_configure_fifo(st);
+
+	return 0;
+}
+
+static const struct iio_buffer_setup_ops adxl372_buffer_ops = {
+	.postenable = adxl372_buffer_postenable,
+	.predisable = adxl372_buffer_predisable,
+};
+
+
+static int adxl372_dready_trig_set_state(struct iio_trigger *trig,
+					 bool state)
+{
+	struct iio_dev *indio_dev = iio_trigger_get_drvdata(trig);
+	struct adxl372_state *st = iio_priv(indio_dev);
+	int ret;
+
+	if (state)
+		ret = adxl372_set_interrupts(st,
+					     ADXL372_INT1_MAP_FIFO_FULL_MSK,
+					     0);
+	else
+		ret = adxl372_set_interrupts(st, 0, 0);
+
+	return ret;
+}
+
+static const struct iio_trigger_ops adxl372_trigger_ops = {
+	.set_trigger_state = adxl372_dready_trig_set_state,
+	.owner = THIS_MODULE,
+};
+
 static const struct iio_info adxl372_info = {
 	.driver_module	= THIS_MODULE,
 	.read_raw	= adxl372_raw,
 	.debugfs_reg_access = &adxl372_reg_access,
+	.hwfifo_set_watermark = adxl372_set_watermark,
 };
 
 static const struct regmap_config adxl372_spi_regmap_config = {
@@ -579,7 +902,7 @@ static int adxl372_probe(struct spi_device *spi)
 	indio_dev->dev.parent = &spi->dev;
 	indio_dev->name = spi_get_device_id(spi)->name;
 	indio_dev->info = &adxl372_info;
-	indio_dev->modes = INDIO_DIRECT_MODE;
+	indio_dev->modes = INDIO_DIRECT_MODE | INDIO_BUFFER_SOFTWARE;
 
 	ret = adxl372_setup(st);
 	if (ret < 0) {
@@ -587,9 +910,45 @@ static int adxl372_probe(struct spi_device *spi)
 		return ret;
 	}
 
-	ret = iio_device_register(indio_dev);
-	if (ret)
+	ret = devm_iio_triggered_buffer_setup(&st->spi->dev,
+					      indio_dev, NULL,
+					      adxl372_trigger_handler,
+					      &adxl372_buffer_ops);
+	if (ret < 0)
 		return ret;
+
+	st->dready_trig = devm_iio_trigger_alloc(&st->spi->dev,
+			  "%s-dev%d",
+			  indio_dev->name);
+	if (st->dready_trig == NULL)
+		return -ENOMEM;
+
+	st->dready_trig->ops = &adxl372_trigger_ops;
+	st->dready_trig->dev.parent = &st->spi->dev;
+	iio_trigger_set_drvdata(st->dready_trig, indio_dev);
+	ret = devm_iio_trigger_register(&st->spi->dev, st->dready_trig);
+	if (ret < 0)
+		return ret;
+
+	indio_dev->trig = iio_trigger_get(st->dready_trig);
+
+	ret = devm_request_threaded_irq(&st->spi->dev, st->spi->irq,
+					iio_trigger_generic_data_rdy_poll,
+					NULL,
+					IRQF_TRIGGER_RISING |
+					IRQF_ONESHOT,
+					indio_dev->name,
+					st->dready_trig);
+	if (ret < 0)
+		return ret;
+
+	iio_buffer_set_attrs(indio_dev->buffer, adxl372_fifo_attributes);
+
+	ret = iio_device_register(indio_dev);
+	if (ret < 0) {
+		dev_err(&indio_dev->dev, "Failed to register iio device\n");
+		return ret;
+	}
 
 	return 0;
 }

--- a/drivers/iio/accel/adxl372.c
+++ b/drivers/iio/accel/adxl372.c
@@ -944,20 +944,11 @@ static int adxl372_probe(struct spi_device *spi)
 
 	iio_buffer_set_attrs(indio_dev->buffer, adxl372_fifo_attributes);
 
-	ret = iio_device_register(indio_dev);
+	ret = devm_iio_device_register(&st->spi->dev, indio_dev);
 	if (ret < 0) {
 		dev_err(&indio_dev->dev, "Failed to register iio device\n");
 		return ret;
 	}
-
-	return 0;
-}
-
-static int adxl372_remove(struct spi_device *spi)
-{
-	struct iio_dev *indio_dev = spi_get_drvdata(spi);
-
-	iio_device_unregister(indio_dev);
 
 	return 0;
 }
@@ -973,7 +964,6 @@ static struct spi_driver adxl372_driver = {
 		.name = KBUILD_MODNAME,
 	},
 	.probe = adxl372_probe,
-	.remove = adxl372_remove,
 	.id_table = adxl372_id,
 };
 

--- a/drivers/iio/accel/bmc150-accel-core.c
+++ b/drivers/iio/accel/bmc150-accel-core.c
@@ -1632,7 +1632,8 @@ int bmc150_accel_core_probe(struct device *dev, struct regmap *regmap, int irq,
 		if (block_supported) {
 			indio_dev->modes |= INDIO_BUFFER_SOFTWARE;
 			indio_dev->info = &bmc150_accel_info_fifo;
-			indio_dev->buffer->attrs = bmc150_accel_fifo_attributes;
+			iio_buffer_set_attrs(indio_dev->buffer,
+					     bmc150_accel_fifo_attributes);
 		}
 	}
 

--- a/drivers/iio/industrialio-buffer.c
+++ b/drivers/iio/industrialio-buffer.c
@@ -265,6 +265,18 @@ void iio_buffer_init(struct iio_buffer *buffer)
 }
 EXPORT_SYMBOL(iio_buffer_init);
 
+/**
+ * iio_buffer_set_attrs - Set buffer specific attributes
+ * @buffer: The buffer for which we are setting attributes
+ * @attrs: Pointer to a null terminated list of pointers to attributes
+ */
+void iio_buffer_set_attrs(struct iio_buffer *buffer,
+			 const struct attribute **attrs)
+{
+	buffer->attrs = attrs;
+}
+EXPORT_SYMBOL_GPL(iio_buffer_set_attrs);
+
 static ssize_t iio_show_scan_index(struct device *dev,
 				   struct device_attribute *attr,
 				   char *buf)

--- a/include/linux/iio/buffer.h
+++ b/include/linux/iio/buffer.h
@@ -45,6 +45,8 @@ struct iio_buffer_block {
 
 struct iio_buffer;
 
+void iio_buffer_set_attrs(struct iio_buffer *buffer,
+			 const struct attribute **attrs);
 /**
  * INDIO_BUFFER_FLAG_FIXED_WATERMARK - Watermark level of the buffer can not be
  *   configured. It has a fixed value which will be buffer specific.


### PR DESCRIPTION
This patch adds support for the adxl372 FIFO. In order to accomplish this, triggered buffers were used.
Therefore, adxl372 is configured to trigger the watermark interrupt when 170 sets of concurrent 3-axis data is available in the FIFO. This data along with the timestamp is pushed to the IIO device's buffer. Also, the FIFO is configured in peak detect and stream mode.