### PR TITLE
dts: arm[64]: Update adi,axi-adxcvr-1.0 device names

### DIFF
--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad6676-fmc.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad6676-fmc.dts
@@ -141,7 +141,7 @@
 		adi,frames-per-multiframe = <16>;
 	};
 
-	axi_adxcvr: axi-adxcvr@44a60000 {
+	axi_adxcvr: axi-adxcvr-rx@44a60000 {
 		compatible = "adi,axi-adxcvr-1.0";
 		reg = <0x44a60000 0x1000>;
 

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad9625-fmcadc2.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad9625-fmcadc2.dts
@@ -116,7 +116,7 @@
 		adi,frames-per-multiframe = <32>;
 	};
 
-	axi_adxcvr: axi-adxcvr@44a60000 {
+	axi_adxcvr: axi-adxcvr-rx@44a60000 {
 		compatible = "adi,axi-adxcvr-1.0";
 		reg = <0x44a60000 0x1000>;
 

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcadc4.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcadc4.dts
@@ -58,7 +58,7 @@
 		adi,frames-per-multiframe = <32>;
 	};
 
-	axi_adxcvr: axi-adxcvr@44a60000 {
+	axi_adxcvr: axi-adxcvr-rx@44a60000 {
 		compatible = "adi,axi-adxcvr-1.0";
 		reg = <0x44a60000 0x1000>;
 

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcdaq2.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcdaq2.dts
@@ -122,7 +122,7 @@
 		clock-output-names = "jesd_adc_lane_clk";
 	};
 
-	axi_ad9680_adxcvr: axi-ad9680-adxcvr@44a50000 {
+	axi_ad9680_adxcvr: axi-adxcvr-rx@44a50000 {
 		compatible = "adi,axi-adxcvr-1.0";
 		reg = <0x44a50000 0x1000>;
 
@@ -138,7 +138,7 @@
 		adi,use-cpll-enable;
 	};
 
-	axi_ad9144_adxcvr: axi-ad9144-adxcvr@44a60000 {
+	axi_ad9144_adxcvr: axi-adxcvr-tx@44a60000 {
 		compatible = "adi,axi-adxcvr-1.0";
 		reg = <0x44a60000 0x1000>;
 

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcdaq3.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcdaq3.dts
@@ -124,7 +124,7 @@
 		clock-output-names = "jesd_adc_lane_clk";
 	};
 
-	axi_ad9680_adxcvr: axi-ad9680-adxcvr@44a50000 {
+	axi_ad9680_adxcvr: axi-adxcvr-rx@44a50000 {
 		#address-cells = <1>;
 		#size-cells = <0>;
 		compatible = "adi,axi-adxcvr-1.0";
@@ -142,7 +142,7 @@
 		adi,use-cpll-enable;
 	};
 
-	axi_ad9152_adxcvr: axi-ad9152-adxcvr@44a60000 {
+	axi_ad9152_adxcvr: axi-adxcvr-tx@44a60000 {
 		#address-cells = <1>;
 		#size-cells = <0>;
 		compatible = "adi,axi-adxcvr-1.0";

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcjesdadc1.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcjesdadc1.dts
@@ -87,7 +87,7 @@
 		spibus-connected = <&adc1_ad9250>;
 	};
 
-	axi_jesd: axi-jesd204b-rx@44aa0000 {
+	axi_jesd: axi-jesd204-rx@44aa0000 {
 		compatible = "adi,axi-jesd204-rx-1.0";
 		reg = <0x44aa0000 0x1000>;
 
@@ -103,7 +103,7 @@
 		adi,frames-per-multiframe = <32>;
 	};
 
-	axi_adxcvr: axi-adxcvr@44a60000 {
+	axi_adxcvr: axi-adxcvr-rx@44a60000 {
 		compatible = "adi,axi-adxcvr-1.0";
 		reg = <0x44a60000 0x1000>;
 

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcomms11.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcomms11.dts
@@ -123,7 +123,7 @@
 		clock-output-names = "jesd_adc_lane_clk";
 	};
 
-	rx_adxcvr: rx-adxcvr@44a50000 {
+	rx_adxcvr: axi-adxcvr-rx@44a50000 {
 		compatible = "adi,axi-adxcvr-1.0";
 		reg = <0x44a50000 0x1000>;
 
@@ -139,7 +139,7 @@
 		adi,use-lpm-enable;
 	};
 
-	tx_adxcvr: tx-adxcvr@44a60000 {
+	tx_adxcvr: axi-adxcvr-tx@44a60000 {
 		compatible = "adi,axi-adxcvr-1.0";
 		reg = <0x44a60000 0x1000>;
 		clocks = <&adc_divclk>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-fmcdaq2.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-fmcdaq2.dts
@@ -133,7 +133,7 @@
 			clock-output-names = "jesd_adc_lane_clk";
 		};
 
-		axi_ad9680_adxcvr: axi-ad9680-adxcvr-rx@84a50000{
+		axi_ad9680_adxcvr: axi-adxcvr-rx@84a50000{
 			compatible = "adi,axi-adxcvr-1.0";
 			reg = <0x84A50000 0x1000>;
 
@@ -149,7 +149,7 @@
 			adi,use-cpll-enable;
 		};
 
-		axi_ad9144_adxcvr: axi-ad9144-adxcvr-tx@84a60000{
+		axi_ad9144_adxcvr: axi-adxcvr-tx@84a60000{
 			compatible = "adi,axi-adxcvr-1.0";
 			reg = <0x84A60000 0x1000>;
 

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-fmcdaq3.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-fmcdaq3.dts
@@ -111,7 +111,7 @@
 			clock-output-names = "jesd_adc_lane_clk";
 		};
 
-		axi_ad9680_adxcvr: axi-ad9680-adxcvr-rx@84a50000 {
+		axi_ad9680_adxcvr: axi-adxcvr-rx@84a50000 {
 			compatible = "adi,axi-adxcvr-1.0";
 			reg = <0x84a50000 0x1000>;
 
@@ -146,7 +146,7 @@
 			clock-output-names = "jesd_dac_lane_clk";
 		};
 
-		axi_ad9152_adxcvr: axi-ad9152-adxcvr-tx@84a60000 {
+		axi_ad9152_adxcvr: axi-adxcvr-tx@84a60000 {
 			compatible = "adi,axi-adxcvr-1.0";
 			reg = <0x84a60000 0x1000>;
 


### PR DESCRIPTION
This update introduces a naming convention allowing the jesd-eye-scan-gtk
application to determine target devices.

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>