### PR TITLE
iio adrv9009 dual observation support

### DIFF
--- a/arch/arm64/boot/dts/xilinx/adi-adrv9009.dtsi
+++ b/arch/arm64/boot/dts/xilinx/adi-adrv9009.dtsi
@@ -145,9 +145,9 @@
 		adi,jesd204-framer-b-bank-id = <0>;
 		adi,jesd204-framer-b-device-id = <0>;
 		adi,jesd204-framer-b-lane0-id = <0>;
-		adi,jesd204-framer-b-m = <2>;
+		adi,jesd204-framer-b-m = <4>;
 		adi,jesd204-framer-b-k = <32>;
-		adi,jesd204-framer-b-f = <2>;
+		adi,jesd204-framer-b-f = <4>;
 		adi,jesd204-framer-b-np = <16>;
 		adi,jesd204-framer-b-scramble = <1>;
 		adi,jesd204-framer-b-external-sysref = <1>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9009.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9009.dts
@@ -82,7 +82,7 @@
 
 				dma-channel@0 {
 					reg = <0>;
-					adi,source-bus-width = <64>;
+					adi,source-bus-width = <128>;
 					adi,source-bus-type = <2>;
 					adi,destination-bus-width = <64>;
 					adi,destination-bus-type = <0>;
@@ -189,7 +189,7 @@
 			#clock-cells = <0>;
 			clock-output-names = "jesd_rx_os_lane_clk";
 
-			adi,octets-per-frame = <2>;
+			adi,octets-per-frame = <4>;
 			adi,frames-per-multiframe = <32>;
 		};
 

--- a/drivers/iio/adc/ad_adc.c
+++ b/drivers/iio/adc/ad_adc.c
@@ -125,6 +125,20 @@ static const struct adc_chip_info m2k_adc_chip_info = {
 	.ctrl_flags = ADI_FORMAT_SIGNEXT | ADI_FORMAT_ENABLE,
 };
 
+static const struct iio_chan_spec adrv9009_obs_rx_channels[] = {
+	AD9361_OBS_RX_CHANNEL(0, IIO_MOD_I, 0),
+	AD9361_OBS_RX_CHANNEL(0, IIO_MOD_Q, 1),
+	AD9361_OBS_RX_CHANNEL(1, IIO_MOD_I, 2),
+	AD9361_OBS_RX_CHANNEL(1, IIO_MOD_Q, 3),
+
+};
+
+static const struct adc_chip_info adrv9009_obs_rx_chip_info = {
+	.channels = adrv9009_obs_rx_channels,
+	.num_channels = ARRAY_SIZE(adrv9009_obs_rx_channels),
+	.ctrl_flags = ADI_FORMAT_SIGNEXT | ADI_FORMAT_ENABLE,
+};
+
 static int axiadc_hw_consumer_postenable(struct iio_dev *indio_dev)
 {
 	struct axiadc_state *st = iio_priv(indio_dev);
@@ -225,7 +239,7 @@ static const struct of_device_id adc_of_match[] = {
 	{ .compatible = "adi,cn0363-adc-1.00.a", .data = &cn0363_chip_info },
 	{ .compatible = "adi,axi-ad9371-obs-1.0", .data = &ad9371_obs_rx_chip_info },
 	{ .compatible = "adi,m2k-adc-1.00.a", .data = &m2k_adc_chip_info },
-	{ .compatible = "adi,axi-adrv9009-obs-1.0", .data = &ad9371_obs_rx_chip_info },
+	{ .compatible = "adi,axi-adrv9009-obs-1.0", .data = &adrv9009_obs_rx_chip_info },
 	{ /* end of list */ },
 };
 MODULE_DEVICE_TABLE(of, adc_of_match);


### PR DESCRIPTION
This adds support for both ORX channels. This patch has a HDL counterpart.
We should merge them to master in sync. 
Should not be merged into 2018_R1.