### PR TITLE
dts: a10gx_adrv9371: Add bypass support for PL FIFO

### DIFF
--- a/arch/nios2/boot/dts/a10gx_adrv9371.dts
+++ b/arch/nios2/boot/dts/a10gx_adrv9371.dts
@@ -474,6 +474,7 @@
 			clocks = <&trx0_ad9371 2>;
 			clock-names = "sampl_clk";
 			spibus-connected = <&trx0_ad9371>;
+			plddrbypass-gpios = <&sys_gpio_out 28 0>;
 		};
 
 		xcvr_rx_os_core: axi-ad9371-rx-obs-hpc@10058000 {


### PR DESCRIPTION
Add the option to bypass the PL FIFO and use the regular DMA instead,
since the FPGA reference design already supports this feature.

Signed-off-by: Laszlo Nagy <laszlo.nagy@analog.com>