### PR TITLE
iio: adc: ad9361: Add ad9361_axi_half_dac_rate() accessor

### DIFF
--- a/drivers/iio/adc/ad9361.c
+++ b/drivers/iio/adc/ad9361.c
@@ -4120,6 +4120,12 @@ bool ad9361_uses_rx2tx2(struct ad9361_rf_phy *phy)
 }
 EXPORT_SYMBOL(ad9361_uses_rx2tx2);
 
+bool ad9361_axi_half_dac_rate(struct ad9361_rf_phy *phy)
+{
+	return phy && phy->pdata && phy->pdata->axi_half_dac_rate_en;
+}
+EXPORT_SYMBOL(ad9361_axi_half_dac_rate);
+
 int ad9361_get_dig_tune_data(struct ad9361_rf_phy *phy,
 			     struct ad9361_dig_tune_data *data)
 {

--- a/drivers/iio/adc/ad9361.h
+++ b/drivers/iio/adc/ad9361.h
@@ -176,6 +176,7 @@ int ad9361_dig_tune(struct ad9361_rf_phy *phy, unsigned long max_freq,
 int ad9361_tx_mute(struct ad9361_rf_phy *phy, u32 state);
 int ad9361_write_bist_reg(struct ad9361_rf_phy *phy, u32 val);
 bool ad9361_uses_rx2tx2(struct ad9361_rf_phy *phy);
+bool ad9361_axi_half_dac_rate(struct ad9361_rf_phy *phy);
 int ad9361_get_dig_tune_data(struct ad9361_rf_phy *phy,
 			     struct ad9361_dig_tune_data *data);
 int ad9361_read_clock_data_delays(struct ad9361_rf_phy *phy);

--- a/drivers/iio/adc/ad9361_conv.c
+++ b/drivers/iio/adc/ad9361_conv.c
@@ -677,7 +677,7 @@ static int ad9361_post_setup(struct iio_dev *indio_dev)
 	struct axiadc_converter *conv = iio_device_get_drvdata(indio_dev);
 	struct ad9361_rf_phy *phy = conv->phy;
 	bool rx2tx2 = ad9361_uses_rx2tx2(phy);
-	bool half_rate = phy->pdata->axi_half_dac_rate_en;
+	bool half_rate = ad9361_axi_half_dac_rate(phy);
 	unsigned tmp, num_chan, flags;
 	int i, ret;
 


### PR DESCRIPTION
Using the new AD9361's driver format, this is required to
avoid includind the ad9361_private.h header.

Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>