### PR TITLE
clk: zynqmp: Fix memory leak

### DIFF
--- a/drivers/clk/zynqmp/clkc.c
+++ b/drivers/clk/zynqmp/clkc.c
@@ -465,7 +465,7 @@ static struct clk *zynqmp_register_clk_topology(int clk_id, char *clk_name,
 {
 	int j, ret;
 	u32 num_nodes, mult, div;
-	char *clk_out = NULL;
+	char *clk_out = NULL, *clk_out_prev = NULL;
 	struct clock_topology *nodes;
 	struct clk *clk = NULL;
 
@@ -526,6 +526,8 @@ static struct clk *zynqmp_register_clk_topology(int clk_id, char *clk_name,
 				     __func__, clk_name, PTR_ERR(clk));
 
 		parent_names[0] = clk_out;
+		kfree(clk_out_prev);
+		clk_out_prev = clk_out;
 	}
 	kfree(clk_out);
 	return clk;


### PR DESCRIPTION
The zynqmp clock driver does multiple memory allocations when registering a
clock but only ever frees the last allocation. Make sure that all
allocations are freed.

This is not critical since it is just a one time memory leak at system
initialization time, but it still shows up as noise in kmemleak.

Signed-off-by: Lars-Peter Clausen <lars@metafoo.de>