### PR TITLE
iio: adc: ad7616: Add suport for AD7616 ADC

### DIFF
--- a/drivers/iio/adc/ad7606.c
+++ b/drivers/iio/adc/ad7606.c
@@ -58,6 +58,10 @@ static const unsigned int ad7606_oversampling_avail[7] = {
 	1, 2, 4, 8, 16, 32, 64,
 };
 
+static const unsigned int ad7616_oversampling_avail[8] = {
+	1, 2, 4, 8, 16, 32, 64, 128,
+};
+
 static const unsigned int ad7606B_oversampling_avail[9] = {
 	1, 2, 4, 8, 16, 32, 64, 128, 256
 };
@@ -307,8 +311,8 @@ static int ad7606_write_raw(struct iio_dev *indio_dev,
 		if (val2)
 			return -EINVAL;
 
-		i = find_closest(val, st->oversampling_avail,
-				 st->num_os_ratios);
+		i = find_closest(val, st->chip_info->oversampling_avail,
+				 st->chip_info->oversampling_num);
 		mutex_lock(&st->lock);
 		if (st->sw_mode_en) {
 			ret = ad7606_spi_reg_write(st, AD7606_OS_MODE, i);
@@ -323,8 +327,10 @@ static int ad7606_write_raw(struct iio_dev *indio_dev,
 
 			gpiod_set_array_value(ARRAY_SIZE(values),
 					      st->gpio_os->desc, values);
+			if (st->chip_info->oversampling_needs_reset)
+				ad7606_reset(st);
 		}
-		st->oversampling = st->oversampling_avail[i];
+		st->oversampling = st->chip_info->oversampling_avail[i];
 		mutex_unlock(&st->lock);
 
 		return 0;
@@ -340,8 +346,8 @@ static ssize_t ad7606_oversampling_ratio_avail(struct device *dev,
 	struct iio_dev *indio_dev = dev_to_iio_dev(dev);
 	struct ad7606_state *st = iio_priv(indio_dev);
 
-	return ad7606_show_avail(buf, st->oversampling_avail,
-				 st->num_os_ratios, false);
+	return ad7606_show_avail(buf, st->chip_info->oversampling_avail,
+				 st->chip_info->oversampling_num, false);
 }
 
 static IIO_DEVICE_ATTR(oversampling_ratio_available, 0444,
@@ -437,6 +443,26 @@ static const struct iio_chan_spec ad7606B_channels[] = {
 	AD7606B_CHANNEL(7),
 };
 
+static const struct iio_chan_spec ad7616_channels[] = {
+	IIO_CHAN_SOFT_TIMESTAMP(16),
+	AD7606_CHANNEL(0),
+	AD7606_CHANNEL(1),
+	AD7606_CHANNEL(2),
+	AD7606_CHANNEL(3),
+	AD7606_CHANNEL(4),
+	AD7606_CHANNEL(5),
+	AD7606_CHANNEL(6),
+	AD7606_CHANNEL(7),
+	AD7606_CHANNEL(8),
+	AD7606_CHANNEL(9),
+	AD7606_CHANNEL(10),
+	AD7606_CHANNEL(11),
+	AD7606_CHANNEL(12),
+	AD7606_CHANNEL(13),
+	AD7606_CHANNEL(14),
+	AD7606_CHANNEL(15),
+};
+
 static const struct ad7606_chip_info ad7606_chip_info_tbl[] = {
 	/* More devices added in future */
 	[ID_AD7605_4] = {
@@ -447,22 +473,38 @@ static const struct ad7606_chip_info ad7606_chip_info_tbl[] = {
 		.channels = ad7606_channels,
 		.num_channels = 9,
 		.has_oversampling = true,
+		.oversampling_avail = ad7606_oversampling_avail,
+		.oversampling_num = ARRAY_SIZE(ad7606_oversampling_avail),
 	},
 	[ID_AD7606_6] = {
 		.channels = ad7606_channels,
 		.num_channels = 7,
 		.has_oversampling = true,
+		.oversampling_avail = ad7606_oversampling_avail,
+		.oversampling_num = ARRAY_SIZE(ad7606_oversampling_avail),
 	},
 	[ID_AD7606_4] = {
 		.channels = ad7606_channels,
 		.num_channels = 5,
 		.has_oversampling = true,
+		.oversampling_avail = ad7606_oversampling_avail,
+		.oversampling_num = ARRAY_SIZE(ad7606_oversampling_avail),
 	},
 	[ID_AD7606B] = {
 		.channels = ad7606_channels,
 		.num_channels = 9,
 		.has_oversampling = true,
+		.oversampling_avail = ad7606_oversampling_avail,
+		.oversampling_num = ARRAY_SIZE(ad7606_oversampling_avail),
 		.sw_mode_config = ad7606B_sw_mode_config,
+	},
+	[ID_AD7616] = {
+		.channels = ad7616_channels,
+		.num_channels = 17,
+		.has_oversampling = true,
+		.oversampling_avail = ad7616_oversampling_avail,
+		.oversampling_num = ARRAY_SIZE(ad7616_oversampling_avail),
+		.oversampling_needs_reset = true,
 	},
 };
 
@@ -621,8 +663,8 @@ static int ad7606B_sw_mode_config(struct iio_dev *indio_dev)
 		st->scale_avail = ad7606B_scale_avail;
 		st->num_scales = ARRAY_SIZE(ad7606B_scale_avail);
 		/* OS of 128 and 256 are available only in software mode */
-		st->oversampling_avail = ad7606B_oversampling_avail;
-		st->num_os_ratios = ARRAY_SIZE(ad7606B_oversampling_avail);
+		st->chip_info->oversampling_avail = ad7606B_oversampling_avail;
+		st->chip_info->oversampling_num = ARRAY_SIZE(ad7606B_oversampling_avail);
 		/* After reset, in software mode, ±10 V is set by default */
 		memset32(st->range, 2, ARRAY_SIZE(st->range));
 		indio_dev->info = &ad7606_info_os_and_range;
@@ -660,8 +702,6 @@ int ad7606_probe(struct device *dev, int irq, void __iomem *base_address,
 	st->oversampling = 1;
 	st->scale_avail = ad7606_scale_avail;
 	st->num_scales = ARRAY_SIZE(ad7606_scale_avail);
-	st->oversampling_avail = ad7606_oversampling_avail;
-	st->num_os_ratios = ARRAY_SIZE(ad7606_oversampling_avail);
 
 	st->reg = devm_regulator_get(dev, "avcc");
 	if (IS_ERR(st->reg))

--- a/drivers/iio/adc/ad7606.h
+++ b/drivers/iio/adc/ad7606.h
@@ -12,14 +12,21 @@
  * struct ad7606_chip_info - chip specific information
  * @channels:		channel specification
  * @num_channels:	number of channels
+ * @oversampling_avail	pointer to the array which stores the available
+ *			oversampling ratios.
+ * @oversampling_num	number of elements stored in oversampling_avail array
  * @has_oversampling:   whether the device has oversampling support
+ * @oversampling_needs_reset some devices require a reset to update oversampling
  * @sw_mode_config:	pointer to a function which configured the device
  *			for software mode
  */
 struct ad7606_chip_info {
 	const struct iio_chan_spec	*channels;
 	unsigned int			num_channels;
+	const unsigned int		*oversampling_avail;
+	unsigned int			oversampling_num;
 	bool				has_oversampling;
+	bool				oversampling_needs_reset;
 	int (*sw_mode_config)(struct iio_dev *indio_dev);
 };
 
@@ -35,9 +42,6 @@ struct ad7606_chip_info {
  * @sw_mode_en		software mode enabled
  * @scale_avail		pointer to the array which stores the available scales
  * @num_scales		number of elements stored in the scale_avail array
- * @oversampling_avail	pointer to the array which stores the available
- *			oversampling ratios.
- * @num_os_ratios	number of elements stored in oversampling_avail array
  * @lock		protect sensor state from concurrent accesses to GPIOs
  * @gpio_convst	GPIO descriptor for conversion start signal (CONVST)
  * @gpio_reset		GPIO descriptor for device hard-reset
@@ -53,7 +57,7 @@ struct ad7606_chip_info {
  */
 struct ad7606_state {
 	struct device			*dev;
-	const struct ad7606_chip_info	*chip_info;
+	struct ad7606_chip_info		*chip_info;
 	struct regulator		*reg;
 	const struct ad7606_bus_ops	*bops;
 	unsigned int			range[8];
@@ -62,8 +66,6 @@ struct ad7606_state {
 	bool				sw_mode_en;
 	const unsigned int		*scale_avail;
 	unsigned int			num_scales;
-	const unsigned int		*oversampling_avail;
-	unsigned int			num_os_ratios;
 
 	struct mutex			lock; /* protect sensor state */
 	struct gpio_desc		*gpio_convst;
@@ -80,7 +82,7 @@ struct ad7606_state {
 	 * transfer buffers to live in their own cache lines.
 	 * 8 * 16-bit samples + 64-bit timestamp
 	 */
-	unsigned short			data[12] ____cacheline_aligned;
+	unsigned short			data[20] ____cacheline_aligned;
 };
 
 /**
@@ -101,7 +103,8 @@ enum ad7606_supported_device_ids {
 	ID_AD7606_8,
 	ID_AD7606_6,
 	ID_AD7606_4,
-	ID_AD7606B
+	ID_AD7606B,
+	ID_AD7616
 };
 
 #ifdef CONFIG_PM_SLEEP

--- a/drivers/iio/adc/ad7606_spi.c
+++ b/drivers/iio/adc/ad7606_spi.c
@@ -54,6 +54,7 @@ static const struct spi_device_id ad7606_id_table[] = {
 	{ "ad7606-6", ID_AD7606_6 },
 	{ "ad7606-8", ID_AD7606_8 },
 	{ "ad7606b",  ID_AD7606B },
+	{ "ad7616",  ID_AD7616 },
 	{}
 };
 MODULE_DEVICE_TABLE(spi, ad7606_id_table);
@@ -64,6 +65,7 @@ static const struct of_device_id ad7606_of_match[] = {
 	{ .compatible = "adi,ad7606-6" },
 	{ .compatible = "adi,ad7606-8" },
 	{ .compatible = "adi,ad7606b" },
+	{ .compatible = "adi,ad7616" },
 	{ },
 };
 MODULE_DEVICE_TABLE(of, ad7606_of_match);


### PR DESCRIPTION
The AD7616 is a 12-bit ADC with 16 channels.

The AD7616 can be configured to work in hardware mode by controlling it via
gpio pins and read data via spi. No support for software mode yet, but it is
a work in progres and will be released in following months.

Signed-off-by: Beniamin Bia <beniamin.bia@analog.com>