### PR TITLE
.travis.yml: exclude xcomm_zynq & adi-4.14.0 from Travis-CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: c
 
+branches:
+  except:
+  - xcomm_zynq
+  - adi-4.14.0 # current rebased versions of master; change this when updating kernel ver
+
 os: linux
 dist: trusty
 


### PR DESCRIPTION
The `xcomm_zynq` is the old master branch, which is kept in sync for legacy
reasons.
The `adi-4.14.0` branch is a rebased version of the current master branch;
this will need to be updated when the master branch will have a new kernel
version.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>