### PR TITLE
Prevent out-of-bounds debug register access

### DIFF
--- a/drivers/iio/adc/cf_axi_adc.h
+++ b/drivers/iio/adc/cf_axi_adc.h
@@ -202,6 +202,7 @@ struct axiadc_state {
 	struct device 			*dev_spi;
 	struct iio_info			iio_info;
 	struct clk 			*clk;
+	size_t				regs_size;
 	void __iomem			*regs;
 	void __iomem			*slave_regs;
 	unsigned				max_usr_channel;

--- a/drivers/iio/adc/cf_axi_adc_core.c
+++ b/drivers/iio/adc/cf_axi_adc_core.c
@@ -199,6 +199,11 @@ static int axiadc_reg_access(struct iio_dev *indio_dev,
 	struct axiadc_state *st = iio_priv(indio_dev);
 	int ret;
 
+	/* Check that the register is in range and aligned */
+	if ((reg & DEBUGFS_DRA_PCORE_REG_MAGIC) &&
+	    ((reg & 0xffff) >= st->regs_size || (reg & 0x3)))
+		return -EINVAL;
+
 	mutex_lock(&indio_dev->mlock);
 
 	if (!(reg & DEBUGFS_DRA_PCORE_REG_MAGIC)) {
@@ -772,6 +777,7 @@ static int axiadc_probe(struct platform_device *pdev)
 	st = iio_priv(indio_dev);
 
 	mem = platform_get_resource(pdev, IORESOURCE_MEM, 0);
+	st->regs_size = resource_size(mem);
 	st->regs = devm_ioremap_resource(&pdev->dev, mem);
 	if (IS_ERR(st->regs))
 		return PTR_ERR(st->regs);

--- a/drivers/iio/frequency/cf_axi_dds.c
+++ b/drivers/iio/frequency/cf_axi_dds.c
@@ -712,6 +712,11 @@ static int cf_axi_dds_reg_access(struct iio_dev *indio_dev,
 	if ((reg & ~DEBUGFS_DRA_PCORE_REG_MAGIC) > 0xFFFF)
 		return -EINVAL;
 
+	/* Check that the register is in range and aligned */
+	if (((reg & DEBUGFS_DRA_PCORE_REG_MAGIC) || st->standalone) &&
+	    ((reg & 0xffff) >= st->regs_size || (reg & 0x3)))
+		return -EINVAL;
+
 	if (st->dev_spi)
 		conv = to_converter(st->dev_spi);
 
@@ -1295,6 +1300,7 @@ static int cf_axi_dds_probe(struct platform_device *pdev)
 	st = iio_priv(indio_dev);
 
 	res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
+	st->regs_size = resource_size(res);
 	st->regs = devm_ioremap(&pdev->dev, res->start, resource_size(res));
 	if (!st->regs) {
 		ret = -ENOMEM;

--- a/drivers/iio/frequency/cf_axi_dds.h
+++ b/drivers/iio/frequency/cf_axi_dds.h
@@ -213,6 +213,7 @@ struct cf_axi_dds_state {
 	bool			pl_dma_fifo_en;
 
 	struct iio_info		iio_info;
+	size_t			regs_size;
 	void __iomem		*regs;
 	void __iomem		*slave_regs;
 	void __iomem		*master_regs;


### PR DESCRIPTION
Make sure that when using the debug register access that registers outside
of the mapped memory region are not accessed. Otherwise undefined behavior
can occur.
