### PR TITLE
drivers: mathworks: fix copy sizes

### DIFF
--- a/drivers/misc/mathworks/mw_stream_channel.c
+++ b/drivers/misc/mathworks/mw_stream_channel.c
@@ -426,12 +426,12 @@ static long mwadma_rx_ctl(struct mwadma_dev *mwdev, unsigned int cmd, unsigned l
             if (NULL == tmp) {
                 return -ENOMEM;
             }
-            if(copy_to_user((unsigned long *) arg, &next_index, sizeof(unsigned long))) {
+            if(copy_to_user((unsigned int *) arg, &next_index, sizeof(next_index))) {
                 return -EACCES;
             }
             break;
         case MWADMA_RX_GET_ERROR:
-            if(copy_from_user(&done_index, (unsigned long *)arg, sizeof(unsigned long))) {
+            if(copy_from_user(&done_index, (unsigned int *)arg, sizeof(done_index))) {
                 return -EACCES;
             }
             spin_lock_irqsave(&mwchan->slock, flags);
@@ -441,7 +441,7 @@ static long mwadma_rx_ctl(struct mwadma_dev *mwdev, unsigned int cmd, unsigned l
             mwchan->blocks[done_index]->state = MWDMA_READY;
             spin_unlock_irqrestore(&mwchan->slock, flags);
             atomic64_dec_if_positive(&rxcount);
-            if(copy_to_user((unsigned long *) arg, &error, sizeof(unsigned long))) {
+            if(copy_to_user((unsigned int *) arg, &error, sizeof(error))) {
                 return -EACCES;
             }
             break;


### PR DESCRIPTION
On 64 bits, `unsigned long` and `unsigned int` differ in size, causing
compile-time errors:
```
./include/linux/thread_info.h:139:19: error: call to ‘__bad_copy_from’ declared with attribute error: copy source size is too small
    __bad_copy_from();

./include/linux/thread_info.h:141:17: error: call to ‘__bad_copy_to’ declared with attribute error: copy destination size is too small
    __bad_copy_to();
                 ^
```

We need to fix this by adjusting the types of the data that get copied
to/from the user-space.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>