### PR TITLE
[Review Only] staging:iio:ad7606: update driver: add ad7605-4 + some fixes/updates

### DIFF
--- a/drivers/staging/iio/adc/Kconfig
+++ b/drivers/staging/iio/adc/Kconfig
@@ -11,7 +11,7 @@ config AD7606
 	select IIO_TRIGGERED_BUFFER
 	help
 	  Say yes here to build support for Analog Devices:
-	  ad7606, ad7606-6, ad7606-4 analog to digital converters (ADC).
+	  ad7605-4, ad7606, ad7606-6, ad7606-4 analog to digital converters (ADC).
 
 	  To compile this driver as a module, choose M here: the
 	  module will be called ad7606.

--- a/drivers/staging/iio/adc/ad7606.c
+++ b/drivers/staging/iio/adc/ad7606.c
@@ -26,9 +26,11 @@
 
 #include "ad7606.h"
 
-/* Scales are computed as 2.5/2**16 and 5/2**16 respectively */
+/* Scales are computed as 5000/32768 and 10000/32768 respectively,
+ * so that when applied to the raw values they provide mV values
+ */
 static const unsigned int scale_avail[2][2] = {
-	{0, 38147}, {0, 76294}
+	{0, 152588}, {0, 305176}
 };
 
 static int ad7606_reset(struct ad7606_state *st)

--- a/drivers/staging/iio/adc/ad7606.c
+++ b/drivers/staging/iio/adc/ad7606.c
@@ -275,7 +275,7 @@ static const struct attribute_group ad7606_attribute_group_range = {
 	.attrs = ad7606_attributes_range,
 };
 
