### PR TITLE
dmaengine: dma-axi-dmac: Fix cyclic transfers 

### DIFF
--- a/drivers/dma/dma-axi-dmac.c
+++ b/drivers/dma/dma-axi-dmac.c
@@ -636,7 +636,7 @@ static struct dma_async_tx_descriptor *axi_dmac_prep_dma_cyclic(
 		return NULL;
 
 	axi_dmac_fill_linear_sg(chan, direction, buf_addr, num_periods,
-		buf_len, desc->sg);
+		period_len, desc->sg);
 
 	desc->cyclic = true;
 


### PR DESCRIPTION
Currently cyclic transfer using dma-axi-dmac driver is broken. Was discovered in a setup where
AXI DMA is used together with soc-generic-dmaengine and ALSA. 

The first problem is that currently callback function is called only when the last period was 
transferred but it should be called after every finished period. 
In this way ALSA can update the data that's in the buffer before the ring buffer will wrap around.

The second problem is when descriptors are allocated for periods composing the cyclic transfer.
The number of periods multiplied with number of periods must be equal with ring buffer length.
So each descriptor must have a length equal with one period and not the whole buffer.

The commits included in this pull request correct the before mentioned problems.

The changes were tested also with FMC-IMAGEON and FMCOMMS3 on ZED board.