### PR TITLE
drivers: mathworks: fix functions type for vm fault

### DIFF
--- a/drivers/misc/mathworks/mathworks_ip_common.c
+++ b/drivers/misc/mathworks/mathworks_ip_common.c
@@ -200,8 +200,9 @@ static void mathworks_ip_mmap_close(struct vm_area_struct *vma)
 }
 
 
-static int mathworks_ip_mmap_fault(struct vm_area_struct *vma, struct vm_fault *vmf)
+static int mathworks_ip_mmap_fault(struct vm_fault *vmf)
 {
+    struct vm_area_struct *vma = vmf->vma;
     struct mathworks_ip_info * thisIpcore = vma->vm_private_data;
     struct page *thisPage;
     unsigned long offset;

--- a/drivers/misc/mathworks/mw_stream_channel.c
+++ b/drivers/misc/mathworks/mw_stream_channel.c
@@ -767,8 +767,9 @@ static void mwadma_mmap_close(struct vm_area_struct *vma)
 /*
  * @brief mwadma_mmap_fault
  */
-static int mwadma_mmap_fault(struct vm_area_struct *vma, struct vm_fault *vmf)
+static int mwadma_mmap_fault(struct vm_fault *vmf)
 {
+    struct vm_area_struct *vma = vmf->vma;
     struct mwadma_dev * mwdev = vma->vm_private_data;
     struct page *thisPage;
     unsigned long offset;


### PR DESCRIPTION
On ARM, this reports as a compiler warning/error:
```
drivers/misc/mathworks/mathworks_ip_common.c:218:14: error: initialization from incompatible pointer type [-Werror=incompatible-pointer-types]
     .fault = mathworks_ip_mmap_fault,

drivers/misc/mathworks/mw_stream_channel.c:785:23: error: initialization from incompatible pointer type [-Werror=incompatible-pointer-types]
     .fault          = mwadma_mmap_fault,
```

It was omitted during merge.
This patch updates the function type to the new required format.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>