### PR TITLE
arm64: dts: zynqmp-zcu102-rev10-ad9361-fmcomms5.dts: Fix core name

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9361-fmcomms5.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9361-fmcomms5.dts
@@ -82,7 +82,7 @@
 		};
 
 		/* Master HDL cores with DMA */
-		cf_ad9361_adc_core_0: cf-ad9361-lpc@99020000 {
+		cf_ad9361_adc_core_0: cf-ad9361-A@99020000 {
 			compatible = "adi,axi-ad9361-6.00.a";
 			reg = <0x0 0x99020000 0x6000>;
 			dmas = <&rx_dma 0>;


### PR DESCRIPTION
This core must be named cf-ad9361-A otherwise the FMCOMMS5 advanced
plugin refuses to load.

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>