-#define AD7606_CHANNEL(num)					\
+#define AD760X_CHANNEL(num, mask)				\
 	{							\
 		.type = IIO_VOLTAGE,				\
 		.indexed = 1,					\
@@ -283,8 +283,7 @@ static const struct attribute_group ad7606_attribute_group_range = {
 		.address = num,					\
 		.info_mask_separate = BIT(IIO_CHAN_INFO_RAW),	\
 		.info_mask_shared_by_type = BIT(IIO_CHAN_INFO_SCALE),\
-		.info_mask_shared_by_all =			\
-			BIT(IIO_CHAN_INFO_OVERSAMPLING_RATIO),	\
+		.info_mask_shared_by_all = mask,		\
 		.scan_index = num,				\
 		.scan_type = {					\
 			.sign = 's',				\
@@ -293,6 +292,20 @@ static const struct attribute_group ad7606_attribute_group_range = {
 			.endianness = IIO_CPU,			\
 		},						\
 	}
+
+#define AD7605_CHANNEL(num)	\
+	AD760X_CHANNEL(num, 0)
+
+#define AD7606_CHANNEL(num)	\
+	AD760X_CHANNEL(num, BIT(IIO_CHAN_INFO_OVERSAMPLING_RATIO))
+
+static const struct iio_chan_spec ad7605_channels[] = {
+	IIO_CHAN_SOFT_TIMESTAMP(4),
+	AD7605_CHANNEL(0),
+	AD7605_CHANNEL(1),
+	AD7605_CHANNEL(2),
+	AD7605_CHANNEL(3),
+};
 
 static const struct iio_chan_spec ad7606_channels[] = {
 	IIO_CHAN_SOFT_TIMESTAMP(8),
@@ -310,17 +323,24 @@ static const struct ad7606_chip_info ad7606_chip_info_tbl[] = {
 	/*
 	 * More devices added in future
 	 */
+	[ID_AD7605_4] = {
+		.channels = ad7605_channels,
+		.num_channels = 5,
+	},
 	[ID_AD7606_8] = {
 		.channels = ad7606_channels,
 		.num_channels = 9,
+		.has_oversampling = true,
 	},
 	[ID_AD7606_6] = {
 		.channels = ad7606_channels,
 		.num_channels = 7,
+		.has_oversampling = true,
 	},
 	[ID_AD7606_4] = {
 		.channels = ad7606_channels,
 		.num_channels = 5,
+		.has_oversampling = true,
 	},
 };
 
@@ -350,6 +370,9 @@ static int ad7606_request_gpios(struct ad7606_state *st)
 						    GPIOD_IN);
 	if (IS_ERR(st->gpio_frstdata))
 		return PTR_ERR(st->gpio_frstdata);
+
+	if (!st->chip_info->has_oversampling)
+		return 0;
 
 	st->gpio_os = devm_gpiod_get_array_optional(dev, "oversampling-ratio",
 			GPIOD_OUT_LOW);
@@ -429,11 +452,11 @@ int ad7606_probe(struct device *dev, int irq, void __iomem *base_address,
 		return ret;
 	}
 
+	st->chip_info = &ad7606_chip_info_tbl[id];
+
 	ret = ad7606_request_gpios(st);
 	if (ret)
 		goto error_disable_reg;
-
-	st->chip_info = &ad7606_chip_info_tbl[id];
 
 	indio_dev->dev.parent = dev;
 	if (st->gpio_os) {

--- a/drivers/staging/iio/adc/ad7606.h
+++ b/drivers/staging/iio/adc/ad7606.h
@@ -11,10 +11,8 @@
 
 /**
  * struct ad7606_chip_info - chip specific information
- * @name:		identification string for chip
  * @channels:		channel specification
  * @num_channels:	number of channels
- * @lock		protect sensor state
  */
 
 struct ad7606_chip_info {

--- a/drivers/staging/iio/adc/ad7606.h
+++ b/drivers/staging/iio/adc/ad7606.h
@@ -22,7 +22,26 @@ struct ad7606_chip_info {
 
 /**
  * struct ad7606_state - driver instance specific data
+ * @dev		pointer to kernel device
+ * @chip_info		entry in the table of chips that describes this device
+ * @reg		regulator info for the the power supply of the device
+ * @poll_work		struct info for reading data in buffer mode
+ * @wq_data_avail	wait queue struct for buffer mode
+ * @bops		bus operations (SPI or parallel)
+ * @range		voltage range selection, selects which scale to apply
+ * @oversampling	oversampling selection
+ * @done		marks whether reading data is done
+ * @base_address	address from where to read data in parallel operation
  * @lock		protect sensor state
+ * @gpio_convst	GPIO descriptor for conversion start signal (CONVST)
+ * @gpio_reset		GPIO descriptor for device hard-reset
+ * @gpio_range		GPIO descriptor for range selection
+ * @gpio_standby	GPIO descriptor for stand-by signal (STBY),
+ *			controls power-down mode of device
+ * @gpio_frstdata	GPIO descriptor for reading from device when data
+ *			is being read on the first channel
+ * @gpio_os		GPIO descriptors to control oversampling on the device
+ * @data		buffer for reading data from the device
  */
 
 struct ad7606_state {
@@ -53,6 +72,10 @@ struct ad7606_state {
 	unsigned short			data[12] ____cacheline_aligned;
 };
 
+/**
+ * struct ad7606_bus_ops - driver bus operations
+ * @read_block			function pointer for reading blocks of data
+ */
 struct ad7606_bus_ops {
 	/* more methods added in future? */
 	int (*read_block)(struct device *dev, int num, void *data);

--- a/drivers/staging/iio/adc/ad7606.h
+++ b/drivers/staging/iio/adc/ad7606.h
@@ -13,11 +13,13 @@
  * struct ad7606_chip_info - chip specific information
  * @channels:		channel specification
  * @num_channels:	number of channels
+ * @has_oversampling:   whether the device has oversampling support
  */
 
 struct ad7606_chip_info {
 	const struct iio_chan_spec	*channels;
 	unsigned int			num_channels;
+	bool				has_oversampling;
 };
 
 /**
@@ -87,6 +89,7 @@ int ad7606_probe(struct device *dev, int irq, void __iomem *base_address,
 int ad7606_remove(struct device *dev, int irq);
 
 enum ad7606_supported_device_ids {
+	ID_AD7605_4,
 	ID_AD7606_8,
 	ID_AD7606_6,
 	ID_AD7606_4

--- a/drivers/staging/iio/adc/ad7606_par.c
+++ b/drivers/staging/iio/adc/ad7606_par.c
@@ -79,6 +79,9 @@ static int ad7606_par_remove(struct platform_device *pdev)
 
 static const struct platform_device_id ad7606_driver_ids[] = {
 	{
+		.name		= "ad7605-4",
+		.driver_data	= ID_AD7605_4,
+	}, {
 		.name		= "ad7606-8",
 		.driver_data	= ID_AD7606_8,
 	}, {

--- a/drivers/staging/iio/adc/ad7606_spi.c
+++ b/drivers/staging/iio/adc/ad7606_spi.c
@@ -55,6 +55,7 @@ static int ad7606_spi_remove(struct spi_device *spi)
 }
 
 static const struct spi_device_id ad7606_id[] = {
+	{"ad7605-4", ID_AD7605_4},
 	{"ad7606-8", ID_AD7606_8},
 	{"ad7606-6", ID_AD7606_6},
 	{"ad7606-4", ID_AD7606_4},


### PR DESCRIPTION
The intent is to move the driver out of staging upstream, and maybe later add some more devices from this family.
Currently, this changeset add support for AD7605-4, does some minor cleanups/docs update, and fixes the voltage scales.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>