### PR TITLE
AD9144 Updates

### DIFF
--- a/drivers/iio/frequency/ad9144.c
+++ b/drivers/iio/frequency/ad9144.c
@@ -119,11 +119,6 @@ static void ad9144_set_nco_freq(struct ad9144_state *st, uint32_t sample_rate,
 		regmap_write(st->map, 0x113, 1);
 }
 
-// static int ad9144_get_fifo_status(struct cf_axi_converter *conv)
-// {
-//      return 0;
-// }
-
 static void ad9144_setup_samplerate(struct ad9144_state *st)
 {
 	struct regmap *map = st->map;

--- a/drivers/iio/frequency/ad9144.c
+++ b/drivers/iio/frequency/ad9144.c
@@ -40,7 +40,6 @@ struct ad9144_platform_data {
 	u8 xbar_lane1_sel;
 	u8 xbar_lane2_sel;
 	u8 xbar_lane3_sel;
-	bool lanes2_3_swap_data;
 	u8 interpolation;
 	unsigned int fcenter_shift;
 };
@@ -333,12 +332,6 @@ static int ad9144_setup(struct ad9144_state *st,
 
 	regmap_write(map, 0x300, 0x01);	// enable link
 
-	/* TODO: remove me
-	 * Fix for an early DAQ3 design bug (swapped SERDIN+ / SERDIN- pins) */
-	if (st->id == CHIPID_AD9152)
-		regmap_write(map, 0x334,
-				pdata->lanes2_3_swap_data ? 0x0c : 0x00);
-
 	return 0;
 }
 
@@ -511,9 +504,6 @@ static struct ad9144_platform_data *ad9144_parse_dt(struct device *dev)
 	tmp = 3;
 	of_property_read_u32(np, "adi,jesd-xbar-lane3-sel", &tmp);
 	pdata->xbar_lane3_sel = tmp;
-
-	pdata->lanes2_3_swap_data = of_property_read_bool(np,
-			"adi,lanes2-3-swap-data");
 
 	tmp = 1;
 	of_property_read_u32(np, "adi,interpolation", &tmp);

--- a/drivers/iio/frequency/ad9144.c
+++ b/drivers/iio/frequency/ad9144.c
@@ -548,6 +548,7 @@ static int ad9144_probe(struct spi_device *spi)
 	struct ad9144_platform_data *pdata;
 	struct ad9144_state *st;
 	unsigned long lane_rate_kHz;
+	unsigned int i;
 	unsigned id;
 	int ret;
 
@@ -586,9 +587,12 @@ static int ad9144_probe(struct spi_device *spi)
 	if (IS_ERR(conv->reset_gpio))
 		return PTR_ERR(conv->reset_gpio);
 
-	conv->txen_gpio = devm_gpiod_get_optional(&spi->dev, "txen", GPIOD_OUT_HIGH);
-	if (IS_ERR(conv->txen_gpio))
-		return PTR_ERR(conv->txen_gpio);
+	for (i = 0; i < 2; i++) {
+		conv->txen_gpio[i] = devm_gpiod_get_index_optional(&spi->dev,
+			"txen", i, GPIOD_OUT_HIGH);
+		if (IS_ERR(conv->txen_gpio[i]))
+			return PTR_ERR(conv->txen_gpio[i]);
+	}
 
 	st->map = devm_regmap_init_spi(spi, &ad9144_regmap_config);
 	if (IS_ERR(st->map))

--- a/drivers/iio/frequency/ad9144.c
+++ b/drivers/iio/frequency/ad9144.c
@@ -197,6 +197,18 @@ static void ad9144_setup_samplerate(struct ad9144_state *st)
 	regmap_write(map, 0x0e7, 0x30);	// turn off cal clock
 }
 
