### PR TITLE
 drivers: mathworks: fix iio buffer include + add COMPILE_TEST builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ env:
     DTS_FILES=arch/arm/boot/dts/zynq-*.dts IMAGE=uImage
   - DEFCONFIG_NAME=adi_zynqmp_defconfig ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu-
     DTS_FILES=arch/arm64/boot/dts/xilinx/zynqmp-*.dts DTS_PREFIX=xilinx/ IMAGE=Image
+  - COMPILE_TEST=y DEFCONFIG_NAME=zynq_xcomm_adv7511_defconfig ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf-
+  - COMPILE_TEST=y DEFCONFIG_NAME=adi_zynqmp_defconfig ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu-
 
 before_install:
   - sudo apt-get update -qq

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,4 @@ before_install:
   - sudo apt-get install -y build-essential bc u-boot-tools gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu
 
 script:
-  - if [[ -n "$TRAVIS_BRANCH" ]]; then git fetch origin +refs/heads/${TRAVIS_BRANCH}:${TRAVIS_BRANCH} ; fi
-  - COMMIT_RANGE=$([ "$TRAVIS_PULL_REQUEST" == "false" ] &&  echo HEAD || echo ${TRAVIS_BRANCH}..)
-  - make ${DEFCONFIG_NAME}
-  - make -j`getconf _NPROCESSORS_ONLN` $IMAGE UIMAGE_LOADADDR=0x8000
-  - for file in $DTS_FILES; do make ${DTS_PREFIX}`basename $file | sed  -e 's\dts\dtb\g'` || exit 1;done
-  - scripts/checkpatch.pl --git ${COMMIT_RANGE} --ignore FILE_PATH_CHANGES --ignore LONG_LINE --ignore LONG_LINE_STRING --ignore LONG_LINE_COMMENT
+  - ./ci/travis/run-build.sh

--- a/ci/travis/run-build.sh
+++ b/ci/travis/run-build.sh
@@ -22,6 +22,15 @@ build_default() {
 		--ignore LONG_LINE_COMMENT
 }
 
+build_compile_test() {
+	make ${DEFCONFIG_NAME}
+	make -j`getconf _NPROCESSORS_ONLN`
+}
+
 BUILD_TYPE=default
+
+if [ "$COMPILE_TEST" == "y" ] ; then
+	BUILD_TYPE=compile_test
+fi
 
 build_${BUILD_TYPE}

--- a/ci/travis/run-build.sh
+++ b/ci/travis/run-build.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -xe
+
+build_default() {
+	if [ -n "$TRAVIS_BRANCH" ]; then
+		git fetch origin +refs/heads/${TRAVIS_BRANCH}:${TRAVIS_BRANCH}
+	fi
+
+	COMMIT_RANGE=$([ "$TRAVIS_PULL_REQUEST" == "false" ] &&  echo HEAD || echo ${TRAVIS_BRANCH}..)
+
+	make ${DEFCONFIG_NAME}
+	make -j`getconf _NPROCESSORS_ONLN` $IMAGE UIMAGE_LOADADDR=0x8000
+
+	for file in $DTS_FILES; do
+		make ${DTS_PREFIX}`basename $file | sed  -e 's\dts\dtb\g'` || exit 1
+	done
+
+	scripts/checkpatch.pl --git ${COMMIT_RANGE} \
+		--ignore FILE_PATH_CHANGES \
+		--ignore LONG_LINE \
+		--ignore LONG_LINE_STRING \
+		--ignore LONG_LINE_COMMENT
+}
+
+BUILD_TYPE=default
+
+build_${BUILD_TYPE}

--- a/drivers/misc/mathworks/mw_stream_iio_channel.c
+++ b/drivers/misc/mathworks/mw_stream_iio_channel.c
@@ -8,7 +8,7 @@
 
 #include <linux/iio/iio.h>
 #include <linux/iio/sysfs.h>
-#include <linux/iio/buffer.h>
+#include <linux/iio/buffer_impl.h>
 #include <linux/iio/buffer-dma.h>
 #include <linux/iio/buffer-dmaengine.h>
 #include <linux/idr.h>


### PR DESCRIPTION
Fixes #212 

Commit b24d8b04bed3 ("iio: Remove buffer_impl.h include from buffer.h") has
removed a temporary workaround for the `buffer.h` that upstream IIO did.
    
The MathWorks IIO driver was omitted in that changeset.
This change fixes it.

Also added compile-test builds.
We sometimes miss few silly things, because our builds don't go through
all the source code, because we don't cover them in defconfigs.
    
The kernel has a `COMPILE_TEST` Kconfig flags, so we enable it to try
to address this.
This should extend code-coverage by compiling more code.
    
This won't necessarily compile everything, but will extend coverage to
parts we don't have in our main defconfigs (like MathWorks driver), and we
may extend stuff to go under this Kconfig symbol later.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>