### PR TITLE
Master ad7768 samp freq support

### DIFF
--- a/Documentation/devicetree/bindings/iio/adc/adi,ad7768.txt
+++ b/Documentation/devicetree/bindings/iio/adc/adi,ad7768.txt
@@ -7,6 +7,8 @@ Required properties:
 	- dmas: DMA specifier, consisting of a phandle to DMA controller node.
 	- dma-names: Must be "rx".
 	- vref-supply: phandle to the regulator for ADC reference voltage.
+	- clocks: phandle to the master clock (mclk).
+	- clock-names: Must be "mclk".
 
 Example:
 
@@ -19,4 +21,6 @@ ad7768: adc@0 {
 	dma-names = "rx";
 
 	vref-supply = <&vref>;
+	clocks = <&adc_clk>;
+	clock-names = "mclk";
 };

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad7768.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad7768.dts
@@ -12,6 +12,14 @@
 		regulator-max-microvolt = <4096000>;
 		regulator-always-on;
 	};
+
+	clocks {
+		ad7768_mclk: clock@0 {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <32768000>;
+		};
+	};
 };
 
 &fpga_axi {
@@ -49,5 +57,7 @@
 		dma-names = "rx";
 
 		vref-supply = <&vref>;
+		clocks = <&ad7768_mclk>;
+		clock-names = "mclk";
 	};
 };

--- a/drivers/iio/adc/ad7768.c
+++ b/drivers/iio/adc/ad7768.c
@@ -5,6 +5,7 @@
  * Copyright 2018 Analog Devices Inc.
  */
 
+#include <linux/clk.h>
 #include <linux/module.h>
 #include <linux/spi/spi.h>
 #include <linux/dma-mapping.h>
@@ -17,12 +18,36 @@
 #include <linux/iio/buffer-dma.h>
 #include <linux/iio/buffer-dmaengine.h>
 
+/* AD7768 registers definition */
+#define AD7768_CH_MODE				0x01
+#define AD7768_POWER_MODE			0x04
+#define AD7768_INTERFACE_CFG			0x07
+
+/* AD7768_CH_MODE */
+#define AD7768_CH_MODE_FILTER_TYPE_MSK		BIT(3)
+#define AD7768_CH_MODE_FILTER_TYPE_MODE(x)	(((x) & 0x1) << 3)
+#define AD7768_CH_MODE_DEC_RATE_MSK		GENMASK(2, 0)
+#define AD7768_CH_MODE_DEC_RATE_MODE(x)		(((x) & 0x7) << 0)
+
+/* AD7768_POWER_MODE */
+#define AD7768_POWER_MODE_POWER_MODE_MSK	GENMASK(5, 4)
+#define AD7768_POWER_MODE_POWER_MODE(x)		(((x) & 0x3) << 4)
+#define AD7768_POWER_MODE_MCLK_DIV_MSK		GENMASK(1, 0)
+#define AD7768_POWER_MODE_MCLK_DIV_MODE(x)	(((x) & 0x3) << 0)
+
+/* AD7768_INTERFACE_CFG */
+#define AD7768_INTERFACE_CFG_DCLK_DIV_MSK	GENMASK(1, 0)
+#define AD7768_INTERFACE_CFG_DCLK_DIV_MODE(x)	(((x) & 0x3) << 0)
+
+#define AD7768_MAX_SAMP_FREQ	256000
 #define AD7768_WR_FLAG_MSK(x)	(0x80 | ((x) & 0x7F))
 
 struct ad7768_state {
 	struct spi_device *spi;
 	struct mutex lock;
 	struct regulator *vref;
+	struct clk *mclk;
+	unsigned int sampling_freq;
 	__be16 d16;
 };
 
@@ -30,10 +55,44 @@ enum ad7768_device_ids {
 	ID_AD7768
 };
 
