### PR TITLE
iio: axi_jesd204_{tx,rx}: Add missing Kconfig dependencies

### DIFF
--- a/drivers/iio/jesd204/Kconfig
+++ b/drivers/iio/jesd204/Kconfig
@@ -20,9 +20,13 @@ config AXI_JESD204B
 
 config AXI_JESD204_TX
 	tristate "Analog Devices AXI JESD204B TX Support"
+	depends on COMMON_CLK
+	select REGMAP_MMIO
 
 config AXI_JESD204_RX
 	tristate "Analog Devices AXI JESD204B RX Support"
+	depends on COMMON_CLK
+	select REGMAP_MMIO
 
 config XILINX_TRANSCEIVER
 	tristate


### PR DESCRIPTION
The axi_jesd204_tx and axi_jesd204_rx drivers depend on the common clock
framework and also use the regmap MMIO infrastructure. Make sure these
relationships are properly stated in the Kconfig entry.

Otherwise the drivers will not build correctly if those dependencies are
not met.

Signed-off-by: Lars-Peter Clausen <lars@metafoo.de>

Tested with `make allnoconfig`.