### PR TITLE
iio: adc: ad7124: Align with upstream version

### DIFF
--- a/Documentation/devicetree/bindings/iio/adc/adi,ad7124.txt
+++ b/Documentation/devicetree/bindings/iio/adc/adi,ad7124.txt
@@ -11,38 +11,25 @@ Required properties for the AD7124:
 	- interrupts: IRQ line for the ADC
 		see: Documentation/devicetree/bindings/interrupt-controller/interrupts.txt
 
-	- adi,channels: List of external channels connected to the ADC:
 	  Required properties:
-		* #address-cells: Must be 2.
+		* #address-cells: Must be 1.
 		* #size-cells: Must be 0.
 
-	  The child nodes of this node represent the external channels which are
-	  connected to the ADC.
-
-	  Each child node represents one channel and has the following
-	  properties:
+	  Subnode(s) represent the external channels which are connected to the ADC.
+	  Each subnode represents one channel and has the following properties:
 		Required properties:
-			* reg: Pins the channel is connected to. The first value specifies
-			  the positive input pin, the second value the negative input pin.
-			* adi,channel-number: It can have up to 4 channels on ad7124-4 and
-			  8 channels on ad7124-8, numbered from 0 to 15.
+			* reg: The channel number. It can have up to 4 channels on ad7124-4
+			  and 8 channels on ad7124-8, numbered from 0 to 15.
+			* diff-channels: see: Documentation/devicetree/bindings/iio/adc/adc.txt
 
 		Optional properties:
-			* adi,bipolar: If set the channel is used in bipolar mode.
+			* bipolar: see: Documentation/devicetree/bindings/iio/adc/adc.txt
 			* adi,reference-select: Select the reference source to use when
 			  converting on the the specific channel. Valid values are:
 			  0: REFIN1(+)/REFIN1(−).
 			  1: REFIN2(+)/REFIN2(−).
 			  3: AVDD
 			  If this field is left empty, internal reference is selected.
-			* adi,gain: Select the gain when converting on the specific channel.
-			  Valid values are: 1, 2, 4, 8, 16, 32, 64, 128.
-			  If this field is left empty, gain of 1 is selected.
-			* adi,odr-hz: The output data rate can be programmed from:
-			  9 to 19200 for full power mode (when the master clock is 614.4 kHz)
-			  2 to 4800 for mid power mode (when the master clock is 153.6 kHz)
-			  1 to 2400 for low power mode (when the master clock is 76.8 kHz)
-			  If this field is left empty, odr of 9 is selected.
 
 Optional properties:
 	- refin1-supply: refin1 supply can be used as reference for conversion.
@@ -60,37 +47,29 @@ Example:
 		clocks = <&ad7124_mclk>;
 		clock-names = "mclk";
 
-		adi,channels {
-			#address-cells = <2>;
-			#size-cells = <0>;
+		#address-cells = <1>;
+		#size-cells = <0>;
 
-			channel@0 {
-				reg = <0 1>;
-				adi,channel-number = <0>;
-				adi,reference-select = <0>;
-				adi,gain = <2>;
-				adi,odr-hz = <10>;
-			};
+		channel@0 {
+			reg = <0>;
+			diff-channels = <0 1>;
+			adi,reference-select = <0>;
+		};
 
-			channel@1 {
-				reg = <2 3>;
-				adi,bipolar;
-				adi,channel-number = <1>;
-				adi,reference-select = <0>;
-				adi,gain = <4>;
-				adi,odr-hz = <50>;
-			};
+		channel@1 {
+			reg = <1>;
+			bipolar;
+			diff-channels = <2 3>;
+			adi,reference-select = <0>;
+		};
 
-			channel@2 {
-				reg = <4 5>;
-				adi,channel-number = <2>;
-				adi,gain = <128>;
-				adi,odr-hz = <19200>;
-			};
+		channel@2 {
+			reg = <2>;
+			diff-channels = <4 5>;
+		};
 
-			channel@3 {
-				reg = <6 7>;
-				adi,channel-number = <3>;
-			};
+		channel@3 {
+			reg = <3>;
+			diff-channels = <6 7>;
 		};
 	};


### PR DESCRIPTION
The ad7124 driver deviates from the upstream version which was modified
according to the feedback received during review.

The most important difference is regarding the properties that were
added in the devicetree. The gain, and odr-hz properties did not belong
in the DT, while bipolar and diff-channels were defined as generic
properties.

Another change is that the scale can be set from the user space.

Signed-off-by: Stefan Popa <stefan.popa@analog.com>