### PR TITLE
microblaze: dts: update ADI JESD204 link-layer peripherals

### DIFF
--- a/Documentation/devicetree/bindings/iio/jesd204/adi,jesd204-rx.txt
+++ b/Documentation/devicetree/bindings/iio/jesd204/adi,jesd204-rx.txt
@@ -1,0 +1,36 @@
+Analog Devices JESD204B Receive Peripheral Driver
+
+The AXI JESD204B RX peripheral driver is a simple driver that supports the
+ADI JESD204B Receive Peripheral. The driver reads JESD204B link configuration
+data from the devicetree and configures the peripheral accordingly. After
+configuration has completed the JESD204B link is enabled. Link state can be
+monitored through sysfs files.
+
+Required properties:
+  - compatible: Must always "adi,axi-jesd204-rx-1.0".
+  - reg: Base address and register area size. This parameter expects a register
+         range.
+  - interrupts: Property with a value describing the interrupt number.
+  - clock-names: List of input clock names - “s_axi_aclk”, “device_clk”
+  - clocks: Clock phandles and specifiers (See clock bindings for details on
+            clock-names and clocks).
+  - adi,frames-per-multiframe: Number of frames per multi-frame (K).
+  - adi,octets-per-frame: Number of octets per frame (N).
+
+Optional properties:
+  - adi,high-density: If specified the JESD204B link is configured for high
+                      density (HD) operation.
+
+Example:
+
+jesd204b-rx@77b00000 {
+	compatible = "adi,axi-jesd204-rx-1.0";
+	reg = <0x77b00000 0x10000>;
+	interrupts = <0 56 4>;
+
+	clock-names = "s_axi_aclk", "device_clk";
+	clocks = <&clkc 14>, <&ad9528 13>;
+
+	adi,octets-per-frame = <32>;
+	adi,frames-per-multiframe = <4>;
+};

--- a/Documentation/devicetree/bindings/iio/jesd204/adi,jesd204-tx.txt
+++ b/Documentation/devicetree/bindings/iio/jesd204/adi,jesd204-tx.txt
@@ -1,0 +1,36 @@
+Analog Devices JESD204B Transmit Peripheral Driver
+
+The AXI JESD204B TX peripheral driver is a simple driver that supports the
+ADI JESD204B Transmit Peripheral. The driver reads JESD204B link configuration
+data from the devicetree and configures the peripheral accordingly. After
+configuration has completed the JESD204B link is enabled. Link state can be
+monitored through sysfs files.
+
+Required properties:
+  - compatible: Must always "adi,axi-jesd204-tx-1.0".
+  - reg: Base address and register area size. This parameter expects a register
+         range.
+  - interrupts: Property with a value describing the interrupt number.
+  - clock-names: List of input clock names - “s_axi_aclk”, “device_clk”
+  - clocks: Clock phandles and specifiers (See clock bindings for details on
+            clock-names and clocks).
+  - adi,frames-per-multiframe: Number of frames per multi-frame (K).
+  - adi,octets-per-frame: Number of octets per frame (N).
+
+Optional properties:
+  - adi,high-density: If specified the JESD204B link is configured for high
+                      density (HD) operation.
+
+Example:
+
+jesd204b-tx@77a00000 {
+	compatible = "adi,axi-jesd204-tx-1.0";
+	reg = <0x77a00000 0x10000>;
+	interrupts = <0 56 4>;
+
+	clock-names = "s_axi_aclk", "device_clk";
+	clocks = <&clkc 14>, <&ad9528 13>;
+
+	adi,octets-per-frame = <32>;
+	adi,frames-per-multiframe = <4>;
+};

--- a/arch/microblaze/boot/dts/adi-fmcjesdadc1.dtsi
+++ b/arch/microblaze/boot/dts/adi-fmcjesdadc1.dtsi
@@ -38,7 +38,7 @@
 			compatible = "adi,ad9250";
 			reg = <2>;
 			spi-max-frequency = <10000000>;
-			clocks = <&axi_ad9250_jesd>, <&clk_ad9517 0>;
+			clocks = <&axi_jesd>, <&clk_ad9517 0>;
 			clock-names = "jesd_dac_clk", "adc_clk";
 		};
 
@@ -46,7 +46,7 @@
 			compatible = "adi,ad9250";
 			reg = <3>;
 			spi-max-frequency = <10000000>;
-			clocks = <&axi_ad9250_jesd>, <&clk_ad9517 1>;
+			clocks = <&axi_jesd>, <&clk_ad9517 1>;
 			clock-names = "jesd_dac_clk", "adc_clk";
 		};
 	};

--- a/arch/microblaze/boot/dts/kc705_fmcdaq2.dts
+++ b/arch/microblaze/boot/dts/kc705_fmcdaq2.dts
@@ -32,12 +32,13 @@
 };
 
 &axi_ad9144_core {
-	dmas = <&axi_ad9144_dma 0>;
+	dmas = <&tx_dma 0>;
 	dma-names = "tx";
 	spibus-connected = <&dac0_ad9144>;
+	adi,axi-pl-fifo-enable;
 };
 
