### PR TITLE
AD9144 PLL and SYSREF changes

### DIFF
--- a/drivers/iio/frequency/ad9144.h
+++ b/drivers/iio/frequency/ad9144.h
@@ -150,6 +150,7 @@
 #define REG_DACPLLTB                             0x1BB /* VCO Bias Control */
 #define REG_DACPLLTD                             0x1BD /* VCO Cal control */
 #define REG_DACPLLT17                            0x1C4 /* Varactor ControlV */
+#define REG_DACPLLT18                            0x1C5 /* Varactor ControlV */
 #define REG_ASPI_SPARE0                          0x1C6 /* Spare Register 0 */
 #define REG_ASPI_SPARE1                          0x1C7 /* Spare Register 1 */
 #define REG_SPISTRENGTH                          0x1DF /* Reg 70 Description */


### PR DESCRIPTION
Two patches that add support for the internal PLL to the AD9144 driver as well as re-configuring the external SYSREF frequency to meet the requirements of the converter.