### PR TITLE
dma: axi-dmac: don't check the number of frames for alignment

### DIFF
--- a/drivers/dma/dma-axi-dmac.c
+++ b/drivers/dma/dma-axi-dmac.c
@@ -577,7 +577,7 @@ static struct dma_async_tx_descriptor *axi_dmac_prep_interleaved(
 
 	if (chan->hw_2d) {
 		if (!axi_dmac_check_len(chan, xt->sgl[0].size) ||
-		    !axi_dmac_check_len(chan, xt->numf))
+		    xt->numf == 0)
 			return NULL;
 		if (xt->sgl[0].size + dst_icg > chan->max_length ||
 		    xt->sgl[0].size + src_icg > chan->max_length)


### PR DESCRIPTION
It doesn't look like the 2D transfers were used much, prior to commit
81b810593ebcf1a537042704c8363bbaafbcba0b, so this may have not received
much attention.

There is no requirement for Y_LENGTH to be aligned to the bus-width (or
anything). X_LENGTH is required to be aligned though.

So, we shouldn't check that the number of frames is aligned.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>