### PR TITLE
devicetree: bindings: hmc7044: Spelling fix & spi: Add NO_MOSI/MISO support

### DIFF
--- a/Documentation/devicetree/bindings/iio/frequency/hmc7044.txt
+++ b/Documentation/devicetree/bindings/iio/frequency/hmc7044.txt
@@ -34,23 +34,23 @@ Optional properties:
 		[Bits 2:0] - see register 0x005A. If this is not specified,
 		0 will be used by default.
 	- adi,clkin0-buffer-mode - CLKIN0 Input Buffer Control, for
-		specifing the Input Buffer Mode (Bits [4:1]) and the
+		specifying the Input Buffer Mode (Bits [4:1]) and the
 		Buffer enable bit ([0]) - see register 0x000A. If this is
 		not specified, 0 will be used by default.
 	- adi,clkin1-buffer-mode - CLKIN1 Input Buffer Control, for
-		specifing the Input Buffer Mode (Bits [4:1]) and the
+		specifying the Input Buffer Mode (Bits [4:1]) and the
 		Buffer enable bit ([0]) - see register 0x000B. If this is
 		not specified, 0 will be used by default.
 	- adi,clkin2-buffer-mode - CLKIN2 Input Buffer Control, for
-		specifing the Input Buffer Mode (Bits [4:1]) and the
+		specifying the Input Buffer Mode (Bits [4:1]) and the
 		Buffer enable bit ([0]) - see register 0x000C. If this is
 		not specified, 0 will be used by default.
 	- adi,clkin3-buffer-mode - CLKIN3 Input Buffer Control, for
-		specifing the Input Buffer Mode (Bits [4:1]) and the
+		specifying the Input Buffer Mode (Bits [4:1]) and the
 		Buffer enable bit ([0]) - see register 0x000D. If this is
 		not specified, 0 will be used by default.
 	- adi,oscin-buffer-mode - OSCIN Input Buffer Control, for
-		specifing the Input Buffer Mode (Bits [4:1]) and the
+		specifying the Input Buffer Mode (Bits [4:1]) and the
 		Buffer enable bit ([0]) - see register 0x000E. If this is
 		not specified, 0 will be used by default.
 

--- a/include/linux/spi/spi.h
+++ b/include/linux/spi/spi.h
@@ -160,6 +160,8 @@ struct spi_device {
 #define	SPI_TX_QUAD	0x200			/* transmit with 4 wires */
 #define	SPI_RX_DUAL	0x400			/* receive with 2 wires */
 #define	SPI_RX_QUAD	0x800			/* receive with 4 wires */
+#define	SPI_NO_MOSI	0x1000			/* no transmit wire */
+#define	SPI_NO_MISO	0x2000			/* no receive wire */
 	int			irq;
 	void			*controller_state;
 	void			*controller_data;


### PR DESCRIPTION
Transmit/receive only is a valid SPI mode. For example, the MOSI line
might be missing from an ADC while for a DAC the MISO line may be
optional. This patch adds these two new modes: SPI_NO_MOSI and
SPI_NO_MISO. This way, the drivers will be able to identify if any of
these two lines is missing and to adjust the transfers accordingly.