### PR TITLE
microblaze: dts: [vc707|kc705|kcu105]_fmcomms2-3.dts: Fix GPIO numbers

### DIFF
--- a/arch/microblaze/boot/dts/kc705_fmcomms2-3.dts
+++ b/arch/microblaze/boot/dts/kc705_fmcomms2-3.dts
@@ -68,9 +68,9 @@
 #include "adi-fmcomms2.dtsi"
 
 &adc0_ad9361 {
-	en_agc-gpios = <&axi_gpio 12 8>;
-	sync-gpios = <&axi_gpio 13 8>;
-	reset-gpios = <&axi_gpio 14 8>;
-	enable-gpios = <&axi_gpio 15 8>;
-	txnrx-gpios = <&axi_gpio 16 8>;
+	en_agc-gpios = <&axi_gpio 44 8>;
+	sync-gpios = <&axi_gpio 45 8>;
+	reset-gpios = <&axi_gpio 46 8>;
+	enable-gpios = <&axi_gpio 47 8>;
+	txnrx-gpios = <&axi_gpio 48 8>;
 };

--- a/arch/microblaze/boot/dts/kcu105_fmcomms2-3.dts
+++ b/arch/microblaze/boot/dts/kcu105_fmcomms2-3.dts
@@ -68,9 +68,9 @@
 #include "adi-fmcomms2.dtsi"
 
 &adc0_ad9361 {
-	en_agc-gpios = <&axi_gpio 12 8>;
-	sync-gpios = <&axi_gpio 13 8>;
-	reset-gpios = <&axi_gpio 14 8>;
-	enable-gpios = <&axi_gpio 15 8>;
-	txnrx-gpios = <&axi_gpio 16 8>;
+	en_agc-gpios = <&axi_gpio 44 8>;
+	sync-gpios = <&axi_gpio 45 8>;
+	reset-gpios = <&axi_gpio 46 8>;
+	enable-gpios = <&axi_gpio 47 8>;
+	txnrx-gpios = <&axi_gpio 48 8>;
 };

--- a/arch/microblaze/boot/dts/vc707_fmcomms2-3.dts
+++ b/arch/microblaze/boot/dts/vc707_fmcomms2-3.dts
@@ -68,9 +68,9 @@
 #include "adi-fmcomms2.dtsi"
 
 &adc0_ad9361 {
-	en_agc-gpios = <&axi_gpio 12 8>;
-	sync-gpios = <&axi_gpio 13 8>;
-	reset-gpios = <&axi_gpio 14 8>;
-	enable-gpios = <&axi_gpio 15 8>;
-	txnrx-gpios = <&axi_gpio 16 8>;
+	en_agc-gpios = <&axi_gpio 44 8>;
+	sync-gpios = <&axi_gpio 45 8>;
+	reset-gpios = <&axi_gpio 46 8>;
+	enable-gpios = <&axi_gpio 47 8>;
+	txnrx-gpios = <&axi_gpio 48 8>;
 };


### PR DESCRIPTION
Apparently all GPIO numbers are off by 32. Which is causing all kinds of
unexpected behaviour since the AD9361 RESETB is floating.

AD9361 GPIO are mapped via on the upper half of the dual axi-gpio
controller. Fixed by adding an offset of 32.

https://github.com/analogdevicesinc/hdl/blob/master/projects/fmcomms2/vc707/system_top.v#L132


Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>