### PR TITLE
iio: jesd204: axi_adxcvr_eyescan: Allow eyescan cancel

### DIFF
--- a/drivers/iio/jesd204/axi_adxcvr_eyescan.c
+++ b/drivers/iio/jesd204/axi_adxcvr_eyescan.c
@@ -140,7 +140,10 @@ adxcvr_eyescan_bin_read(struct file *filp, struct kobject *kobj,
 	if (unlikely(!count))
 		return count;
 
-	wait_for_completion(&st->eye->complete);
+	if (wait_for_completion_interruptible(&st->eye->complete)) {
+		adxcvr_eyescan_write(st, ADXCVR_REG_ES_REQ, 0);
+		return -EINTR;
+	}
 
 	memcpy(buf, st->eye->buf_virt + off, count);
 


### PR DESCRIPTION
If a signal is received while waiting return -EINTR.

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>