### PR TITLE
iio: adc: ad9361: use gpiod_set_value_cansleep() when resetting chip

### DIFF
--- a/drivers/iio/adc/ad9361.c
+++ b/drivers/iio/adc/ad9361.c
@@ -934,9 +934,9 @@ static int ad9361_1rx1tx_channel_map(struct ad9361_rf_phy *phy, bool tx, int cha
 static int ad9361_reset(struct ad9361_rf_phy *phy)
 {
 	if (phy->pdata->reset_gpio) {
-		gpiod_set_value(phy->pdata->reset_gpio, 0);
+		gpiod_set_value_cansleep(phy->pdata->reset_gpio, 0);
 		mdelay(1);
-		gpiod_set_value(phy->pdata->reset_gpio, 1);
+		gpiod_set_value_cansleep(phy->pdata->reset_gpio, 1);
 		mdelay(1);
 		dev_dbg(&phy->spi->dev, "%s: by GPIO", __func__);
 		return 0;


### PR DESCRIPTION
The gpiod_set_value() invocation for the reset pin always happens in a context where sleeping is possible. Use gpiod_set_value_cansleep() to indicate this. This will make sure that GPIO drivers that will sleep can be used to driver the reset GPIO.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>