### PR TITLE
drivers/bus/Kconfig: add back empty line

### DIFF
--- a/drivers/bus/Kconfig
+++ b/drivers/bus/Kconfig
@@ -183,4 +183,5 @@ config DA8XX_MSTPRI
 	  Driver for Texas Instruments da8xx master peripheral priority
 	  configuration. Allows to adjust the priorities of all master
 	  peripherals.
+
 endmenu


### PR DESCRIPTION
Was removed via a merge commit.

Only helps for diff-ing with branch `adi-4.14.0`.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>