### PR TITLE
[2017_R1] iio: adc: ad9361: add ad9361_write_bist_reg() accessor to cache bist reg value

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,8 @@ before_install:
   - sudo apt-get install -y build-essential bc u-boot-tools gcc-arm-linux-gnueabihf
 
 script:
-  - COMMIT_RANGE=$([ -z "$TRAVIS_COMMIT_RANGE" ] &&  echo "HEAD~1" || echo ${TRAVIS_COMMIT_RANGE/.../..})
+  - if [[ -n "$TRAVIS_BRANCH" ]] ; then git fetch origin +refs/heads/${TRAVIS_BRANCH}:${TRAVIS_BRANCH} ; fi
+  - COMMIT_RANGE=$([ "$TRAVIS_PULL_REQUEST" == "false" ] &&  echo "HEAD~1" || echo ${TRAVIS_BRANCH}..)
   - make ${DEFCONFIG_NAME}
   - make -j`getconf _NPROCESSORS_ONLN` uImage UIMAGE_LOADADDR=0x8000
   - for file in `ls arch/arm/boot/dts/zynq-*.dts`; do make `basename $file | sed  -e 's\dts\dtb\g'` || exit 1;done

--- a/drivers/iio/adc/ad9361.c
+++ b/drivers/iio/adc/ad9361.c
@@ -1027,6 +1027,15 @@ int ad9361_bist_loopback(struct ad9361_rf_phy *phy, unsigned mode)
 }
 EXPORT_SYMBOL(ad9361_bist_loopback);
 
+int ad9361_write_bist_reg(struct ad9361_rf_phy *phy, u32 val)
+{
+	if (!phy)
+		return -EINVAL;
+	phy->bist_config = val;
+	return ad9361_spi_write(phy->spi, REG_BIST_CONFIG, val);
+}
+EXPORT_SYMBOL(ad9361_write_bist_reg);
+
 int ad9361_bist_prbs(struct ad9361_rf_phy *phy, enum ad9361_bist_mode mode)
 {
 	u32 reg = 0;
@@ -1045,9 +1054,7 @@ int ad9361_bist_prbs(struct ad9361_rf_phy *phy, enum ad9361_bist_mode mode)
 		break;
 	};
 
-	phy->bist_config = reg;
-
-	return ad9361_spi_write(phy->spi, REG_BIST_CONFIG, reg);
+	return ad9361_write_bist_reg(phy, reg);
 }
 EXPORT_SYMBOL(ad9361_bist_prbs);
 
@@ -1090,9 +1097,7 @@ static int ad9361_bist_tone(struct ad9361_rf_phy *phy,
 	reg1 = ((mask << 2) & reg_mask);
 	ad9361_spi_write(phy->spi, REG_BIST_AND_DATA_PORT_TEST_CONFIG, reg1);
 
-	phy->bist_config = reg;
-
-	return ad9361_spi_write(phy->spi, REG_BIST_CONFIG, reg);
+	return ad9361_write_bist_reg(phy, reg);
 }
 
 static int ad9361_check_cal_done(struct ad9361_rf_phy *phy, u32 reg,

--- a/drivers/iio/adc/ad9361.h
+++ b/drivers/iio/adc/ad9361.h
@@ -3416,6 +3416,7 @@ int ad9361_set_trx_clock_chain(struct ad9361_rf_phy *phy,
 int ad9361_dig_tune(struct ad9361_rf_phy *phy, unsigned long max_freq,
 			   enum dig_tune_flags flags);
 int ad9361_tx_mute(struct ad9361_rf_phy *phy, u32 state);
+int ad9361_write_bist_reg(struct ad9361_rf_phy *phy, u32 val);
 
 #endif
 

--- a/drivers/iio/adc/ad9361_conv.c
+++ b/drivers/iio/adc/ad9361_conv.c
@@ -633,7 +633,7 @@ int ad9361_dig_tune(struct ad9361_rf_phy *phy, unsigned long max_freq,
 			ret = ad9361_dig_tune_tx(phy, max_freq, flags);
 
 		ad9361_bist_loopback(phy, loopback);
-		ad9361_spi_write(phy->spi, REG_BIST_CONFIG, bist);
+		ad9361_write_bist_reg(phy, bist);
 
 		if (ret == -EIO)
 			restore = true;


### PR DESCRIPTION
The value of the BIST register via ad9361_get_dig_tune_data() needs to be
stored on the state struct when written back.
Otherwise there could be a discrepancy when between the cached value and
the value in the register.

To do this, the ad9361_write_bist_reg() accessor has been added, which
always caches the last written value.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>