+/*
+ * Required device configuration as per table 16 from the AD9144
+ * datasheet Rev B.
+ */
+static const struct reg_sequence ad9144_required_device_config[] = {
+	{ 0x12d, 0x8b },
+	{ 0x146, 0x01 },
+	{ 0x2a4, 0xff },
+	{ 0x232, 0xff },
+	{ 0x333, 0x01 },
+};
+
 static int ad9144_setup(struct ad9144_state *st,
 		struct ad9144_platform_data *pdata)
 {
@@ -215,17 +227,8 @@ static int ad9144_setup(struct ad9144_state *st,
 	regmap_write(map, 0x314, 0x01);	// pclk == qbd master clock
 
 	if (st->id == CHIPID_AD9144) {
-		// required device configurations
-
-		regmap_write(map, 0x12d, 0x8b);	// data-path
-		regmap_write(map, 0x146, 0x01);	// data-path
-		regmap_write(map, 0x2a4, 0xff);	// clock
-		regmap_write(map, 0x1c4, 0x73);	// dac-pll
-		regmap_write(map, 0x291, 0x49);	// serde-pll
-		regmap_write(map, 0x29c, 0x24);	// serde-pll
-		regmap_write(map, 0x29f, 0x73);	// serde-pll
-		regmap_write(map, 0x232, 0xff);	// jesd
-		regmap_write(map, 0x333, 0x01);	// jesd
+		regmap_multi_reg_write(map, ad9144_required_device_config,
+			ARRAY_SIZE(ad9144_required_device_config));
 
 		/* Write optimal settings for the SERDES PLL, as per table 39 of the
 		 * datasheet. */

--- a/drivers/iio/frequency/ad9144.c
+++ b/drivers/iio/frequency/ad9144.c
@@ -406,9 +406,36 @@ static int ad9144_set_sample_rate(struct cf_axi_converter *conv,
 	struct regmap *map = st->map;
 	unsigned long lane_rate_kHz;
 	unsigned long sysref_rate;
+	unsigned int max_sample_rate;
 	int ret;
 
-	sample_rate = clamp(sample_rate, 200000000U, 1000000000U);
+	switch (st->id) {
+	case CHIPID_AD9144:
+		switch (st->interpolation) {
+		case 1:
+			max_sample_rate = 1060000000U;
+			break;
+		case 2:
+			max_sample_rate = 2120000000U;
+			break;
+		default:
+			max_sample_rate = 2800000000U;
+			break;
+		}
+		break;
+	default:
+		switch (st->interpolation) {
+		case 1:
+			max_sample_rate = 1238000000U;
+			break;
+		default:
+			max_sample_rate = 2250000000U;
+			break;
+		}
+		break;
+	}
+
+	sample_rate = clamp(sample_rate, 200000000U, max_sample_rate);
 	sample_rate = clk_round_rate(conv->clk[CLK_DAC], sample_rate);
 
 	sysref_rate = DIV_ROUND_CLOSEST(sample_rate, 32);

--- a/drivers/iio/frequency/ad9144.h
+++ b/drivers/iio/frequency/ad9144.h
@@ -94,6 +94,7 @@
 #define REG_CAL_ADDR                             0x0EA /* Calibration DAC Address */
 #define REG_CAL_DATA                             0x0EB /* Calibration DAC Data */
 #define REG_CAL_UPDATE                           0x0EC /* Calibration DAC Write Update */
+#define REG_CAL_INIT                             0x0ED /* Calibration DAC initial value */
 #define REG_DATA_FORMAT                          0x110 /* Data format */
 #define REG_DATAPATH_CTRL                        0x111 /* Datapath Control */
 #define REG_INTERP_MODE                          0x112 /* Interpolation Mode */
@@ -179,10 +180,7 @@
 #define REG_LMFC_DELAY_1                         0x305 /* Register 4 description */
 #define REG_LMFC_VAR_0                           0x306 /* Register 5 description */
 #define REG_LMFC_VAR_1                           0x307 /* Register 6 description */
-#define REG_XBAR_LN_0_1                          0x308 /* Register 7 description */
-#define REG_XBAR_LN_2_3                          0x309 /* Register 8 description */
-#define REG_XBAR_LN_4_5                          0x30A /* Register 9 description */
-#define REG_XBAR_LN_6_7                          0x30B /* Register 10 description */
+#define REG_XBAR(x)                              (0x308 + (x))
 #define REG_FIFO_STATUS_REG_0                    0x30C /* Register 11 description */
 #define REG_FIFO_STATUS_REG_1                    0x30D /* Register 12 description */
 #define REG_FIFO_STATUS_REG_2                    0x30E /* Register 13 description */
@@ -243,6 +241,7 @@
 #define REG_ILS_BID                              0x451 /* Reg 81 Description */
 #define REG_ILS_LID0                             0x452 /* Reg 82 Description */
 #define REG_ILS_SCR_L                            0x453 /* Reg 83 Description */
+#define REG_ILS_F                                0x454 /* Reg 84 Description */
 #define REG_ILS_K                                0x455 /* Reg 85 Description */
 #define REG_ILS_M                                0x456 /* Reg 86 Description */
 #define REG_ILS_CS_N                             0x457 /* Reg 87 Description */

--- a/drivers/iio/frequency/ad9162.c
+++ b/drivers/iio/frequency/ad9162.c
@@ -419,9 +419,9 @@ static int ad9162_probe(struct spi_device *spi)
 	if (IS_ERR(conv->reset_gpio))
 		return PTR_ERR(conv->reset_gpio);
 
-	conv->txen_gpio = devm_gpiod_get_optional(&spi->dev, "txen", GPIOD_OUT_HIGH);
-	if (IS_ERR(conv->txen_gpio))
-		return PTR_ERR(conv->txen_gpio);
+	conv->txen_gpio[0] = devm_gpiod_get_optional(&spi->dev, "txen", GPIOD_OUT_HIGH);
+	if (IS_ERR(conv->txen_gpio[0]))
+		return PTR_ERR(conv->txen_gpio[0]);
 
 	st->map = devm_regmap_init_spi(spi, &ad9162_regmap_config);
 	if (IS_ERR(st->map))

--- a/drivers/iio/frequency/cf_axi_dds.h
+++ b/drivers/iio/frequency/cf_axi_dds.h
@@ -184,6 +184,8 @@ enum dds_data_select {
 enum {
 	ID_AD9122,
 	ID_AD9739A,
+	ID_AD9135,
+	ID_AD9136,
 	ID_AD9144,
 	ID_AD9152,
 	ID_AD9162,

--- a/drivers/iio/frequency/cf_axi_dds.h
+++ b/drivers/iio/frequency/cf_axi_dds.h
@@ -240,7 +240,7 @@ struct cf_axi_converter {
 	void		*phy;
 	struct gpio_desc			*pwrdown_gpio;
 	struct gpio_desc			*reset_gpio;
-	struct gpio_desc			*txen_gpio;
+	struct gpio_desc			*txen_gpio[2];
 	unsigned		id;
 	unsigned		interp_factor;
 	unsigned		fcenter_shift;


### PR DESCRIPTION
This series updates the AD9144 driver to match the latest datasheet recommendation, adds support for configuring all JESD204 modes of the device and also adds support for the AD9135/AD9136.