### PR TITLE
iio: altera_adxcvr: Support more than 4 lanes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
 
 script:
   - if [[ -n "$TRAVIS_BRANCH" ]]; then git fetch origin +refs/heads/${TRAVIS_BRANCH}:${TRAVIS_BRANCH} ; fi
-  - COMMIT_RANGE=$([ "$TRAVIS_PULL_REQUEST" == "false" ] &&  echo "HEAD~1" || echo ${TRAVIS_BRANCH}..)
+  - COMMIT_RANGE=$([ "$TRAVIS_PULL_REQUEST" == "false" ] &&  echo HEAD || echo ${TRAVIS_BRANCH}..)
   - make ${DEFCONFIG_NAME}
   - make -j`getconf _NPROCESSORS_ONLN` uImage UIMAGE_LOADADDR=0x8000
   - for file in `ls arch/arm/boot/dts/zynq-*.dts`; do make `basename $file | sed  -e 's\dts\dtb\g'` || exit 1;done


### PR DESCRIPTION
The altera_adxcvr driver currently only supports up to 4 lanes. The number
of lanes of the hardware is read from a configuration register and if it
exceeds 4 the driver will exhibit undefined behavior.

Increase the number of supported lanes to 32, that should be enough for a
while.

Also add a check to prevent undefined behavior if the hardware has more
transceivers than what the driver supports.

Signed-off-by: Lars-Peter Clausen <lars@metafoo.de>