### PR TITLE
iio: adc: ad7768: Fix iio_buffer removal

### DIFF
--- a/drivers/iio/adc/ad7768.c
+++ b/drivers/iio/adc/ad7768.c
@@ -398,6 +398,8 @@ error_disable_clk:
 error_disable_reg:
 	regulator_disable(st->vref);
 
+	iio_dmaengine_buffer_free(indio_dev->buffer);
+
 	return ret;
 }
 
@@ -406,6 +408,7 @@ static int ad7768_remove(struct spi_device *spi)
 	struct iio_dev *indio_dev = spi_get_drvdata(spi);
 	struct ad7768_state *st = iio_priv(indio_dev);
 
+	iio_dmaengine_buffer_free(indio_dev->buffer);
 	clk_disable_unprepare(st->mclk);
 	regulator_disable(st->vref);
 


### PR DESCRIPTION
This patch adds iio_dmaengine_buffer_free in case of error or if the device
is removed.

Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>