### PR TITLE
ci/travis: implement basic branch sync-ing mechanism for master 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ notifications:
 
 env:
   matrix:
+  - BUILD_TYPE=sync_branches_with_master
+    BRANCH1="xcomm_zynq:fast-forward"
+    BRANCH2="adi-4.14.0:cherry-pick"
   - BUILD_TYPE=checkpatch
   - BUILD_TYPE=dtb_build_test
   - DEFCONFIG_NAME=zynq_xcomm_adv7511_defconfig ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf-

--- a/ci/travis/lib.sh
+++ b/ci/travis/lib.sh
@@ -1,0 +1,42 @@
+#!/bin/sh -e
+
+TRAVIS_BUILD_DIR=${TRAVIS_BUILD_DIR:-'./'}
+
+command_exists() {
+	local cmd=$1
+	[ -n "$cmd" ] || return 1
+	type "$cmd" >/dev/null 2>&1
+}
+
+ensure_command_exists() {
+	local cmd="$1"
+	local package="$2"
+	[ -n "$cmd" ] || return 1
+	[ -n "$package" ] || package="$cmd"
+	! command_exists "$cmd" || return 0
+	# go through known package managers
+	for pacman in apt-get brew yum ; do
+		command_exists $pacman || continue
+		$pacman install -y $package || {
+			# Try an update if install doesn't work the first time
+			$pacman -y update && \
+				$pacman install -y $package
+		}
+		return $?
+	done
+	return 1
+}
+
+ensure_command_exists wget
+ensure_command_exists sudo
+
+LOCAL_BUILD_DIR="patches-build"
+
+# Get the common stuff from libiio
+[ -f ${TRAVIS_BUILD_DIR}/${LOCAL_BUILD_DIR}/lib.sh ] || {
+	mkdir -p ${TRAVIS_BUILD_DIR}/${LOCAL_BUILD_DIR}
+	wget https://raw.githubusercontent.com/analogdevicesinc/libiio/master/CI/travis/lib.sh \
+		-O ${TRAVIS_BUILD_DIR}/${LOCAL_BUILD_DIR}/lib.sh
+}
+
+. ${TRAVIS_BUILD_DIR}/${LOCAL_BUILD_DIR}/lib.sh

--- a/ci/travis/run-build.sh
+++ b/ci/travis/run-build.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+. ./ci/travis/lib.sh
+
 build_default() {
 	make ${DEFCONFIG_NAME}
 	make -j`getconf _NPROCESSORS_ONLN` $IMAGE UIMAGE_LOADADDR=0x8000
@@ -27,6 +29,85 @@ build_checkpatch() {
 build_dtb_build_test() {
 	for file in $DTS_FILES; do
 		make ${DTS_PREFIX}`basename $file | sed  -e 's\dts\dtb\g'` || exit 1
+	done
+}
+
+branch_contains_commit() {
+	local commit="$1"
+	local branch="$2"
+	git merge-base --is-ancestor $commit $branch &> /dev/null
+}
+
+commit_is_merge() {
+	local cm="$1"
+	cm="$(git cat-file -p "$cm" 2>/dev/null | grep parent | wc -l)"
+	[ "$cm" != "1" ]
+}
+
+__update_git_ref() {
+	local ref="$1"
+	git fetch origin +refs/heads/${ref}:${ref}
+}
+
+__handle_sync_with_master() {
+	local dst_branch="$1"
+	local method="$2"
+	for ref in master ${dst_branch} ; do
+		__update_git_ref "$ref" || {
+			echo_red "Could not fetch branch '$dst_branch'"
+			return 1
+		}
+	done
+
+	if [ "$method" == "fast-forward" ] ; then
+		git checkout ${dst_branch}
+		git merge --ff-only master || {
+			echo_red "Failed while syncing master over '$dst_branch'"
+			return 1
+		}
+		return 0
+	fi
+
+	if [ "$method" == "cherry-pick" ] ; then
+		# FIXME: kind of dumb, the code below; maybe do this a bit neater
+		local cm="$(git log "${dst_branch}~1..${dst_branch}" | grep "cherry picked from commit" | awk '{print $5}' | cut -d')' -f1)"
+		[ -n "$cm" ] || {
+			echo_red "Top commit in branch '${dst_branch}' is not cherry-picked"
+			return 1
+		}
+		branch_contains_commit "$cm" "master" || {
+			echo_red "Commit '$cm' is not in branch master"
+			return 1
+		}
+
+		git checkout ${dst_branch}
+		for cm in $(git rev-list "${cm}..master") ; do
+			! commit_is_merge "${cm}" || continue
+			git cherry-pick -x "${cm}" || {
+				echo_red "Failed to cherry-pick commit $cm"
+				return 1
+			}
+		done
+
+		return 0
+	fi
+}
+
+build_sync_branches_with_master() {
+	# make sure this is on master, and not a PR
+	[ -n "$TRAVIS_PULL_REQUEST" ] || return 0
+	[ "$TRAVIS_PULL_REQUEST" == "false" ] || return 0
+	[ "$TRAVIS_BRANCH" == "master" ] || return 0
+
+	# support sync-ing up to 100 branches; should be enough
+	for iter in $(seq 1 100) ; do
+		local branch="$(eval "echo \$BRANCH${iter}")"
+		[ -n "$branch" ] || break
+		local dst_branch="$(echo $branch | cut -d: -f1)"
+		[ -n "$dst_branch" ] || break
+		local method="$(echo $branch | cut -d: -f2)"
+		[ -n "$method" ] || break
+		__handle_sync_with_master "$dst_branch" "$method"
 	done
 }
 

--- a/ci/travis/run-build.sh
+++ b/ci/travis/run-build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -xe
+set -e
 
 build_default() {
 	make ${DEFCONFIG_NAME}


### PR DESCRIPTION
This change implements sync-ing branches with master.
The basic gist of it is that there's a new build in Travis-CI (called
`sync_branches_with_master`) which will sync the branches based on 2
strategies (one is fast-forward, the other is cherry-pick).

Normally a better Github-ish mechanism should be implemented by probably
using Github Apps or something, but that takes too much
effort/time/learning to do properly, and it still may be an idea later.

This build won't do any push-es yet, so as not to break stuff and do more
testing. After all looks good, pushing these sync-branches should be fine.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>