### PR TITLE
fix some compiler warnings

### DIFF
--- a/drivers/iio/adc/ad9680.c
+++ b/drivers/iio/adc/ad9680.c
@@ -732,7 +732,7 @@ static int ad9680_setup_link(struct spi_device *spi,
 {
 	unsigned int val;
 	unsigned int i;
-	int ret;
+	int ret = 0;
 
 	val = ilog2(config->octets_per_frame);
 	val |= ilog2(config->num_converters) << 3;

--- a/drivers/misc/mathworks/mw_stream_channel.c
+++ b/drivers/misc/mathworks/mw_stream_channel.c
@@ -87,7 +87,7 @@ static int mwadma_allocate_desc(struct mwadma_slist **new, struct mwadma_chan *m
     tmp->state = MWDMA_READY;
     tmp->qchan = mwchan;
     INIT_LIST_HEAD(&(tmp->userid));
-    dev_dbg(&mwchan->dev,"buf_phys_addr 0x%08lx, size %u\n", (unsigned long) tmp->phys, tmp->length);
+    dev_dbg(&mwchan->dev,"buf_phys_addr 0x%08lx, size %zu\n", (unsigned long) tmp->phys, tmp->length);
     *new = tmp;
     return 0;
 }
@@ -293,7 +293,7 @@ int mwadma_start(struct mwadma_chan *mwchan)
     }
     thisDesc = dmaengine_prep_slave_single(mwchan->chan, mwchan->curr->phys, mwchan->curr->length, mwchan->direction, mwchan->flags);
     if (NULL == thisDesc) {
-        dev_err(&mwchan->dev,"prep_slave_single failed: buf_phys_addr 0x%08lx, size %u\n", (unsigned long) mwchan->curr->phys, mwchan->curr->length);
+        dev_err(&mwchan->dev,"prep_slave_single failed: buf_phys_addr 0x%08lx, size %zu\n", (unsigned long) mwchan->curr->phys, mwchan->curr->length);
         ret = -ENOMEM;
         goto start_failed;
     }


### PR DESCRIPTION
This fixes 2 compiler warnings that were noticed in the Travis-CI build.

There are still some warnings left to look at, but these are the low-hanging-fruit ones.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>