### PR TITLE
Misc ad9361 driver and dt fixes

### DIFF
--- a/arch/arm/boot/dts/adi-fmcomms2.dtsi
+++ b/arch/arm/boot/dts/adi-fmcomms2.dtsi
@@ -84,6 +84,7 @@
 		adi,tx-rf-port-input-select = <0>; /* TX1A, TX2A */
 		//adi,update-tx-gain-in-alert-enable;
 		adi,tx-attenuation-mdB = <10000>;
+		adi,tx-lo-powerdown-managed-enable;
 
 		adi,rf-rx-bandwidth-hz = <18000000>;
 		adi,rf-tx-bandwidth-hz = <18000000>;

--- a/arch/arm/boot/dts/adi-fmcomms4.dtsi
+++ b/arch/arm/boot/dts/adi-fmcomms4.dtsi
@@ -81,6 +81,7 @@
 		adi,tx-rf-port-input-select = <0>; /* TX1A */
 		//adi,update-tx-gain-in-alert-enable;
 		adi,tx-attenuation-mdB = <10000>;
+		adi,tx-lo-powerdown-managed-enable;
 
 		adi,rf-rx-bandwidth-hz = <18000000>;
 		adi,rf-tx-bandwidth-hz = <18000000>;

--- a/arch/arm/boot/dts/adi-fmcomms5.dtsi
+++ b/arch/arm/boot/dts/adi-fmcomms5.dtsi
@@ -84,6 +84,7 @@
 		adi,tx-rf-port-input-select = <0>; /* TX1A, TX2A */
 		//adi,update-tx-gain-in-alert-enable;
 		adi,tx-attenuation-mdB = <10000>;
+		adi,tx-lo-powerdown-managed-enable;
 
 		adi,rf-rx-bandwidth-hz = <18000000>;
 		adi,rf-tx-bandwidth-hz = <18000000>;
@@ -306,6 +307,7 @@
 		adi,tx-rf-port-input-select = <0>; /* TX1A, TX2A */
 		//adi,update-tx-gain-in-alert-enable;
 		adi,tx-attenuation-mdB = <10000>;
+		adi,tx-lo-powerdown-managed-enable;
 
 		adi,rf-rx-bandwidth-hz = <18000000>;
 		adi,rf-tx-bandwidth-hz = <18000000>;

--- a/arch/arm/boot/dts/zynq-adrv9361-z7035.dtsi
+++ b/arch/arm/boot/dts/zynq-adrv9361-z7035.dtsi
@@ -278,6 +278,7 @@
 		adi,tx-rf-port-input-select = <0>; /* TX1A, TX2A */
 		//adi,update-tx-gain-in-alert-enable;
 		adi,tx-attenuation-mdB = <10000>;
+		adi,tx-lo-powerdown-managed-enable;
 
 		adi,rf-rx-bandwidth-hz = <18000000>;
 		adi,rf-tx-bandwidth-hz = <18000000>;

--- a/arch/arm/boot/dts/zynq-adrv9364-z7020.dtsi
+++ b/arch/arm/boot/dts/zynq-adrv9364-z7020.dtsi
@@ -268,6 +268,7 @@
 		adi,tx-rf-port-input-select = <0>; /* TX1A, TX2A */
 		//adi,update-tx-gain-in-alert-enable;
 		adi,tx-attenuation-mdB = <10000>;
+		adi,tx-lo-powerdown-managed-enable;
 
 		adi,rf-rx-bandwidth-hz = <18000000>;
 		adi,rf-tx-bandwidth-hz = <18000000>;

--- a/arch/arm/boot/dts/zynq-e310.dts
+++ b/arch/arm/boot/dts/zynq-e310.dts
@@ -297,6 +297,7 @@
 		adi,tx-rf-port-input-select = <0>; /* TX1A, TX2A */
 		//adi,update-tx-gain-in-alert-enable;
 		adi,tx-attenuation-mdB = <10000>;
+		adi,tx-lo-powerdown-managed-enable;
 
 		adi,rf-rx-bandwidth-hz = <18000000>;
 		adi,rf-tx-bandwidth-hz = <18000000>;

--- a/arch/arm/boot/dts/zynq-pluto-sdr.dtsi
+++ b/arch/arm/boot/dts/zynq-pluto-sdr.dtsi
@@ -267,6 +267,7 @@
 
 		//adi,update-tx-gain-in-alert-enable;
 		adi,tx-attenuation-mdB = <10000>;
+		adi,tx-lo-powerdown-managed-enable;
 
 		adi,rf-rx-bandwidth-hz = <18000000>;
 		adi,rf-tx-bandwidth-hz = <18000000>;

--- a/arch/arm64/boot/dts/xilinx/adi-fmcomms2.dtsi
+++ b/arch/arm64/boot/dts/xilinx/adi-fmcomms2.dtsi
@@ -84,6 +84,7 @@
 		adi,tx-rf-port-input-select = <0>; /* TX1A, TX2A */
 		//adi,update-tx-gain-in-alert-enable;
 		adi,tx-attenuation-mdB = <10000>;
