### PR TITLE
Enable DAC PL FIFO for a10gx_daq2

### DIFF
--- a/arch/nios2/boot/dts/a10gx_daq2.dts
+++ b/arch/nios2/boot/dts/a10gx_daq2.dts
@@ -328,7 +328,7 @@
 			dmas = <&tx_dma 0>;
 			dma-names = "tx";
 			spibus-connected = <&dac0_ad9144>;
-//			adi,axi-pl-fifo-enable;
+			adi,axi-pl-fifo-enable;
 		};
 
 		axi_ad9144_jesd: axi-jesd204-tx@10020000 {


### PR DESCRIPTION
The FPGA system features now a PL (Programmable Logic) FIFO, so this attribute
should be set.

Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>