### PR TITLE
media: i2c: adv7604: Select CEC_CORE too

### DIFF
--- a/drivers/media/i2c/Kconfig
+++ b/drivers/media/i2c/Kconfig
@@ -222,6 +222,7 @@ config VIDEO_ADV7604
 	depends on GPIOLIB || COMPILE_TEST
 	select HDMI
 	select V4L2_FWNODE
+	select CEC_CORE
 	---help---
 	  Support for the Analog Devices ADV7604 video decoder.
 
@@ -234,7 +235,6 @@ config VIDEO_ADV7604
 config VIDEO_ADV7604_CEC
 	bool "Enable Analog Devices ADV7604 CEC support"
 	depends on VIDEO_ADV7604
-	select CEC_CORE
 	---help---
 	  When selected the adv7604 will support the optional
 	  HDMI CEC feature.


### PR DESCRIPTION
This driver is dependent on functions like cec_get_edid_phys_addr()
and cec_phys_addr_validate() that were part of the standalone
cec-edid module. Since cec-edid was recently integrated in the cec
module and MEDIA_CEC_EDID was removed, CEC_CORE should be also
selected.

Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>