### PR TITLE
iio: adc: ad9361: Fix to prevent invalid RFBW setting during enable FIR

### DIFF
--- a/drivers/iio/adc/ad9361.c
+++ b/drivers/iio/adc/ad9361.c
@@ -5642,8 +5642,8 @@ static int ad9361_validate_enable_fir(struct ad9361_rf_phy *phy)
 		ad9361_dig_tune(phy, 0, RESTORE_DEFAULT);
 
 	return ad9361_update_rf_bandwidth(phy,
-		valid ? st->filt_rx_bw_Hz : st->current_rx_bw_Hz,
-		valid ? st->filt_tx_bw_Hz : st->current_tx_bw_Hz);
+		(valid && st->filt_rx_bw_Hz) ? st->filt_rx_bw_Hz : st->current_rx_bw_Hz,
+		(valid && st->filt_tx_bw_Hz) ? st->filt_tx_bw_Hz : st->current_tx_bw_Hz);
 }
 
 static void ad9361_work_func(struct work_struct *work)


### PR DESCRIPTION
Only if filt_[rx|tx]_bw_Hz is set in ad9361_parse_fir() use it otherwise
keep current RFBW for chain.

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>