### PR TITLE
iio: dac: ad5758: Add support for hard reset

### DIFF
--- a/Documentation/devicetree/bindings/iio/dac/ad5758.txt
+++ b/Documentation/devicetree/bindings/iio/dac/ad5758.txt
@@ -8,6 +8,9 @@ Required properties for the AD5758:
 
 Optional properties:
 
+ - reset-gpios : GPIO spec for the RESET pin. If specified, it will be
+ 		 asserted during driver probe.
+
  - adi,dc-dc-mode: Mode of operation of the dc-to-dc converter
 		   The following values are currently supported:
 		   	* 0: DC-to-DC converter powered off
@@ -76,6 +79,8 @@ AD5758 Example:
 		reg = <0>;
 		spi-max-frequency = <1000000>;
 		spi-cpha;
+
+		reset-gpios = <&gpio 22 0>;
 
 		adi,dc-dc-mode = <2>;
 		adi,dc-dc-ilim = <200>;


### PR DESCRIPTION
The ad5758 has a hardware reset active low input pin. This patch adds a
devicetree entry for a reset GPIO and a new ad5758_reset() function. This
function checks if the reset property is specified and asserts the GPIO
during probe, otherwise, a software reset is performed.

Signed-off-by: Stefan Popa <stefan.popa@analog.com>