### PR TITLE
iio: dac: ad5686: Fix bit shift read register

### DIFF
--- a/drivers/iio/dac/ad5686.c
+++ b/drivers/iio/dac/ad5686.c
@@ -34,10 +34,10 @@ static int ad5686_write(struct ad5686_state *st,
 	return st->write(st, cmd, addr, val);
 }
 
-static int ad5686_read(struct ad5686_state *st, u8 addr)
+static int ad5686_read(struct ad5686_state *st, u8 addr, u8 shift)
 {
 
-	return st->read(st, addr);
+	return st->read(st, addr) >> shift;
 }
 
 static int ad5686_get_powerdown_mode(struct iio_dev *indio_dev,
@@ -134,11 +134,11 @@ static int ad5686_read_raw(struct iio_dev *indio_dev,
 	switch (m) {
 	case IIO_CHAN_INFO_RAW:
 		mutex_lock(&indio_dev->mlock);
-		ret = ad5686_read(st, chan->address);
+		ret = ad5686_read(st, chan->address, chan->scan_type.shift);
 		mutex_unlock(&indio_dev->mlock);
 		if (ret < 0)
 			return ret;
-		*val = ret;
+		*val = ret & GENMASK(chan->scan_type.realbits - 1, 0);
 		return IIO_VAL_INT;
 	case IIO_CHAN_INFO_SCALE:
 		*val = st->vref_mv;


### PR DESCRIPTION
This patch solves the register readback issue with the bit shift. When the
dac resolution was lower than the register size (ex. 12 bits out of 16
bits) the readback value was not shifted with the difference in bits and
the value was higher. Also a mask is applied on the read value in order to get
the value relative to the actual bit size.

Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>