-&axi_ad9144_dma {
+&tx_dma {
 	#dma-cells = <1>;
 	clocks = <&clk_bus_0>;
 
@@ -47,29 +48,29 @@
 		adi,type = <1>;
 		adi,cyclic;
 	};
-
 };
 
 &axi_ad9144_jesd {
+	clocks = <&clk_bus_0>, <&axi_ad9144_adxcvr 1>, <&axi_ad9144_adxcvr 0>;
+	clock-names = "s_axi_aclk", "device_clk", "lane_clk";
+
+	adi,octets-per-frame = <1>;
+	adi,frames-per-multiframe = <32>;
+	adi,converter-resolution = <16>;
+	adi,bits-per-sample = <16>;
+	adi,converters-per-device = <2>;
+
 	#clock-cells = <0>;
-	clocks = <&axi_ad9144_adxcvr>;
-	clock-names = "dac_gt_clk";
-	clock-output-names = "jesd_dac_clk";
-	xlnx,frames-per-multiframe = <32>;
-	xlnx,bytes-per-frame = <1>;
-	xlnx,subclass = <1>;
-	xlnx,lanesync-enable;
-	xlnx,scramble-enable;
-	xlnx,lanes = <0x4>;
+	clock-output-names = "jesd_dac_lane_clk";
 };
 
 &axi_ad9680_core {
-	dmas = <&axi_ad9680_dma 0>;
+	dmas = <&rx_dma 0>;
 	dma-names = "rx";
 	spibus-connected = <&adc0_ad9680>;
 };
 
-&axi_ad9680_dma {
+&rx_dma {
 	#dma-cells = <1>;
 	clocks = <&clk_bus_0>;
 
@@ -78,27 +79,27 @@
 		adi,destination-bus-width = <64>;
 		adi,type = <0>;
 	};
-
 };
 
 &axi_ad9680_jesd {
-	#clock-cells = <0>;
-	clocks = <&axi_ad9680_adxcvr>;
-	clock-names = "adc_gt_clk";
-	clock-output-names = "jesd_adc_clk";
+	clocks = <&clk_bus_0>, <&axi_ad9680_adxcvr 1>, <&axi_ad9680_adxcvr 0>;
+	clock-names = "s_axi_aclk", "device_clk", "lane_clk";
 
-	xlnx,frames-per-multiframe = <32>;
-	xlnx,bytes-per-frame = <1>;
-	xlnx,subclass = <1>;
-	xlnx,lanesync-enable;
-	xlnx,scramble-enable;
+	adi,octets-per-frame = <1>;
+	adi,frames-per-multiframe = <32>;
+
+	#clock-cells = <0>;
+	clock-output-names = "jesd_adc_lane_clk";
 };
 
 &axi_ad9680_adxcvr {
 	#clock-cells = <0>;
 	clocks = <&clk0_ad9523 4>;
-	clock-names = "conv"
-	clock-output-names = "adc_gt_clk";
+	clock-names = "conv";
+
+	#clock-cells = <1>;
+	clock-output-names = "adc_gt_clk", "rx_out_clk";
+
 	adi,sys-clk-select = <0>;
 	adi,out-clk-select = <4>;
 	adi,use-lpm-enable;
@@ -109,8 +110,10 @@
 	#clock-cells = <0>;
 	clocks = <&clk0_ad9523 9>;
 	clock-names = "conv";
-	clock-output-names = "dac_gt_clk";
-	adi,link-is-transmit-enable;
+
+	#clock-cells = <1>;
+	clock-output-names = "dac_gt_clk", "tx_out_clk";
+
 	adi,sys-clk-select = <3>;
 	adi,out-clk-select = <4>;
 	adi,use-lpm-enable;

--- a/arch/microblaze/boot/dts/kc705_fmcdaq2_pl.dtsi
+++ b/arch/microblaze/boot/dts/kc705_fmcdaq2_pl.dtsi
@@ -144,119 +144,45 @@
 			compatible = "adi,axi-ad9144-1.0";
 			reg = <0x44a04000 0x4000>;
 		};
-		axi_ad9144_dma: axi_dmac@7c420000 {
+		tx_dma: tx-dmac@7c420000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			interrupt-parent = <&axi_intc>;
 			interrupts = <13 2>;
 			reg = <0x7c420000 0x10000>;
-			xlnx,2d-transfer = <0x0>;
-			xlnx,axi-slice-dest = <0x0>;
-			xlnx,axi-slice-src = <0x0>;
-			xlnx,clks-async-dest-req = <0x1>;
-			xlnx,clks-async-req-src = <0x1>;
-			xlnx,clks-async-src-dest = <0x1>;
-			xlnx,cyclic = <0x0>;
-			xlnx,dma-axi-protocol-dest = <0x0>;
-			xlnx,dma-axi-protocol-src = <0x0>;
-			xlnx,dma-data-width-dest = <0x80>;
-			xlnx,dma-data-width-src = <0x80>;
-			xlnx,dma-length-width = <0x18>;
-			xlnx,dma-type-dest = <0x1>;
-			xlnx,dma-type-src = <0x0>;
-			xlnx,fifo-size = <0x4>;
-			xlnx,max-bytes-per-burst = <0x80>;
-			xlnx,sync-transfer-start = <0x0>;
 		};
