### PR TITLE
iio: jesd204: axi_adxcvr: Fix PCORE version major

### DIFF
--- a/drivers/iio/jesd204/axi_adxcvr.c
+++ b/drivers/iio/jesd204/axi_adxcvr.c
@@ -584,7 +584,7 @@ static int adxcvr_probe(struct platform_device *pdev)
 
 	st->dev = &pdev->dev;
 	st->xcvr.version = adxcvr_read(st, AXI_REG_VERSION);
-	if (AXI_PCORE_VER_MAJOR(st->xcvr.version) > 0x12)
+	if (AXI_PCORE_VER_MAJOR(st->xcvr.version) > 0x10)
 		adxcvr_get_info(st);
 	platform_set_drvdata(pdev, st);
 
@@ -595,7 +595,7 @@ static int adxcvr_probe(struct platform_device *pdev)
 	xcvr_type = (synth_conf >> 16) & 0xf;
 
 	/* Ensure compliance with legacy xcvr type */
-	if (AXI_PCORE_VER_MAJOR(st->xcvr.version) <= 0x12) {
+	if (AXI_PCORE_VER_MAJOR(st->xcvr.version) <= 0x10) {
 		switch (xcvr_type) {
 		case XILINX_XCVR_LEGACY_TYPE_S7_GTX2:
 			st->xcvr.type = XILINX_XCVR_TYPE_S7_GTX2;

--- a/drivers/iio/jesd204/xilinx_transceiver.c
+++ b/drivers/iio/jesd204/xilinx_transceiver.c
@@ -342,7 +342,7 @@ int xilinx_xcvr_calc_cpll_config(struct xilinx_xcvr *xcvr,
 		return -EINVAL;
 	}
 
-	if (AXI_PCORE_VER_MAJOR(xcvr->version) > 0x11)
+	if (AXI_PCORE_VER_MAJOR(xcvr->version) > 0x10)
 		xilinx_xcvr_setup_cpll_vco_range(xcvr, &vco_max);
 
 	for (m = 1; m <= 2; m++) {
@@ -418,7 +418,7 @@ int xilinx_xcvr_calc_qpll_config(struct xilinx_xcvr *xcvr,
 		return -EINVAL;
 	}
 
-	if (AXI_PCORE_VER_MAJOR(xcvr->version) > 0x11)
+	if (AXI_PCORE_VER_MAJOR(xcvr->version) > 0x10)
 		xilinx_xcvr_setup_qpll_vco_range(xcvr,
 						 &vco0_min, &vco0_max,
 						 &vco1_min, &vco1_max);


### PR DESCRIPTION
This patch fixed PCORE version major verification. The new PCORE version is
0x110161 so we need to use 0x10 as the major in our comparisons.

Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>