### PR TITLE
iio: axi_jesd204_rx: Use early buffer release in subclass 0 mode

### DIFF
--- a/drivers/iio/jesd204/axi_jesd204_rx.c
+++ b/drivers/iio/jesd204/axi_jesd204_rx.c
@@ -62,6 +62,9 @@
 /* JESD204_RX_REG_SYSREF_CONF */
 #define JESD204_RX_REG_SYSREF_CONF_SYSREF_DISABLE	BIT(0)
 
+/* JESD204_RX_REG_LINK_CONF2 */
+#define JESD204_RX_LINK_CONF2_BUFFER_EARLY_RELEASE	BIT(16)
+
 struct jesd204_rx_config {
 	uint8_t device_id;
 	uint8_t bank_id;
@@ -318,9 +321,12 @@ static int axi_jesd204_rx_apply_config(struct axi_jesd204_rx *jesd,
 
 	writel_relaxed(val, jesd->base + JESD204_RX_REG_LINK_CONF0);
 
-	if (config->subclass_version == 0)
+	if (config->subclass_version == 0) {
 		writel_relaxed(JESD204_RX_REG_SYSREF_CONF_SYSREF_DISABLE,
 			       jesd->base + JESD204_RX_REG_SYSREF_CONF);
+		writel_relaxed(JESD204_RX_LINK_CONF2_BUFFER_EARLY_RELEASE,
+			       jesd->base + JESD204_RX_REG_LINK_CONF2);
+	}
 
 	return 0;
 }


### PR DESCRIPTION
Usually the buffer release point of the JESD204 receiver core is aligned to
the local-multi-frame-clock (LMFC). This ensure a deterministic latency of
the data over the link.

This only works though if the LMFC of the FPGA and converter are aligned.
In subclass 0 mode no SYSREF is supplied and the LMFCs are not aligned.

This this case there is no benefit of delay the buffer release to the next
LMFC edge. So enable early buffer release to release the data as soon as it
is available on all lanes.

In fact this gives a smaller uncertainty than aligning the release to the
LMFC. With early release the uncertainty is the uncertainty of the link,
whereas without early release the uncertainty is +-LMFC period / 2. The
later usually being larger than the former.

Signed-off-by: Lars-Peter Clausen <lars@metafoo.de>