### PR TITLE
iio: jesd204: xcvr: Avoid using DRP broadcast to prevent undesired be…

### DIFF
--- a/drivers/iio/jesd204/axi_adxcvr.h
+++ b/drivers/iio/jesd204/axi_adxcvr.h
@@ -58,11 +58,9 @@
 #define ADXCVR_DRP_PORT_ADDR_COMMON	0x00
 #define ADXCVR_DRP_PORT_ADDR_CHANNEL	0x20
 
-#define ADXCVR_DRP_PORT_COMMON		0x00
-#define ADXCVR_DRP_PORT_CHANNEL(x)	(0x1 + x)
-#define ADXCVR_DRP_PORT_CHANNEL_BCAST	0xff
+#define ADXCVR_DRP_PORT_COMMON(x)	(x)
+#define ADXCVR_DRP_PORT_CHANNEL(x)	(0x100 + (x))
 
-#define ADXCVR_BROADCAST		0xff
 
 struct adxcvr_state {
 	struct device		*dev;

--- a/drivers/iio/jesd204/axi_adxcvr_eyescan.c
+++ b/drivers/iio/jesd204/axi_adxcvr_eyescan.c
@@ -161,7 +161,7 @@ static ssize_t adxcvr_eyescan_set_enable(struct device *dev,
 	if (ret)
 		return ret;
 
-	if (st->eye->lane >= ADXCVR_BROADCAST || st->eye->lane < 0)
+	if (st->eye->lane >= 0xFF || st->eye->lane < 0)
 		return -EINVAL;
 
 	if (!completion_done(&st->eye->complete)) {


### PR DESCRIPTION
…havior

In some use cases DRP broadcast can lead to undesired behavior.

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>