### PR TITLE
iio: axi_adxcvr: Add support for when the ref clock is equal to the div40 clock

### DIFF
--- a/drivers/iio/jesd204/axi_adxcvr.c
+++ b/drivers/iio/jesd204/axi_adxcvr.c
@@ -82,6 +82,7 @@ struct adxcvr_state {
 
 	bool				cpll_enable;
 	bool				lpm_enable;
+	bool				ref_is_div40;
 
 	unsigned int			num_lanes;
 };
@@ -306,6 +307,9 @@ static long adxcvr_clk_round_rate(struct clk_hw *hw, unsigned long rate,
 		container_of(hw, struct adxcvr_state, lane_clk_hw);
 	int ret;
 
+	if (st->ref_is_div40)
+		*prate = rate * (1000 / 40);
+
 	dev_dbg(st->dev, "%s: Rate %lu Hz Parent Rate %lu Hz",
 		__func__, rate, *prate);
 
@@ -419,7 +423,7 @@ static int adxcvr_clk_register(struct device *dev, struct device_node *node,
 
 	init.name = clk_names[0];
 	init.ops = &clkout_ops;
-	init.flags = CLK_SET_RATE_GATE;
+	init.flags = CLK_SET_RATE_GATE | CLK_SET_RATE_PARENT;
 
 	init.parent_names = (parent_name ? &parent_name : NULL);
 	init.num_parents = (parent_name ? 1 : 0);
@@ -540,6 +544,17 @@ static int adxcvr_probe(struct platform_device *pdev)
 	if (IS_ERR(st->lane_rate_div40_clk)) {
 		if (PTR_ERR(st->lane_rate_div40_clk) != -ENOENT)
 			return PTR_ERR(st->lane_rate_div40_clk);
+	}
+
+	if (clk_is_match(st->conv_clk, st->lane_rate_div40_clk)) {
+		/*
+		 * In this case we need to make sure that the reference clock
+		 * runs at lanerate / 40. No need to keep two references to the
+		 * same clock around.
+		 */
+		st->ref_is_div40 = true;
+		devm_clk_put(&pdev->dev, st->lane_rate_div40_clk);
+		st->lane_rate_div40_clk = ERR_PTR(-ENOENT);
 	}
 
 	ret = clk_prepare_enable(st->conv_clk);


### PR DESCRIPTION
Currently the axi_adxcvr driver adjusts the div40 clock rate after the lane
rate has been updated.

But when the div40 clock is equal to the reference clock of the transceiver
PLL, like it is in some designs, it is necessary to adjust the reference
clock rate to the new target rate before computing the PLL.

This enables dynamic reconfiguration of the lane rate on these platforms.

Signed-off-by: Lars-Peter Clausen <lars@metafoo.de>