### PR TITLE
iio: ad6676: Fix default attenuation value

### DIFF
--- a/drivers/iio/adc/ad6676.c
+++ b/drivers/iio/adc/ad6676.c
@@ -1160,6 +1160,8 @@ static int ad6676_probe(struct spi_device *spi)
 		return -EINVAL;
 	}
 
+	phy->pdata->base.attenuation = 0x0C;
+
 	ad6676_gpio_config(conv);
 
 	/* RESET here */


### PR DESCRIPTION
The reset value of the attenuation is according to the datasheet 12 dB
but pdata->base.attenuation was incorrectly set to 0.

Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>