### PR TITLE
Fix dwc3 crashes

### DIFF
--- a/drivers/usb/dwc3/core.h
+++ b/drivers/usb/dwc3/core.h
@@ -532,6 +532,9 @@ struct dwc3_event_buffer {
  * @pending_list: list of pending requests for this endpoint
  * @started_list: list of started requests on this endpoint
  * @wait_end_transfer: wait_queue_head_t for waiting on End Transfer complete
+ * @aborted_trbs: Pointer to the first aborted TRB. These will be cleared at the
+ *                End of Transfer complete.
+ * @num_aborted_trbs: Number of aborted TRBs.
  * @lock: spinlock for endpoint request queue traversal
  * @regs: pointer to first endpoint register
  * @trb_pool: array of transaction buffers
@@ -557,6 +560,9 @@ struct dwc3_ep {
 	struct list_head	started_list;
 
 	wait_queue_head_t	wait_end_transfer;
+
+	struct dwc3_trb		*aborted_trbs;
+	unsigned int		num_aborted_trbs;
 
 	spinlock_t		lock;
 	void __iomem		*regs;

--- a/drivers/usb/dwc3/ep0.c
+++ b/drivers/usb/dwc3/ep0.c
@@ -246,7 +246,7 @@ static void dwc3_ep0_stall_and_restart(struct dwc3 *dwc)
 		struct dwc3_request	*req;
 
 		req = next_request(&dep->pending_list);
-		dwc3_gadget_giveback(dep, req, -ECONNRESET);
+		dwc3_gadget_giveback(dep, req, -ECONNRESET, true);
 	}
 
 	dwc->ep0state = EP0_SETUP_PHASE;
@@ -906,7 +906,7 @@ static void dwc3_ep0_complete_data(struct dwc3 *dwc,
 	if (status == DWC3_TRBSTS_SETUP_PENDING) {
 		dwc->setup_packet_pending = true;
 		if (r)
-			dwc3_gadget_giveback(ep0, r, -ECONNRESET);
+			dwc3_gadget_giveback(ep0, r, -ECONNRESET, true);
 
 		return;
 	}
@@ -932,7 +932,7 @@ static void dwc3_ep0_complete_data(struct dwc3 *dwc,
 	if ((epnum & 1) && ur->actual < ur->length)
 		dwc3_ep0_stall_and_restart(dwc);
 	else
-		dwc3_gadget_giveback(ep0, r, 0);
+		dwc3_gadget_giveback(ep0, r, 0, true);
 }
 
 static void dwc3_ep0_complete_status(struct dwc3 *dwc,
@@ -951,7 +951,7 @@ static void dwc3_ep0_complete_status(struct dwc3 *dwc,
 	if (!list_empty(&dep->pending_list)) {
 		r = next_request(&dep->pending_list);
 
-		dwc3_gadget_giveback(dep, r, 0);
+		dwc3_gadget_giveback(dep, r, 0, true);
 	}
 
 	if (dwc->test_mode) {

--- a/drivers/usb/dwc3/gadget.c
+++ b/drivers/usb/dwc3/gadget.c
@@ -2705,7 +2705,7 @@ void dwc3_stop_active_transfer(struct dwc3 *dwc, u32 epnum, bool force)
 	cmd |= DWC3_DEPCMD_PARAM(dep->resource_index);
 	memset(&params, 0, sizeof(params));
 	ret = dwc3_send_gadget_ep_cmd(dep, cmd, &params);
-	WARN_ON_ONCE(ret);
+	WARN_ON_ONCE(ret && ret != -ETIMEDOUT);
 	dep->flags &= ~DWC3_EP_BUSY;
 
 	/*

--- a/drivers/usb/dwc3/gadget.c
+++ b/drivers/usb/dwc3/gadget.c
@@ -1472,6 +1472,9 @@ static int dwc3_gadget_ep_dequeue(struct usb_ep *ep,
 				break;
 		}
 		if (r == req) {
+			if (dep->stream_capable)
+				del_timer(&dep->stream_timeout_timer);
+
 			/* wait until it is processed */
 			dwc3_stop_active_transfer(dwc, dep->number, true);
 

--- a/drivers/usb/dwc3/gadget.c
+++ b/drivers/usb/dwc3/gadget.c
@@ -1507,7 +1507,7 @@ static int dwc3_gadget_ep_dequeue(struct usb_ep *ep,
 					dwc->lock);
 
 			if (!r->trb)
-				goto out1;
+				goto out0;
 
 			if (r->num_pending_sgs) {
 				struct dwc3_trb *trb;

--- a/drivers/usb/dwc3/gadget.c
+++ b/drivers/usb/dwc3/gadget.c
@@ -1299,7 +1299,8 @@ int __dwc3_gadget_kick_transfer(struct dwc3_ep *dep, u16 cmd_param, bool givebac
 	dep->flags |= DWC3_EP_BUSY;
 
 	if (starting) {
-		if (dep->stream_capable) {
+		/* FIXME: Enable this again once it works properly */
+		if (dep->stream_capable && 0) {
 			dep->stream_timeout_timer.expires = jiffies +
 					msecs_to_jiffies(STREAM_TIMEOUT);
 			add_timer(&dep->stream_timeout_timer);

--- a/drivers/usb/dwc3/gadget.c
+++ b/drivers/usb/dwc3/gadget.c
@@ -1470,89 +1470,34 @@ static int dwc3_gadget_ep_dequeue(struct usb_ep *ep,
 
 	list_for_each_entry(r, &dep->pending_list, list) {
 		if (r == req)
+			goto out1;
+	}
+
+	list_for_each_entry(r, &dep->started_list, list) {
+		if (r == req)
 			break;
 	}
 
 	if (r != req) {
-		list_for_each_entry(r, &dep->started_list, list) {
-			if (r == req)
-				break;
-		}
-		if (r == req) {
-			if (dep->stream_capable)
-				del_timer(&dep->stream_timeout_timer);
-
-			/* wait until it is processed */
-			dwc3_stop_active_transfer(dwc, dep->number, true);
-
-			/*
-			 * If request was already started, this means we had to
-			 * stop the transfer. With that we also need to ignore
-			 * all TRBs used by the request, however TRBs can only
-			 * be modified after completion of END_TRANSFER
-			 * command. So what we do here is that we wait for
-			 * END_TRANSFER completion and only after that, we jump
-			 * over TRBs by clearing HWO and incrementing dequeue
-			 * pointer.
-			 *
-			 * Note that we have 2 possible types of transfers here:
-			 *
-			 * i) Linear buffer request
-			 * ii) SG-list based request
-			 *
-			 * SG-list based requests will have r->num_pending_sgs
-			 * set to a valid number (> 0). Linear requests,
-			 * normally use a single TRB.
-			 *
-			 * For each of these two cases, if r->unaligned flag is
-			 * set, one extra TRB has been used to align transfer
-			 * size to wMaxPacketSize.
-			 *
-			 * All of these cases need to be taken into
-			 * consideration so we don't mess up our TRB ring
-			 * pointers.
-			 */
-			wait_event_lock_irq(dep->wait_end_transfer,
-					!(dep->flags & DWC3_EP_END_TRANSFER_PENDING),
-					dwc->lock);
-
-			if (!r->trb)
-				goto out0;
-
-			if (r->num_pending_sgs) {
-				struct dwc3_trb *trb;
-				int i = 0;
-
-				for (i = 0; i < r->num_pending_sgs; i++) {
-					trb = r->trb + i;
-					trb->ctrl &= ~DWC3_TRB_CTRL_HWO;
-					dwc3_ep_inc_deq(dep);
-				}
-
-				if (r->unaligned || r->zero) {
-					trb = r->trb + r->num_pending_sgs + 1;
-					trb->ctrl &= ~DWC3_TRB_CTRL_HWO;
-					dwc3_ep_inc_deq(dep);
-				}
-			} else {
-				struct dwc3_trb *trb = r->trb;
-
-				trb->ctrl &= ~DWC3_TRB_CTRL_HWO;
-				dwc3_ep_inc_deq(dep);
-
-				if (r->unaligned || r->zero) {
-					trb = r->trb + 1;
-					trb->ctrl &= ~DWC3_TRB_CTRL_HWO;
-					dwc3_ep_inc_deq(dep);
-				}
-			}
-			goto out1;
-		}
 		dev_err(dwc->dev, "request %pK was not queued to %s\n",
 				request, ep->name);
 		ret = -EINVAL;
 		goto out0;
 	}
+
+	if (dep->stream_capable)
+		del_timer(&dep->stream_timeout_timer);
+
+	dep->aborted_trbs = r->trb;
+	if (r->num_pending_sgs)
+		dep->num_aborted_trbs = r->num_pending_sgs;
+	else
+		dep->num_aborted_trbs = 1;
+
+	if (r->unaligned || r->zero)
+		dep->num_aborted_trbs += 1;
+
+	dwc3_stop_active_transfer(dwc, dep->number, true);
 
 out1:
 	/* giveback the request */
@@ -2648,6 +2593,19 @@ static void dwc3_endpoint_interrupt(struct dwc3 *dwc,
 		cmd = DEPEVT_PARAMETER_CMD(event->parameters);
 
 		if (cmd == DWC3_DEPCMD_ENDTRANSFER) {
+			if (dep->aborted_trbs) {
+				struct dwc3_trb *trb = dep->aborted_trbs;
+				int i = 0;
+
+				for (i = 0; i < dep->num_aborted_trbs; i++) {
+					trb->ctrl &= ~DWC3_TRB_CTRL_HWO;
+					dwc3_ep_inc_deq(dep);
+					trb++;
+				}
+
+				dep->aborted_trbs = NULL;
+				dep->num_aborted_trbs = 0;
+			}
 			dep->flags &= ~DWC3_EP_END_TRANSFER_PENDING;
 			wake_up(&dep->wait_end_transfer);
 		}

--- a/drivers/usb/dwc3/gadget.h
+++ b/drivers/usb/dwc3/gadget.h
@@ -96,7 +96,7 @@ static inline void dwc3_gadget_move_started_request(struct dwc3_request *req)
 }
 
 void dwc3_gadget_giveback(struct dwc3_ep *dep, struct dwc3_request *req,
-		int status);
+		int status, bool giveback);
 
 void dwc3_ep0_interrupt(struct dwc3 *dwc,
 		const struct dwc3_event_depevt *event);
@@ -110,7 +110,7 @@ int dwc3_gadget_ep0_queue(struct usb_ep *ep, struct usb_request *request,
 int __dwc3_gadget_ep_set_halt(struct dwc3_ep *dep, int value, int protocol);
 int __dwc3_gadget_ep_enable(struct dwc3_ep *dep, bool modify, bool restore);
 int __dwc3_gadget_ep_disable(struct dwc3_ep *dep);
-int __dwc3_gadget_kick_transfer(struct dwc3_ep *dep, u16 cmd_param);
+int __dwc3_gadget_kick_transfer(struct dwc3_ep *dep, u16 cmd_param, bool giveback);
 void dwc3_stop_active_transfer(struct dwc3 *dwc, u32 epnum, bool force);
 int dwc3_gadget_run_stop(struct dwc3 *dwc, int is_on, int suspend);
 dma_addr_t dwc3_trb_dma_offset(struct dwc3_ep *dep, struct dwc3_trb *trb);

--- a/drivers/usb/dwc3/gadget_hibernation.c
+++ b/drivers/usb/dwc3/gadget_hibernation.c
@@ -217,7 +217,7 @@ static int restore_eps(struct dwc3 *dwc)
 				dep->resource_index =
 					dwc3_gadget_ep_get_transfer_index(dep);
 			} else {
-				ret = __dwc3_gadget_kick_transfer(dep, 0);
+				ret = __dwc3_gadget_kick_transfer(dep, 0, true);
 				if (ret) {
 					dev_err(dwc->dev,
 						"%s: restart transfer failed\n",

--- a/drivers/usb/dwc3/otg.c
+++ b/drivers/usb/dwc3/otg.c
@@ -518,7 +518,7 @@ static void start_peripheral(struct dwc3_otg *otg)
 		struct dwc3_ep		*dep;
 		int			ret;
 
-		spin_lock(&otg->lock);
+		spin_lock_irq(&otg->lock);
 		dep = dwc->eps[0];
 
 		ret = __dwc3_gadget_ep_enable(dep, false, false);
@@ -541,7 +541,7 @@ static void start_peripheral(struct dwc3_otg *otg)
 
 		otg_write(otg, DCTL, otg_read(otg, DCTL) | DCTL_RUN_STOP);
 		otg_dbg(otg, "Setting DCTL_RUN_STOP to 1 in DCTL\n");
-		spin_unlock(&otg->lock);
+		spin_unlock_irq(&otg->lock);
 	}
 
 	gadget->b_hnp_enable = 0;
@@ -580,13 +580,13 @@ static void stop_peripheral(struct dwc3_otg *otg)
 		return;
 
 	otg_dbg(otg, "disabled ep in gadget driver\n");
-	spin_lock(&otg->lock);
+	spin_lock_irq(&otg->lock);
 
 	dwc3_gadget_disable_irq(dwc);
 	__dwc3_gadget_ep_disable(dwc->eps[0]);
 	__dwc3_gadget_ep_disable(dwc->eps[1]);
 
-	spin_unlock(&otg->lock);
+	spin_unlock_irq(&otg->lock);
 
 	otg->peripheral_started = 0;
 	msleep(20);

--- a/drivers/usb/gadget/function/f_fs.c
+++ b/drivers/usb/gadget/function/f_fs.c
@@ -1016,7 +1016,7 @@ static ssize_t ffs_epfile_io(struct file *file, struct ffs_io_data *io_data)
 		else
 			ret = ep->status;
 		goto error_mutex;
-	} else if (!(req = usb_ep_alloc_request(ep->ep, GFP_KERNEL))) {
+	} else if (!(req = usb_ep_alloc_request(ep->ep, GFP_ATOMIC))) {
 		ret = -ENOMEM;
 	} else {
 		req->buf      = data;

--- a/drivers/usb/gadget/function/f_fs.c
+++ b/drivers/usb/gadget/function/f_fs.c
@@ -1539,7 +1539,6 @@ ffs_fs_kill_sb(struct super_block *sb)
 	if (sb->s_fs_info) {
 		ffs_release_dev(sb->s_fs_info);
 		ffs_data_closed(sb->s_fs_info);
-		ffs_data_put(sb->s_fs_info);
 	}
 }
 

--- a/drivers/usb/gadget/function/f_fs.c
+++ b/drivers/usb/gadget/function/f_fs.c
@@ -1073,18 +1073,19 @@ static int ffs_aio_cancel(struct kiocb *kiocb)
 {
 	struct ffs_io_data *io_data = kiocb->private;
 	struct ffs_epfile *epfile = kiocb->ki_filp->private_data;
+	unsigned long flags;
 	int value;
 
 	ENTER();
 
-	spin_lock_irq(&epfile->ffs->eps_lock);
+	spin_lock_irqsave(&epfile->ffs->eps_lock, flags);
 
 	if (likely(io_data && io_data->ep && io_data->req))
 		value = usb_ep_dequeue(io_data->ep, io_data->req);
 	else
 		value = -EINVAL;
 
-	spin_unlock_irq(&epfile->ffs->eps_lock);
+	spin_unlock_irqrestore(&epfile->ffs->eps_lock, flags);
 
 	return value;
 }


### PR DESCRIPTION
Some backports from upstream kernel that seem to fix the remaining crashes of the DWC3 gadget driver when being used with IIOD.

The last patch is more of a workaround than a fix, but it is in upstream, so lets use it.

With these patches the board survived 1h of starting and stopping transfers every 5 seconds.