### PR TITLE
[backports] iio: adc: ad7303: backport upstream patches

### DIFF
--- a/drivers/iio/dac/ad7303.c
+++ b/drivers/iio/dac/ad7303.c
@@ -308,8 +308,10 @@ static int ad7303_probe(struct spi_device *spi)
 
 	if (ext_ref) {
 		st->vref_reg = regulator_get(&spi->dev, "REF");
-		if (IS_ERR(st->vref_reg))
+		if (IS_ERR(st->vref_reg)) {
+			ret = PTR_ERR(st->vref_reg);
 			goto err_disable_vdd_reg;
+		}
 
 		ret = regulator_enable(st->vref_reg);
 		if (ret)

--- a/drivers/iio/dac/ad7303.c
+++ b/drivers/iio/dac/ad7303.c
@@ -276,7 +276,7 @@ static int ad7303_probe(struct spi_device *spi)
 	bool ext_ref;
 	int ret;
 
-	indio_dev = iio_device_alloc(sizeof(*st));
+	indio_dev = devm_iio_device_alloc(&spi->dev, sizeof(*st));
 	if (indio_dev == NULL)
 		return -ENOMEM;
 
@@ -285,15 +285,13 @@ static int ad7303_probe(struct spi_device *spi)
 
 	st->spi = spi;
 
-	st->vdd_reg = regulator_get(&spi->dev, "Vdd");
-	if (IS_ERR(st->vdd_reg)) {
-		ret = PTR_ERR(st->vdd_reg);
-		goto err_free;
-	}
+	st->vdd_reg = devm_regulator_get(&spi->dev, "Vdd");
+	if (IS_ERR(st->vdd_reg))
+		return PTR_ERR(st->vdd_reg);
 
 	ret = regulator_enable(st->vdd_reg);
 	if (ret)
-		goto err_put_vdd_reg;
+		return ret;
 
 	if (spi->dev.of_node) {
 		ext_ref = of_property_read_bool(spi->dev.of_node,
@@ -307,7 +305,7 @@ static int ad7303_probe(struct spi_device *spi)
 	}
 
 	if (ext_ref) {
-		st->vref_reg = regulator_get(&spi->dev, "REF");
+		st->vref_reg = devm_regulator_get(&spi->dev, "REF");
 		if (IS_ERR(st->vref_reg)) {
 			ret = PTR_ERR(st->vref_reg);
 			goto err_disable_vdd_reg;
@@ -315,7 +313,7 @@ static int ad7303_probe(struct spi_device *spi)
 
 		ret = regulator_enable(st->vref_reg);
 		if (ret)
-			goto err_put_vref_reg;
+			goto err_disable_vdd_reg;
 
 		st->config |= AD7303_CFG_EXTERNAL_VREF;
 	}
@@ -344,16 +342,8 @@ err_buffer_cleanup:
 err_disable_vref_reg:
 	if (st->vref_reg)
 		regulator_disable(st->vref_reg);
-err_put_vref_reg:
-	if (st->vref_reg)
-		regulator_put(st->vref_reg);
 err_disable_vdd_reg:
 	regulator_disable(st->vdd_reg);
-err_put_vdd_reg:
-	regulator_put(st->vdd_reg);
-err_free:
-	iio_device_free(indio_dev);
-
 	return ret;
 }
 
@@ -365,14 +355,9 @@ static int ad7303_remove(struct spi_device *spi)
 	iio_device_unregister(indio_dev);
 	iio_triggered_buffer_cleanup(indio_dev);
 
-	if (st->vref_reg) {
+	if (st->vref_reg)
 		regulator_disable(st->vref_reg);
-		regulator_put(st->vref_reg);
-	}
 	regulator_disable(st->vdd_reg);
-	regulator_put(st->vdd_reg);
-
-	iio_device_free(indio_dev);
 
 	return 0;
 }


### PR DESCRIPTION
These patches are not present in the ADI tree.
They are present in the ADI history, but they were probably reverted by accident at some point in time.

This changeset, brings them back.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>