### PR TITLE
Add devicetrees for AD9136-FMC-EBZ

### DIFF
--- a/arch/arm/boot/dts/adi-ad9136-fmc-ebz.dtsi
+++ b/arch/arm/boot/dts/adi-ad9136-fmc-ebz.dtsi
@@ -1,0 +1,82 @@
+/ {
+	clocks {
+		ad9516_clkin: refclk {
+			compatible = "fixed-clock";
+
+			clock-frequency = <1400000000>;
+			clock-output-names = "ad9516-extclk";
+			#clock-cells = <0>;
+		};
+
+/* Ref clock for external clock chip
+		ref_clock: clock@0 {
+			compatible = "fixed-clock";
+
+			clock-frequency = <10000000 >;
+			clock-output-names = "10M-TCXO";
+			#clock-cells = <0>;
+		};
+*/
+	};
+};
+
+/*
+ * Example of how to use a programmable external clock generator connected to
+ * the PMOD SPI to generate the input clock frequency for the board.
+
+&pmod_spi {
+	status = "okay";
+
+	ad9516_clkin: pll@0 {
+		compatible = "adi,adf4360-7";
+		reg = <0>;
+		spi-max-frequency = <2000000>;
+
+		#clock-cells = <0>;
+
+		clocks = <&ref_clock>;
+		clock-output-names = "adf4360-7";
+
+		adi,loop-filter-charge-pump-current = <5>;
+		adi,loop-filter-pfd-frequency-hz = <2500000>;
+
+		assigned-clocks = <&ad9516_clkin>;
+		assigned-clock-rates = <750000000>;
+	};
+};
+*/
+
+&fmc_spi {
+	status = "okay";
+
+	ad9516: clockchip@0 {
+		compatible = "adi,ad9516-1";
+		reg = <0>;
+
+		spi-max-frequency = <10000000>;
+
+		clocks = <&ad9516_clkin>;
+		clock-names = "clkin";
+		clock-output-names = "ad9516-out0", "ad9516-out1", "ad9516-out2",
+			"ad9516-out3", "ad9516-out4", "ad9516-out5", "ad9516-out6",
+			"ad9516-out7", "ad9516-out8", "ad9516-out9";
+		#clock-cells = <1>;
+
+		/* DAC clock, DAC SYSREF, FPGA clock, FPGA SYSREF */
+		assigned-clocks = <&ad9516 1>, <&ad9516 6>, <&ad9516 9>, <&ad9516 7>;
+		assigned-clock-rates = <1400000000>, <683594>, <87500000>, <683594>;
+	};
+
+	dac: dac@1 {
+		compatible = "adi,ad9136";
+		reg = <1>;
+		adi,spi-4wire-enable;
+
+		spi-max-frequency = <1000000>;
+
+		txen-gpios = <&fmc_gpio (fmc_gpio_base + 0) 0>, <&fmc_gpio (fmc_gpio_base + 1) 0>;
+
+		clocks = <&jesd204_link>, <&ad9516 1>, <&ad9516 6>;
+		clock-names = "jesd_dac_clk", "dac_clk", "dac_sysref";
+	};
+};

--- a/arch/arm/boot/dts/adi-common-dac-fmc-ebz.dtsi
+++ b/arch/arm/boot/dts/adi-common-dac-fmc-ebz.dtsi
@@ -1,0 +1,41 @@
+&dac_dma {
+	compatible = "adi,axi-dmac-1.00.a";
+
+	#dma-cells = <1>;
+
+	adi,channels {
+		#size-cells = <0>;
+		#address-cells = <1>;
+
+		dma-channel@0 {
+			reg = <0>;
+			adi,source-bus-width = <64>;
+			adi,source-bus-type = <0>;
+			adi,destination-bus-width = <256>;
+			adi,destination-bus-type = <2>;
+		};
+	};
+};
+
+&jesd204_transport {
+	compatible = "adi,axi-ad9136-1.0";
+
+	dmas = <&dac_dma 0>;
+	dma-names = "tx";
+
+	spibus-connected = <&dac>;
+	adi,axi-pl-fifo-enable;
+};
+
+&jesd204_link {
+	compatible = "adi,axi-jesd204-tx-1.0";
+
+	adi,octets-per-frame = <1>;
+	adi,frames-per-multiframe = <32>;
+	adi,converter-resolution = <16>;
+	adi,bits-per-sample = <16>;
+	adi,converters-per-device = <2>;
+
+	#clock-cells = <0>;
+	clock-output-names = "jesd_dac_lane_clk";
+};

