### PR TITLE
build,travis: split builds into smaller parts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ notifications:
 
 env:
   matrix:
+  - BUILD_TYPE=checkpatch
+  - BUILD_TYPE=dtb_build_test
   - DEFCONFIG_NAME=zynq_xcomm_adv7511_defconfig ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf-
     DTS_FILES=arch/arm/boot/dts/zynq-*.dts IMAGE=uImage
   - DEFCONFIG_NAME=zynq_pluto_defconfig ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf-
@@ -18,8 +20,8 @@ env:
     DTS_FILES=arch/arm/boot/dts/zynq-*.dts IMAGE=uImage
   - DEFCONFIG_NAME=adi_zynqmp_defconfig ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu-
     DTS_FILES=arch/arm64/boot/dts/xilinx/zynqmp-*.dts DTS_PREFIX=xilinx/ IMAGE=Image
-  - COMPILE_TEST=y DEFCONFIG_NAME=zynq_xcomm_adv7511_defconfig ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf-
-  - COMPILE_TEST=y DEFCONFIG_NAME=adi_zynqmp_defconfig ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu-
+  - BUILD_TYPE=compile_test DEFCONFIG_NAME=zynq_xcomm_adv7511_defconfig ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf-
+  - BUILD_TYPE=compile_test DEFCONFIG_NAME=adi_zynqmp_defconfig ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu-
 
 before_install:
   - sudo apt-get update -qq


### PR DESCRIPTION
The checkpatch part generates all builds as red, if at least one format
element is wrong, which really reduces the value of builds.

Isolating the checkpatch and dtb builds into their own container,
highlights compile issues better, and if there are any checkpatch stuff
that's easy to fix, this can be re-spun in less than 10 minutes (which is
what a normal Linux build takes).

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>