### PR TITLE
iio: adc: ad9371: Add support for set/get GPIO Monitor Out via debugfs

### DIFF
--- a/drivers/iio/adc/ad9371.c
+++ b/drivers/iio/adc/ad9371.c
@@ -823,6 +823,7 @@ static int ad9371_setup(struct ad9371_rf_phy *phy)
 
 	MYKONOS_setupAuxAdcs(mykDevice, 4, 1);
 	MYKONOS_setupAuxDacs(mykDevice);
+	MYKONOS_setupGpio(mykDevice);
 
 	clk_set_rate(phy->clks[RX_SAMPL_CLK],
 		     mykDevice->rx->rxProfile->iqRate_kHz * 1000);
@@ -2308,6 +2309,7 @@ static ssize_t ad9371_debugfs_read(struct file *file, char __user *userbuf,
 				   size_t count, loff_t *ppos)
 {
 	struct ad9371_debugfs_entry *entry = file->private_data;
+	struct ad9371_rf_phy *phy = entry->phy;
 	char buf[700];
 	u64 val = 0;
 	ssize_t len = 0;
@@ -2331,11 +2333,29 @@ static ssize_t ad9371_debugfs_read(struct file *file, char __user *userbuf,
 			val = *(u64*)entry->out_value;
 			break;
 		default:
-			ret = -EINVAL;
+			return -EINVAL;
 		}
 
 	} else if (entry->cmd) {
-		val = entry->val;
+		u8 index, mask;
+
+		switch (entry->cmd) {
+		case DBGFS_MONITOR_OUT:
+			mutex_lock(&phy->indio_dev->mlock);
+			ret = MYKONOS_getGpioMonitorOut(phy->mykDevice,
+							&index, &mask);
+			mutex_unlock(&phy->indio_dev->mlock);
+			if (ret < 0)
+				return ret;
+
+			len = snprintf(buf, sizeof(buf), "%u %u\n",
+				       index, mask);
+			break;
+		default:
+			val = entry->val;
+			break;
+		}
+
 	} else
 		return -EFAULT;
 
@@ -2444,6 +2464,16 @@ static ssize_t ad9371_debugfs_write(struct file *file,
 
 		entry->val = val;
 		return count;
+	case DBGFS_MONITOR_OUT:
+		if (ret != 2)
+			return -EINVAL;
+		mutex_lock(&phy->indio_dev->mlock);
+		ret = MYKONOS_setGpioMonitorOut(phy->mykDevice, val, val2);
+		mutex_unlock(&phy->indio_dev->mlock);
+		if (ret < 0)
+			return ret;
+
+		return count;
 	default:
 		break;
 	}
@@ -2509,6 +2539,7 @@ static int ad9371_register_debugfs(struct iio_dev *indio_dev)
 	ad9371_add_debugfs_entry(phy, "bist_prbs_rx", DBGFS_BIST_PRBS_RX);
 	ad9371_add_debugfs_entry(phy, "bist_prbs_obs", DBGFS_BIST_PRBS_OBS);
 	ad9371_add_debugfs_entry(phy, "bist_tone", DBGFS_BIST_TONE);
+	ad9371_add_debugfs_entry(phy, "monitor_out", DBGFS_MONITOR_OUT);
 
 	for (i = 0; i < phy->ad9371_debugfs_entry_index; i++)
 		d = debugfs_create_file(

--- a/drivers/iio/adc/ad9371.h
+++ b/drivers/iio/adc/ad9371.h
@@ -38,6 +38,7 @@ enum debugfs_cmd {
 	DBGFS_BIST_PRBS_RX,
 	DBGFS_BIST_PRBS_OBS,
 	DBGFS_BIST_TONE,
+	DBGFS_MONITOR_OUT,
 };
 
 
@@ -190,7 +191,7 @@ struct ad9371_rf_phy {
 	struct ad9371_clock	clk_priv[NUM_AD9371_CLKS];
 	struct clk_onecell_data	clk_data;
 	struct ad9371_phy_platform_data *pdata;
-	struct ad9371_debugfs_entry debugfs_entry[338];
+	struct ad9371_debugfs_entry debugfs_entry[339];
 	struct bin_attribute 	bin;
 	struct bin_attribute 	bin_gt;
 	struct iio_dev 		*indio_dev;


### PR DESCRIPTION
This debug attribute configures the monitor output function for the GPIOs

The monitor outputs are grouped in set of nibbles, the user can set
individual nibbles for having the monitor output function across the
available GPIO. In order to enable the GPIO monitor function the
function setupGpio has to be run and the
structure should have the proper setup:
- device->auxIo->gpio->gpioOe = 0xXXXFF the first D7:D0 GPIOs will
  have the output enable
- device->auxIo->gpio->gpioSrcCtrl3_0 = GPIO_MONITOR_MODE
- device->auxIo->gpio->gpioSrcCtrl4_7 = GPIO_MONITOR_MODE

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>