### PR TITLE
iio: adc: re-organize Makefile alphabetically (2nd attempt) + fix `admc_drv` name collisions

### DIFF
--- a/drivers/iio/adc/Makefile
+++ b/drivers/iio/adc/Makefile
@@ -7,8 +7,7 @@ ad9361_drv-$(CONFIG_AD9361_EXT_BAND_CONTROL) += ad9361_ext_band_ctrl.o
 ad9371_drv-y := ad9371.o ad9371_conv.o \
 	mykonos/common.o  mykonos/mykonos.o  \
 	mykonos/mykonos_gpio.o  mykonos/mykonos_user.o
-admc_drv-y := admc_adc.o admc_speed.o admc_ctrl.o ad_adc.o
-cf_axi_adc_drv-y := cf_axi_adc_core.o cf_axi_adc_ring_stream.o
+cf_axi_adc-y := cf_axi_adc_core.o cf_axi_adc_ring_stream.o
 
 # When adding new entries keep the list in alphabetical order
 obj-$(CONFIG_AD_SIGMA_DELTA) += ad_sigma_delta.o
@@ -31,7 +30,7 @@ obj-$(CONFIG_AD9467) += ad9467.o
 obj-$(CONFIG_AD9680) += ad9680.o
 obj-$(CONFIG_AD9963) += ad9963.o
 obj-$(CONFIG_ADM1177) += adm1177.o
-obj-$(CONFIG_ADMC) += admc_drv.o
+obj-$(CONFIG_ADMC) += admc_adc.o admc_speed.o admc_ctrl.o ad_adc.o
 obj-$(CONFIG_AT91_ADC) += at91_adc.o
 obj-$(CONFIG_AT91_SAMA5D2_ADC) += at91-sama5d2_adc.o
 obj-$(CONFIG_AXI_FMCADC5_SYNC) += axi_fmcadc5_sync.o
@@ -39,7 +38,7 @@ obj-$(CONFIG_AXP288_ADC) += axp288_adc.o
 obj-$(CONFIG_BCM_IPROC_ADC) += bcm_iproc_adc.o
 obj-$(CONFIG_BERLIN2_ADC) += berlin2-adc.o
 obj-$(CONFIG_CC10001_ADC) += cc10001_adc.o
-obj-$(CONFIG_CF_AXI_ADC) += cf_axi_adc_drv.o
+obj-$(CONFIG_CF_AXI_ADC) += cf_axi_adc.o
 obj-$(CONFIG_CF_AXI_TDD) += cf_axi_tdd.o
 obj-$(CONFIG_DA9150_GPADC) += da9150-gpadc.o
 obj-$(CONFIG_EXYNOS_ADC) += exynos_adc.o

--- a/drivers/iio/adc/Makefile
+++ b/drivers/iio/adc/Makefile
@@ -2,6 +2,14 @@
 # Makefile for IIO ADC drivers
 #
 
+ad9361_drv-y := ad9361.o ad9361_conv.o
+ad9361_drv-$(CONFIG_AD9361_EXT_BAND_CONTROL) += ad9361_ext_band_ctrl.o
+ad9371_drv-y := ad9371.o ad9371_conv.o \
+	mykonos/common.o  mykonos/mykonos.o  \
+	mykonos/mykonos_gpio.o  mykonos/mykonos_user.o
+admc_drv-y := admc_adc.o admc_speed.o admc_ctrl.o ad_adc.o
+cf_axi_adc_drv-y := cf_axi_adc_core.o cf_axi_adc_ring_stream.o
+
 # When adding new entries keep the list in alphabetical order
 obj-$(CONFIG_AD_SIGMA_DELTA) += ad_sigma_delta.o
 obj-$(CONFIG_AD6676) += ad6676.o
@@ -17,33 +25,22 @@ obj-$(CONFIG_AD7791) += ad7791.o
 obj-$(CONFIG_AD7793) += ad7793.o
 obj-$(CONFIG_AD7887) += ad7887.o
 obj-$(CONFIG_AD799X) += ad799x.o
-obj-$(CONFIG_AD9963) += ad9963.o
-obj-$(CONFIG_ADM1177) += adm1177.o
-
-cf_axi_adc-y := cf_axi_adc_core.o cf_axi_adc_ring_stream.o
-obj-$(CONFIG_CF_AXI_ADC) += cf_axi_adc.o
-
-ad9361_drv-y := ad9361.o ad9361_conv.o
-ad9361_drv-$(CONFIG_AD9361_EXT_BAND_CONTROL) += ad9361_ext_band_ctrl.o
 obj-$(CONFIG_AD9361) += ad9361_drv.o
-
-ad9371_drv-y := ad9371.o ad9371_conv.o mykonos/common.o  mykonos/mykonos.o  mykonos/mykonos_gpio.o  mykonos/mykonos_user.o
 obj-$(CONFIG_AD9371) += ad9371_drv.o
-
 obj-$(CONFIG_AD9467) += ad9467.o
 obj-$(CONFIG_AD9680) += ad9680.o
-obj-$(CONFIG_ADMC) += admc_adc.o admc_speed.o admc_ctrl.o ad_adc.o
-
-obj-$(CONFIG_CF_AXI_TDD) += cf_axi_tdd.o
-
-obj-$(CONFIG_AXI_FMCADC5_SYNC) += axi_fmcadc5_sync.o
-
+obj-$(CONFIG_AD9963) += ad9963.o
+obj-$(CONFIG_ADM1177) += adm1177.o
+obj-$(CONFIG_ADMC) += admc_drv.o
 obj-$(CONFIG_AT91_ADC) += at91_adc.o
 obj-$(CONFIG_AT91_SAMA5D2_ADC) += at91-sama5d2_adc.o
+obj-$(CONFIG_AXI_FMCADC5_SYNC) += axi_fmcadc5_sync.o
 obj-$(CONFIG_AXP288_ADC) += axp288_adc.o
 obj-$(CONFIG_BCM_IPROC_ADC) += bcm_iproc_adc.o
 obj-$(CONFIG_BERLIN2_ADC) += berlin2-adc.o
 obj-$(CONFIG_CC10001_ADC) += cc10001_adc.o
+obj-$(CONFIG_CF_AXI_ADC) += cf_axi_adc_drv.o
+obj-$(CONFIG_CF_AXI_TDD) += cf_axi_tdd.o
 obj-$(CONFIG_DA9150_GPADC) += da9150-gpadc.o
 obj-$(CONFIG_EXYNOS_ADC) += exynos_adc.o
 obj-$(CONFIG_FSL_MX25_ADC) += fsl-imx25-gcq.o


### PR DESCRIPTION
Commit 5f937ee reverted the first attempt to organize the iio/adc/Makefile.
This is the 2nd attempt.

Tested on ZC706.

It seems that assigning `xxx-y := a.o b.o c.o` the KBUILD_MODNAME macro
becomes `xxx` for all 3 files/modules.

For the ADMC driver, even though it's 1 Kconfig symbol, it's actually 4
separate modules, and each module defines the name via KBUILD_MODNAME.
So, with the above construct, this becomes that all drivers are named
`admc_drv`.

These 4 drivers are the only one that were affected by the previous change
as all other modules are the same module organized over multiple file, and
only a single `module_platform_driver()` defined for all files.

Also, renamed `cf_axi_adc_drv-y` to `cf_axi_adc-y`, since this was the
KBUILD_MODNAME before the Makefile re-organization.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>