### PR TITLE
iio: adc: talise: Fix unused variable warnings

### DIFF
--- a/drivers/iio/adc/talise/talise_cals.c
+++ b/drivers/iio/adc/talise/talise_cals.c
@@ -22,10 +22,11 @@ uint32_t TALISE_runInitCals(taliseDevice_t *device, uint32_t calMask)
 {
     talRecoveryActions_t retVal = TALACT_NO_ACTION;
     talRecoveryActions_t retValWarn = TALACT_NO_ACTION;
-    adiHalErr_t halError = ADIHAL_OK;
     uint8_t payload[4] = {0};
 
 #if TALISE_VERBOSE
+    adiHalErr_t halError = ADIHAL_OK;
+
     halError = talWriteToLog(device->devHalInfo, ADIHAL_LOG_MSG, TAL_ERR_OK, "TALISE_runInitCals()\n");
     retVal = talApiErrHandler(device, TAL_ERRHDL_HAL_LOG, halError, retVal, TALACT_WARN_RESET_LOG);
 #endif
@@ -55,7 +56,6 @@ uint32_t TALISE_waitInitCals(taliseDevice_t *device, uint32_t timeoutMs, uint8_t
 {
     talRecoveryActions_t retVal = TALACT_NO_ACTION;
     talRecoveryActions_t retValWarn = TALACT_NO_ACTION;
-    adiHalErr_t halError = ADIHAL_OK;
     uint8_t cmdStatusByte = 0;
     uint8_t _errFlag = 0;
 
@@ -63,6 +63,8 @@ uint32_t TALISE_waitInitCals(taliseDevice_t *device, uint32_t timeoutMs, uint8_t
     static const uint32_t CODECHECK_PARAM_WAITINITCALS_ERR = 2;
 
 #if TALISE_VERBOSE
+    adiHalErr_t halError = ADIHAL_OK;
+
     halError = talWriteToLog(device->devHalInfo, ADIHAL_LOG_MSG, TAL_ERR_OK, "TALISE_waitInitCals()\n");
     retVal = talApiErrHandler(device, TAL_ERRHDL_HAL_LOG, halError, retVal, TALACT_WARN_RESET_LOG);
 #endif
@@ -121,13 +123,14 @@ uint32_t TALISE_waitInitCals(taliseDevice_t *device, uint32_t timeoutMs, uint8_t
 uint32_t TALISE_checkInitCalComplete(taliseDevice_t *device, uint8_t *areCalsRunning, uint8_t *errorFlag)
 {
     talRecoveryActions_t retVal = TALACT_NO_ACTION;
-    adiHalErr_t halError = ADIHAL_OK;
     uint8_t cmdStatusByte = 0;
     uint8_t armErrorFlag = 0;
 
     static const uint32_t CODECHECK_PARAM_CHECKINITCALCOMPLETE_ERR3 = 3;
 
 #if TALISE_VERBOSE
+    adiHalErr_t halError = ADIHAL_OK;
+
     talWriteToLog(device->devHalInfo, ADIHAL_LOG_MSG, TAL_ERR_OK, "TALISE_checkInitCalComplete()\n");
     retVal = talApiErrHandler(device, TAL_ERRHDL_HAL_LOG, halError, retVal, TALACT_WARN_RESET_LOG);
 #endif
@@ -192,7 +195,6 @@ uint32_t TALISE_abortInitCals(taliseDevice_t *device, uint32_t *calsCompleted)
 {
     talRecoveryActions_t retVal = TALACT_NO_ACTION;
     talRecoveryActions_t retValWarn = TALACT_NO_ACTION;
-    adiHalErr_t halError = ADIHAL_OK;
     uint8_t cmdStatusByte = 0;
     uint8_t calCompleteBitField[4] = {0};
     uint8_t extData[1] = {TALISE_ARM_OBJECTID_INITCAL_STATUS};
@@ -202,6 +204,8 @@ uint32_t TALISE_abortInitCals(taliseDevice_t *device, uint32_t *calsCompleted)
     static const uint32_t CODECHECK_PARAM_ABORTINITCALS_ERR3 = 3;
 
 #if TALISE_VERBOSE
+    adiHalErr_t halError = ADIHAL_OK;
+
     halError = talWriteToLog(device->devHalInfo, ADIHAL_LOG_MSG, TAL_ERR_OK, "TALISE_abortInitCals()\n");
     retVal = talApiErrHandler(device, TAL_ERRHDL_HAL_LOG, halError, retVal, TALACT_WARN_RESET_LOG);
 #endif
@@ -277,7 +281,6 @@ uint32_t TALISE_getInitCalStatus(taliseDevice_t *device, uint32_t *calsSincePowe
 {
     talRecoveryActions_t retVal = TALACT_NO_ACTION;
     talRecoveryActions_t retValWarn = TALACT_NO_ACTION;
-    adiHalErr_t halError = ADIHAL_OK;
     uint8_t cmdStatusByte = 0;
     uint8_t calBitField[14] = {0};
     static const uint8_t talInitCalDoneObjectID = 0x43;
@@ -286,6 +289,8 @@ uint32_t TALISE_getInitCalStatus(taliseDevice_t *device, uint32_t *calsSincePowe
     static const uint32_t CODECHECK_PARAM_GETINITCALSTATUS_ERR2 = 7;
 
 #if TALISE_VERBOSE
+    adiHalErr_t halError = ADIHAL_OK;
+
     halError = talWriteToLog(device->devHalInfo, ADIHAL_LOG_MSG, TAL_ERR_OK, "TALISE_getInitCalStatus()\n");
     retVal = talApiErrHandler(device, TAL_ERRHDL_HAL_LOG, halError, retVal, TALACT_WARN_RESET_LOG);
 #endif
@@ -389,7 +394,6 @@ uint32_t TALISE_enableTrackingCals(taliseDevice_t *device, uint32_t enableMask)
 {
     talRecoveryActions_t retVal = TALACT_NO_ACTION;
     talRecoveryActions_t retValWarn = TALACT_NO_ACTION;
-    adiHalErr_t halError = ADIHAL_OK;
     uint8_t armData[4] = {0};
     uint8_t cmdStatusByte = 0;
     uint32_t radioStatus = 0;
@@ -401,6 +405,8 @@ uint32_t TALISE_enableTrackingCals(taliseDevice_t *device, uint32_t enableMask)
     static const uint32_t CODECHECK_PARAM_ENABLETRACKINGCALS_ERR2 = 2;
 
 #if TALISE_VERBOSE
+    adiHalErr_t halError = ADIHAL_OK;
+
     halError = talWriteToLog(device->devHalInfo, ADIHAL_LOG_MSG, TAL_ERR_OK, "TALISE_enableTrackingCals()\n");
     retVal = talApiErrHandler(device, TAL_ERRHDL_HAL_LOG, halError, retVal, TALACT_WARN_RESET_LOG);
 #endif
@@ -474,10 +480,11 @@ uint32_t TALISE_enableTrackingCals(taliseDevice_t *device, uint32_t enableMask)
 uint32_t TALISE_getEnabledTrackingCals(taliseDevice_t *device, uint32_t *enableMask)
 {
     talRecoveryActions_t retVal = TALACT_NO_ACTION;
-    adiHalErr_t halError = ADIHAL_OK;
     uint8_t armData[4] = {0};
 
 #if TALISE_VERBOSE
+    adiHalErr_t halError = ADIHAL_OK;
+
     halError = talWriteToLog(device->devHalInfo, ADIHAL_LOG_MSG, TAL_ERR_OK, "TALISE_getEnabledTrackingCals()\n");
     retVal = talApiErrHandler(device, TAL_ERRHDL_HAL_LOG, halError, retVal, TALACT_WARN_RESET_LOG);
 #endif
@@ -533,13 +540,14 @@ uint32_t TALISE_getPendingTrackingCals(taliseDevice_t *device, uint32_t *pending
 uint32_t TALISE_rescheduleTrackingCal(taliseDevice_t *device, taliseTrackingCalibrations_t trackingCal)
 {
     talRecoveryActions_t retVal = TALACT_NO_ACTION;
-    adiHalErr_t halError = ADIHAL_OK;
     uint8_t extData[3] = {0};
     uint8_t cmdStatusByte = 0;
 
     static const uint32_t CODECHECK_PARAM_RESCHEDULETRACKINGCAL_ERR1 = 1;
 
 #if TALISE_VERBOSE
+    adiHalErr_t halError = ADIHAL_OK;
+
     halError = talWriteToLog(device->devHalInfo, ADIHAL_LOG_MSG, TAL_ERR_OK, "TALISE_rescheduleTrackingCal()\n");
     retVal = talApiErrHandler(device, TAL_ERRHDL_HAL_LOG, halError, retVal, TALACT_WARN_RESET_LOG);
 #endif
@@ -621,7 +629,6 @@ uint32_t TALISE_setAllTrackCalState(taliseDevice_t *device, uint32_t calSubsetMa
 {
     talRecoveryActions_t retVal = TALACT_NO_ACTION;
     talRecoveryActions_t retValWarn = TALACT_NO_ACTION;
-    adiHalErr_t halError = ADIHAL_OK;
     uint8_t cfgData[8] = {0};
     uint8_t extData[2] = {TALISE_ARM_OBJECTID_TRACKING_CAL_SUSPEND_RESUME, 0x0F};
     uint8_t cmdStatusByte = 0;
@@ -629,6 +636,8 @@ uint32_t TALISE_setAllTrackCalState(taliseDevice_t *device, uint32_t calSubsetMa
     static const uint32_t CODECHECK_PARAM_SETALLTRACKCALSTATE_ERR1 = 1;
 
 #if TALISE_VERBOSE
+    adiHalErr_t halError = ADIHAL_OK;
+
     halError = talWriteToLog(device->devHalInfo, ADIHAL_LOG_MSG, TAL_ERR_OK, "TALISE_setAllTrackCalState()\n");
     retVal = talApiErrHandler(device, TAL_ERRHDL_HAL_LOG, halError, retVal, TALACT_WARN_RESET_LOG);
 #endif
@@ -695,7 +704,6 @@ uint32_t TALISE_getAllTrackCalState(taliseDevice_t *device, uint32_t *resumeCalM
 {
     talRecoveryActions_t retVal = TALACT_NO_ACTION;
     talRecoveryActions_t retValWarn = TALACT_NO_ACTION;
-    adiHalErr_t halError = ADIHAL_OK;
     uint8_t extData[1] = {TALISE_ARM_OBJECTID_TRACKING_CAL_SUSPEND_RESUME};
     uint8_t armData[4] = {0};
     uint8_t cmdStatusByte = 0;
@@ -703,6 +711,8 @@ uint32_t TALISE_getAllTrackCalState(taliseDevice_t *device, uint32_t *resumeCalM
     static const uint32_t CODECHECK_PARAM_GETALLTRACKCALSTATE_ERR1 = 2;
 
 #if TALISE_VERBOSE
+    adiHalErr_t halError = ADIHAL_OK;
+
     halError = talWriteToLog(device->devHalInfo, ADIHAL_LOG_MSG, TAL_ERR_OK, "TALISE_getAllTrackCalState()\n");
     retVal = talApiErrHandler(device, TAL_ERRHDL_HAL_LOG, halError, retVal, TALACT_WARN_RESET_LOG);
 #endif
@@ -762,7 +772,6 @@ uint32_t TALISE_getAllTrackCalState(taliseDevice_t *device, uint32_t *resumeCalM
 uint32_t TALISE_getTxLolStatus(taliseDevice_t *device, taliseTxChannels_t channelSel, taliseTxLolStatus_t *txLolStatus)
 {
     talRecoveryActions_t retVal = TALACT_NO_ACTION;
-    adiHalErr_t halError = ADIHAL_OK;
     uint8_t extData[3] = {TALISE_ARM_OBJECTID_CAL_STATUS, TALISE_ARM_OBJECTID_TXLOL_TRACKING, 0};
     uint8_t cmdStatusByte = 0;
     uint8_t armReadBack[20] = {0};
@@ -770,6 +779,8 @@ uint32_t TALISE_getTxLolStatus(taliseDevice_t *device, taliseTxChannels_t channe
     static const uint32_t CODECHECK_PARAM_GETTXLOWSTATUS_ERR1 = 2;
 
 #if TALISE_VERBOSE
+    adiHalErr_t halError = ADIHAL_OK;
+
     halError = talWriteToLog(device->devHalInfo, ADIHAL_LOG_MSG, TAL_ERR_OK, "TALISE_getTxLolStatus()\n");
     retVal = talApiErrHandler(device, TAL_ERRHDL_HAL_LOG, halError, retVal, TALACT_WARN_RESET_LOG);
 #endif
@@ -838,7 +849,6 @@ uint32_t TALISE_getTxLolStatus(taliseDevice_t *device, taliseTxChannels_t channe
 uint32_t TALISE_getTxQecStatus(taliseDevice_t *device, taliseTxChannels_t channelSel, taliseTxQecStatus_t *txQecStatus)
 {
     talRecoveryActions_t retVal = TALACT_NO_ACTION;
-    adiHalErr_t halError = ADIHAL_OK;
     uint8_t extData[3] = {TALISE_ARM_OBJECTID_CAL_STATUS, TALISE_ARM_OBJECTID_TXQEC_TRACKING, 0};
     uint8_t cmdStatusByte = 0;
     uint8_t armReadBack[20] = {0};
@@ -846,6 +856,8 @@ uint32_t TALISE_getTxQecStatus(taliseDevice_t *device, taliseTxChannels_t channe
     static const uint32_t CODECHECK_PARAM_GETTXQECSTATUS_ERR1 = 2;
 
 #if TALISE_VERBOSE
+    adiHalErr_t halError = ADIHAL_OK;
+
     halError = talWriteToLog(device->devHalInfo, ADIHAL_LOG_MSG, TAL_ERR_OK, "TALISE_getTxQecStatus()\n");
     retVal = talApiErrHandler(device, TAL_ERRHDL_HAL_LOG, halError, retVal, TALACT_WARN_RESET_LOG);
 #endif
@@ -914,7 +926,6 @@ uint32_t TALISE_getTxQecStatus(taliseDevice_t *device, taliseTxChannels_t channe
 uint32_t TALISE_getRxQecStatus(taliseDevice_t *device, taliseRxChannels_t channelSel, taliseRxQecStatus_t *rxQecStatus)
 {
     talRecoveryActions_t retVal = TALACT_NO_ACTION;
-    adiHalErr_t halError = ADIHAL_OK;
     uint8_t extData[3] = {TALISE_ARM_OBJECTID_CAL_STATUS, TALISE_ARM_OBJECTID_RXQEC_TRACKING, 0};
     uint8_t cmdStatusByte = 0;
     uint8_t armReadBack[20] = {0};
@@ -922,6 +933,8 @@ uint32_t TALISE_getRxQecStatus(taliseDevice_t *device, taliseRxChannels_t channe
     static const uint32_t CODECHECK_PARAM_GETRXQECSTATUS_ERR1 = 2;
 
 #if TALISE_VERBOSE
+    adiHalErr_t halError = ADIHAL_OK;
+
     halError = talWriteToLog(device->devHalInfo, ADIHAL_LOG_MSG, TAL_ERR_OK, "TALISE_getRxQecStatus()\n");
     retVal = talApiErrHandler(device, TAL_ERRHDL_HAL_LOG, halError, retVal, TALACT_WARN_RESET_LOG);
 #endif
@@ -990,7 +1003,6 @@ uint32_t TALISE_getRxQecStatus(taliseDevice_t *device, taliseRxChannels_t channe
 uint32_t TALISE_getOrxQecStatus(taliseDevice_t *device, taliseObsRxChannels_t channelSel, taliseOrxQecStatus_t *orxQecStatus)
 {
     talRecoveryActions_t retVal = TALACT_NO_ACTION;
-    adiHalErr_t halError = ADIHAL_OK;
     uint8_t extData[3] = {TALISE_ARM_OBJECTID_CAL_STATUS, TALISE_ARM_OBJECTID_ORXQEC_TRACKING, 0};
     uint8_t cmdStatusByte = 0;
     uint8_t armReadBack[20] = {0};
@@ -998,6 +1010,8 @@ uint32_t TALISE_getOrxQecStatus(taliseDevice_t *device, taliseObsRxChannels_t ch
     static const uint32_t CODECHECK_PARAM_GETORXQECSTATUS_ERR1 = 2;
 
 #if TALISE_VERBOSE
+    adiHalErr_t halError = ADIHAL_OK;
+
     halError = talWriteToLog(device->devHalInfo, ADIHAL_LOG_MSG, TAL_ERR_OK, "TALISE_getOrxQecStatus()\n");
     retVal = talApiErrHandler(device, TAL_ERRHDL_HAL_LOG, halError, retVal, TALACT_WARN_RESET_LOG);
 #endif
@@ -1066,7 +1080,6 @@ uint32_t TALISE_getOrxQecStatus(taliseDevice_t *device, taliseObsRxChannels_t ch
 uint32_t TALISE_getRxHd2Status(taliseDevice_t *device, taliseRxChannels_t channelSel, taliseRxHd2Status_t *rxHd2Status)
 {
     talRecoveryActions_t retVal = TALACT_NO_ACTION;
-    adiHalErr_t halError = ADIHAL_OK;
     uint8_t extData[3] = {TALISE_ARM_OBJECTID_CAL_STATUS, TALISE_ARM_OBJECTID_RXHD2_TRACKING, 0};
     uint8_t cmdStatusByte = 0;
     uint8_t armReadBack[20] = {0};
@@ -1074,6 +1087,8 @@ uint32_t TALISE_getRxHd2Status(taliseDevice_t *device, taliseRxChannels_t channe
     static const uint32_t CODECHECK_PARAM_GETRXHD2STATUS_ERR1 = 2;
 
 #if TALISE_VERBOSE
+    adiHalErr_t halError = ADIHAL_OK;
+
     halError = talWriteToLog(device->devHalInfo, ADIHAL_LOG_MSG, TAL_ERR_OK, "TALISE_getRxHd2Status()\n");
     retVal = talApiErrHandler(device, TAL_ERRHDL_HAL_LOG, halError, retVal, TALACT_WARN_RESET_LOG);
 #endif
@@ -1365,12 +1380,13 @@ uint32_t TALISE_resetExtTxLolChannel(taliseDevice_t *device, taliseTxChannels_t 
     static const uint32_t CODECHECK_PARAM_RESETEXTTXLOLCHANNEL_ERR2 = 2;
 
     talRecoveryActions_t retVal = TALACT_NO_ACTION;
-    adiHalErr_t halError = ADIHAL_OK;
     uint8_t extData[3] = {TALISE_ARM_OBJECTID_TRACKING_CAL_CTRL, TXLOL_RESET_CHANNEL_ESTIMATE, 0};
     uint8_t cmdStatusByte = 0;
     uint32_t radioStatus = 0;
 
 #if TALISE_VERBOSE
+    adiHalErr_t halError = ADIHAL_OK;
+
     halError = talWriteToLog(device->devHalInfo, ADIHAL_LOG_MSG, TAL_ERR_OK, "TALISE_resetExtTxLolChannel()\n");
     retVal = talApiErrHandler(device, TAL_ERRHDL_HAL_LOG, halError, retVal, TALACT_WARN_RESET_LOG);
 #endif
@@ -1437,7 +1453,6 @@ uint32_t TALISE_setRxHd2Config(taliseDevice_t *device, taliseRxHd2Config_t *hd2C
 {
     talRecoveryActions_t retVal = TALACT_NO_ACTION;
     talRecoveryActions_t retValWarn = TALACT_NO_ACTION;
-    adiHalErr_t halError = ADIHAL_OK;
 
     uint8_t armFieldValue[4] = {0};
     uint32_t radioStatus = 0;
@@ -1446,6 +1461,8 @@ uint32_t TALISE_setRxHd2Config(taliseDevice_t *device, taliseRxHd2Config_t *hd2C
     static const uint32_t CODECHECK_PARAM_SETRXHD2CONFIG_ERR1 = 2;
 
 #if TALISE_VERBOSE
+    adiHalErr_t halError = ADIHAL_OK;
+
     halError = talWriteToLog(device->devHalInfo, ADIHAL_LOG_MSG, TAL_ERR_OK, "TALISE_setRxHd2Config()\n");
     retVal = talApiErrHandler(device, TAL_ERRHDL_HAL_LOG, halError, retVal, TALACT_WARN_RESET_LOG);
 #endif
@@ -1499,7 +1516,6 @@ uint32_t TALISE_getRxHd2Config(taliseDevice_t *device, taliseRxHd2Config_t *hd2C
 {
     talRecoveryActions_t retVal = TALACT_NO_ACTION;
     talRecoveryActions_t retValWarn = TALACT_NO_ACTION;
-    adiHalErr_t halError = ADIHAL_OK;
 
     uint8_t armFieldValue[4] = {0};
     uint32_t radioStatus = 0;
@@ -1508,6 +1524,8 @@ uint32_t TALISE_getRxHd2Config(taliseDevice_t *device, taliseRxHd2Config_t *hd2C
     static const uint32_t CODECHECK_PARAM_GETRXHD2CONFIG_ERR1 = 2;
 
 #if TALISE_VERBOSE
+    adiHalErr_t halError = ADIHAL_OK;
+
     halError = talWriteToLog(device->devHalInfo, ADIHAL_LOG_MSG, TAL_ERR_OK, "TALISE_getRxHd2Config()\n");
     retVal = talApiErrHandler(device, TAL_ERRHDL_HAL_LOG, halError, retVal, TALACT_WARN_RESET_LOG);
 #endif

--- a/drivers/iio/adc/talise/talise_gpio.c
+++ b/drivers/iio/adc/talise/talise_gpio.c
@@ -436,7 +436,6 @@ uint32_t TALISE_getGpIntStatus(taliseDevice_t *device, uint16_t *gpIntStatus)
 uint32_t TALISE_getTemperature(taliseDevice_t *device, int16_t *temperatureDegC)
 {
     talRecoveryActions_t retVal = TALACT_NO_ACTION;
-    adiHalErr_t halError = ADIHAL_OK;
     uint8_t armExtData[1] = {TALISE_ARM_OBJECTID_TEMP_SENSOR};
     uint8_t cmdStatusByte = 0;
     uint8_t armReadBack[2] = {0};
@@ -445,6 +444,8 @@ uint32_t TALISE_getTemperature(taliseDevice_t *device, int16_t *temperatureDegC)
     static const int16_t CODE_TO_DEGREE_CELSIUS = 359; /* Nominal 25C value  = code 384, Scale by 384-25 to normalize */
 
 #if TALISE_VERBOSE
+    adiHalErr_t halError = ADIHAL_OK;
+
     halError = talWriteToLog(device->devHalInfo, ADIHAL_LOG_MSG, TAL_ERR_OK, "TALISE_getTemperature()\n");
     retVal = talApiErrHandler(device, TAL_ERRHDL_HAL_LOG, halError, retVal, TALACT_WARN_RESET_LOG);
 #endif

--- a/drivers/iio/adc/talise/talise_radioctrl.c
+++ b/drivers/iio/adc/talise/talise_radioctrl.c
@@ -133,9 +133,10 @@ uint32_t TALISE_setArmGpioPins(taliseDevice_t *device, taliseArmGpioConfig_t *ar
     uint32_t usedGpiopins = 0;
 
     talRecoveryActions_t retVal = TALACT_NO_ACTION;
-    adiHalErr_t halError = ADIHAL_OK;
 
 #if TALISE_VERBOSE
+    adiHalErr_t halError = ADIHAL_OK;
+
     halError = talWriteToLog(device->devHalInfo, ADIHAL_LOG_MSG, TAL_ERR_OK, "TALISE_setArmGpioPins()\n");
     retVal = talApiErrHandler(device, TAL_ERRHDL_HAL_LOG, halError, retVal, TALACT_WARN_RESET_LOG);
 #endif
@@ -731,18 +732,19 @@ uint32_t TALISE_setTxToOrxMapping(taliseDevice_t *device, uint8_t txCalEnable, t
 {
     talRecoveryActions_t retVal = TALACT_NO_ACTION;
     talRecoveryActions_t retValWarn = TALACT_NO_ACTION;
-    adiHalErr_t halError = ADIHAL_OK;
     uint8_t extData[2] = {0};
     uint8_t cmdStatusByte = 0x0;
 
     static const uint8_t ENABLE_TXCALS = 0x10;
 
-    extData[0] = TALISE_ARM_OBJECTID_ORX_TXCAL_CTRL;
-
 #if TALISE_VERBOSE
+    adiHalErr_t halError = ADIHAL_OK;
+
     halError = talWriteToLog(device->devHalInfo, ADIHAL_LOG_MSG, TAL_ERR_OK, "TALISE_setTxToOrxMapping()\n");
     retVal = talApiErrHandler(device, TAL_ERRHDL_HAL_LOG, halError, retVal, TALACT_WARN_RESET_LOG);
 #endif
+
+    extData[0] = TALISE_ARM_OBJECTID_ORX_TXCAL_CTRL;
 
     retValWarn = retVal;
 
@@ -1203,9 +1205,10 @@ uint32_t TALISE_setRfPllLoopFilter(taliseDevice_t *device, uint16_t loopBandwidt
 {
     talRecoveryActions_t retVal = TALACT_NO_ACTION;
     talRecoveryActions_t retValWarn = TALACT_NO_ACTION;
-    adiHalErr_t halError = ADIHAL_OK;
 
 #if TALISE_VERBOSE
+    adiHalErr_t halError = ADIHAL_OK;
+
     halError = talWriteToLog(device->devHalInfo, ADIHAL_LOG_MSG, TAL_ERR_OK, "TALISE_setRfPllLoopFilter()\n");
     retVal = talApiErrHandler(device, TAL_ERRHDL_HAL_LOG, halError, retVal, TALACT_WARN_RESET_LOG);
 #endif
@@ -1228,9 +1231,10 @@ uint32_t TALISE_getRfPllLoopFilter(taliseDevice_t *device, uint16_t *loopBandwid
 {
     talRecoveryActions_t retVal = TALACT_NO_ACTION;
     talRecoveryActions_t retValWarn = TALACT_NO_ACTION;
-    adiHalErr_t halError = ADIHAL_OK;
 
 #if TALISE_VERBOSE
+    adiHalErr_t halError = ADIHAL_OK;
+
     halError = talWriteToLog(device->devHalInfo, ADIHAL_LOG_MSG, TAL_ERR_OK, "TALISE_getRfPllLoopFilter()\n");
     retVal = talApiErrHandler(device, TAL_ERRHDL_HAL_LOG, halError, retVal, TALACT_WARN_RESET_LOG);
 #endif
@@ -1257,10 +1261,11 @@ uint32_t TALISE_setPllLoopFilter(taliseDevice_t *device, taliseRfPllName_t pllNa
     uint8_t cmdStatusByte = 0;
     talRecoveryActions_t retVal = TALACT_NO_ACTION;
     talRecoveryActions_t retValWarn = TALACT_NO_ACTION;
-    adiHalErr_t halError = ADIHAL_OK;
     uint8_t auxPllSel = 0;
 
 #if TALISE_VERBOSE
+    adiHalErr_t halError = ADIHAL_OK;
+
     halError = talWriteToLog(device->devHalInfo, ADIHAL_LOG_MSG, TAL_ERR_OK, "TALISE_setPllLoopFilter()\n");
     retVal = talApiErrHandler(device, TAL_ERRHDL_HAL_LOG, halError, retVal, TALACT_WARN_RESET_LOG);
 #endif
@@ -1334,10 +1339,11 @@ uint32_t TALISE_getPllLoopFilter(taliseDevice_t *device, taliseRfPllName_t pllNa
     uint8_t armData[3] = {0};
     uint8_t cmdStatusByte = 0;
     talRecoveryActions_t retVal = TALACT_NO_ACTION;
-    adiHalErr_t halError = ADIHAL_OK;
     uint8_t auxPllSel = 0;
 
 #if TALISE_VERBOSE
+    adiHalErr_t halError = ADIHAL_OK;
+
     halError = talWriteToLog(device->devHalInfo, ADIHAL_LOG_MSG, TAL_ERR_OK, "TALISE_getPllLoopFilter()\n");
     retVal = talApiErrHandler(device, TAL_ERRHDL_HAL_LOG, halError, retVal, TALACT_WARN_RESET_LOG);
 #endif
@@ -1647,12 +1653,13 @@ uint32_t TALISE_setFhmConfig(taliseDevice_t *device, taliseFhmConfig_t *fhmConfi
     static const uint8_t ARM_CFG_BUF_SIZE = 8;
     talRecoveryActions_t retVal = TALACT_NO_ACTION;
     talRecoveryActions_t retValWarn = TALACT_NO_ACTION;
-    adiHalErr_t halError = ADIHAL_OK;
     int64_t freqValid = 0;
     uint8_t byteOffset = 0;
     uint8_t armConfigBuf[8] = {0};
 
 #if TALISE_VERBOSE
+    adiHalErr_t halError = ADIHAL_OK;
+
     halError = talWriteToLog(device->devHalInfo, ADIHAL_LOG_MSG, TAL_ERR_OK, "TALISE_setFhmConfig()\n");
     retVal = talApiErrHandler(device, TAL_ERRHDL_HAL_LOG, halError, retVal, TALACT_WARN_RESET_LOG);
 #endif
@@ -1742,11 +1749,12 @@ uint32_t TALISE_getFhmConfig(taliseDevice_t *device, taliseFhmConfig_t *fhmConfi
     static const uint8_t ARM_CFG_BUF_SIZE = 8;
     talRecoveryActions_t retVal = TALACT_NO_ACTION;
     talRecoveryActions_t retValWarn = TALACT_NO_ACTION;
-    adiHalErr_t halError = ADIHAL_OK;
     uint8_t armCfgBuf[8] = {0};
     uint8_t byteOffset = 0;
 
 #if TALISE_VERBOSE
+    adiHalErr_t halError = ADIHAL_OK;
+
     halError = talWriteToLog(device->devHalInfo, ADIHAL_LOG_MSG, TAL_ERR_OK, "TALISE_getFhmConfig()\n");
     retVal = talApiErrHandler(device, TAL_ERRHDL_HAL_LOG, halError, retVal, TALACT_WARN_RESET_LOG);
 #endif
@@ -1836,11 +1844,12 @@ uint32_t TALISE_setFhmMode(taliseDevice_t *device, taliseFhmMode_t *fhmMode)
 
     talRecoveryActions_t retVal = TALACT_NO_ACTION;
     talRecoveryActions_t retValWarn = TALACT_NO_ACTION;
-    adiHalErr_t halError = ADIHAL_OK;
     uint8_t cmdStatusByte = 0;
     uint8_t armFhmModeCfgCmd[3] = { 0 };
 
 #if TALISE_VERBOSE
+    adiHalErr_t halError = ADIHAL_OK;
+
     halError = talWriteToLog(device->devHalInfo, ADIHAL_LOG_MSG, TAL_ERR_OK, "TALISE_setFhmMode()\n");
     retVal = talApiErrHandler(device, TAL_ERRHDL_HAL_LOG, halError, retVal, TALACT_WARN_RESET_LOG);
 #endif
@@ -1959,12 +1968,13 @@ uint32_t TALISE_getFhmMode(taliseDevice_t *device, taliseFhmMode_t *fhmMode)
 
     talRecoveryActions_t retVal = TALACT_NO_ACTION;
     talRecoveryActions_t retValWarn = TALACT_NO_ACTION;
-    adiHalErr_t halError = ADIHAL_OK;
     uint8_t cmdStatusByte = 0;
     uint8_t fhmExitMode = 0;
     uint8_t armGetFhmModeCmdArr[ARM_FHM_MODE_READ_CMD_NUM_BYTES];
 
 #if TALISE_VERBOSE
+    adiHalErr_t halError = ADIHAL_OK;
+
     halError = talWriteToLog(device->devHalInfo, ADIHAL_LOG_MSG, TAL_ERR_OK, "TALISE_getFhmMode()\n");
     retVal = talApiErrHandler(device, TAL_ERRHDL_HAL_LOG, halError, retVal, TALACT_WARN_RESET_LOG);
 #endif
@@ -2024,11 +2034,12 @@ uint32_t TALISE_setFhmHop(taliseDevice_t *device, uint64_t nextRfPllFrequency_Hz
 
     talRecoveryActions_t retVal = TALACT_NO_ACTION;
     talRecoveryActions_t retValWarn = TALACT_NO_ACTION;
-    adiHalErr_t halError = ADIHAL_OK;
     uint8_t cmdStatusByte = 0;
     uint8_t armSetFhmHopCmdArr[ARM_FHM_HOP_SET_CMD_BYTES];
 
 #if TALISE_VERBOSE
+    adiHalErr_t halError = ADIHAL_OK;
+
     halError = talWriteToLog(device->devHalInfo, ADIHAL_LOG_MSG, TAL_ERR_OK, "TALISE_setFhmHop()\n");
     retVal = talApiErrHandler(device, TAL_ERRHDL_HAL_LOG, halError, retVal, TALACT_WARN_RESET_LOG);
 #endif
@@ -2092,12 +2103,13 @@ uint32_t TALISE_getFhmRfPllFrequency(taliseDevice_t *device, uint64_t *fhmRfPllF
 
     talRecoveryActions_t retVal = TALACT_NO_ACTION;
     talRecoveryActions_t retValWarn = TALACT_NO_ACTION;
-    adiHalErr_t halError = ADIHAL_OK;
     uint8_t cmdStatusByte = 0;
     uint8_t armGetFhmModeCmdArr[1] = { 0 };
     uint8_t armGetFhmRfPllFreqArr[8] = { 0 };
 
 #if TALISE_VERBOSE
+    adiHalErr_t halError = ADIHAL_OK;
+
     halError = talWriteToLog(device->devHalInfo, ADIHAL_LOG_MSG, TAL_ERR_OK, "TALISE_getFhmRfPllFrequency()\n");
     retVal = talApiErrHandler(device, TAL_ERRHDL_HAL_LOG, halError, retVal, TALACT_WARN_RESET_LOG);
 #endif
@@ -2174,10 +2186,16 @@ uint32_t TALISE_getFhmStatus(taliseDevice_t *device, taliseFhmStatus_t *fhmStatu
 
     talRecoveryActions_t retVal = TALACT_NO_ACTION;
     talRecoveryActions_t retValWarn = TALACT_NO_ACTION;
-    adiHalErr_t halError = ADIHAL_OK;
     uint8_t cmdStatusByte = 0;
     uint8_t armGetFhmModeCmdArr[ARM_FHM_STS_READ_CMD_NUM_BYTES];
     uint8_t armFhmStsData[8] = { 0 };
+
+#if TALISE_VERBOSE
+    adiHalErr_t halError = ADIHAL_OK;
+
+    halError = talWriteToLog(device->devHalInfo, ADIHAL_LOG_MSG, TAL_ERR_OK, "TALISE_getFhmStatus()\n");
+    retVal = talApiErrHandler(device, TAL_ERRHDL_HAL_LOG, halError, retVal, TALACT_WARN_RESET_LOG);
+#endif
 
     /*Check for NULL*/
     if(fhmStatus == NULL)
@@ -2185,11 +2203,6 @@ uint32_t TALISE_getFhmStatus(taliseDevice_t *device, taliseFhmStatus_t *fhmStatu
         return (uint32_t)talApiErrHandler(device, TAL_ERRHDL_INVALID_PARAM,
                                           TAL_ERR_GETFHMSTS_NULL_PARAM, retVal, TALACT_ERR_CHECK_PARAM);
     }
-
-#if TALISE_VERBOSE
-    halError = talWriteToLog(device->devHalInfo, ADIHAL_LOG_MSG, TAL_ERR_OK, "TALISE_getFhmStatus()\n");
-    retVal = talApiErrHandler(device, TAL_ERRHDL_HAL_LOG, halError, retVal, TALACT_WARN_RESET_LOG);
-#endif
 
     retValWarn = retVal;
 


### PR DESCRIPTION
warning: unused variable ‘halError’ [-Wunused-variable]
     adiHalErr_t halError = ADIHAL_OK;
                 ^~~~~~~~

Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>