### PR TITLE
staging: iio: adc: ad7192: Add device tree example

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -96,6 +96,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	qca7000.dtbo \
 	rotary-encoder.dtbo \
 	rpi-ad5686.dtbo \
+	rpi-ad7190.dtbo \
 	rpi-ad738x.dtbo \
 	rpi-ad7768.dtbo \
 	rpi-ad9834.dtbo \

--- a/arch/arm/boot/dts/overlays/rpi-ad7190-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ad7190-overlay.dts
@@ -1,0 +1,64 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709";
+
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			dvdd: fixedregulator@0 {
+				compatible = "regulator-fixed";
+				regulator-name = "fixed-supply";
+				regulator-min-microvolt = <3300000>;
+				regulator-max-microvolt = <3300000>;
+				regulator-boot-on;
+			};
+		};
+	};
+
+	fragment@1 {
+		target-path = "/";
+		__overlay__ {
+			avdd: fixedregulator@1 {
+				compatible = "regulator-fixed";
+				regulator-name = "fixed-supply2";
+				regulator-min-microvolt = <3300000>;
+				regulator-max-microvolt = <3300000>;
+				regulator-boot-on;
+			};
+		};
+	};
+
+	fragment@3 {
+		target = <&spi0>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			ad7190@0 {
+				compatible = "adi,ad7190";
+				reg = <0>;
+				spi-max-frequency = <1000000>;
+				spi-cpol;
+				spi-cpha;
+				#interrupt-cells = <2>;
+				interrupts = <25 0x2>;
+				interrupt-parent = <&gpio>;
+				dvdd-supply = <&dvdd>;
+				avdd-supply = <&avdd>;
+
+				adi,reference-voltage-mv = /bits/ 16  <3300>;
+				adi,clock-source-select = [02];
+				adi,refin2-pins-enable;
+				adi,rejection-60-Hz-enable;
+				adi,chop-enable;
+				adi,buffer-enable;
+				adi,burnout-currents-enable;
+				adi,sinc3-filter-enable;
+				adi,unipolar-enable;
+			};
+		};
+	};
+};


### PR DESCRIPTION
This is an example of a device tree used for ad7192 driver.

Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>