### PR TITLE
dmaengine: axi-dmac: sync changes with upstream version

### DIFF
--- a/drivers/dma/dma-axi-dmac.c
+++ b/drivers/dma/dma-axi-dmac.c
@@ -236,11 +236,10 @@ static void axi_dmac_start_transfer(struct axi_dmac_chan *chan)
 	desc->num_submitted++;
 	if (desc->num_submitted == desc->num_sgs ||
 	    desc->have_partial_xfer) {
-		if (desc->cyclic) {
+		if (desc->cyclic)
 			desc->num_submitted = 0; /* Start again */
-		} else {
+		else
 			chan->next_desc = NULL;
-		}
 		flags |= AXI_DMAC_FLAG_LAST;
 	} else {
 		chan->next_desc = desc;

--- a/drivers/dma/dma-axi-dmac.c
+++ b/drivers/dma/dma-axi-dmac.c
@@ -585,7 +585,10 @@ static struct dma_async_tx_descriptor *axi_dmac_prep_slave_sg(
 	if (direction != chan->direction)
 		return NULL;
 
-	num_sgs = sg_nents_for_dma(sgl, sg_len, chan->max_length);
+	num_sgs = 0;
+	for_each_sg(sgl, sg, sg_len, i)
+		num_sgs += DIV_ROUND_UP(sg_dma_len(sg), chan->max_length);
+
 	desc = axi_dmac_alloc_desc(num_sgs);
 	if (!desc)
 		return NULL;

--- a/include/linux/scatterlist.h
+++ b/include/linux/scatterlist.h
@@ -244,7 +244,6 @@ static inline void *sg_virt(struct scatterlist *sg)
 
 int sg_nents(struct scatterlist *sg);
 int sg_nents_for_len(struct scatterlist *sg, u64 len);
-int sg_nents_for_dma(struct scatterlist *sgl, unsigned int sglen, size_t len);
 struct scatterlist *sg_next(struct scatterlist *);
 struct scatterlist *sg_last(struct scatterlist *s, unsigned int);
 void sg_init_table(struct scatterlist *, unsigned int);

--- a/lib/scatterlist.c
+++ b/lib/scatterlist.c
@@ -90,32 +90,6 @@ int sg_nents_for_len(struct scatterlist *sg, u64 len)
 EXPORT_SYMBOL(sg_nents_for_len);
 
 /**
- * sg_nents_for_dma - return count of DMA-capable entries in scatterlist
- * @sgl:	The scatterlist
- * @sglen:	The current number of entries
- * @len:	The maximum length of DMA-capable block
- *
- * Description:
- *   Determines the number of entries in @sgl which would be permitted in
- *   DMA-capable transfer if list had been split accordingly, taking into
- *   account chaining as well.
- *
- * Returns:
- *   the number of sgl entries needed
- *
- **/
-int sg_nents_for_dma(struct scatterlist *sgl, unsigned int sglen, size_t len)
-{
-	struct scatterlist *sg;
-	int i, nents = 0;
-
-	for_each_sg(sgl, sg, sglen, i)
-		nents += DIV_ROUND_UP(sg_dma_len(sg), len);
-	return nents;
-}
-EXPORT_SYMBOL(sg_nents_for_dma);
-
-/**
  * sg_last - return the last scatterlist entry in a list
  * @sgl:	First entry in the scatterlist
  * @nents:	Number of entries in the scatterlist


### PR DESCRIPTION
These changes sync parts of the AXI DMAC driver with the version that is upstreamed.
There are still some parts to upstream about it.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>