### PR TITLE
[backport] staging: rtl8188eu: force driver to be built as a module

### DIFF
--- a/drivers/staging/rtl8188eu/Kconfig
+++ b/drivers/staging/rtl8188eu/Kconfig
@@ -1,6 +1,7 @@
 config R8188EU
 	tristate "Realtek RTL8188EU Wireless LAN NIC driver"
 	depends on WLAN && USB && CFG80211
+	depends on m
 	select WIRELESS_EXT
 	select WEXT_PRIV
 	---help---


### PR DESCRIPTION
PR note: this change shows up in branch `adi-4.14.0` but does not seem to show up in master.
Probably lost during a merge.
It was cherry-picked.

------------------------------------------------------------------------

The rtl8188eu driver defines a ton of global symbols which tend to
conflict with other realtek wifi drivers, force it to be built as
a module.

Signed-off-by: Hans de Goede <hdegoede@redhat.com>
Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>