### PR TITLE
iio: ad5758: The DAC channel should be output

### DIFF
--- a/drivers/iio/dac/ad5758.c
+++ b/drivers/iio/dac/ad5758.c
@@ -612,6 +612,7 @@ static const struct iio_chan_spec ad5758_channels[] = {
 		.info_mask_separate = BIT(IIO_CHAN_INFO_RAW),
 		.info_mask_shared_by_type = BIT(IIO_CHAN_INFO_SCALE),
 		.indexed = 1,
+		.output = 1,
 		.channel = 0,
 		.scan_index = 0,
 		.scan_type = {


### PR DESCRIPTION
The output field which is part of the iio_chan_spec struct should be set
to 1.

Signed-off-by: Stefan Popa <stefan.popa@analog.com>