### PR TITLE
power: supply: adp5061: Fix a couple off by ones

### DIFF
--- a/drivers/power/supply/adp5061.c
+++ b/drivers/power/supply/adp5061.c
@@ -274,8 +274,8 @@ static int adp5061_get_max_voltage(struct adp5061_state *st,
 		return ret;
 
 	regval = ((regval & ADP5061_TERM_SET_VTRM_MSK) >> 2) - 0x0F;
-	if (regval > ARRAY_SIZE(adp5061_vmax))
-		regval = ARRAY_SIZE(adp5061_vmax);
+	if (regval >= ARRAY_SIZE(adp5061_vmax))
+		regval = ARRAY_SIZE(adp5061_vmax) - 1;
 
 	val->intval = adp5061_vmax[regval] * 1000;
 
@@ -352,8 +352,8 @@ static int adp5061_get_const_chg_current(struct adp5061_state *st,
 		return ret;
 
 	regval = ((regval & ADP5061_CHG_CURR_ICHG_MSK) >> 2);
-	if (regval > ARRAY_SIZE(adp5061_const_ichg))
-		regval = ARRAY_SIZE(adp5061_const_ichg);
+	if (regval >= ARRAY_SIZE(adp5061_const_ichg))
+		regval = ARRAY_SIZE(adp5061_const_ichg) - 1;
 
 	val->intval = adp5061_const_ichg[regval] * 1000;
 


### PR DESCRIPTION
[ Upstream commit 89b135ba ]

We end up reading one element beyond the end of the adp5061_vmax[] array
here.

Fixes: fe8e81b7e899 ("adp5061: New driver for ADP5061 I2C battery charger")
Signed-off-by: Dan Carpenter <dan.carpenter@oracle.com>
Signed-off-by: Sebastian Reichel <sebastian.reichel@collabora.co.uk>