### PR TITLE
staging: iio: adc: ad7192: Add low_pass_3db_filter_frequency

### DIFF
--- a/drivers/staging/iio/adc/ad7192.h
+++ b/drivers/staging/iio/adc/ad7192.h
@@ -35,8 +35,6 @@ struct ad7192_platform_data {
 	u16		vref_mv;
 	bool		refin2_en;
 	bool		rej60_en;
-	bool		sinc3_en;
-	bool		chop_en;
 	bool		buf_en;
 	bool		unipolar_en;
 	bool		burnout_curr_en;


### PR DESCRIPTION
By adding this option we are able to remove the sync3 field and dt binding.
When setting the required cutoff frequency we also determine the ADC
configuration for chop and sync filter.

Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>
(cherry picked from commit 5f3cbb78cd77e3af5971568746d4fc61eeae84f3)