### PR TITLE
iio: jesd204: adi_xcvr: Add direct register access debug interface

### DIFF
--- a/drivers/iio/jesd204/axi_adxcvr.h
+++ b/drivers/iio/jesd204/axi_adxcvr.h
@@ -87,6 +87,7 @@ struct adxcvr_state {
 	bool			ref_is_div40;
 
 	unsigned int		num_lanes;
+	unsigned int		addr;
 };
 
 #endif /* AXI_ADXCVR_H_ */


### PR DESCRIPTION
Usage:
	echo <axi|drp> [drp_port] <reg> [write-val] > reg_access

 * Examples:
  * AXI access:
	root@analog:/sys/bus/platform/devices/44a60000.axi-adxcvr-rx# echo axi 8 0x1234  > reg_access
	root@analog:/sys/bus/platform/devices/44a60000.axi-adxcvr-rx# cat reg_access
	0x1234

  * DRP Access:
	root@analog:/sys/bus/platform/devices/44a60000.axi-adxcvr-rx# echo drp 1 0x88 > reg_access
	root@analog:/sys/bus/platform/devices/44a60000.axi-adxcvr-rx# cat reg_access
	0x20
	root@analog:/sys/bus/platform/devices/44a60000.axi-adxcvr-rx# echo drp 1 0x88 0x21 > reg_access
	axi-jesd204-rx 44aa0000.axi-jesd204-rx: Lane 0 desynced (10 errors), restarting link
	root@analog:/sys/bus/platform/devices/44a60000.axi-adxcvr-rx# cat reg_access
	0x21

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>