### PR TITLE
sidekiqz2: renamed dts to Rev B and fix GPIO reset reference in device-tree

### DIFF
--- a/arch/arm/boot/dts/zynq-sidekiqz2-revb.dts
+++ b/arch/arm/boot/dts/zynq-sidekiqz2-revb.dts
@@ -5,7 +5,7 @@
 #include <dt-bindings/interrupt-controller/irq.h>
 
 / {
-	model = "Epiq Solutions Sidekiq Z2 Rev.A (Z7010/AD9364)";
+	model = "Epiq Solutions Sidekiq Z2 Rev.B (Z7010/AD9364)";
 
 	leds {
 		compatible = "gpio-leds";

--- a/arch/arm/boot/dts/zynq-sidekiqz2-revb.dts
+++ b/arch/arm/boot/dts/zynq-sidekiqz2-revb.dts
@@ -92,5 +92,9 @@
 	adi,gpo-manual-mode-enable;
 	adi,gpo-manual-mode-enable-mask = <0x4>;
 
-	reset-gpio = <&tca6408_u21 1 GPIO_OPEN_DRAIN>;
+	/* Make sure to define `reset-gpios` otherwise, Pluto's reset pin
+	 * will still be used. `reset-gpios` takes precedence over
+	 * `reset-gpio`
+	 */
+	reset-gpios = <&tca6408_u21 1 GPIO_OPEN_DRAIN>;
 };


### PR DESCRIPTION
RevA won't exist; no need to keep references about it.

Fix GPIO reset pin in device-tree.
Previously Pluto's reset pin was being used because there were 2 `reset-gpios` and `reset-gpio` properties in the device-tree.
Both are valid, but `-gpios` suffixes take precedence, and they don't override the `-gpio` properties.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>