### PR TITLE
Validate hb rates

### DIFF
--- a/drivers/iio/adc/ad9361.c
+++ b/drivers/iio/adc/ad9361.c
@@ -3882,8 +3882,13 @@ out:
 }
 
 static int ad9361_validate_trx_clock_chain(struct ad9361_rf_phy *phy,
-				      unsigned long *rx_path_clks)
+					   unsigned long *rx_path_clks,
+					   unsigned long *tx_path_clks)
 {
+	const unsigned long max_rx_rates[] = {MAX_BBPLL_FREQ, MAX_ADC_CLK,
+		MAX_RX_HB3, MAX_RX_HB2, MAX_RX_HB1, MAX_BASEBAND_RATE};
+	const unsigned long max_tx_rates[] = {MAX_BBPLL_FREQ, MAX_DAC_CLK,
+		MAX_TX_HB3, MAX_TX_HB2, MAX_TX_HB1, MAX_BASEBAND_RATE};
 	int i, data_clk;
 
 	data_clk = (phy->pdata->rx2tx2 ? 4 : 2) /
@@ -3898,6 +3903,24 @@ static int ad9361_validate_trx_clock_chain(struct ad9361_rf_phy *phy,
 		return -EINVAL;
 	}
 
+	/* Validate MAX PLL, ADC, DAC and HB filter rates */
+	for (i = 0; i < ARRAY_SIZE(max_rx_rates); i++) {
+		if (rx_path_clks[i] > max_rx_rates[i]) {
+			dev_err(&phy->spi->dev,
+				"%s: Failed RX max rate check (%lu > %lu)",
+				__func__, rx_path_clks[i], max_rx_rates[i]);
+			return -EINVAL;
+		}
+
+		if (tx_path_clks[i] > max_tx_rates[i]) {
+			dev_err(&phy->spi->dev,
+				"%s: Failed TX max rate check (%lu > %lu)",
+				__func__, tx_path_clks[i], max_tx_rates[i]);
+			return -EINVAL;
+		}
+	}
+
+	/* Validate that DATA_CLK exist within the clock chain */
 	for (i = 1; i <= 3; i++) {
 		if (abs(rx_path_clks[ADC_FREQ] / i - data_clk) < 4)
 			return 0;
@@ -3936,7 +3959,7 @@ int ad9361_set_trx_clock_chain(struct ad9361_rf_phy *phy,
 		tx_path_clks[R2_FREQ], tx_path_clks[R1_FREQ],
 		tx_path_clks[CLKRF_FREQ], tx_path_clks[RX_SAMPL_FREQ]);
 
-	ret = ad9361_validate_trx_clock_chain(phy, rx_path_clks);
+	ret = ad9361_validate_trx_clock_chain(phy, rx_path_clks, tx_path_clks);
 	if (ret < 0)
 		return ret;
 

--- a/drivers/iio/adc/ad9361.c
+++ b/drivers/iio/adc/ad9361.c
@@ -3885,9 +3885,9 @@ static int ad9361_validate_trx_clock_chain(struct ad9361_rf_phy *phy,
 					   unsigned long *rx_path_clks,
 					   unsigned long *tx_path_clks)
 {
-	const unsigned long max_rx_rates[] = {MAX_BBPLL_FREQ, MAX_ADC_CLK,
+	static const unsigned long max_rx_rates[] = {MAX_BBPLL_FREQ, MAX_ADC_CLK,
 		MAX_RX_HB3, MAX_RX_HB2, MAX_RX_HB1, MAX_BASEBAND_RATE};
-	const unsigned long max_tx_rates[] = {MAX_BBPLL_FREQ, MAX_DAC_CLK,
+	static const unsigned long max_tx_rates[] = {MAX_BBPLL_FREQ, MAX_DAC_CLK,
 		MAX_TX_HB3, MAX_TX_HB2, MAX_TX_HB1, MAX_BASEBAND_RATE};
 	int i, data_clk;
 
@@ -3897,7 +3897,7 @@ static int ad9361_validate_trx_clock_chain(struct ad9361_rf_phy *phy,
 
 	/* CMOS Mode */
 	if (!(phy->pdata->port_ctrl.pp_conf[2] & LVDS_MODE) &&
-		(data_clk > 61440000UL)) {
+		(data_clk > MAX_BASEBAND_RATE)) {
 		dev_err(&phy->spi->dev,
 			"%s: Failed CMOS MODE DATA_CLK > 61.44MSPS", __func__);
 		return -EINVAL;
@@ -4084,7 +4084,7 @@ static int ad9361_calculate_rf_clock_chain(struct ad9361_rf_phy *phy,
 		__func__, tx_sample_rate, tx_intdec, rx_intdec,
 		rate_gov ? "Nominal" : "Highest OSR");
 
-	if (tx_sample_rate > 61440000UL)
+	if (tx_sample_rate > MAX_BASEBAND_RATE)
 		return -EINVAL;
 
 	clktf = tx_sample_rate * tx_intdec;

--- a/drivers/iio/adc/ad9361.h
+++ b/drivers/iio/adc/ad9361.h
@@ -2797,6 +2797,17 @@
 #define MAX_ADC_CLK			640000000UL /* 640 MHz */
 #define MAX_DAC_CLK			(MAX_ADC_CLK / 2)
 
+/* Associated with outputs of stage */
+#define MAX_RX_HB1			245760000UL
+#define MAX_RX_HB2			320000000UL
+#define MAX_RX_HB3			640000000UL
+/* Associated with inputs of stage */
+#define MAX_TX_HB1			160000000UL
+#define MAX_TX_HB2			320000000UL
+#define MAX_TX_HB3			320000000UL
+
+#define MAX_BASEBAND_RATE		61440000UL
+
 #define MAX_MBYTE_SPI			8
 
 #define RFPLL_MODULUS			8388593UL


### PR DESCRIPTION
 iio: adc: ad9361: Validate MAX Half Band filter rates

The Half Band decimation and interpolation filters do have some max rate
they can run on. Typically the driver itself or AD9361 filter wizard
takes these into account. However recently we discovered a corner case
where max TX_HB1 rate of 160MSPS could have been exceed by using a
interpolate by 4 FIR filter and a Baseband rate of > 40 MSPS.

This patch adds a check for all max ratings of BBPPL, ADC, DAC, HB3, HB2
and HB1 filters in the system.