### PR TITLE
[RFC][Review-Only] ASoC: adau171x1: Connect playback DAI to the DSP

### DIFF
--- a/sound/soc/codecs/adau17x1.c
+++ b/sound/soc/codecs/adau17x1.c
@@ -299,6 +299,7 @@ static const struct snd_soc_dapm_route adau17x1_dsp_dapm_routes[] = {
 
 	{ "DSP", NULL, "Left Decimator" },
 	{ "DSP", NULL, "Right Decimator" },
+	{ "DSP", NULL, "Playback" },
 };
 
 static const struct snd_soc_dapm_route adau17x1_no_dsp_dapm_routes[] = {


### PR DESCRIPTION
The playback DAI is connected to the DSP and the DSP might be sourcing
signals from the playback stream. Add a DAPM route between the two to make
sure that the playback DAI is powered up, when the DSP is active.

Signed-off-by: Lars-Peter Clausen <lars@metafoo.de>
Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>