+		adi,tx-lo-powerdown-managed-enable;
 
 		adi,rf-rx-bandwidth-hz = <18000000>;
 		adi,rf-tx-bandwidth-hz = <18000000>;

--- a/arch/arm64/boot/dts/xilinx/adi-fmcomms4.dtsi
+++ b/arch/arm64/boot/dts/xilinx/adi-fmcomms4.dtsi
@@ -81,6 +81,7 @@
 		adi,tx-rf-port-input-select = <0>; /* TX1A */
 		//adi,update-tx-gain-in-alert-enable;
 		adi,tx-attenuation-mdB = <10000>;
+		adi,tx-lo-powerdown-managed-enable;
 
 		adi,rf-rx-bandwidth-hz = <18000000>;
 		adi,rf-tx-bandwidth-hz = <18000000>;

--- a/arch/arm64/boot/dts/xilinx/adi-fmcomms5.dtsi
+++ b/arch/arm64/boot/dts/xilinx/adi-fmcomms5.dtsi
@@ -84,6 +84,7 @@
 		adi,tx-rf-port-input-select = <0>; /* TX1A, TX2A */
 		//adi,update-tx-gain-in-alert-enable;
 		adi,tx-attenuation-mdB = <10000>;
+		adi,tx-lo-powerdown-managed-enable;
 
 		adi,rf-rx-bandwidth-hz = <18000000>;
 		adi,rf-tx-bandwidth-hz = <18000000>;
@@ -306,6 +307,7 @@
 		adi,tx-rf-port-input-select = <0>; /* TX1A, TX2A */
 		//adi,update-tx-gain-in-alert-enable;
 		adi,tx-attenuation-mdB = <10000>;
+		adi,tx-lo-powerdown-managed-enable;
 
 		adi,rf-rx-bandwidth-hz = <18000000>;
 		adi,rf-tx-bandwidth-hz = <18000000>;

--- a/arch/microblaze/boot/dts/adi-fmcomms2.dtsi
+++ b/arch/microblaze/boot/dts/adi-fmcomms2.dtsi
@@ -78,6 +78,7 @@
 		adi,tx-rf-port-input-select = <0>; /* TX1A, TX2A */
 		//adi,update-tx-gain-in-alert-enable;
 		adi,tx-attenuation-mdB = <10000>;
+		adi,tx-lo-powerdown-managed-enable;
 
 		adi,rf-rx-bandwidth-hz = <18000000>;
 		adi,rf-tx-bandwidth-hz = <18000000>;

--- a/arch/microblaze/boot/dts/adi-fmcomms4.dtsi
+++ b/arch/microblaze/boot/dts/adi-fmcomms4.dtsi
@@ -77,6 +77,7 @@
 		adi,tx-rf-port-input-select = <0>; /* TX1A */
 		//adi,update-tx-gain-in-alert-enable;
 		adi,tx-attenuation-mdB = <10000>;
+		adi,tx-lo-powerdown-managed-enable;
 
 		adi,rf-rx-bandwidth-hz = <18000000>;
 		adi,rf-tx-bandwidth-hz = <18000000>;

--- a/drivers/iio/adc/ad9361.c
+++ b/drivers/iio/adc/ad9361.c
@@ -7862,7 +7862,7 @@ static int ad9361_phy_read_avail(struct iio_dev *indio_dev,
 	switch (mask) {
 	case IIO_CHAN_INFO_HARDWAREGAIN:
 		if (chan->output) {
-			static const int tx_hw_gain[3] = {0, 250, 89750};
+			static const int tx_hw_gain[3] = {-89750, 250, 0};
 			*vals = tx_hw_gain;
 			*type = IIO_VAL_INT;
 			return IIO_AVAIL_RANGE;

--- a/drivers/iio/adc/ad9361.h
+++ b/drivers/iio/adc/ad9361.h
@@ -138,7 +138,7 @@ struct ad9361_rf_phy {
 	struct refclk_scale	clk_priv[NUM_AD9361_CLKS];
 	struct clk_onecell_data	clk_data;
 	struct ad9361_phy_platform_data *pdata;
-	struct ad9361_debugfs_entry debugfs_entry[180];
+	struct ad9361_debugfs_entry debugfs_entry[181];
 	struct bin_attribute 	bin;
 	struct bin_attribute 	bin_gt;
 	struct iio_dev 		*indio_dev;

--- a/drivers/iio/adc/ad9361_private.h
+++ b/drivers/iio/adc/ad9361_private.h
@@ -327,6 +327,7 @@ struct ad9361_phy_platform_data {
 	bool			rx1rx2_phase_inversion_en;
 	bool			qec_tracking_slow_mode_en;
 	bool			dig_interface_tune_fir_disable;
+	bool			lo_powerdown_managed_en;
 	u8			dc_offset_update_events;
 	u8			dc_offset_attenuation_high;
 	u8			dc_offset_attenuation_low;


### PR DESCRIPTION
This small series fixes the out_volatge_hardwaregain_available readings. And introduces a new TX LO power-down managed mode, which is then made the default for all ad936x based boards and modules.