### PR TITLE
Untangle buffer.h/buffer_impl.h split

### DIFF
--- a/drivers/iio/adc/ad7768.c
+++ b/drivers/iio/adc/ad7768.c
@@ -14,7 +14,7 @@
 
 #include <linux/iio/iio.h>
 #include <linux/iio/sysfs.h>
-#include <linux/iio/buffer.h>
+#include <linux/iio/buffer_impl.h>
 #include <linux/iio/buffer-dma.h>
 #include <linux/iio/buffer-dmaengine.h>
 

--- a/drivers/iio/adc/cf_axi_adc_ring_stream.c
+++ b/drivers/iio/adc/cf_axi_adc_ring_stream.c
@@ -16,7 +16,7 @@
 
 #include <linux/iio/iio.h>
 #include <linux/iio/sysfs.h>
-#include <linux/iio/buffer.h>
+#include <linux/iio/buffer_impl.h>
 #include <linux/iio/buffer-dma.h>
 #include <linux/iio/buffer-dmaengine.h>
 #include "cf_axi_adc.h"

--- a/drivers/iio/buffer/hw_consumer.c
+++ b/drivers/iio/buffer/hw_consumer.c
@@ -9,7 +9,7 @@
 #include <linux/iio/driver.h>
 #include <linux/iio/consumer.h>
 #include <linux/iio/hw_consumer.h>
-#include <linux/iio/buffer.h>
+#include <linux/iio/buffer_impl.h>
 
 struct iio_hw_consumer {
 	struct list_head buffers;

--- a/drivers/iio/frequency/cf_axi_dds_buffer_stream.c
+++ b/drivers/iio/frequency/cf_axi_dds_buffer_stream.c
@@ -15,7 +15,7 @@
 
 #include <linux/iio/iio.h>
 #include <linux/iio/sysfs.h>
-#include <linux/iio/buffer.h>
+#include <linux/iio/buffer_impl.h>
 #include <linux/iio/buffer-dma.h>
 #include <linux/iio/buffer-dmaengine.h>
 

--- a/drivers/iio/industrialio-buffer.c
+++ b/drivers/iio/industrialio-buffer.c
@@ -1532,6 +1532,11 @@ int iio_push_to_buffers(struct iio_dev *indio_dev, const void *data)
 }
 EXPORT_SYMBOL_GPL(iio_push_to_buffers);
 
+int iio_buffer_remove_sample(struct iio_buffer *buffer, u8 *data)
+{
+	return buffer->access->remove_from(buffer, data);
+}
+
 /**
  * iio_buffer_release() - Free a buffer's resources
  * @ref: Pointer to the kref embedded in the iio_buffer struct

--- a/drivers/iio/inkern.c
+++ b/drivers/iio/inkern.c
@@ -14,7 +14,7 @@
 
 #include <linux/iio/iio.h>
 #include "iio_core.h"
-#include <linux/iio/buffer.h>
+#include <linux/iio/buffer_impl.h>
 #include <linux/iio/machine.h>
 #include <linux/iio/driver.h>
 #include <linux/iio/consumer.h>

--- a/drivers/iio/logic/m2k-logic-analyzer.c
+++ b/drivers/iio/logic/m2k-logic-analyzer.c
@@ -10,7 +10,7 @@
 
 #include <linux/iio/iio.h>
 #include <linux/iio/sysfs.h>
-#include <linux/iio/buffer.h>
+#include <linux/iio/buffer_impl.h>
 #include <linux/iio/buffer-dma.h>
 #include <linux/iio/buffer-dmaengine.h>
 

--- a/include/linux/iio/buffer.h
+++ b/include/linux/iio/buffer.h
@@ -18,6 +18,7 @@ void iio_buffer_set_attrs(struct iio_buffer *buffer,
 			 const struct attribute **attrs);
 
 int iio_push_to_buffers(struct iio_dev *indio_dev, const void *data);
+int iio_buffer_remove_sample(struct iio_buffer *buffer, u8 *data);
 
 /**
  * iio_push_to_buffers_with_timestamp() - push data and timestamp to buffers

--- a/include/linux/iio/buffer.h
+++ b/include/linux/iio/buffer.h
@@ -44,9 +44,6 @@ static inline int iio_push_to_buffers_with_timestamp(struct iio_dev *indio_dev,
 	return iio_push_to_buffers(indio_dev, data);
 }
 
-int iio_buffer_alloc_scanmask(struct iio_buffer *buffer,
-	struct iio_dev *indio_dev);
-void iio_buffer_free_scanmask(struct iio_buffer *buffer);
 
 bool iio_validate_scan_mask_onehot(struct iio_dev *indio_dev,
 				   const unsigned long *mask);

--- a/include/linux/iio/buffer.h
+++ b/include/linux/iio/buffer.h
@@ -52,7 +52,4 @@ bool iio_validate_scan_mask_onehot(struct iio_dev *indio_dev,
 void iio_device_attach_buffer(struct iio_dev *indio_dev,
 			      struct iio_buffer *buffer);
 
-/* FIXME: this is a temp hack (during the merge) until stuff will be better sorted out */
-#include <linux/iio/buffer_impl.h>
-
 #endif /* _IIO_BUFFER_GENERIC_H_ */

--- a/include/linux/iio/buffer_impl.h
+++ b/include/linux/iio/buffer_impl.h
@@ -184,11 +184,6 @@ static inline int iio_buffer_write(struct iio_buffer *buffer, size_t n,
 	return buffer->access->write(buffer, n, buf);
 }
 
-static inline int iio_buffer_remove_sample(struct iio_buffer *buffer, u8 *data)
-{
-	return buffer->access->remove_from(buffer, data);
-}
-
 /**
  * iio_update_buffers() - add or remove buffer from active list
  * @indio_dev:		device to add buffer to

--- a/include/linux/iio/consumer.h
+++ b/include/linux/iio/consumer.h
@@ -15,6 +15,7 @@
 
 struct iio_dev;
 struct iio_chan_spec;
+struct iio_buffer;
 struct device;
 
 /**

--- a/include/linux/iio/consumer.h
+++ b/include/linux/iio/consumer.h
@@ -320,6 +320,10 @@ void iio_buffer_channel_enable(struct iio_buffer *buffer,
 void iio_buffer_channel_disable(struct iio_buffer *buffer,
 	const struct iio_channel *chan);
 
+int iio_buffer_alloc_scanmask(struct iio_buffer *buffer,
+	struct iio_dev *indio_dev);
+void iio_buffer_free_scanmask(struct iio_buffer *buffer);
+
 /**
  * iio_get_channel_ext_info_count() - get number of ext_info attributes
  *				      connected to the channel.


### PR DESCRIPTION
Upstream split buffer.h into two files buffer.h and buffer_impl.h. This change is not fully reflected in the ADI tree. This patch series cleans this up.

Should also be applied to adi-4.14.0