### PR TITLE
iio: adc: ad9371: Add support for setting the SYSREF rate

### DIFF
--- a/arch/arm/boot/dts/adi-adrv9371.dtsi
+++ b/arch/arm/boot/dts/adi-adrv9371.dtsi
@@ -96,8 +96,12 @@
 		spi-max-frequency = <25000000>;
 
 		/* Clocks */
-		clocks = <&axi_ad9371_rx_jesd>, <&axi_ad9371_tx_jesd>, <&axi_ad9371_rx_os_jesd>, <&clk0_ad9528 13>, <&clk0_ad9528 1>;
-		clock-names = "jesd_rx_clk", "jesd_tx_clk", "jesd_rx_os_clk", "dev_clk", "fmc_clk";
+		clocks = <&axi_ad9371_rx_jesd>, <&axi_ad9371_tx_jesd>,
+			<&axi_ad9371_rx_os_jesd>, <&clk0_ad9528 13>,
+			<&clk0_ad9528 1>,  <&clk0_ad9528 12>, <&clk0_ad9528 3>;
+		clock-names = "jesd_rx_clk", "jesd_tx_clk",
+			"jesd_rx_os_clk", "dev_clk", "fmc_clk",
+			"sysref_dev_clk", "sysref_fmc_clk";
 
 		clock-output-names = "rx_sampl_clk", "rx_os_sampl_clk", "tx_sampl_clk";
 		#clock-cells = <1>;

--- a/arch/arm64/boot/dts/xilinx/adi-adrv9371.dtsi
+++ b/arch/arm64/boot/dts/xilinx/adi-adrv9371.dtsi
@@ -96,8 +96,12 @@
 		spi-max-frequency = <25000000>;
 
 		/* Clocks */
-		clocks = <&axi_ad9371_rx_jesd>, <&axi_ad9371_tx_jesd>, <&axi_ad9371_rx_os_jesd>, <&clk0_ad9528 13>, <&clk0_ad9528 1>;
-		clock-names = "jesd_rx_clk", "jesd_tx_clk", "jesd_rx_os_clk", "dev_clk", "fmc_clk";
+		clocks = <&axi_ad9371_rx_jesd>, <&axi_ad9371_tx_jesd>,
+			<&axi_ad9371_rx_os_jesd>, <&clk0_ad9528 13>,
+			<&clk0_ad9528 1>,  <&clk0_ad9528 12>, <&clk0_ad9528 3>;
+		clock-names = "jesd_rx_clk", "jesd_tx_clk",
+			"jesd_rx_os_clk", "dev_clk", "fmc_clk",
+			"sysref_dev_clk", "sysref_fmc_clk";
 
 		clock-output-names = "rx_sampl_clk", "rx_os_sampl_clk", "tx_sampl_clk";
 		#clock-cells = <1>;

--- a/arch/microblaze/boot/dts/adi-adrv9371.dtsi
+++ b/arch/microblaze/boot/dts/adi-adrv9371.dtsi
@@ -97,8 +97,12 @@
 		spi-max-frequency = <25000000>;
 
 		/* Clocks */
-		clocks = <&axi_ad9371_rx_jesd>, <&axi_ad9371_tx_jesd>, <&axi_ad9371_rx_os_jesd>, <&clk0_ad9528 13>, <&clk0_ad9528 1>;
-		clock-names = "jesd_rx_clk", "jesd_tx_clk", "jesd_rx_os_clk", "dev_clk", "fmc_clk";
+		clocks = <&axi_adrv9009_rx_jesd>, <&axi_adrv9009_tx_jesd>,
+			<&axi_adrv9009_rx_os_jesd>, <&clk0_ad9528 13>,
+			<&clk0_ad9528 1>, <&clk0_ad9528 12>, <&clk0_ad9528 3>;
+		clock-names = "jesd_rx_clk", "jesd_tx_clk", "jesd_rx_os_clk",
+			"dev_clk", "fmc_clk", "sysref_dev_clk",
+			"sysref_fmc_clk";
 		clock-output-names = "rx_sampl_clk", "rx_os_sampl_clk", "tx_sampl_clk";
 
 		adi,clocks-clk-pll-vco-freq_khz = <9830400>;

--- a/drivers/iio/adc/ad9371.h
+++ b/drivers/iio/adc/ad9371.h
@@ -182,6 +182,8 @@ struct ad9371_rf_phy {
 	mykonosDevice_t 	*mykDevice;
 	struct clk 		*dev_clk;
 	struct clk 		*fmc_clk;
+	struct clk		*sysref_dev_clk;
+	struct clk		*sysref_fmc_clk;
 	struct clk 		*jesd_rx_clk;
 	struct clk 		*jesd_tx_clk;
 	struct clk 		*jesd_rx_os_clk;


### PR DESCRIPTION
The frequency of the SYSREF signal needs to be a integer division of the
LMFC frequency of the converter. The LMFC depends on the sample rate as
well as the JESD204 link settings.

At the moment it is up to somebody with system knowledge to configure the
SYSREF frequency beforehand so it matches the requirements.

Add some code to the driver that verifies that the currently selected
SYSREF frequency is OK and if it is not reconfigure the clock rate of the
SYSREF provider.

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>