### PR TITLE
iio: logic: add Kconfig menu for logic analyzers

### DIFF
--- a/drivers/iio/Kconfig
+++ b/drivers/iio/Kconfig
@@ -82,6 +82,7 @@ source "drivers/iio/humidity/Kconfig"
 source "drivers/iio/imu/Kconfig"
 source "drivers/iio/jesd204/Kconfig"
 source "drivers/iio/light/Kconfig"
+source "drivers/iio/logic/Kconfig"
 source "drivers/iio/magnetometer/Kconfig"
 source "drivers/iio/orientation/Kconfig"
 if IIO_TRIGGER

--- a/drivers/iio/logic/Kconfig
+++ b/drivers/iio/logic/Kconfig
@@ -1,0 +1,14 @@
+#
+# Logi Analyzer drivers
+#
+# When adding new entries keep the list in alphabetical order
+
+menu "Logic Analyzers"
+
+config M2K_LOGIC_ANALYZER
+	tristate "M2k Logic Analyzer support"
+	help
+	  Support for the Logic Analyzer module on the Analog Devices
+	  ADALM-2000 (M2k) platform.
+
+endmenu

--- a/drivers/iio/logic/Makefile
+++ b/drivers/iio/logic/Makefile
@@ -1,3 +1,3 @@
-obj-y += m2k-logic-analyzer.o
-obj-y += m2k-fabric.o
-obj-y += m2k-trigger-ad.o
+obj-$(CONFIG_M2K_LOGIC_ANALYZER) += m2k-logic-analyzer.o
+obj-$(CONFIG_M2K_LOGIC_ANALYZER) += m2k-fabric.o
+obj-$(CONFIG_M2K_LOGIC_ANALYZER) += m2k-trigger-ad.o


### PR DESCRIPTION
Otherwise the M2k logic analyzer always gets built for all devices, and we
don't need this for RPis and some other targets.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>