### PR TITLE
iio: adxl372: Fix revid check

### DIFF
--- a/drivers/iio/accel/adxl372_i2c.c
+++ b/drivers/iio/accel/adxl372_i2c.c
@@ -34,7 +34,8 @@ static int adxl372_i2c_probe(struct i2c_client *client,
 
 	/* Starting with the 3rd revision an I2C chip bug was fixed */
 	if (regval < 3)
-		return -ENODEV;
+		dev_warn(&client->dev,
+		"I2C might not work properly with other devices on the bus");
 
 	return adxl372_probe(&client->dev, regmap, client->irq, id->name);
 }


### PR DESCRIPTION
Before the 3rd revision of the chip, the I2C communication was not
working properly if there were any other I2C devices present on the bus.
Howerver, if adxl372 is the only device, then it should still work, this
is why it is enough to just print a warning and continue with the device
probe.

Signed-off-by: Stefan Popa <stefan.popa@analog.com>