### PR TITLE
[RFC][Review-Only] net: ieee802154: adf7242: set of patches present in ADI tree; not yet in upstream

### DIFF
--- a/drivers/net/ieee802154/adf7242.c
+++ b/drivers/net/ieee802154/adf7242.c
@@ -275,6 +275,8 @@ struct adf7242_local {
 	struct spi_message stat_msg;
 	struct spi_transfer stat_xfer;
 	struct dentry *debugfs_root;
+	struct delayed_work work;
+	struct workqueue_struct *wqueue;
 	unsigned long flags;
 	int tx_stat;
 	bool promiscuous;
@@ -575,8 +577,25 @@ static int adf7242_cmd_rx(struct adf7242_local *lp)
 	/* Wait until the ACK is sent */
 	adf7242_wait_status(lp, RC_STATUS_PHY_RDY, RC_STATUS_MASK, __LINE__);
 	adf7242_clear_irqstat(lp);
+	mod_delayed_work(lp->wqueue, &lp->work, msecs_to_jiffies(400));
 
 	return adf7242_cmd(lp, CMD_RC_RX);
+}
+
+static void adf7242_rx_cal_work(struct work_struct *work)
+{
+	struct adf7242_local *lp =
+	container_of(work, struct adf7242_local, work.work);
+
+	/*
+	 * Reissuing RC_RX every 400ms - to adjust for offset
+	 * drift in receiver (datasheet page 61, OCL section)
+	 */
+
+	if (!test_bit(FLAG_XMIT, &lp->flags)) {
+		adf7242_cmd(lp, CMD_RC_PHY_RDY);
+		adf7242_cmd_rx(lp);
+	}
 }
 
 static int adf7242_set_txpower(struct ieee802154_hw *hw, int mbm)
@@ -686,7 +705,7 @@ static int adf7242_start(struct ieee802154_hw *hw)
 	enable_irq(lp->spi->irq);
 	set_bit(FLAG_START, &lp->flags);
 
-	return adf7242_cmd(lp, CMD_RC_RX);
+	return adf7242_cmd_rx(lp);
 }
 
 static void adf7242_stop(struct ieee802154_hw *hw)
@@ -694,6 +713,7 @@ static void adf7242_stop(struct ieee802154_hw *hw)
 	struct adf7242_local *lp = hw->priv;
 
 	disable_irq(lp->spi->irq);
+	cancel_delayed_work_sync(&lp->work);
 	adf7242_cmd(lp, CMD_RC_IDLE);
 	clear_bit(FLAG_START, &lp->flags);
 	adf7242_clear_irqstat(lp);
@@ -814,6 +834,7 @@ static int adf7242_xmit(struct ieee802154_hw *hw, struct sk_buff *skb)
 	/* ensure existing instances of the IRQ handler have completed */
 	disable_irq(lp->spi->irq);
 	set_bit(FLAG_XMIT, &lp->flags);
+	cancel_delayed_work_sync(&lp->work);
 	reinit_completion(&lp->tx_complete);
 	adf7242_cmd(lp, CMD_RC_PHY_RDY);
 	adf7242_clear_irqstat(lp);
@@ -952,6 +973,7 @@ static irqreturn_t adf7242_isr(int irq, void *data)
 	unsigned int xmit;
 	u8 irq1;
 
+	mod_delayed_work(lp->wqueue, &lp->work, msecs_to_jiffies(400));
 	adf7242_read_reg(lp, REG_IRQ1_SRC1, &irq1);
 
 	if (!(irq1 & (IRQ_RX_PKT_RCVD | IRQ_CSMA_CA)))
@@ -1241,6 +1263,8 @@ static int adf7242_probe(struct spi_device *spi)
 	spi_message_add_tail(&lp->stat_xfer, &lp->stat_msg);
 
 	spi_set_drvdata(spi, lp);
+	INIT_DELAYED_WORK(&lp->work, adf7242_rx_cal_work);
+	lp->wqueue = alloc_ordered_workqueue(dev_name(&spi->dev), WQ_MEM_RECLAIM);
 
 	ret = adf7242_hw_init(lp);
 	if (ret)
@@ -1283,6 +1307,9 @@ static int adf7242_remove(struct spi_device *spi)
 
 	if (!IS_ERR_OR_NULL(lp->debugfs_root))
 		debugfs_remove_recursive(lp->debugfs_root);
+
+	cancel_delayed_work_sync(&lp->work);
+	destroy_workqueue(lp->wqueue);
 
 	ieee802154_unregister_hw(lp->hw);
 	mutex_destroy(&lp->bmux);

--- a/drivers/net/ieee802154/adf7242.c
+++ b/drivers/net/ieee802154/adf7242.c
@@ -739,7 +739,10 @@ static int adf7242_channel(struct ieee802154_hw *hw, u8 page, u8 channel)
 	adf7242_write_reg(lp, REG_CH_FREQ1, freq >> 8);
 	adf7242_write_reg(lp, REG_CH_FREQ2, freq >> 16);
 
-	return adf7242_cmd(lp, CMD_RC_RX);
+	if (test_bit(FLAG_START, &lp->flags))
+		return adf7242_cmd_rx(lp);
+	else
+		return adf7242_cmd(lp, CMD_RC_PHY_RDY);
 }
 
 static int adf7242_set_hw_addr_filt(struct ieee802154_hw *hw,


### PR DESCRIPTION
PR note:
* added my SoB ; in case I will send these upstream
* if @mhennerich wants/has time to send these, my SoB should be removed
* master is from https://git.kernel.org/pub/scm/linux/kernel/git/sschmidt/wpan-next.git

The patch has been cherry-picked from the adi-4.14.0 branch ; nothing changed to the patch content.
Commits in master are  0fcb381447d1badbce3977f9dc9b7fbdb8e89e95  &   40c215821145dd6eed6a2f1ff636d67d344e1ab4

---------------------------------------------

These 2 patches are all that's needed to sync the driver with upstream.
All other patches are in kernel 4.18.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>