### PR TITLE
[RFC] .travis.yml: limit the builds to certain branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,11 @@
+branches:
+  only:
+  - master
+  - /^feature-.*$/
+  - /^test-.*$/
+  - /^wip-.*$/
+  - /^20.*$/
+
 language: c
 
 os: linux


### PR DESCRIPTION
PR is tagged for RFC, since this is something that could be objected against.
[Or] Opinions may vary whether this is good idea or not.

------------------------------------------------------------------

By default, Travis CI will build any branch.
In the context of a PR, that usually means building the code twice: once
for the branch [itself] and once for the PR.

This can be viewed here:
      https://travis-ci.org/analogdevicesinc/linux/requests

Since the Linux build takes some time, and we may want to increase our
build matrix, that will make things slower.

To address this, we can allow branch builds for branches starting with
certain prefixes (feature-\*, wip-\*, test-\*, 20\*) and master.
These should also for PRs targeting these branches.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>