+enum ad7768_mclk_div {
+	AD7768_MCLK_DIV_32,
+	AD7768_MCLK_DIV_8 = 2,
+	AD7768_MCLK_DIV_4
+};
+
+enum ad7768_dclk_div {
+	AD7768_DCLK_DIV_8,
+	AD7768_DCLK_DIV_4,
+	AD7768_DCLK_DIV_2,
+	AD7768_DCLK_DIV_1
+};
+
+struct ad7768_div_settings {
+	unsigned int mclk_div;
+	unsigned int dclk_div;
+	unsigned int clk_div;
+};
+
+static const struct ad7768_div_settings ad7768_div_set[] = {
+	{ AD7768_MCLK_DIV_4, AD7768_DCLK_DIV_1, 4 },
+	{ AD7768_MCLK_DIV_4, AD7768_DCLK_DIV_2, 8 },
+	{ AD7768_MCLK_DIV_8, AD7768_DCLK_DIV_2, 16 },
+	{ AD7768_MCLK_DIV_8, AD7768_DCLK_DIV_4, 32 },
+	{ AD7768_MCLK_DIV_8, AD7768_DCLK_DIV_8, 64 },
+	{ AD7768_MCLK_DIV_32, AD7768_DCLK_DIV_4, 128 },
+	{ AD7768_MCLK_DIV_32, AD7768_DCLK_DIV_8, 256 }
+};
+
+static const int ad7768_dec_rate[6] = {
+	32, 64, 128, 256, 512, 1024
+};
+
 #define AD7768_CHAN(index)						\
 	{								\
 		.type = IIO_VOLTAGE,					\
 		.info_mask_shared_by_type = BIT(IIO_CHAN_INFO_SCALE),	\
+		.info_mask_shared_by_all = BIT(IIO_CHAN_INFO_SAMP_FREQ),\
 		.address = index,					\
 		.indexed = 1,						\
 		.channel = index,					\
@@ -91,6 +150,23 @@ static int ad7768_spi_reg_write(struct ad7768_state *st,
 	return spi_write(st->spi, &st->d16, sizeof(st->d16));
 }
 
+static int ad7768_spi_write_mask(struct ad7768_state *st,
+				 unsigned int addr,
+				 unsigned long int mask,
+				 unsigned int val)
+{
+	int regval;
+
+	regval = ad7768_spi_reg_read(st, addr);
+	if (regval < 0)
+		return regval;
+
+	regval &= ~mask;
+	regval |= val;
+
+	return ad7768_spi_reg_write(st, addr, regval);
+}
+
 static int ad7768_reg_access(struct iio_dev *indio_dev,
 			     unsigned int reg,
 			     unsigned int writeval,
@@ -116,6 +192,91 @@ exit:
 	return ret;
 }
 
+static int ad7768_set_samp_freq(struct ad7768_state *st,
+				enum ad7768_mclk_div mclk_div,
+				enum ad7768_dclk_div dclk_div,
+				unsigned int dec_rate_index)
+{
+	unsigned int power_mode;
+	unsigned long int power_mask;
+	int ret;
+
+	mutex_lock(&st->lock);
+	power_mode = AD7768_POWER_MODE_POWER_MODE(mclk_div) |
+		     AD7768_POWER_MODE_MCLK_DIV_MODE(mclk_div);
+	power_mask = AD7768_POWER_MODE_POWER_MODE_MSK |
+		     AD7768_POWER_MODE_MCLK_DIV_MSK;
+
+	ret = ad7768_spi_write_mask(st, AD7768_POWER_MODE,
+				    power_mask, power_mode);
+	if (ret < 0)
+		goto err_unlock;
+
+	ret = ad7768_spi_write_mask(st, AD7768_INTERFACE_CFG,
+			AD7768_INTERFACE_CFG_DCLK_DIV_MSK,
+			AD7768_INTERFACE_CFG_DCLK_DIV_MODE(dclk_div));
+	if (ret < 0)
+		goto err_unlock;
+
+	ret = ad7768_spi_write_mask(st, AD7768_CH_MODE,
+			AD7768_CH_MODE_DEC_RATE_MSK,
+			AD7768_CH_MODE_DEC_RATE_MODE(dec_rate_index));
+err_unlock:
+	mutex_unlock(&st->lock);
+
+	return ret;
+}
+
+static int ad7768_samp_freq_config(struct ad7768_state *st,
+				   unsigned int freq)
+{
+	unsigned int res, dclk, calc_freq, diff_new;
+	unsigned int div_set_idx, dec_rate_idx, mclk_freq;
+	int diff_old, i, j, ret;
+
+	diff_old = S32_MAX;
+	div_set_idx = 0;
+	dec_rate_idx = 0;
+	calc_freq = AD7768_MAX_SAMP_FREQ;
+	mclk_freq = clk_get_rate(st->mclk);
+
+	/*
+	 * Sampling freq is defined by MCLK, MCLK_DIV, DCLK_DIV and DEC_RATE:
+	 * samp_freq = MCLK / (MCLK_DIV * DCLK_DIV * DEC_RATE)
+	 */
+	for (i = 0; i < ARRAY_SIZE(ad7768_div_set); i++) {
+		if (calc_freq <= freq)
+			break;
+		/* DCLK = MCLK / (MCLK_DIV * DCLK_DIV) */
+		dclk = DIV_ROUND_CLOSEST(mclk_freq, ad7768_div_set[i].clk_div);
+		/*
+		 * Go through each decimation rate and determine a valid value
+		 * for the sampling frequency which is closest to the desired
+		 * sampling frequency
+		 */
+		for (j = 0; j < ARRAY_SIZE(ad7768_dec_rate); j++) {
+			res = DIV_ROUND_CLOSEST(dclk, ad7768_dec_rate[j]);
+			diff_new = abs(freq - res);
+			if (diff_new < diff_old) {
+				diff_old = diff_new;
+				div_set_idx = j;
+				dec_rate_idx = i;
+				calc_freq = res;
+			}
+		}
+	}
+
+	ret = ad7768_set_samp_freq(st, ad7768_div_set[div_set_idx].mclk_div,
+				   ad7768_div_set[div_set_idx].dclk_div,
+				   dec_rate_idx);
+	if (ret < 0)
+		return ret;
+
+	st->sampling_freq = calc_freq;
+
+	return ret;
+}
+
 static int ad7768_read_raw(struct iio_dev *indio_dev,
 			   const struct iio_chan_spec *chan,
 			   int *val, int *val2, long info)
@@ -132,13 +293,31 @@ static int ad7768_read_raw(struct iio_dev *indio_dev,
 		*val = 2 * (ret / 1000);
 		*val2 = chan->scan_type.realbits;
 		return IIO_VAL_FRACTIONAL_LOG2;
+	case IIO_CHAN_INFO_SAMP_FREQ:
+		*val = st->sampling_freq;
+		return IIO_VAL_INT;
+	default:
+		return -EINVAL;
 	}
+}
 
