### PR TITLE
iio: adc: ad9361: Fix max filter HB rates and update the available attr.

### DIFF
--- a/drivers/iio/adc/ad9361.c
+++ b/drivers/iio/adc/ad9361.c
@@ -7951,6 +7951,9 @@ static int ad9361_phy_read_avail(struct iio_dev *indio_dev,
 			else
 				int_dec = st->tx_fir_int;
 
+			if (int_dec == 4)
+				max = MAX_TX_HB1 / 4;
+
 			st->tx_sampl_freq_avail[0] = MIN_ADC_CLK / (12 * int_dec);
 			st->tx_sampl_freq_avail[1] = 1;
 			st->tx_sampl_freq_avail[2] = max;
@@ -7963,6 +7966,9 @@ static int ad9361_phy_read_avail(struct iio_dev *indio_dev,
 				int_dec = 1;
 			else
 				int_dec = st->rx_fir_dec;
+
+			if (int_dec == 4)
+				max = MAX_RX_HB1 / 4;
 
 			st->rx_sampl_freq_avail[0] = MIN_ADC_CLK / (12 * int_dec);
 			st->rx_sampl_freq_avail[1] = 1;

--- a/drivers/iio/adc/ad9361_regs.h
+++ b/drivers/iio/adc/ad9361_regs.h
@@ -2798,12 +2798,12 @@
 #define MAX_DAC_CLK			(MAX_ADC_CLK / 2)
 
 /* Associated with outputs of stage */
-#define MAX_RX_HB1			245760000UL
-#define MAX_RX_HB2			320000000UL
-#define MAX_RX_HB3			640000000UL
+#define MAX_RX_HB1			122880000UL
+#define MAX_RX_HB2			245760000UL
+#define MAX_RX_HB3			320000000UL
 /* Associated with inputs of stage */
-#define MAX_TX_HB1			160000000UL
-#define MAX_TX_HB2			320000000UL
+#define MAX_TX_HB1			122880000UL
+#define MAX_TX_HB2			245760000UL
 #define MAX_TX_HB3			320000000UL
 
 #define MAX_BASEBAND_RATE		61440000UL


### PR DESCRIPTION
This should not limit the rates which were previously computed.
It just enforces max rates which could have been selected by a
handcrafted filter file.

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>