### PR TITLE
iio: adc: adrv9009: Remove unhandled AGC modes

### DIFF
--- a/drivers/iio/adc/adrv9009.c
+++ b/drivers/iio/adc/adrv9009.c
@@ -1138,13 +1138,7 @@ static int adrv9009_set_agc_mode(struct iio_dev *indio_dev,
 		val = TAL_MGC;
 		break;
 	case 1:
-		val = TAL_AGCFAST;
-		break;
-	case 2:
 		val = TAL_AGCSLOW;
-		break;
-	case 3:
-		val = TAL_HYBRID;
 		break;
 	default:
 		return -EINVAL;
@@ -1166,7 +1160,7 @@ static int adrv9009_get_agc_mode(struct iio_dev *indio_dev,
 }
 
 static const char * const adrv9009_agc_modes[] =
-{"manual", "fast_attack", "slow_attack", "hybrid"};
+	{"manual", "slow_attack"};
 
 static const struct iio_enum adrv9009_agc_modes_available = {
 	.items = adrv9009_agc_modes,


### PR DESCRIPTION
Talise API version: 3.5.0.2 and earlier doesn't handle all documented
AGC modes. In order to avoid confusion remove them for now.

talise_rx.c:534
    /* performing AGC type check */
    switch (mode)
    {
        case TAL_MGC:
            break;
        case TAL_AGCSLOW:
             break;
        case TAL_AGCFAST: /* Fall through to next case */
        case TAL_HYBRID:
            return (uint32_t)talApiErrHandler(device, TAL_ERRHDL_INVALID_PARAM,
                    TAL_ERR_UNSUPPORTED_RX_GAIN_MODE_PARM, retVal, TALACT_ERR_CHECK_PARAM);
        default:
            return (uint32_t)talApiErrHandler(device, TAL_ERRHDL_INVALID_PARAM,
                    TAL_ERR_INV_RX_GAIN_MODE_PARM, retVal, TALACT_ERR_CHECK_PARAM);
    }

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>