--- a/arch/arm/boot/dts/adi-intel-dac-fmc-ebz.dtsi
+++ b/arch/arm/boot/dts/adi-intel-dac-fmc-ebz.dtsi
@@ -1,0 +1,97 @@
+/ {
+	soc {
+		sys_hps_bridges: bridge@ff200000 {
+			compatible = "altr,bridge-16.0", "simple-bus";
+			reg = <0xff200000 0x00200000>;
+
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges = <0x00000000 0xff200000 0x00200000>;
+
+			sys_gpio_in: sys-gpio-in@0 {
+				compatible = "altr,pio-16.0", "altr,pio-1.0";
+				reg = <0x00 0x10>;
+
+				#gpio-cells = <2>;
+				gpio-controller;
+			};
+
+			sys_gpio_out: sys-gpio-out@20 {
+				compatible = "altr,pio-16.0", "altr,pio-1.0";
+				reg = <0x20 0x10>;
+
+				#gpio-cells = <2>;
+				gpio-controller;
+			};
+
+			sys_spi: spi@40 {
+				compatible = "altr,spi-16.0", "altr,spi-1.0";
+				reg = <0x40 0x20>;
+
+				interrupt-parent = <&intc>;
+				interrupts = <0 26 4>;
+
+				#address-cells = <0x1>;
+				#size-cells = <0x0>;
+			};
+
+			dac_dma: dmac@40000 {
+				reg = <0x40000 0x4000>;
+
+				interrupt-parent = <&intc>;
+				interrupts = <0 30 0>;
+
+				clocks = <&dma_clk>;
+			};
+
+			jesd204_transport: jesd204-transport-layer@34000 {
+				reg = <0x34000 0x4000>;
+			};
+
+			jesd204_link: jesd204-link-layer@20000 {
+				reg = <0x20000 0x4000>;
+
+				interrupt-parent = <&intc>;
+				interrupts = <0 28 0>;
+
+				clocks = <&sys_clk>, <&tx_device_clk_pll>, <&jesd204_phy>;
+				clock-names = "s_axi_aclk", "device_clk", "lane_clk";
+			};
+
+			jesd204_phy: jesd204-phy@24000 {
+				compatible = "adi,altera-adxcvr-1.00.a";
+				reg = <0x24000 0x1000>,
+				      <0x26000 0x1000>,
+				      <0x28000 0x1000>,
+				      <0x29000 0x1000>,
+				      <0x2a000 0x1000>,
+				      <0x2b000 0x1000>,
+				      <0x2c000 0x1000>,
+				      <0x2d000 0x1000>,
+				      <0x2e000 0x1000>,
+				      <0x2f000 0x1000>;
+				reg-names = "adxcvr", "atx-pll",
+					"adxcfg-0", "adxcfg-1", "adxcfg-2", "adxcfg-3",
+					"adxcfg-4", "adxcfg-5", "adxcfg-6", "adxcfg-7";
+
+				clocks = <&fpga_device_clk>, <&tx_device_clk_pll>;
+				clock-names = "ref", "link";
+
+				#clock-cells = <0>;
+				clock-output-names = "jesd204_tx_lane_clock";
+			};
+
+			tx_device_clk_pll: altera-a10-fpll@25000 {
+				compatible = "altr,a10-fpll";
+				reg = <0x25000 0x1000>;
+
+				clocks = <&fpga_device_clk>;
+
+				#clock-cells = <0>;
+				clock-output-names = "jesd204_tx_link_clock";
+			};
+		};
+	};
+};
+
+#include "adi-common-dac-fmc-ebz.dtsi"

--- a/arch/arm/boot/dts/adi-xilinx-dac-fmc-ebz.dtsi
+++ b/arch/arm/boot/dts/adi-xilinx-dac-fmc-ebz.dtsi
@@ -1,0 +1,38 @@
+&fpga_axi {
+	dac_dma: dma@7c420000 {
+		reg = <0x7c420000 0x10000>;
+
+		interrupts = <0 56 0>;
+		clocks = <&axi_clk>;
+	};
+
+	jesd204_transport: jesd204-transport-layer@44a04000 {
+		reg = <0x44a14000 0x4000>;
+	};
+
+	jesd204_link: jesd204-link-layer@44a90000 {
+		reg = <0x44a20000 0x1000>;
+
+		interrupts = <0 54 0>;
+
+		clocks = <&axi_clk>, <&fpga_device_clk>, <&jesd204_phy 0>;
+		clock-names = "s_axi_aclk", "device_clk", "lane_clk";
+	};
+
+	jesd204_phy: jesd204-phy@44a60000 {
+		compatible = "adi,axi-adxcvr-1.0";
+		reg = <0x44a00000 0x1000>;
+
+		clocks = <&fpga_device_clk>, <&fpga_device_clk>;
+		clock-names = "conv", "div40";
+
+		#clock-cells = <1>;
+		clock-output-names = "dac_gt_clk", "tx_out_clk";
+
+		adi,sys-clk-select = <3>;
+		adi,out-clk-select = <4>;
+		adi,use-lpm-enable;
+	};
+};
+
+#include "adi-common-dac-fmc-ebz.dtsi"

--- a/arch/arm/boot/dts/socfpga_arria10_socdk_ad9136_fmc_ebz.dts
+++ b/arch/arm/boot/dts/socfpga_arria10_socdk_ad9136_fmc_ebz.dts
@@ -1,0 +1,8 @@
+/dts-v1/;
+
+#define fmc_gpio sys_gpio_out
+#define fmc_gpio_base 0
+#define fpga_device_clk ad9516 9
+
+#include "socfpga_arria10_socdk_dac_fmc_ebz.dtsi"
+#include "adi-ad9136-fmc-ebz.dtsi"

