### PR TITLE
spi: use upstream's SPI lock mechanism for device registration

### DIFF
--- a/drivers/spi/spi.c
+++ b/drivers/spi/spi.c
@@ -500,6 +500,7 @@ static int spi_dev_check(struct device *dev, void *data)
  */
 int spi_add_device(struct spi_device *spi)
 {
+	static DEFINE_MUTEX(spi_add_lock);
 	struct spi_master *master = spi->master;
 	struct device *dev = master->dev.parent;
 	int status;
@@ -519,7 +520,7 @@ int spi_add_device(struct spi_device *spi)
 	 * chipselect **BEFORE** we call setup(), else we'll trash
 	 * its configuration.  Lock against concurrent add() calls.
 	 */
-	mutex_lock(&master->add_lock);
+	mutex_lock(&spi_add_lock);
 
 	status = bus_for_each_dev(&spi_bus_type, NULL, spi, spi_dev_check);
 	if (status) {
@@ -551,7 +552,7 @@ int spi_add_device(struct spi_device *spi)
 		dev_dbg(dev, "registered child %s\n", dev_name(&spi->dev));
 
 done:
-	mutex_unlock(&master->add_lock);
+	mutex_unlock(&spi_add_lock);
 	return status;
 }
 EXPORT_SYMBOL_GPL(spi_add_device);
@@ -1910,8 +1911,6 @@ int spi_register_master(struct spi_master *master)
 		master->bus_num = atomic_dec_return(&dyn_bus_id);
 		dynamic = 1;
 	}
-
-	mutex_init(&master->add_lock);
 
 	INIT_LIST_HEAD(&master->queue);
 	spin_lock_init(&master->queue_lock);

--- a/include/linux/spi/spi.h
+++ b/include/linux/spi/spi.h
@@ -318,8 +318,6 @@ static inline void spi_unregister_driver(struct spi_driver *sdrv)
  * @bus_lock_spinlock: spinlock for SPI bus locking
  * @bus_lock_mutex: mutex for exclusion of multiple callers
  * @bus_lock_flag: indicates that the SPI bus is locked for exclusive use
- * @add_lock: protects against concurrent registration of slaves with the same
- *	chip_select.
  * @setup: updates the device mode and clocking records used by a
  *	device's SPI controller; protocol code may call this.  This
  *	must fail if an unrecognized or unsupported mode is requested.
@@ -473,8 +471,6 @@ struct spi_master {
 
 	/* flag indicating that the SPI bus is locked for exclusive use */
 	bool			bus_lock_flag;
-
-	struct mutex		add_lock;
 
 	/* Setup mode and clock, etc (spi driver may call many times).
 	 *


### PR DESCRIPTION
After a few merges, the SPI lock mechanism for device registration in the
ADI master branch diverged from upstream.
It's not wrong, it's just a different approach.
For now, prefer upstream's version.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>