### PR TITLE
[RFC][Review-Only] iio: ad9523: Fix displayed phase

### DIFF
--- a/drivers/iio/frequency/ad9523.c
+++ b/drivers/iio/frequency/ad9523.c
@@ -642,7 +642,7 @@ static int ad9523_read_raw(struct iio_dev *indio_dev,
 		code = (AD9523_CLK_DIST_DIV_PHASE_REV(ret) * 3141592) /
 			AD9523_CLK_DIST_DIV_REV(ret);
 		*val = code / 1000000;
-		*val2 = (code % 1000000) * 10;
+		*val2 = code % 1000000;
 		return IIO_VAL_INT_PLUS_MICRO;
 	default:
 		return -EINVAL;


### PR DESCRIPTION
**PR Note:** the original commit f94a3713883897466da037911e2cfe87a6847b98 targets 2 drivers `ad9523` & `ad9528` ; since only `ad9523` is upstreamed [atm], this patch has been reduced to this driver only ; title & comment were adjusted ;

------------------------------

Fix the displayed phase for the ad9523 driver. Currently the most
significant decimal place is dropped and all other digits are shifted one
to the left. This is due to a multiplication by 10, which is not necessary,
so remove it.

Signed-off-by: Lars-Peter Clausen <lars@metafoo.de>