-		axi_ad9144_jesd: axi-jesd204b-tx@44a90000 {
-			compatible = "xlnx,jesd204-6.0";
+		axi_ad9144_jesd: axi-jesd204-tx@44a90000 {
+			compatible = "adi,axi-jesd204-tx-1.0";
+			interrupt-parent = <&axi_intc>;
+			interrupts = <15 0>;
 			reg = <0x44a90000 0x1000>;
-			xlnx,component-name = "system_axi_ad9144_jesd_0";
-			xlnx,default-f = <0x2>;
-			xlnx,default-k = <0x20>;
-			xlnx,default-scr = <0x0>;
-			xlnx,default-sysref-always = <0x0>;
-			xlnx,default-sysref-required = <0x0>;
-			xlnx,drpclk-freq = "156.25";
-			xlnx,elaboration-transient-dir = <0x0>;
-			xlnx,global-clk-sel = "false";
-			xlnx,gt-line-rate = "6.25";
-			xlnx,gt-refclk-freq = "156.250";
-			xlnx,lanes = <0x4>;
-			xlnx,lmfc-buffer-size = <0x6>;
-			xlnx,node-is-transmit = <0x1>;
-			xlnx,pll-selection = <0x0>;
-			xlnx,speedgrade = "-2";
-			xlnx,supportlevel = <0x0>;
-			xlnx,sysref-sampling-edge = <0x0>;
-			xlnx,transceivercontrol = "false";
-			xlnx,use-bram = <0x1>;
-			xlnx,use-jspat = "false";
-			xlnx,use-rpat = "false";
 		};
 		axi_ad9680_core: axi-ad9680-hpc@44a10000 {
 			compatible = "adi,axi-ad9680-1.0";
 			reg = <0x44a10000 0x10000>;
 		};
-		axi_ad9680_dma: axi_dmac@7c400000 {
+		rx_dma: rx-dmac@7c400000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			interrupt-parent = <&axi_intc>;
 			interrupts = <12 2>;
 			reg = <0x7c400000 0x10000>;
-			xlnx,2d-transfer = <0x0>;
-			xlnx,axi-slice-dest = <0x0>;
-			xlnx,axi-slice-src = <0x0>;
-			xlnx,clks-async-dest-req = <0x1>;
-			xlnx,clks-async-req-src = <0x1>;
-			xlnx,clks-async-src-dest = <0x1>;
-			xlnx,cyclic = <0x0>;
-			xlnx,dma-axi-protocol-dest = <0x0>;
-			xlnx,dma-axi-protocol-src = <0x0>;
-			xlnx,dma-data-width-dest = <0x40>;
-			xlnx,dma-data-width-src = <0x40>;
-			xlnx,dma-length-width = <0x18>;
-			xlnx,dma-type-dest = <0x0>;
-			xlnx,dma-type-src = <0x1>;
-			xlnx,fifo-size = <0x4>;
-			xlnx,max-bytes-per-burst = <0x80>;
-			xlnx,sync-transfer-start = <0x1>;
 		};
-		axi_ad9680_jesd: axi-jesd204b-rx@44a910000 {
-			compatible = "xlnx,jesd204-6.0";
-			reg = <0x44a91000 0x1000>;
-			xlnx,component-name = "system_axi_ad9680_jesd_0";
-			xlnx,default-f = <0x2>;
-			xlnx,default-k = <0x20>;
-			xlnx,default-scr = <0x0>;
-			xlnx,default-sysref-always = <0x0>;
-			xlnx,default-sysref-required = <0x0>;
-			xlnx,drpclk-freq = "156.25";
-			xlnx,elaboration-transient-dir = <0x0>;
-			xlnx,global-clk-sel = "false";
-			xlnx,gt-line-rate = "6.25";
-			xlnx,gt-refclk-freq = "156.250";
-			xlnx,lanes = <0x4>;
-			xlnx,lmfc-buffer-size = <0x6>;
-			xlnx,node-is-transmit = <0x0>;
-			xlnx,pll-selection = <0x0>;
-			xlnx,speedgrade = "-2";
-			xlnx,supportlevel = <0x0>;
-			xlnx,sysref-sampling-edge = <0x0>;
-			xlnx,transceivercontrol = "false";
-			xlnx,use-bram = <0x1>;
-			xlnx,use-jspat = "false";
-			xlnx,use-rpat = "false";
+		axi_ad9680_jesd: axi-jesd204-rx@44aa0000 {
+			compatible = "adi,axi-jesd204-rx-1.0";
+			interrupt-parent = <&axi_intc>;
+			interrupts = <14 0>;
+			reg = <0x44aa0000 0x1000>;
 		};
 		axi_ad9680_adxcvr: axi-ad9680-adxcvr@44a50000 {
 			#address-cells = <1>;
 			#size-cells = <0>;
 			compatible = "adi,axi-adxcvr-1.0";
-			reg = < 0x44a50000 0x1000 >;
+			reg = <0x44a50000 0x1000>;
 		};
 		axi_ad9144_adxcvr: axi-ad9144-adxcvr@44a60000 {
 			#address-cells = <1>;
 			#size-cells = <0>;
 			compatible = "adi,axi-adxcvr-1.0";
-			reg = < 0x44a60000 0x1000 >;
+			reg = <0x44a60000 0x1000>;
 		};
 		axi_ethernet: ethernet@40e00000 {
 			compatible = "xlnx,xps-ethernetlite-1.00.a";

--- a/arch/microblaze/boot/dts/kc705_fmcjesdadc1.dts
+++ b/arch/microblaze/boot/dts/kc705_fmcjesdadc1.dts
@@ -31,19 +31,19 @@
 	};
 };
 
-&axi_ad9250_0_core {
-	dmas = <&axi_ad9250_0_dma 0>;
+&axi_ad9250_core0{
+	dmas = <&rx_dma0 0>;
 	dma-names = "rx";
 	spibus-connected = <&adc0_ad9250>;
 };
 
-&axi_ad9250_1_core {
-	dmas = <&axi_ad9250_1_dma 0>;
+&axi_ad9250_core1{
+	dmas = <&rx_dma1 0>;
 	dma-names = "rx";
 	spibus-connected = <&adc1_ad9250>;
 };
 
-&axi_ad9250_0_dma {
+&rx_dma0 {
 	#dma-cells = <1>;
 	clocks = <&clk_bus_0>;
 
@@ -53,7 +53,7 @@
 	};
 };
 
-&axi_ad9250_1_dma {
+&rx_dma1 {
 	#dma-cells = <1>;
 	clocks = <&clk_bus_0>;
 
@@ -63,27 +63,22 @@
 	};
 };
 
-&axi_ad9250_jesd {
+&axi_jesd{
 	#clock-cells = <0>;
-	clocks = <&axi_adxcvr 0>;
-	clock-names = "adc_gt_clk";
-	clock-output-names = "jesd_adc_clk";
+	clocks = <&clk_bus_0>, <&axi_adxcvr 1>, <&axi_adxcvr 0>;
+	clock-names = "s_axi_aclk", "device_clk", "lane_clk";
+	clock-output-names = "jesd_adc_lane_clk";
 
-	xlnx,lanes = <4>;
-	xlnx,frames-per-multiframe = <32>;
-	xlnx,bytes-per-frame = <2>;
-	xlnx,subclass = <1>;
-	xlnx,lanesync-enable;
-	xlnx,scramble-enable;
-	xlnx,sysref-enable;
+	adi,octets-per-frame = <2>;
+	adi,frames-per-multiframe = <32>;
 };
 
 &axi_adxcvr {
-	#clock-cells = <0>;
+	#clock-cells = <1>;
 
 	clocks = <&clk_ad9517 0>;
 	clock-names = "conv";
-	clock-output-names = "adc_gt_clk";
+	clock-output-names = "adc_gt_clk", "rx_out_clk";
 
 	adi,sys-clk-select = <0>;
 	adi,out-clk-select = <2>;

--- a/arch/microblaze/boot/dts/kc705_fmcjesdadc1_pl.dtsi
+++ b/arch/microblaze/boot/dts/kc705_fmcjesdadc1_pl.dtsi
@@ -140,61 +140,28 @@
 		#size-cells = <1>;
 		compatible = "simple-bus";
 		ranges ;
-		axi_ad9250_0_core: axi-ad9250-hpc-0@44a10000 {
+		axi_ad9250_core0: axi-ad9250-hpc-0@44a10000 {
 			compatible = "xlnx,axi-ad9250-1.00.a";
 			reg = <0x44a10000 0x10000>;
 			xlnx,s-axi-min-size = <0x0000FFFF>;
 		};
-		axi_ad9250_0_dma: axi_dmac@7c420000 {
+		rx_dma0: rx-dmac@7c420000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			interrupt-parent = <&axi_intc>;
 			interrupts = <13 2>;
 			reg = <0x7c420000 0x10000>;
-			xlnx,2d-transfer = <0x0>;
-			xlnx,axi-slice-dest = <0x0>;
-			xlnx,axi-slice-src = <0x0>;
-			xlnx,clks-async-dest-req = <0x1>;
-			xlnx,clks-async-req-src = <0x1>;
-			xlnx,clks-async-src-dest = <0x1>;
-			xlnx,cyclic = <0x0>;
-			xlnx,dma-axi-protocol-dest = <0x0>;
-			xlnx,dma-axi-protocol-src = <0x0>;
-			xlnx,dma-data-width-dest = <0x40>;
-			xlnx,dma-data-width-src = <0x40>;
-			xlnx,dma-length-width = <0x18>;
-			xlnx,dma-type-dest = <0x0>;
-			xlnx,dma-type-src = <0x2>;
-			xlnx,fifo-size = <0x4>;
-			xlnx,max-bytes-per-burst = <0x80>;
-			xlnx,sync-transfer-start = <0x1>;
+
 		};
-		axi_ad9250_1_core: axi-ad9250-hpc-1@44a20000 {
+		axi_ad9250_core1: axi-ad9250-hpc-1@44a20000 {
 			compatible = "xlnx,axi-ad9250-1.00.a";
 			reg = <0x44a20000 0x10000>;
 			xlnx,s-axi-min-size = <0x0000FFFF>;
 		};
-		axi_ad9250_1_dma: axi_dmac@7c430000 {
+		rx_dma1: rx-dmac@7c430000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			interrupt-parent = <&axi_intc>;
 			interrupts = <12 2>;
 			reg = <0x7c430000 0x10000>;
-			xlnx,2d-transfer = <0x0>;
-			xlnx,axi-slice-dest = <0x0>;
-			xlnx,axi-slice-src = <0x0>;
-			xlnx,clks-async-dest-req = <0x1>;
-			xlnx,clks-async-req-src = <0x1>;
-			xlnx,clks-async-src-dest = <0x1>;
-			xlnx,cyclic = <0x0>;
-			xlnx,dma-axi-protocol-dest = <0x0>;
-			xlnx,dma-axi-protocol-src = <0x0>;
-			xlnx,dma-data-width-dest = <0x40>;
-			xlnx,dma-data-width-src = <0x40>;
-			xlnx,dma-length-width = <0x18>;
-			xlnx,dma-type-dest = <0x0>;
-			xlnx,dma-type-src = <0x2>;
-			xlnx,fifo-size = <0x4>;
-			xlnx,max-bytes-per-burst = <0x80>;
-			xlnx,sync-transfer-start = <0x1>;
 		};
 		axi_adxcvr: axi-adxcvr@44a60000 {
 			#address-cells = <1>;
@@ -202,31 +169,11 @@
 			compatible = "adi,axi-adxcvr-1.0";
 			reg = < 0x44a60000 0x1000 >;
 		};
-		axi_ad9250_jesd: axi-jesd204b-rx@44a91000 {
-			compatible = "xlnx,jesd204-6.0";
-			reg = <0x44a91000 0x1000>;
-			xlnx,component-name = "system_axi_ad9250_jesd_0";
-			xlnx,default-f = <0x2>;
-			xlnx,default-k = <0x20>;
-			xlnx,default-scr = <0x0>;
-			xlnx,default-sysref-always = <0x0>;
-			xlnx,default-sysref-required = <0x0>;
-			xlnx,drpclk-freq = "156.25";
-			xlnx,elaboration-transient-dir = <0x0>;
-			xlnx,global-clk-sel = "false";
-			xlnx,gt-line-rate = "6.25";
-			xlnx,gt-refclk-freq = "156.250";
-			xlnx,lanes = <0x4>;
-			xlnx,lmfc-buffer-size = <0x6>;
-			xlnx,node-is-transmit = <0x0>;
-			xlnx,pll-selection = <0x0>;
-			xlnx,speedgrade = "-2";
-			xlnx,supportlevel = <0x0>;
-			xlnx,sysref-sampling-edge = <0x0>;
-			xlnx,transceivercontrol = "false";
-			xlnx,use-bram = <0x1>;
-			xlnx,use-jspat = "false";
-			xlnx,use-rpat = "false";
+		axi_jesd: axi-jesd204b-rx@44aa0000 {
+			compatible = "adi,axi-jesd204-rx-1.0";
+			reg = <0x44aa0000 0x1000>;
+			interrupt-parent = <&axi_intc>;
+			interrupts = <14 0>;
 		};
 		axi_ethernet: ethernet@40e00000 {
 			compatible = "xlnx,xps-ethernetlite-1.00.a";

--- a/arch/microblaze/boot/dts/vc707_fmcdaq2.dts
+++ b/arch/microblaze/boot/dts/vc707_fmcdaq2.dts
@@ -37,13 +37,13 @@
 };
 
 &axi_ad9144_core {
-	dmas = <&axi_ad9144_dma 0>;
+	dmas = <&tx_dma 0>;
 	dma-names = "tx";
 	spibus-connected = <&dac0_ad9144>;
 	adi,axi-pl-fifo-enable;
 };
 
-&axi_ad9144_dma {
+&tx_dma {
 	#dma-cells = <1>;
 	clocks = <&clk_bus_0>;
 
@@ -53,30 +53,29 @@
 		adi,type = <1>;
 		adi,cyclic;
 	};
-
 };
 
 &axi_ad9144_jesd {
+	clocks = <&clk_bus_0>, <&axi_ad9144_adxcvr 1>, <&axi_ad9144_adxcvr 0>;
+	clock-names = "s_axi_aclk", "device_clk", "lane_clk";
+
+	adi,octets-per-frame = <1>;
+	adi,frames-per-multiframe = <32>;
+	adi,converter-resolution = <16>;
+	adi,bits-per-sample = <16>;
+	adi,converters-per-device = <2>;
+
 	#clock-cells = <0>;
-	clocks = <&axi_ad9144_adxcvr>;
-	clock-names = "dac_gt_clk";
-	clock-output-names = "jesd_dac_clk";
-
-	xlnx,frames-per-multiframe = <32>;
-	xlnx,bytes-per-frame = <1>;
-	xlnx,subclass = <1>;
-	xlnx,lanesync-enable;
-	xlnx,scramble-enable;
-
+	clock-output-names = "jesd_dac_lane_clk";
 };
 
 &axi_ad9680_core {
-	dmas = <&axi_ad9680_dma 0>;
+	dmas = <&rx_dma 0>;
 	dma-names = "rx";
 	spibus-connected = <&adc0_ad9680>;
 };
 
-&axi_ad9680_dma {
+&rx_dma {
 	#dma-cells = <1>;
 	clocks = <&clk_bus_0>;
 
@@ -85,27 +84,27 @@
 		adi,destination-bus-width = <64>;
 		adi,type = <0>;
 	};
-
 };
 
 &axi_ad9680_jesd {
-	#clock-cells = <0>;
-	clocks = <&axi_ad9680_adxcvr>;
-	clock-names = "adc_gt_clk";
-	clock-output-names = "jesd_adc_clk";
+	clocks = <&clk_bus_0>, <&axi_ad9680_adxcvr 1>, <&axi_ad9680_adxcvr 0>;
+	clock-names = "s_axi_aclk", "device_clk", "lane_clk";
 
-	xlnx,frames-per-multiframe = <32>;
-	xlnx,bytes-per-frame = <1>;
-	xlnx,subclass = <1>;
-	xlnx,lanesync-enable;
-	xlnx,scramble-enable;
+	adi,octets-per-frame = <1>;
+	adi,frames-per-multiframe = <32>;
+
+	#clock-cells = <0>;
+	clock-output-names = "jesd_adc_lane_clk";
 };
 
 &axi_ad9680_adxcvr {
 	#clock-cells = <0>;
 	clocks = <&clk0_ad9523 4>;
 	clock-names = "conv";
-	clock-output-names = "adc_gt_clk";
+
+	#clock-cells = <1>;
+	clock-output-names = "adc_gt_clk", "rx_out_clk";
+
 	adi,sys-clk-select = <0>;
 	adi,out-clk-select = <4>;
 	adi,use-lpm-enable;
@@ -116,8 +115,10 @@
 	#clock-cells = <0>;
 	clocks = <&clk0_ad9523 9>;
 	clock-names = "conv";
-	clock-output-names = "dac_gt_clk";
-	adi,link-is-transmit-enable;
+
+	#clock-cells = <1>;
+	clock-output-names = "dac_gt_clk", "tx_out_clk";
+
 	adi,sys-clk-select = <3>;
 	adi,out-clk-select = <4>;
 	adi,use-lpm-enable;

--- a/arch/microblaze/boot/dts/vc707_fmcdaq2_pl.dtsi
+++ b/arch/microblaze/boot/dts/vc707_fmcdaq2_pl.dtsi
@@ -144,119 +144,45 @@
 			compatible = "adi,axi-ad9144-1.0";
 			reg = <0x44a04000 0x4000>;
 		};
-		axi_ad9144_dma: axi_dmac@7c420000 {
+		tx_dma: tx-dmac@7c420000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			interrupt-parent = <&axi_intc>;
 			interrupts = <13 2>;
 			reg = <0x7c420000 0x10000>;
-			xlnx,2d-transfer = <0x0>;
-			xlnx,axi-slice-dest = <0x0>;
-			xlnx,axi-slice-src = <0x0>;
-			xlnx,clks-async-dest-req = <0x1>;
-			xlnx,clks-async-req-src = <0x1>;
-			xlnx,clks-async-src-dest = <0x1>;
-			xlnx,cyclic = <0x0>;
-			xlnx,dma-axi-protocol-dest = <0x0>;
-			xlnx,dma-axi-protocol-src = <0x0>;
-			xlnx,dma-data-width-dest = <0x80>;
-			xlnx,dma-data-width-src = <0x80>;
-			xlnx,dma-length-width = <0x18>;
-			xlnx,dma-type-dest = <0x1>;
-			xlnx,dma-type-src = <0x0>;
-			xlnx,fifo-size = <0x4>;
-			xlnx,max-bytes-per-burst = <0x80>;
-			xlnx,sync-transfer-start = <0x0>;
 		};
-		axi_ad9144_jesd: axi-jesd204b-tx@44a90000 {
-			compatible = "xlnx,jesd204-6.0";
+		axi_ad9144_jesd: axi-jesd204-tx@44a90000 {
+			compatible = "adi,axi-jesd204-tx-1.0";
+			interrupt-parent = <&axi_intc>;
+			interrupts = <15 0>;
 			reg = <0x44a90000 0x1000>;
-			xlnx,component-name = "system_axi_ad9144_jesd_0";
-			xlnx,default-f = <0x2>;
-			xlnx,default-k = <0x20>;
-			xlnx,default-scr = <0x0>;
-			xlnx,default-sysref-always = <0x0>;
-			xlnx,default-sysref-required = <0x0>;
-			xlnx,drpclk-freq = "156.25";
-			xlnx,elaboration-transient-dir = <0x0>;
-			xlnx,global-clk-sel = "false";
-			xlnx,gt-line-rate = "6.25";
-			xlnx,gt-refclk-freq = "156.250";
-			xlnx,lanes = <0x4>;
-			xlnx,lmfc-buffer-size = <0x6>;
-			xlnx,node-is-transmit = <0x1>;
-			xlnx,pll-selection = <0x0>;
-			xlnx,speedgrade = "-2";
-			xlnx,supportlevel = <0x0>;
-			xlnx,sysref-sampling-edge = <0x0>;
-			xlnx,transceivercontrol = "false";
-			xlnx,use-bram = <0x1>;
-			xlnx,use-jspat = "false";
-			xlnx,use-rpat = "false";
 		};
 		axi_ad9680_core: axi-ad9680-hpc@44a10000 {
 			compatible = "adi,axi-ad9680-1.0";
 			reg = <0x44a10000 0x10000>;
 		};
-		axi_ad9680_dma: axi_dmac@7c400000 {
+		rx_dma: rx-dmac@7c400000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			interrupt-parent = <&axi_intc>;
 			interrupts = <12 2>;
 			reg = <0x7c400000 0x10000>;
-			xlnx,2d-transfer = <0x0>;
-			xlnx,axi-slice-dest = <0x0>;
-			xlnx,axi-slice-src = <0x0>;
-			xlnx,clks-async-dest-req = <0x1>;
-			xlnx,clks-async-req-src = <0x1>;
-			xlnx,clks-async-src-dest = <0x1>;
-			xlnx,cyclic = <0x0>;
-			xlnx,dma-axi-protocol-dest = <0x0>;
-			xlnx,dma-axi-protocol-src = <0x0>;
-			xlnx,dma-data-width-dest = <0x40>;
-			xlnx,dma-data-width-src = <0x40>;
-			xlnx,dma-length-width = <0x18>;
-			xlnx,dma-type-dest = <0x0>;
-			xlnx,dma-type-src = <0x1>;
-			xlnx,fifo-size = <0x4>;
-			xlnx,max-bytes-per-burst = <0x80>;
-			xlnx,sync-transfer-start = <0x1>;
 		};
-		axi_ad9680_jesd: axi-jesd204b-rx@44a910000 {
-			compatible = "xlnx,jesd204-6.0";
-			reg = <0x44a91000 0x1000>;
-			xlnx,component-name = "system_axi_ad9680_jesd_0";
-			xlnx,default-f = <0x2>;
-			xlnx,default-k = <0x20>;
-			xlnx,default-scr = <0x0>;
-			xlnx,default-sysref-always = <0x0>;
-			xlnx,default-sysref-required = <0x0>;
-			xlnx,drpclk-freq = "156.25";
-			xlnx,elaboration-transient-dir = <0x0>;
-			xlnx,global-clk-sel = "false";
-			xlnx,gt-line-rate = "6.25";
-			xlnx,gt-refclk-freq = "156.250";
-			xlnx,lanes = <0x4>;
-			xlnx,lmfc-buffer-size = <0x6>;
-			xlnx,node-is-transmit = <0x0>;
-			xlnx,pll-selection = <0x0>;
-			xlnx,speedgrade = "-2";
-			xlnx,supportlevel = <0x0>;
-			xlnx,sysref-sampling-edge = <0x0>;
-			xlnx,transceivercontrol = "false";
-			xlnx,use-bram = <0x1>;
-			xlnx,use-jspat = "false";
-			xlnx,use-rpat = "false";
+		axi_ad9680_jesd: axi-jesd204-rx@44aa0000 {
+			compatible = "adi,axi-jesd204-rx-1.0";
+			interrupt-parent = <&axi_intc>;
+			interrupts = <14 0>;
+			reg = <0x44aa0000 0x1000>;
 		};
 		axi_ad9680_adxcvr: axi-ad9680-adxcvr@44a50000 {
 			#address-cells = <1>;
 			#size-cells = <0>;
 			compatible = "adi,axi-adxcvr-1.0";
-			reg = < 0x44a50000 0x1000 >;
+			reg = <0x44a50000 0x1000>;
 		};
 		axi_ad9144_adxcvr: axi-ad9144-adxcvr@44a60000 {
 			#address-cells = <1>;
 			#size-cells = <0>;
 			compatible = "adi,axi-adxcvr-1.0";
-			reg = < 0x44a60000 0x1000 >;
+			reg = <0x44a60000 0x1000>;
 		};
 		axi_ethernet_dma: dma@41e10000 {
 			axistream-connected = <&axi_ethernet_eth_buf>;

--- a/arch/microblaze/boot/dts/vc707_fmcjesdadc1.dts
+++ b/arch/microblaze/boot/dts/vc707_fmcjesdadc1.dts
@@ -36,19 +36,19 @@
 	};
 };
 
-&axi_ad9250_0_core {
-	dmas = <&axi_ad9250_0_dma 0>;
+&axi_ad9250_core0{
+	dmas = <&rx_dma0 0>;
 	dma-names = "rx";
 	spibus-connected = <&adc0_ad9250>;
 };
 
-&axi_ad9250_1_core {
-	dmas = <&axi_ad9250_1_dma 0>;
+&axi_ad9250_core1{
+	dmas = <&rx_dma1 0>;
 	dma-names = "rx";
 	spibus-connected = <&adc1_ad9250>;
 };
 
-&axi_ad9250_0_dma {
+&rx_dma0 {
 	#dma-cells = <1>;
 	clocks = <&clk_bus_0>;
 
@@ -58,7 +58,7 @@
 	};
 };
 
-&axi_ad9250_1_dma {
+&rx_dma1 {
 	#dma-cells = <1>;
 	clocks = <&clk_bus_0>;
 
@@ -68,27 +68,22 @@
 	};
 };
 
-&axi_ad9250_jesd {
+&axi_jesd{
 	#clock-cells = <0>;
-	clocks = <&axi_adxcvr 0>;
-	clock-names = "adc_gt_clk";
-	clock-output-names = "jesd_adc_clk";
+	clocks = <&clk_bus_0>, <&axi_adxcvr 1>, <&axi_adxcvr 0>;
+	clock-names = "s_axi_aclk", "device_clk", "lane_clk";
+	clock-output-names = "jesd_adc_lane_clk";
 
-	xlnx,lanes = <4>;
-	xlnx,frames-per-multiframe = <32>;
-	xlnx,bytes-per-frame = <2>;
-	xlnx,subclass = <1>;
-	xlnx,lanesync-enable;
-	xlnx,scramble-enable;
-	xlnx,sysref-enable;
+	adi,octets-per-frame = <2>;
+	adi,frames-per-multiframe = <32>;
 };
 
 &axi_adxcvr {
-	#clock-cells = <0>;
+	#clock-cells = <1>;
 
 	clocks = <&clk_ad9517 0>;
 	clock-names = "conv";
-	clock-output-names = "adc_gt_clk";
+	clock-output-names = "adc_gt_clk", "rx_out_clk";
 
 	adi,sys-clk-select = <0>;
 	adi,out-clk-select = <2>;

--- a/arch/microblaze/boot/dts/vc707_fmcjesdadc1_pl.dtsi
+++ b/arch/microblaze/boot/dts/vc707_fmcjesdadc1_pl.dtsi
@@ -140,61 +140,27 @@
 		#size-cells = <1>;
 		compatible = "simple-bus";
 		ranges ;
-		axi_ad9250_0_core: axi-ad9250-hpc-0@44a10000 {
+		axi_ad9250_core0: axi-ad9250-hpc-0@44a10000 {
 			compatible = "xlnx,axi-ad9250-1.00.a";
 			reg = <0x44a10000 0x10000>;
 			xlnx,s-axi-min-size = <0x0000FFFF>;
 		};
-		axi_ad9250_0_dma: axi_dmac@7c420000 {
+		rx_dma0: rx-dmac@7c420000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			interrupt-parent = <&axi_intc>;
 			interrupts = <13 2>;
 			reg = <0x7c420000 0x10000>;
-			xlnx,2d-transfer = <0x0>;
-			xlnx,axi-slice-dest = <0x0>;
-			xlnx,axi-slice-src = <0x0>;
-			xlnx,clks-async-dest-req = <0x1>;
-			xlnx,clks-async-req-src = <0x1>;
-			xlnx,clks-async-src-dest = <0x1>;
-			xlnx,cyclic = <0x0>;
-			xlnx,dma-axi-protocol-dest = <0x0>;
-			xlnx,dma-axi-protocol-src = <0x0>;
-			xlnx,dma-data-width-dest = <0x40>;
-			xlnx,dma-data-width-src = <0x40>;
-			xlnx,dma-length-width = <0x18>;
-			xlnx,dma-type-dest = <0x0>;
-			xlnx,dma-type-src = <0x2>;
-			xlnx,fifo-size = <0x4>;
-			xlnx,max-bytes-per-burst = <0x80>;
-			xlnx,sync-transfer-start = <0x1>;
 		};
-		axi_ad9250_1_core: axi-ad9250-hpc-1@44a20000 {
+		axi_ad9250_core1: axi-ad9250-hpc-1@44a20000 {
 			compatible = "xlnx,axi-ad9250-1.00.a";
 			reg = <0x44a20000 0x10000>;
 			xlnx,s-axi-min-size = <0x0000FFFF>;
 		};
-		axi_ad9250_1_dma: axi_dmac@7c430000 {
+		rx_dma1: rx-dmac@7c430000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			interrupt-parent = <&axi_intc>;
 			interrupts = <12 2>;
 			reg = <0x7c430000 0x10000>;
-			xlnx,2d-transfer = <0x0>;
-			xlnx,axi-slice-dest = <0x0>;
-			xlnx,axi-slice-src = <0x0>;
-			xlnx,clks-async-dest-req = <0x1>;
-			xlnx,clks-async-req-src = <0x1>;
-			xlnx,clks-async-src-dest = <0x1>;
-			xlnx,cyclic = <0x0>;
-			xlnx,dma-axi-protocol-dest = <0x0>;
-			xlnx,dma-axi-protocol-src = <0x0>;
-			xlnx,dma-data-width-dest = <0x40>;
-			xlnx,dma-data-width-src = <0x40>;
-			xlnx,dma-length-width = <0x18>;
-			xlnx,dma-type-dest = <0x0>;
-			xlnx,dma-type-src = <0x2>;
-			xlnx,fifo-size = <0x4>;
-			xlnx,max-bytes-per-burst = <0x80>;
-			xlnx,sync-transfer-start = <0x1>;
 		};
 		axi_adxcvr: axi-adxcvr@44a60000 {
 			#address-cells = <1>;
@@ -202,31 +168,11 @@
 			compatible = "adi,axi-adxcvr-1.0";
 			reg = < 0x44a60000 0x1000 >;
 		};
-		axi_ad9250_jesd: axi-jesd204b-rx@44a91000 {
-			compatible = "xlnx,jesd204-6.0";
-			reg = <0x44a91000 0x1000>;
-			xlnx,component-name = "system_axi_ad9250_jesd_0";
-			xlnx,default-f = <0x2>;
-			xlnx,default-k = <0x20>;
-			xlnx,default-scr = <0x0>;
-			xlnx,default-sysref-always = <0x0>;
-			xlnx,default-sysref-required = <0x0>;
-			xlnx,drpclk-freq = "156.25";
-			xlnx,elaboration-transient-dir = <0x0>;
-			xlnx,global-clk-sel = "false";
-			xlnx,gt-line-rate = "6.25";
-			xlnx,gt-refclk-freq = "156.250";
-			xlnx,lanes = <0x4>;
-			xlnx,lmfc-buffer-size = <0x6>;
-			xlnx,node-is-transmit = <0x0>;
-			xlnx,pll-selection = <0x0>;
-			xlnx,speedgrade = "-2";
-			xlnx,supportlevel = <0x0>;
-			xlnx,sysref-sampling-edge = <0x0>;
-			xlnx,transceivercontrol = "false";
-			xlnx,use-bram = <0x1>;
-			xlnx,use-jspat = "false";
-			xlnx,use-rpat = "false";
+		axi_jesd: axi-jesd204b-rx@44aa0000 {
+			compatible = "adi,axi-jesd204-rx-1.0";
+			reg = <0x44aa0000 0x1000>;
+			interrupt-parent = <&axi_intc>;
+			interrupts = <14 0>;
 		};
 		axi_ethernet_dma: dma@41e10000 {
 			axistream-connected = <&axi_ethernet_eth_buf>;


### PR DESCRIPTION
Follow up to  PR #68.
Changes vs PR #68 :
* added documentation adapted from ADI Wiki ; so that `checkpatch.pl` does not throw any warnings
* minor re-format of commit comments to fit in the 75 col-width limits ;

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>