-	return -EINVAL;
+static int ad7768_write_raw(struct iio_dev *indio_dev,
+			    struct iio_chan_spec const *chan,
+			    int val, int val2, long mask)
+{
+	struct ad7768_state *st = iio_priv(indio_dev);
+
+	switch (mask) {
+	case IIO_CHAN_INFO_SAMP_FREQ:
+		return ad7768_samp_freq_config(st, val);
+	default:
+		return -EINVAL;
+	}
 }
 
 static const struct iio_info ad7768_info = {
 	.read_raw = &ad7768_read_raw,
+	.write_raw = &ad7768_write_raw,
 	.debugfs_reg_access = &ad7768_reg_access,
 };
 
@@ -172,6 +351,10 @@ static int ad7768_probe(struct spi_device *spi)
 	if (IS_ERR(st->vref))
 		return PTR_ERR(st->vref);
 
+	st->mclk = devm_clk_get(&spi->dev, "mclk");
+	if (IS_ERR(st->mclk))
+		return PTR_ERR(st->mclk);
+
 	spi_set_drvdata(spi, indio_dev);
 
 	st->spi = spi;
@@ -196,12 +379,22 @@ static int ad7768_probe(struct spi_device *spi)
 	if (ret)
 		return ret;
 
-	ret = devm_iio_device_register(&spi->dev, indio_dev);
+	ret = clk_prepare_enable(st->mclk);
 	if (ret < 0)
 		goto error_disable_reg;
 
+	ret = ad7768_samp_freq_config(st, AD7768_MAX_SAMP_FREQ);
+	if (ret < 0)
+		goto error_disable_clk;
+
+	ret = devm_iio_device_register(&spi->dev, indio_dev);
+	if (ret < 0)
+		goto error_disable_clk;
+
 	return 0;
 
+error_disable_clk:
+	clk_disable_unprepare(st->mclk);
 error_disable_reg:
 	regulator_disable(st->vref);
 
@@ -213,7 +406,10 @@ static int ad7768_remove(struct spi_device *spi)
 	struct iio_dev *indio_dev = spi_get_drvdata(spi);
 	struct ad7768_state *st = iio_priv(indio_dev);
 
-	return regulator_disable(st->vref);
+	clk_disable_unprepare(st->mclk);
+	regulator_disable(st->vref);
+
+	return 0;
 }
 
 static const struct spi_device_id ad7768_id[] = {


### PR DESCRIPTION
This patch set adds the option for the user to set the sampling frequency. In
order to accomplish this, the master clock signal (MCLK) must be provided
in the device-tree.

MLCK signal is used to define the digital output clock (DCLK). Divider
settings for MCLK and DCLK in conjunction with the digital filter
decimation rate further determine the sampling frequency.

The user can input the desired sampling frequency and by controling MCLK
and DCLK division, the closest valid rate will be set. The power mode
(fast, median or eco) is also modified with every MCLK_DIV change.