### PR TITLE
gpu: drm: bridge: adv7511: Fix de-referencing initialized pointer

### DIFF
--- a/drivers/gpu/drm/bridge/adv7511/adv7511_drv.c
+++ b/drivers/gpu/drm/bridge/adv7511/adv7511_drv.c
@@ -1020,6 +1020,7 @@ static int adv7511_probe(struct i2c_client *i2c, const struct i2c_device_id *id)
 
 	adv7511->powered = false;
 	adv7511->status = connector_status_disconnected;
+	adv7511->i2c_main = i2c;
 
 	if (dev->of_node)
 		adv7511->type = (enum adv7511_type)of_device_get_match_data(dev);
@@ -1083,7 +1084,6 @@ static int adv7511_probe(struct i2c_client *i2c, const struct i2c_device_id *id)
 
 	adv7511_packet_disable(adv7511, 0xffff);
 
-	adv7511->i2c_main = i2c;
 	adv7511->i2c_edid = i2c_new_secondary_device(i2c, "edid",
 						     edid_i2c_addr >> 1);
 	if (!adv7511->i2c_edid) {


### PR DESCRIPTION
adv7511->i2c_main must be initialized prior in calling
adv7511_init_regulators().

This fixes this kernel panic:

i2c i2c-0: Added multiplexed i2c bus 1
Unable to handle kernel NULL pointer dereference at virtual address 00000174
pgd = c0004000
[00000174] *pgd=00000000
Internal error: Oops: 5 [#1] PREEMPT SMP ARM
Modules linked in:
CPU: 1 PID: 1 Comm: swapper/0 Not tainted 4.14.0-11988-g7ede93a #2457
Hardware name: Xilinx Zynq Platform
task: ef03f840 task.stack: ef040000
PC is at _raw_spin_lock_irqsave+0x28/0x64
LR is at devres_add+0x18/0x38
pc : [<c06a99d8>]    lr : [<c03af8d8>]    psr: 40000193
sp : ef041be0  ip : 00000000  fp : 00000000
r10: 00000000  r9 : c073d078  r8 : 00000020
r7 : ef387790  r6 : 00000020  r5 : 00000020  r4 : 00000174
r3 : ef040000  r2 : 00000174  r1 : 00000001  r0 : 40000113
Flags: nZcv  IRQs off  FIQs on  Mode SVC_32  ISA ARM  Segment none
Control: 18c5387d  Table: 0000404a  DAC: 00000051
Process swapper/0 (pid: 1, stack limit = 0xef040210)
Stack: (0xef041be0 to 0xef042000)
1be0: c03af200 ef387780 ef387790 00000020 00000039 c03af998 ef2ae810 ee97b000
1c00: ee97b020 c03a4988 00000000 00000000 ee8836e0 ee882108 00000000 dfffa11c
1c20: 00000008 00000000 00000000 00000001 00000002 00000000 00000000 00000003
1c40: 00000000 00000000 00000000 ee97b020 c03a4744 c0b17e30 ee97b000 00000000
1c60: 00000000 00000000 00000000 c048817c ee97b020 c0b6af18 c0b6af1c 00000000
1c80: c0b17e30 c03ac6d0 00000000 ef041cc0 c03ac870 00000001 c0b6aef4 00000000
1ca0: c0b227dc c03aab94 ef09c86c ef115138 ee97b020 ee97b054 c0b22820 c03ac3b8
1cc0: ee97b020 00000001 ee97b028 ee97b028 ee97b020 c0b22820 00000000 c03ab9ac
1ce0: ee97b028 ee97b020 ef23a040 c03a9e54 00000000 c03b8a24 ee97b098 ee97b020
1d00: ee97b000 ef041d50 ef23a000 ee97b004 ee97b020 00000000 00000000 c048939c
1d20: 60000113 c0529fb8 ef7f34e4 ef7f34e4 ef7f3534 ef7f338c 00000039 ef23a000
1d40: ef23a868 c048af44 00000000 00000008 37766461 00313135 00000000 00000000
1d60: 00000000 00390000 00000000 ef041d48 ef7f34e4 00000000 00000000 00000000
1d80: 00000000 00000000 ef23a868 ef23a000 c0b6bc90 ef23a040 00000000 ef7f2edc
1da0: ef23a868 c04898c8 ffffffff eec63170 00000001 00000002 ef23a000 ef3eef10
1dc0: 00000001 c0489cdc 00000000 014000c0 00000000 ef7f4484 c08bf508 00000002
1de0: ef7f338c ef7f338c ef23a000 c048c488 00000000 ef7f2edc ee97ba00 00000001
1e00: 2d6c656e ef7f0030 a0000113 c0750d90 c0b6c61c 00000001 ef3eef50 00000000
1e20: c07515b8 ef3eef10 00000000 ee97ba00 ee97ba20 c04902bc 00000000 c048fe14
1e40: c048fdd8 00000000 ee97ba20 ee97ba00 00000000 ee97ba20 c048ffa8 c0b22ae0
1e60: ee97ba00 00000000 00000000 00000000 00000000 c048817c ee97ba20 c0b6af18
1e80: c0b6af1c 00000000 c0b22ae0 c03ac6d0 ee97ba20 c0b22ae0 ee97ba54 c0b22820
1ea0: c0b4b800 000000c6 c0a3183c c03ac838 00000000 c0b22ae0 c03ac78c c03aaae8
1ec0: ef09c858 ef24fcb4 c0b22ae0 ef387d00 00000000 c03abc44 c08bfb48 c0b22ae0
1ee0: c0a1cb90 c0b22ae0 c0a1cb90 00000000 c0b4b800 c03ad0c8 c0b22b2c c0b22ac0
1f00: c0a1cb90 c0488a1c 00000000 c0a3bee0 c0a1cb90 c01019f0 00000000 c093a454
1f20: 00000000 efffcdf9 000003d9 000000c6 c093a454 c0138168 c08bc554 00000000
1f40: 00000006 00000006 efffce09 00000000 00000000 00000000 00000006 c0a31830
1f60: c0a3bee0 00000006 c0a31834 c0b4b800 000000c6 c0a00dd0 00000006 00000006
1f80: 00000000 c0a005a4 00000000 c06a4428 00000000 00000000 00000000 00000000
1fa0: 00000000 c06a4430 00000000 c0107af0 00000000 00000000 00000000 00000000
1fc0: 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
1fe0: 00000000 00000000 00000000 00000000 00000013 00000000 2b427724 04991a10
[<c06a99d8>] (_raw_spin_lock_irqsave) from [<c03af8d8>] (devres_add+0x18/0x38)
[<c03af8d8>] (devres_add) from [<c03af998>] (devm_kmalloc+0x4c/0x5c)
[<c03af998>] (devm_kmalloc) from [<c03a4988>] (adv7511_probe+0x244/0x7c4)
[<c03a4988>] (adv7511_probe) from [<c048817c>] (i2c_device_probe+0x1f0/0x268)
[<c048817c>] (i2c_device_probe) from [<c03ac6d0>] (driver_probe_device+0x23c/0x2f8)
[<c03ac6d0>] (driver_probe_device) from [<c03aab94>] (bus_for_each_drv+0x64/0x98)
[<c03aab94>] (bus_for_each_drv) from [<c03ac3b8>] (__device_attach+0xb0/0x110)
[<c03ac3b8>] (__device_attach) from [<c03ab9ac>] (bus_probe_device+0x84/0x8c)
[<c03ab9ac>] (bus_probe_device) from [<c03a9e54>] (device_add+0x3ec/0x574)
[<c03a9e54>] (device_add) from [<c048939c>] (i2c_new_device+0x168/0x28c)
[<c048939c>] (i2c_new_device) from [<c048af44>] (of_i2c_register_devices+0x18c/0x240)
[<c048af44>] (of_i2c_register_devices) from [<c04898c8>] (i2c_register_adapter+0x15c/0x3bc)
[<c04898c8>] (i2c_register_adapter) from [<c0489cdc>] (i2c_add_adapter+0x98/0x12c)
[<c0489cdc>] (i2c_add_adapter) from [<c048c488>] (i2c_mux_add_adapter+0x248/0x3e0)
[<c048c488>] (i2c_mux_add_adapter) from [<c04902bc>] (pca954x_probe+0x314/0x39c)
[<c04902bc>] (pca954x_probe) from [<c048817c>] (i2c_device_probe+0x1f0/0x268)
[<c048817c>] (i2c_device_probe) from [<c03ac6d0>] (driver_probe_device+0x23c/0x2f8)
[<c03ac6d0>] (driver_probe_device) from [<c03ac838>] (__driver_attach+0xac/0xb0)
[<c03ac838>] (__driver_attach) from [<c03aaae8>] (bus_for_each_dev+0x6c/0xa0)
[<c03aaae8>] (bus_for_each_dev) from [<c03abc44>] (bus_add_driver+0x198/0x210)
[<c03abc44>] (bus_add_driver) from [<c03ad0c8>] (driver_register+0x78/0xf8)
[<c03ad0c8>] (driver_register) from [<c0488a1c>] (i2c_register_driver+0x3c/0x80)
[<c0488a1c>] (i2c_register_driver) from [<c01019f0>] (do_one_initcall+0x40/0x168)
[<c01019f0>] (do_one_initcall) from [<c0a00dd0>] (kernel_init_freeable+0x144/0x1e0)
[<c0a00dd0>] (kernel_init_freeable) from [<c06a4430>] (kernel_init+0x8/0x110)
[<c06a4430>] (kernel_init) from [<c0107af0>] (ret_from_fork+0x14/0x24)
Code: e5931004 e2811001 e5831004 f592f000 (e1923f9f)
---[ end trace 3b8b12fc86672f21 ]---
note: swapper/0[1] exited with preempt_count 1
Kernel panic - not syncing: Attempted to kill init! exitcode=0x0000000b


Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>