### PR TITLE
spi: move registration lock to master SPI device struct

### DIFF
--- a/drivers/spi/spi.c
+++ b/drivers/spi/spi.c
@@ -506,7 +506,6 @@ static int spi_dev_check(struct device *dev, void *data)
  */
 int spi_add_device(struct spi_device *spi)
 {
-	static DEFINE_MUTEX(spi_add_lock);
 	struct spi_controller *ctlr = spi->controller;
 	struct device *dev = ctlr->dev.parent;
 	int status;
@@ -525,7 +524,7 @@ int spi_add_device(struct spi_device *spi)
 	 * chipselect **BEFORE** we call setup(), else we'll trash
 	 * its configuration.  Lock against concurrent add() calls.
 	 */
-	mutex_lock(&spi_add_lock);
+	mutex_lock(&ctlr->add_lock);
 
 	status = bus_for_each_dev(&spi_bus_type, NULL, spi, spi_dev_check);
 	if (status) {
@@ -557,7 +556,7 @@ int spi_add_device(struct spi_device *spi)
 		dev_dbg(dev, "registered child %s\n", dev_name(&spi->dev));
 
 done:
-	mutex_unlock(&spi_add_lock);
+	mutex_unlock(&ctlr->add_lock);
 	return status;
 }
 EXPORT_SYMBOL_GPL(spi_add_device);
@@ -2133,6 +2132,7 @@ int spi_register_controller(struct spi_controller *ctlr)
 	INIT_LIST_HEAD(&ctlr->queue);
 	spin_lock_init(&ctlr->queue_lock);
 	spin_lock_init(&ctlr->bus_lock_spinlock);
+	mutex_init(&ctlr->add_lock);
 	mutex_init(&ctlr->bus_lock_mutex);
 	mutex_init(&ctlr->io_mutex);
 	ctlr->bus_lock_flag = 0;

--- a/include/linux/spi/spi.h
+++ b/include/linux/spi/spi.h
@@ -322,6 +322,8 @@ static inline void spi_unregister_driver(struct spi_driver *sdrv)
  * @bus_lock_spinlock: spinlock for SPI bus locking
  * @bus_lock_mutex: mutex for exclusion of multiple callers
  * @bus_lock_flag: indicates that the SPI bus is locked for exclusive use
+ * @add_lock: protects against concurrent registration of slaves with the same
+ *	chip_select.
  * @setup: updates the device mode and clocking records used by a
  *	device's SPI controller; protocol code may call this.  This
  *	must fail if an unrecognized or unsupported mode is requested.
@@ -485,6 +487,8 @@ struct spi_controller {
 
 	/* flag indicating that the SPI bus is locked for exclusive use */
 	bool			bus_lock_flag;
+
+	struct mutex		add_lock;
 
 	/* Setup mode and clock, etc (spi driver may call many times).
 	 *


### PR DESCRIPTION
Should prevent dead-locks when SPI-to-SPI bridges are added.
Upstream kernel has a local lock defined via commit e48880e02e7e7 ("spi:
bugfix spi_add_device() with duplicate chipselects").

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>