### PR TITLE
.travis.yml: add ZynqMP to the build run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,16 +11,20 @@ notifications:
 env:
   matrix:
   - DEFCONFIG_NAME=zynq_xcomm_adv7511_defconfig ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf-
+    DTS_FILES=arch/arm/boot/dts/zynq-*.dts IMAGE=uImage
   - DEFCONFIG_NAME=zynq_pluto_defconfig ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf-
+    DTS_FILES=arch/arm/boot/dts/zynq-*.dts IMAGE=uImage
+  - DEFCONFIG_NAME=adi_zynqmp_defconfig ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu-
+    DTS_FILES=arch/arm64/boot/dts/xilinx/zynqmp-*.dts DTS_PREFIX=xilinx/ IMAGE=Image
 
 before_install:
   - sudo apt-get update -qq
-  - sudo apt-get install -y build-essential bc u-boot-tools gcc-arm-linux-gnueabihf
+  - sudo apt-get install -y build-essential bc u-boot-tools gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu
 
 script:
   - if [[ -n "$TRAVIS_BRANCH" ]]; then git fetch origin +refs/heads/${TRAVIS_BRANCH}:${TRAVIS_BRANCH} ; fi
   - COMMIT_RANGE=$([ "$TRAVIS_PULL_REQUEST" == "false" ] &&  echo HEAD || echo ${TRAVIS_BRANCH}..)
   - make ${DEFCONFIG_NAME}
-  - make -j`getconf _NPROCESSORS_ONLN` uImage UIMAGE_LOADADDR=0x8000
-  - for file in `ls arch/arm/boot/dts/zynq-*.dts`; do make `basename $file | sed  -e 's\dts\dtb\g'` || exit 1;done
+  - make -j`getconf _NPROCESSORS_ONLN` $IMAGE UIMAGE_LOADADDR=0x8000
+  - for file in $DTS_FILES; do make ${DTS_PREFIX}`basename $file | sed  -e 's\dts\dtb\g'` || exit 1;done
   - scripts/checkpatch.pl --git ${COMMIT_RANGE} --ignore FILE_PATH_CHANGES --ignore LONG_LINE --ignore LONG_LINE_STRING --ignore LONG_LINE_COMMENT


### PR DESCRIPTION
This change extends the matrix to also test out the build of the ZynqMP
target, which is an ARM64 machine.
It will increase the test coverage a bit.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>