### PR TITLE
iio: Fix kfifo checks in iio_kfifo_remove_from

### DIFF
--- a/drivers/iio/buffer/kfifo_buf.c
+++ b/drivers/iio/buffer/kfifo_buf.c
@@ -144,11 +144,11 @@ static int iio_kfifo_remove_from(struct iio_buffer *r, void *data)
 	int ret;
 	struct iio_kfifo *kf = iio_to_kfifo(r);
 
-	if (kfifo_size(&kf->kf) < r->bytes_per_datum)
+	if (kfifo_len(&kf->kf) < 1)
 		return -EBUSY;
 
-	ret = kfifo_out(&kf->kf, data, r->bytes_per_datum);
-	if (ret != r->bytes_per_datum)
+	ret = kfifo_out(&kf->kf, data, 1);
+	if (ret != 1)
 		return -EBUSY;
 
 	wake_up_interruptible_poll(&r->pollq, POLLOUT | POLLWRNORM);


### PR DESCRIPTION
This patch resolves a bug introduced in c559afbfb08c7eac215ba417251225d3a8e01062 where the element size and length was used to set up the FIFO, instead of just the required number of bytes.

The patch has been tested on a TI OMAP4460, using a custom IIO device whose buffer contains samples made up of two 16-bit signed integers. This patch also resolves issue #143.

Signed-off-by: Michael Allwright <allsey87@gmail.com>