### PR TITLE
treewide: sync white-space with upstream

### DIFF
--- a/drivers/bus/Kconfig
+++ b/drivers/bus/Kconfig
@@ -167,5 +167,4 @@ config VEXPRESS_CONFIG
 	help
 	  Platform configuration infrastructure for the ARM Ltd.
 	  Versatile Express.
-
 endmenu

--- a/drivers/usb/chipidea/host.c
+++ b/drivers/usb/chipidea/host.c
@@ -78,7 +78,6 @@ static int ehci_ci_portpower(struct usb_hcd *hcd, int portnum, bool enable)
 		hw_port_test_set(ci, 5);
 		hw_port_test_set(ci, 0);
 	}
-
 	return 0;
 };
 


### PR DESCRIPTION
These newlines (white-spaces) have been added during merges.
Upstream doesn't have these, so remove them to make things easier to diff.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>