### PR TITLE
.travis.yml: fix malformed yaml file 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,4 @@ script:
   - COMMIT_RANGE=$([ "$TRAVIS_PULL_REQUEST" == "false" ] &&  echo "HEAD~1" || echo ${TRAVIS_BRANCH}..)
   - make ${DEFCONFIG_NAME}
   - make -j`getconf _NPROCESSORS_ONLN` uImage UIMAGE_LOADADDR=0x8000
-  - for file in `ls arch/arm/boot/dts/zynq-*.dts`; do make `basename $file | sed  -e 's\dts\dtb\g'` || exit 1;done
   - scripts/checkpatch.pl --git ${COMMIT_RANGE} --ignore FILE_PATH_CHANGES --ignore LONG_LINE --ignore LONG_LINE_STRING --ignore LONG_LINE_COMMENT

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
   - sudo apt-get install -y build-essential bc u-boot-tools gcc-arm-linux-gnueabihf
 
 script:
-  - [ -z "$TRAVIS_BRANCH" ] || git fetch origin +refs/heads/${TRAVIS_BRANCH}:${TRAVIS_BRANCH}
+  - if [[ -n "$TRAVIS_BRANCH" ]] ; then git fetch origin +refs/heads/${TRAVIS_BRANCH}:${TRAVIS_BRANCH} ; fi
   - COMMIT_RANGE=$([ "$TRAVIS_PULL_REQUEST" == "false" ] &&  echo "HEAD~1" || echo ${TRAVIS_BRANCH}..)
   - make ${DEFCONFIG_NAME}
   - make -j`getconf _NPROCESSORS_ONLN` uImage UIMAGE_LOADADDR=0x8000


### PR DESCRIPTION
This PR introduced then broken .travis.yml file.
  https://github.com/analogdevicesinc/linux/pull/63/commits

The merge button was green when the change was not merged.
Apparently that only meant that the code did not have any conflicts.
The last Travis run was on the commit that ran before the commit the broke
the .travis.yml file.

Travis does not seem to highlight very well on Github if a .travis.yml
file is malformed.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>