### PR TITLE
Rpi 4.9.y adxl372 regmap fixes

### DIFF
--- a/drivers/iio/accel/adxl372.c
+++ b/drivers/iio/accel/adxl372.c
@@ -291,7 +291,6 @@ static const struct iio_chan_spec adxl372_channels[] = {
 	ADXL372_ACCEL_CHANNEL(0, ADXL372_X_DATA_H, X),
 	ADXL372_ACCEL_CHANNEL(1, ADXL372_Y_DATA_H, Y),
 	ADXL372_ACCEL_CHANNEL(2, ADXL372_Z_DATA_H, Z),
-	IIO_CHAN_SOFT_TIMESTAMP(3),
 };
 
 struct adxl372_state {
@@ -596,9 +595,7 @@ static irqreturn_t adxl372_trigger_handler(int irq, void  *p)
 			goto err;
 
 		for (i = 0; i < fifo_entries * 2; i += st->fifo_set_size * 2)
-			iio_push_to_buffers_with_timestamp(indio_dev,
-						&st->fifo_buf[i],
-						iio_get_time_ns(indio_dev));
+			iio_push_to_buffers(indio_dev, &st->fifo_buf[i]);
 	}
 err:
 	iio_trigger_notify_done(indio_dev->trig);

--- a/drivers/iio/accel/adxl372.c
+++ b/drivers/iio/accel/adxl372.c
@@ -311,26 +311,6 @@ struct adxl372_state {
 	__be16				fifo_buf[512];
 };
 
-static int adxl372_spi_write_mask(struct adxl372_state *st,
-				  u8 reg_addr,
-				  unsigned int mask,
-				  u8 data)
-{
-	unsigned int regval;
-	int ret;
-
-	ret = regmap_read(st->regmap, ADXL372_REG_READ(reg_addr), &regval);
-	if (ret < 0)
-		return ret;
-
-	regval &= ~mask;
-	regval |= data;
-
-	ret = regmap_write(st->regmap, ADXL372_REG_WRITE(reg_addr), regval);
-
-	return ret;
-}
-
 static int adxl372_read_fifo(struct adxl372_state *st, u16 fifo_entries)
 {
 	int ret;
@@ -362,10 +342,9 @@ static int adxl372_set_op_mode(struct adxl372_state *st,
 {
 	int ret;
 
-	ret = adxl372_spi_write_mask(st,
-				     ADXL372_POWER_CTL,
-				     ADXL372_POWER_CTL_MODE_MSK,
-				     ADXL372_POWER_CTL_MODE(op_mode));
+	ret = regmap_update_bits(st->regmap, ADXL372_POWER_CTL,
+				 ADXL372_POWER_CTL_MODE_MSK,
+				 ADXL372_POWER_CTL_MODE(op_mode));
 
 	if (ret < 0) {
 		dev_err(&st->spi->dev, "Error writing mode of operation\n");
@@ -382,10 +361,9 @@ static int adxl372_set_odr(struct adxl372_state *st,
 {
 	int ret;
 
-	ret = adxl372_spi_write_mask(st,
-				     ADXL372_TIMING,
-				     ADXL372_TIMING_ODR_MSK,
-				     ADXL372_TIMING_ODR_MODE(odr));
+	ret = regmap_update_bits(st->regmap, ADXL372_TIMING,
+				 ADXL372_TIMING_ODR_MSK,
+				 ADXL372_TIMING_ODR_MODE(odr));
 
 	if (ret < 0) {
 		dev_err(&st->spi->dev, "Error setting output data rate\n");
@@ -426,10 +404,9 @@ static int adxl372_set_bandwidth(struct adxl372_state *st,
 {
 	int ret;
 
-	ret = adxl372_spi_write_mask(st,
-				     ADXL372_MEASURE,
-				     ADXL372_MEASURE_BANDWIDTH_MSK,
-				     ADXL372_MEASURE_BANDWIDTH_MODE(bw));
+	ret = regmap_update_bits(st->regmap, ADXL372_MEASURE,
+				 ADXL372_MEASURE_BANDWIDTH_MSK,
+				 ADXL372_MEASURE_BANDWIDTH_MODE(bw));
 
 	if (ret < 0) {
 		dev_err(&st->spi->dev, "Error setting bandwidth\n");
@@ -446,10 +423,10 @@ static int adxl372_set_act_proc_mode(struct adxl372_state *st,
 {
 	int ret;
 
-	ret = adxl372_spi_write_mask(st,
-				     ADXL372_MEASURE,
-				     ADXL372_MEASURE_LINKLOOP_MSK,
-				     ADXL372_MEASURE_LINKLOOP_MODE(mode));
+	ret = regmap_update_bits(st->regmap,
+				 ADXL372_MEASURE,
+				 ADXL372_MEASURE_LINKLOOP_MSK,
+				 ADXL372_MEASURE_LINKLOOP_MODE(mode));
 
 	if (ret < 0) {
 		dev_err(&st->spi->dev,

--- a/drivers/iio/accel/adxl372.c
+++ b/drivers/iio/accel/adxl372.c
@@ -697,10 +697,13 @@ static int adxl372_read_raw(struct iio_dev *indio_dev,
 
 	switch (info) {
 	case IIO_CHAN_INFO_RAW:
-		if (iio_buffer_enabled(indio_dev))
-			return -EBUSY;
+		ret = iio_device_claim_direct_mode(indio_dev);
+		if (ret)
+			return ret;
 
 		ret = adxl372_read_axis(st, chan->address);
+		iio_device_release_direct_mode(indio_dev);
+
 		if (ret < 0)
 			return ret;
 


### PR DESCRIPTION
This set of patches does two things:
* replaces the DMA buffer with integers on stack, because for regmap DMA buffer is not needed.
* replaces `adxl372_spi_write_mask()` with `regmap_update_bits()` which does the same thing.