### PR TITLE
staging: iio: frequency: ad9833

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -98,6 +98,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	rpi-ad5686.dtbo \
 	rpi-ad738x.dtbo \
 	rpi-ad7768.dtbo \
+	rpi-ad9834.dtbo \
 	rpi-adxl372.dtbo \
 	rpi-adxl375.dtbo \
 	rpi-ad5770r.dtbo \

--- a/arch/arm/boot/dts/overlays/rpi-ad9834-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ad9834-overlay.dts
@@ -1,0 +1,45 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2708", "brcm,bcm2709";
+
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			vcc: fixedregulator@0 {
+				compatible = "regulator-fixed";
+				regulator-name = "fixed-supply";
+				regulator-min-microvolt = <2500000>;
+				regulator-max-microvolt = <2500000>;
+				regulator-boot-on;
+			};
+
+			osc: oscillator {
+				#clock-cells = <0>;
+				compatible = "fixed-clock";
+				clock-frequency = <25000000>;
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&spi0>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			ad9833@0{
+				#clock-cells = <0>;
+				compatible = "ad9833";
+				reg = <0>;
+				spi-max-frequency = <1000000>;
+				spi-cpol;
+				clocks = <&osc>;
+				vcc-supply = <&vcc>;
+			};
+		};
+	};
+};
+

--- a/drivers/staging/iio/frequency/ad9834.c
+++ b/drivers/staging/iio/frequency/ad9834.c
@@ -6,6 +6,7 @@
  * Licensed under the GPL-2.
  */
 
+#include <linux/clk.h>
 #include <linux/interrupt.h>
 #include <linux/workqueue.h>
 #include <linux/device.h>
@@ -71,7 +72,7 @@
 struct ad9834_state {
 	struct spi_device		*spi;
 	struct regulator		*reg;
-	unsigned int			mclk;
+	struct clk			*mclk;
 	unsigned short			control;
 	unsigned short			devid;
 	struct spi_transfer		xfer;
@@ -100,7 +101,6 @@ enum ad9834_supported_device_ids {
 };
 
 static struct ad9834_platform_data default_config = {
-	.mclk = 25000000,
 	.freq0 = 1000000,
 	.freq1 = 5000000,
 	.phase0 = 512,
@@ -120,12 +120,15 @@ static unsigned int ad9834_calc_freqreg(unsigned long mclk, unsigned long fout)
 static int ad9834_write_frequency(struct ad9834_state *st,
 				  unsigned long addr, unsigned long fout)
 {
+	unsigned long clk_freq;
 	unsigned long regval;
 
-	if (fout > (st->mclk / 2))
+	clk_freq = clk_get_rate(st->mclk);
+
+	if (fout > (clk_freq / 2))
 		return -EINVAL;
 
-	regval = ad9834_calc_freqreg(st->mclk, fout);
+	regval = ad9834_calc_freqreg(clk_freq, fout);
 
 	st->freq_data[0] = cpu_to_be16(addr | (regval &
 				       RES_MASK(AD9834_FREQ_BITS / 2)));
@@ -405,6 +408,7 @@ static int ad9834_probe(struct spi_device *spi)
 	struct ad9834_state *st;
 	struct iio_dev *indio_dev;
 	struct regulator *reg;
+	struct clk *clk;
 	int ret;
 
 	pdata = &default_config;
@@ -419,6 +423,14 @@ static int ad9834_probe(struct spi_device *spi)
 		return ret;
 	}
 
+	clk = devm_clk_get(&spi->dev, NULL);
+
+	ret = clk_prepare_enable(clk);
+	if (ret) {
+		dev_err(&spi->dev, "Failed to enable master clock\n");
+		return ret;
+	}
+
 	indio_dev = devm_iio_device_alloc(&spi->dev, sizeof(*st));
 	if (!indio_dev) {
 		ret = -ENOMEM;
@@ -427,7 +439,7 @@ static int ad9834_probe(struct spi_device *spi)
 	spi_set_drvdata(spi, indio_dev);
 	st = iio_priv(indio_dev);
 	mutex_init(&st->lock);
-	st->mclk = pdata->mclk;
+	st->mclk = clk;
 	st->spi = spi;
 	st->devid = spi_get_device_id(spi)->driver_data;
 	st->reg = reg;
@@ -501,6 +513,7 @@ static int ad9834_probe(struct spi_device *spi)
 
 error_disable_reg:
 	regulator_disable(reg);
+	clk_disable_unprepare(st->mclk);
 
 	return ret;
 }
@@ -512,6 +525,7 @@ static int ad9834_remove(struct spi_device *spi)
 
 	iio_device_unregister(indio_dev);
 	regulator_disable(st->reg);
+	clk_disable_unprepare(st->mclk);
 
 	return 0;
 }

--- a/drivers/staging/iio/frequency/ad9834.c
+++ b/drivers/staging/iio/frequency/ad9834.c
@@ -99,6 +99,16 @@ enum ad9834_supported_device_ids {
 	ID_AD9838,
 };
 
+static struct ad9834_platform_data default_config = {
+	.mclk = 25000000,
+	.freq0 = 1000000,
+	.freq1 = 5000000,
+	.phase0 = 512,
+	.phase1 = 1024,
+	.en_div2 = false,
+	.en_signbit_msb_out = false,
+};
+
 static unsigned int ad9834_calc_freqreg(unsigned long mclk, unsigned long fout)
 {
 	unsigned long long freqreg = (u64)fout * (u64)BIT(AD9834_FREQ_BITS);
@@ -391,16 +401,13 @@ static const struct iio_info ad9833_info = {
 
 static int ad9834_probe(struct spi_device *spi)
 {
-	struct ad9834_platform_data *pdata = dev_get_platdata(&spi->dev);
+	struct ad9834_platform_data *pdata;
 	struct ad9834_state *st;
 	struct iio_dev *indio_dev;
 	struct regulator *reg;
 	int ret;
 
-	if (!pdata) {
-		dev_dbg(&spi->dev, "no platform data?\n");
-		return -ENODEV;
-	}
+	pdata = &default_config;
 
 	reg = devm_regulator_get(&spi->dev, "avdd");
 	if (IS_ERR(reg))

--- a/drivers/staging/iio/frequency/ad9834.h
+++ b/drivers/staging/iio/frequency/ad9834.h
@@ -14,7 +14,6 @@
 
 /**
  * struct ad9834_platform_data - platform specific information
- * @mclk:		master clock in Hz
  * @freq0:		power up freq0 tuning word in Hz
  * @freq1:		power up freq1 tuning word in Hz
  * @phase0:		power up phase0 value [0..4095] correlates with 0..2PI
@@ -27,7 +26,6 @@
  */
 
 struct ad9834_platform_data {
-	unsigned int		mclk;
 	unsigned int		freq0;
 	unsigned int		freq1;
 	unsigned short		phase0;


### PR DESCRIPTION
The platform data for ad9833/9834 are retrieved from an overlay file.