### PR TITLE
iio: adc: adrv9009: Handle <clkPllHsDiv=X.0> cases in parse profile

### DIFF
--- a/drivers/iio/adc/adrv9009.c
+++ b/drivers/iio/adc/adrv9009.c
@@ -3412,7 +3412,7 @@ static int adrv9009_parse_profile(struct adrv9009_rf_phy *phy,
 			GET_TOKEN(phy->talInit.clocks, clkPllVcoFreq_kHz);
 			ret = sscanf(line, " <clkPllHsDiv=%u.%u>", &int32, &int32_2);
 			if (ret > 0) {
-				if (ret == 1) {
+				if (ret == 1 || ((ret == 2) && (int32_2 == 0))) {
 					switch (int32) {
 					case 2:
 						num = TAL_HSDIV_2;


### PR DESCRIPTION
The profile wizard may generate not just 2, 2.5, 3, 4, 5 but also
2.0, 3.0, etc. This patch takes care of that.

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>