--- a/arch/arm/boot/dts/socfpga_arria10_socdk_dac_fmc_ebz.dtsi
+++ b/arch/arm/boot/dts/socfpga_arria10_socdk_dac_fmc_ebz.dtsi
@@ -1,0 +1,34 @@
+
+#include "socfpga_arria10_socdk.dtsi"
+
+&mmc {
+	status = "okay";
+	num-slots = <1>;
+	cap-sd-highspeed;
+	broken-cd;
+	bus-width = <4>;
+	altr,dw-mshc-ciu-div = <3>;
+	altr,dw-mshc-sdr-timing = <0 3>;
+};
+
+/ {
+	clocks {
+		sys_clk: sys_clk {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <100000000>;
+			clock-output-names = "system_clock";
+		};
+
+		dma_clk: dma_clk {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <166666667>;
+			clock-output-names = "dma_clock";
+		};
+	};
+};
+
+#include "adi-intel-dac-fmc-ebz.dtsi"
+
+#define fmc_spi sys_spi

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad9136-fmc-ebz.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad9136-fmc-ebz.dts
@@ -1,0 +1,33 @@
+/dts-v1/;
+
+/include/ "zynq-zc706.dtsi"
+/include/ "zynq-zc706-adv7511.dtsi"
+
+&i2c_mux {
+	i2c@5 { /* HPC IIC */
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <5>;
+
+		eeprom@50 {
+			compatible = "at24,24c02";
+			reg = <0x50>;
+		};
+
+		eeprom@54 {
+			compatible = "at24,24c02";
+			reg = <0x54>;
+		};
+	};
+};
+
+#define fmc_spi spi0
+#define pmod_spi spi1
+#define axi_clk clkc 16
+#define fpga_device_clk ad9516 9
+
+#define fmc_gpio_base 86
+#define fmc_gpio gpio0
+
+#include "adi-xilinx-dac-fmc-ebz.dtsi"
+#include "adi-ad9136-fmc-ebz.dtsi"

--- a/drivers/iio/frequency/cf_axi_dds.c
+++ b/drivers/iio/frequency/cf_axi_dds.c
@@ -943,6 +943,30 @@ static struct cf_axi_dds_chip_info cf_axi_dds_chip_info_tbl[] = {
 		.num_buf_channels = 1,
 
 	},
+	[ID_AD9136] = {
+		.name = "AD9136",
+		.channel = {
+			{
+				.type = IIO_TEMP,
+				.indexed = 1,
+				.channel = 0,
+				.scan_index = -1,
+				.info_mask_separate =
+					BIT(IIO_CHAN_INFO_PROCESSED) |
+					BIT(IIO_CHAN_INFO_CALIBBIAS),
+			},
+			CF_AXI_DDS_CHAN_BUF(0),
+			CF_AXI_DDS_CHAN_BUF(1),
+			CF_AXI_DDS_CHAN(0, 0, "1A"),
+			CF_AXI_DDS_CHAN(1, 0, "1B"),
+			CF_AXI_DDS_CHAN(2, 0, "2A"),
+			CF_AXI_DDS_CHAN(3, 0, "2B"),
+		},
+		.num_channels = 7,
+		.num_dp_disable_channels = 3,
+		.num_dds_channels = 4,
+		.num_buf_channels = 2,
+	},
 	[ID_AD9144] = {
 		.name = "AD9144",
 		.channel = {
@@ -1272,7 +1296,8 @@ static const struct axidds_core_info ad9963_1_00_a_info = {
 /* Match table for of_platform binding */
 static const struct of_device_id cf_axi_dds_of_match[] = {
 	{ .compatible = "adi,axi-ad9122-6.00.a", .data = &ad9122_6_00_a_info},
-	{ .compatible = "adi,axi-ad9144-1.0", .data = &ad9144_7_00_a_info},
+	{ .compatible = "adi,axi-ad9136-1.0", .data = &ad9144_7_00_a_info },
+	{ .compatible = "adi,axi-ad9144-1.0", .data = &ad9144_7_00_a_info, },
 	{ .compatible = "adi,axi-ad9739a-8.00.b", .data = &ad9739a_8_00_b_info},
 	{
 	    .compatible = "adi,axi-ad9361x2-dds-6.00.a",


### PR DESCRIPTION
Add the devicetrees for supporting the AD9136-FMC-EBZ connected to either the Arria10 SoC or ZC706 carrier.

The devicetrees have been split into multiple sub include devicetree files that can be used to easily add support for other similar DAC FMC boards that use the same HDL reference design.

Note that this will not work as is as long as the framer settings from the HDL are not propagated to the AD9144 driver. (Alternative is to manually change the AD9144 source to a different JESD204 link setting). 