### PR TITLE
iio: adc: adrv9009: Fix get in_voltage1_gain_control_pin_mode_en for RX2

### DIFF
--- a/drivers/iio/adc/adrv9009.c
+++ b/drivers/iio/adc/adrv9009.c
@@ -1440,7 +1440,7 @@ static ssize_t adrv9009_phy_rx_read(struct iio_dev *indio_dev,
 			ret = TALISE_getRxGainCtrlPin(phy->talDevice, TAL_RX1, &rxGainCtrlPin);
 			break;
 		case CHAN_RX2:
-			ret = TALISE_getRxGainCtrlPin(phy->talDevice, TAL_RX1, &rxGainCtrlPin);
+			ret = TALISE_getRxGainCtrlPin(phy->talDevice, TAL_RX2, &rxGainCtrlPin);
 			break;
 		default:
 			ret = -EINVAL;


### PR DESCRIPTION
This fixes a typo which caused in_voltage1_gain_control_pin_mode_en to
return the value for in_voltage0_gain_control_pin_mode_en.


Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>