### PR TITLE
Add fpga info

### DIFF
--- a/drivers/clk/clk-axi-clkgen.c
+++ b/drivers/clk/clk-axi-clkgen.c
@@ -10,6 +10,7 @@
 
 #include <linux/platform_device.h>
 #include <linux/clk-provider.h>
+#include <linux/fpga/adi-axi-common.h>
 #include <linux/slab.h>
 #include <linux/io.h>
 #include <linux/of.h>
@@ -46,6 +47,7 @@
 struct axi_clkgen {
 	void __iomem *base;
 	struct clk_hw clk_hw;
+	unsigned int pcore_version;
 };
 
 static uint32_t axi_clkgen_lookup_filter(unsigned int m)
@@ -98,15 +100,15 @@ static uint32_t axi_clkgen_lookup_lock(unsigned int m)
 }
 
 #ifdef ARCH_ZYNQMP
-static const unsigned int fpfd_min = 10000;
-static const unsigned int fpfd_max = 450000;
-static const unsigned int fvco_min = 800000;
-static const unsigned int fvco_max = 1600000;
+static unsigned int fpfd_min = 10000;
+static unsigned int fpfd_max = 450000;
+static unsigned int fvco_min = 800000;
+static unsigned int fvco_max = 1600000;
 #else
-static const unsigned int fpfd_min = 10000;
-static const unsigned int fpfd_max = 300000;
-static const unsigned int fvco_min = 600000;
-static const unsigned int fvco_max = 1200000;
+static unsigned int fpfd_min = 10000;
+static unsigned int fpfd_max = 300000;
+static unsigned int fvco_min = 600000;
+static unsigned int fvco_max = 1200000;
 #endif
 
 static void axi_clkgen_calc_params(unsigned long fin, unsigned long fout,
@@ -224,6 +226,49 @@ static void axi_clkgen_read(struct axi_clkgen *axi_clkgen,
 	unsigned int reg, unsigned int *val)
 {
 	*val = readl(axi_clkgen->base + reg);
+}
+
+static void axi_clkgen_setup_ranges(struct axi_clkgen *axi_clkgen)
+{
+	unsigned int reg_value;
+	unsigned int tech, family, speed_grade, voltage;
+
+	axi_clkgen_read(axi_clkgen, AXI_REG_FPGA_INFO, &reg_value);
+	tech = AXI_INFO_FPGA_TECH(reg_value);
+	family = AXI_INFO_FPGA_FAMILY(reg_value);
+	speed_grade = AXI_INFO_FPGA_SPEED_GRADE(reg_value);
+
+	axi_clkgen_read(axi_clkgen, AXI_REG_FPGA_VOLTAGE, &reg_value);
+	voltage = AXI_INFO_FPGA_VOLTAGE(reg_value);
+
+	switch (speed_grade) {
+	case AXI_FPGA_SPEED_1 ... AXI_FPGA_SPEED_1LV:
+		fvco_max = 1200000;
+		fpfd_max = 450000;
+		break;
+	case AXI_FPGA_SPEED_2 ... AXI_FPGA_SPEED_2LV:
+		fvco_max = 1440000;
+		fpfd_max = 500000;
+		if ((family == AXI_FPGA_FAMILY_KINTEX) |
+		    (family == AXI_FPGA_FAMILY_ARTIX)) {
+			if (voltage < 950) {
+				fvco_max = 1200000;
+				fpfd_max = 450000;
+			}
+		}
+		break;
+	case AXI_FPGA_SPEED_3:
+		fvco_max = 1600000;
+		fpfd_max = 550000;
+		break;
+	default:
+		break;
+	};
+
+	if (tech == AXI_FPGA_TECH_ULTRASCALE_PLUS) {
+		fvco_max = 1600000;
+		fvco_min = 800000;
+	}
 }
 
 static int axi_clkgen_wait_non_busy(struct axi_clkgen *axi_clkgen)
@@ -520,6 +565,11 @@ static int axi_clkgen_probe(struct platform_device *pdev)
 	axi_clkgen->base = devm_ioremap_resource(&pdev->dev, mem);
 	if (IS_ERR(axi_clkgen->base))
 		return PTR_ERR(axi_clkgen->base);
+
+	axi_clkgen_read(axi_clkgen, AXI_REG_VERSION, &axi_clkgen->pcore_version);
+
+	if (AXI_PCORE_VER_MAJOR(axi_clkgen->pcore_version) > 0x04)
+		axi_clkgen_setup_ranges(axi_clkgen);
 
 	init.num_parents = of_clk_get_parent_count(pdev->dev.of_node);
 	if (init.num_parents < 1 || init.num_parents > 2)

--- a/drivers/iio/jesd204/axi_adxcvr.h
+++ b/drivers/iio/jesd204/axi_adxcvr.h
@@ -13,22 +13,9 @@
 
 #include <linux/clk.h>
 #include <linux/clk-provider.h>
+#include <linux/fpga/adi-axi-common.h>
 
 #include "xilinx_transceiver.h"
-
-#define PCORE_VER(major, minor, letter)	((major << 16) | (minor << 8) | letter)
-#define PCORE_VER_MAJOR(version)	(version >> 16)
-#define PCORE_VER_MINOR(version)	((version >> 8) & 0xff)
-#define PCORE_VER_LETTER(version)	(version & 0xff)
-
-#define ADXCVR_REG_VERSION		0x0000
-#define ADXCVR_VERSION(x)		(((x) & 0xffffffff) << 0)
-#define ADXCVR_VERSION_IS(x, y, z)	((x) << 16 | (y) << 8 | (z))
-#define ADXCVR_VERSION_MAJOR(x)		((x) >> 16)
-
-#define ADXCVR_REG_ID			0x0004
-
-#define ADXCVR_REG_SCRATCH		0x0008
 
 #define ADXCVR_REG_RESETN		0x0010
 #define ADXCVR_RESETN			(1 << 0)

--- a/drivers/iio/jesd204/xilinx_transceiver.h
+++ b/drivers/iio/jesd204/xilinx_transceiver.h
@@ -10,10 +10,18 @@
 #ifndef XILINX_XCVR_H
 #define XILINX_XCVR_H
 
+#include <linux/fpga/adi-axi-common.h>
+
 enum xilinx_xcvr_type {
-	XILINX_XCVR_TYPE_S7_GTX2,
-	XILINX_XCVR_TYPE_US_GTH3,
-	XILINX_XCVR_TYPE_US_GTH4,
+	XILINX_XCVR_TYPE_S7_GTX2 = 2,
+	XILINX_XCVR_TYPE_US_GTH3 = 5,
+	XILINX_XCVR_TYPE_US_GTH4 = 8,
+};
+
+enum xilinx_xcvr_legacy_type {
+	XILINX_XCVR_LEGACY_TYPE_S7_GTX2,
+	XILINX_XCVR_LEGACY_TYPE_US_GTH3,
+	XILINX_XCVR_LEGACY_TYPE_US_GTH4,
 };
 
 enum xilinx_xcvr_refclk_ppm {
@@ -40,6 +48,12 @@ struct xilinx_xcvr {
 	enum xilinx_xcvr_type type;
 	enum xilinx_xcvr_refclk_ppm refclk_ppm;
 	unsigned int encoding;
+	unsigned int version;
+	enum axi_fgpa_technology tech;
+	enum axi_fpga_family family;
+	enum axi_fpga_speed_grade speed_grade;
+	enum axi_fpga_dev_pack dev_package;
+	unsigned int voltage;
 };
 
 #define ENC_8B10B					810

--- a/include/linux/fpga/adi-axi-common.h
+++ b/include/linux/fpga/adi-axi-common.h
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * ADI AXI-COMMON Module
+ *
+ * Copyright 2019 Analog Devices Inc.
+ *
+ * https://wiki.analog.com/resources/fpga/docs/axi_ip
+ */
+
+#ifndef ADI_AXI_COMMON_H_
+#define ADI_AXI_COMMON_H_
+
+#define AXI_PCORE_VER(major, minor, letter)	((major << 16) | (minor << 8) | letter)
+#define AXI_PCORE_VER_MAJOR(version)	(version >> 16)
+#define AXI_PCORE_VER_MINOR(version)	((version >> 8) & 0xff)
+#define AXI_PCORE_VER_LETTER(version)	(version & 0xff)
+
+#define	AXI_REG_VERSION			0x0000
+#define AXI_VERSION(x)			(((x) & 0xffffffff) << 0)
+#define AXI_VERSION_IS(x, y, z)		((x) << 16 | (y) << 8 | (z))
+#define AXI_VERSION_MAJOR(x)		((x) >> 16)
+
+#define AXI_REG_FPGA_INFO		0x001C
+#define AXI_REG_FPGA_VOLTAGE		0x0140
+
+#define AXI_INFO_FPGA_TECH(info)        ((info) >> 24)
+#define AXI_INFO_FPGA_FAMILY(info)      (((info) >> 16) & 0xff)
+#define AXI_INFO_FPGA_SPEED_GRADE(info)	(((info) >> 8) & 0xff)
+#define AXI_INFO_FPGA_DEV_PACKAGE(info)	((info) & 0xff)
+#define AXI_INFO_FPGA_VOLTAGE(val)      ((val) & 0xffff)
+
+#define AXI_REG_ID			0x0004
+#define AXI_REG_SCRATCH			0x0008
+#define AXI_REG_CONFIG			0x000c
+
+enum axi_fgpa_technology {
+	AXI_FPGA_TECH_UNKNOWN = 0,
+	AXI_FPGA_TECH_SERIES7,
+	AXI_FPGA_TECH_ULTRASCALE,
+	AXI_FPGA_TECH_ULTRASCALE_PLUS,
+};
+
+enum axi_fpga_family {
+	AXI_FPGA_FAMILY_UNKNOWN = 0,
+	AXI_FPGA_FAMILY_ARTIX,
+	AXI_FPGA_FAMILY_KINTEX,
+	AXI_FPGA_FAMILY_VIRTEX,
+	AXI_FPGA_FAMILY_ZYNQ,
+};
+
+enum axi_fpga_speed_grade {
+	AXI_FPGA_SPEED_UNKNOWN	= 0,
+	AXI_FPGA_SPEED_1	= 10,
+	AXI_FPGA_SPEED_1L	= 11,
+	AXI_FPGA_SPEED_1H	= 12,
+	AXI_FPGA_SPEED_1HV	= 13,
+	AXI_FPGA_SPEED_1LV	= 14,
+	AXI_FPGA_SPEED_2	= 20,
+	AXI_FPGA_SPEED_2L	= 21,
+	AXI_FPGA_SPEED_2LV	= 22,
+	AXI_FPGA_SPEED_3	= 30,
+};
+
+enum axi_fpga_dev_pack {
+	AXI_FPGA_DEV_UNKNOWN = 0,
+	AXI_FPGA_DEV_RF,
+	AXI_FPGA_DEV_FL,
+	AXI_FPGA_DEV_FF,
+	AXI_FPGA_DEV_FB,
+	AXI_FPGA_DEV_HC,
+	AXI_FPGA_DEV_FH,
+	AXI_FPGA_DEV_CS,
+	AXI_FPGA_DEV_CP,
+	AXI_FPGA_DEV_FT,
+	AXI_FPGA_DEV_FG,
+	AXI_FPGA_DEV_SB,
+	AXI_FPGA_DEV_RB,
+	AXI_FPGA_DEV_RS,
+	AXI_FPGA_DEV_CL,
+	AXI_FPGA_DEV_SF,
+	AXI_FPGA_DEV_BA,
+	AXI_FPGA_DEV_FA,
+};
+
+#endif /* ADI_AXI_COMMON_H_ */


### PR DESCRIPTION
This modification is need to use the new information supplied by the two new registers in the ip core. This required modifying the ranges for VCO frequency mainly. 

Added FPGA info register to the common section of axi_adxcvr, axi_clkgen, axi_hdmi_tx, ADC and DAC cores.
0x0007 >>>  0x001C
{FPGA_TECHNOLOGY, FPGA_FAMILY, SPEED_GRADE, DEV_PACKAGE}; // [8,8,8,8]

For axi_adxcvr and axi_clkgen added also FPGA_VOLTAGE {16'd0, FPGA_VOLTAGE}; // mV
0x0050 >>> 0x0140
XCVR encoding:
INTEL: set xcvr_type_list { 0 9 } # transceiver speedgrade

New XCVR PHY encodings:

XILINX  { \
        { Unknown             0 } \
        { GTPE2_NOT_SUPPORTED 1 } \
        { GTXE2               2 } \
        { GTHE2_NOT_SUPPORTED 3 } \
        { GTZE2_NOT_SUPPORTED 4 } \
        { GTHE3               5 } \
        { GTYE3_NOT_SUPPORTED 6 } \
        { GTRE4_NOT_SUPPORTED 7 } \
        { GTHE4               8 } \
        { GTYE4_NOT_SUPPORTED 9 } \
        { GTME4_NOT_SUPPORTED 10}}

Old encoding:
0 - GTXE2
1 – GTHE3
2 – GTHE4