### PR TITLE
clk: Revert "drivers/clk/clk: fix CLK_GET_RATE_NOCACHE"

### DIFF
--- a/drivers/clk/clk.c
+++ b/drivers/clk/clk.c
@@ -1112,19 +1112,11 @@ static void __clk_recalc_rates(struct clk_core *core, unsigned long msg)
 static unsigned long clk_core_get_rate(struct clk_core *core)
 {
 	unsigned long rate;
-	struct clk_core *_clk, *recalc_clk = NULL;
 
 	clk_prepare_lock();
 
-	_clk = core;
-	while (_clk) {
-		if (_clk->flags & CLK_GET_RATE_NOCACHE)
-			recalc_clk = _clk;
-		_clk = _clk->parent;
-	}
-
-	if (recalc_clk)
-		__clk_recalc_rates(recalc_clk, 0);
+	if (core && (core->flags & CLK_GET_RATE_NOCACHE))
+		__clk_recalc_rates(core, 0);
 
 	rate = clk_core_get_rate_nolock(core);
 	clk_prepare_unlock();


### PR DESCRIPTION
58d6e6c

The current commit brings clk.c in sync with the upstream version.

Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>
Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>