### PR TITLE
iio: adc: ad9361: add short-hand var `new_rate` in clk notifier funcs

### DIFF
--- a/drivers/iio/adc/ad9361.c
+++ b/drivers/iio/adc/ad9361.c
@@ -6157,14 +6157,15 @@ static int ad9361_rx_rfpll_rate_change(struct notifier_block *nb,
 	struct clk_notifier_data *cnd = data;
 	struct ad9361_rf_phy *phy =
 		container_of(nb, struct ad9361_rf_phy, clk_nb_rx);
+	u64 new_rate;
 
 
 	if (flags == POST_RATE_CHANGE) {
+		new_rate = ad9361_from_clk(cnd->new_rate);
 		dev_dbg(&phy->spi->dev, "%s: rate %llu Hz", __func__,
-			ad9361_from_clk(cnd->new_rate));
+			new_rate);
 		if (cnd->new_rate)
-			ad9361_load_gt(phy, ad9361_from_clk(cnd->new_rate),
-				       GT_RX1 + GT_RX2);
+			ad9361_load_gt(phy, new_rate, GT_RX1 + GT_RX2);
 	}
 
 	return NOTIFY_OK;
@@ -6176,21 +6177,23 @@ static int ad9361_tx_rfpll_rate_change(struct notifier_block *nb,
 	struct clk_notifier_data *cnd = data;
 	struct ad9361_rf_phy *phy =
 		container_of(nb, struct ad9361_rf_phy, clk_nb_tx);
+	u64 new_rate;
 
 	if (flags == POST_RATE_CHANGE) {
+		new_rate = ad9361_from_clk(cnd->new_rate);
 		dev_dbg(&phy->spi->dev, "%s: rate %llu Hz", __func__,
-			ad9361_from_clk(cnd->new_rate));
+			new_rate);
 		/* For RX LO we typically have the tracking option enabled
 		* so for now do nothing here.
 		*/
 		if (phy->auto_cal_en)
-			if (abs(phy->last_tx_quad_cal_freq - ad9361_from_clk(cnd->new_rate)) >
+			if (abs(phy->last_tx_quad_cal_freq - new_rate) >
 				phy->cal_threshold_freq) {
 
 				set_bit(0, &phy->flags);
 				reinit_completion(&phy->complete);
 				schedule_work(&phy->work);
-				phy->last_tx_quad_cal_freq = ad9361_from_clk(cnd->new_rate);
+				phy->last_tx_quad_cal_freq = new_rate;
 			}
 	}
 


### PR DESCRIPTION
The intent is to have this variable readily available when adding the
external band selection call/code.
The focus is not so much on performance here, but more on keeping the code
within the 80 col width [preferred] limit.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>