### PR TITLE
arm64: dts: adi-daq2: Increase ADC sampling rate

### DIFF
--- a/arch/arm64/boot/dts/xilinx/adi-daq2.dtsi
+++ b/arch/arm64/boot/dts/xilinx/adi-daq2.dtsi
@@ -52,7 +52,7 @@
 			adi,extended-name = "ADC_CLK_FMC";
 			adi,driver-mode = <3>;
 			adi,divider-phase = <1>;
-			adi,channel-divider = <4>;
+			adi,channel-divider = <2>;
 //			adi,output-dis;
 		};
 
@@ -106,7 +106,7 @@
 			adi,extended-name = "ADC_CLK";
 			adi,driver-mode = <3>;
 			adi,divider-phase = <1>;
-			adi,channel-divider = <2>;
+			adi,channel-divider = <1>;
 //			adi,output-dis;
 		};
 	};


### PR DESCRIPTION
AD-FMCDAQ2-EBZ is described as a Dual Channel 1GSPS Data Acquisition Kit.
Increase the ADC sampling rate from 500 MSPS to 1 GSPS.

Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>