### PR TITLE
iio: jesd204: axi_jesd204_{rx,tx}: Store subclass version in the corr…

### DIFF
--- a/drivers/iio/jesd204/axi_jesd204_rx.c
+++ b/drivers/iio/jesd204/axi_jesd204_rx.c
@@ -318,7 +318,7 @@ static int axi_jesd204_rx_apply_config(struct axi_jesd204_rx *jesd,
 
 	writel_relaxed(val, jesd->base + JESD204_RX_REG_LINK_CONF0);
 
-	if (config->jesd_version == 0)
+	if (config->subclass_version == 0)
 		writel_relaxed(JESD204_RX_REG_SYSREF_CONF_SYSREF_DISABLE,
 			       jesd->base + JESD204_RX_REG_SYSREF_CONF);
 
@@ -350,10 +350,11 @@ static int axi_jesd204_rx_parse_dt_config(struct device_node *np,
 	config->enable_scrambling = true;
 	config->lanes_per_device = jesd->num_lanes;
 	config->jesd_version = 1;
+	config->subclass_version = 1;
 
 	ret = of_property_read_u32(np, "adi,subclass", &val);
 	if (ret == 0)
-		config->jesd_version = val;
+		config->subclass_version = val;
 
 	return 0;
 }

--- a/drivers/iio/jesd204/axi_jesd204_tx.c
+++ b/drivers/iio/jesd204/axi_jesd204_tx.c
@@ -269,7 +269,7 @@ static int axi_jesd204_tx_apply_config(struct axi_jesd204_tx *jesd,
 	val = (octets_per_multiframe - 1);
 	val |= (config->octets_per_frame - 1) << 16;
 
-	if (config->jesd_version == 0)
+	if (config->subclass_version == 0)
 		writel_relaxed(JESD204_TX_REG_SYSREF_CONF_SYSREF_DISABLE,
 			       jesd->base + JESD204_TX_REG_SYSREF_CONF);
 
@@ -334,7 +334,7 @@ static int axi_jesd204_tx_parse_dt_config(struct device_node *np,
 
 	ret = of_property_read_u32(np, "adi,subclass", &val);
 	if (ret == 0)
-		config->jesd_version = val;
+		config->subclass_version = val;
 
 	return 0;
 }


### PR DESCRIPTION
…ect field

Commit a6a208363c2c ("iio: jesd204: axi_jesd204_[rx|tx]: Add support for
JESD204 Subclass 0") added support for subclass 0. But it stores the
selected subclass in the jesd_version field instead of the subclass_version
field of the jesd204_{rx,tx}_config struct.

On RX this currently doesn't have any effect and on TX it means that the
wrong values for the jesd version and subclass version are send during the
ILAS.

Correct this by storing the subclass version in the right field.

Signed-off-by: Lars-Peter Clausen <lars@metafoo.de>