### PR TITLE
arm64: dts: adi-adrv9009.dtsi: Fix SPI reg properties

### DIFF
--- a/arch/arm64/boot/dts/xilinx/adi-adrv9009.dtsi
+++ b/arch/arm64/boot/dts/xilinx/adi-adrv9009.dtsi
@@ -19,7 +19,7 @@
 
 	clk0_ad9528: ad9528-1@0 {
 		compatible = "adi,ad9528";
-		reg = <1>;
+		reg = <0>;
 
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -104,7 +104,7 @@
 
 	trx0_adrv9009: adrv9009-phy@1 {
 		compatible = "adrv9009";
-		reg = <0>;
+		reg = <1>;
 
 		#address-cells = <1>;
 		#size-cells = <0>;


### PR DESCRIPTION
commit: 69c3c384bade328eb4412bc9e3ef2ef33eb26ae9
devicetree: Cleanup adi-*.dtsi

Accidentally reverted the reg properties - This patch fixes it.

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>