### PR TITLE
iio: core: fix enums with gaps

### DIFF
--- a/drivers/iio/industrialio-core.c
+++ b/drivers/iio/industrialio-core.c
@@ -487,16 +487,21 @@ ssize_t iio_enum_write(struct iio_dev *indio_dev,
 	size_t len)
 {
 	const struct iio_enum *e = (const struct iio_enum *)priv;
+	unsigned int i;
 	int ret;
 
 	if (!e->set)
 		return -EINVAL;
 
-	ret = __sysfs_match_string(e->items, e->num_items, buf);
-	if (ret < 0)
-		return ret;
+	for (i = 0; i < e->num_items; i++) {
+		if (e->items[i] && sysfs_streq(buf, e->items[i]))
+			break;
+	}
 
-	ret = e->set(indio_dev, chan, ret);
+	if (i == e->num_items)
+		return -EINVAL;
+
+	ret = e->set(indio_dev, chan, i);
 	return ret ? ret : len;
 }
 EXPORT_SYMBOL_GPL(iio_enum_write);


### PR DESCRIPTION
Commit 9823c72f97ab ("iio: Handle enumerated properties with gaps") added
support for handling enum properties with gaps.

This seems to have been broken during the merge with 4.14, but only on the
`iio_enum_write()` path. The `iio_enum_read()` &
`iio_enum_read_available()` functions were merged properly.

This commit also reverts commit 02e9a0ff0d7a ("iio: core: Use
__sysfs_match_string() helper").

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>