### PR TITLE
iio: adc: ad9361: fix arguments for ad9361_phy_parse_dt() when not using DT

### DIFF
--- a/drivers/iio/adc/ad9361.c
+++ b/drivers/iio/adc/ad9361.c
@@ -8690,8 +8690,8 @@ static struct ad9361_phy_platform_data
 	return pdata;
 }
 #else
-static
-struct ad9361_phy_platform_data *ad9361_phy_parse_dt(struct device *dev)
+static inline struct ad9361_phy_platform_data
+	*ad9361_phy_parse_dt(struct iio_dev *iodev, struct device *dev)
 {
 	return NULL;
 }


### PR DESCRIPTION
The `ad9361_phy_parse_dt()` is missing a parameter for when no DT support
is enabled.
Add it.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>