### PR TITLE
iio: Fix scan mask selection

### DIFF
--- a/drivers/iio/industrialio-buffer.c
+++ b/drivers/iio/industrialio-buffer.c
@@ -405,9 +405,8 @@ static int iio_channel_mask_set(struct iio_dev *indio_dev,
 	unsigned long *trialmask;
 	unsigned int ch;
 
-	trialmask = kmalloc_array(BITS_TO_LONGS(indio_dev->masklength),
-				  sizeof(*trialmask),
-				  GFP_KERNEL);
+	trialmask = kcalloc(BITS_TO_LONGS(indio_dev->masklength),
+			    sizeof(*trialmask), GFP_KERNEL);
 	if (trialmask == NULL)
 		return -ENOMEM;
 	if (!indio_dev->masklength) {


### PR DESCRIPTION
The trialmask is expected to have all bits set to 0 after allocation.
Currently kmalloc_array() is used which does not zero the memory and so
random bits are set. This results in random channels being enabled when
they shouldn't. Replace kmalloc_array() with kcalloc() which has the same
interface but zeros the memory.

The issue was introduced in commit dc54e5c90fc2 ("Merge remote-tracking
branch 'xilinx/master' into adi-master-4-14") due to a mismerge of commit
81d00795b153 ("iio: Track enabled channels on a per channel basis") which
replaced kmalloc() with kzalloc() and commit 057ac1acdfc4 ("iio: Use
kmalloc_array() in iio_scan_mask_set()") which replaced kmalloc() with
kmalloc_array().

Signed-off-by: Lars-Peter Clausen <lars@metafoo.de>