### PR TITLE
arm64: dts: Fix and update ADI device trees for 4.14

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9361-fmcomms2-3.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9361-fmcomms2-3.dts
@@ -9,7 +9,7 @@
 #include "zynqmp-zcu102-rev1.0.dts"
 
 &i2c1 {
-	i2cswitch@75 {
+	i2c-mux@75 {
 		i2c@0 {
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9361-fmcomms5.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9361-fmcomms5.dts
@@ -9,7 +9,7 @@
 #include "zynqmp-zcu102-rev1.0.dts"
 
 &i2c1 {
-	i2cswitch@75 {
+	i2c-mux@75 {
 		fmc_i2c: i2c@0 {
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9364-fmcomms4.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9364-fmcomms4.dts
@@ -9,7 +9,7 @@
 #include "zynqmp-zcu102-rev1.0.dts"
 
 &i2c1 {
-	i2cswitch@75 {
+	i2c-mux@75 {
 		i2c@0 {
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9371.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9371.dts
@@ -1,7 +1,7 @@
 #include "zynqmp-zcu102-rev1.0.dts"
 
 &i2c1 {
-	i2cswitch@75 {
+	i2c-mux@75 {
 		i2c@0 {
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-fmcdaq2.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-fmcdaq2.dts
@@ -9,7 +9,7 @@
 #include "zynqmp-zcu102-rev1.0.dts"
 
 &i2c1 {
-	i2cswitch@75 {
+	i2c-mux@75 {
 		i2c@0 {
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-revB-ad9361-fmcomms2-3.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-revB-ad9361-fmcomms2-3.dts
@@ -9,7 +9,7 @@
 #include "zynqmp-zcu102-revB.dts"
 
 &i2c1 {
-	i2cswitch@75 {
+	i2c-mux@75 {
 		i2c@0 {
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-revB-ad9364-fmcomms4.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-revB-ad9364-fmcomms4.dts
@@ -9,7 +9,7 @@
 #include "zynqmp-zcu102-revB.dts"
 
 &i2c1 {
-	i2cswitch@75 {
+	i2c-mux@75{
 		i2c@0 {
 			#address-cells = <1>;
 			#size-cells = <0>;


### PR DESCRIPTION
This fixes following errors/warnings:
arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9361-fmcomms2-3.dtb: Warning (reg_format): "reg" property in /amba/i2c@ff030000/i2cswitch@75/i2c@0 has invalid length (4 bytes) (#address-cells == 2, #size-cells == 1)
arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9361-fmcomms2-3.dtb: Warning (avoid_default_addr_size): Relying on default #address-cells value for /amba/i2c@ff030000/i2cswitch@75/i2c@0
arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9361-fmcomms2-3.dtb: Warning (avoid_default_addr_size): Relying on default #size-cells value for /amba/i2c@ff030000/i2cswitch@75/i2c@0

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>