### PR TITLE
Master adis16480 err flags

### DIFF
--- a/drivers/iio/imu/adis16480.c
+++ b/drivers/iio/imu/adis16480.c
@@ -454,6 +454,7 @@ enum {
 	ADIS16480_SCAN_MAGN_Z,
 	ADIS16480_SCAN_BARO,
 	ADIS16480_SCAN_TEMP,
+	ADIS16480_SCAN_SYS_E_FLAGS,
 };
 
 static const unsigned int adis16480_calibbias_regs[] = {
@@ -801,6 +802,19 @@ static int adis16480_write_raw(struct iio_dev *indio_dev,
 		}, \
 	}
 
+#define ADIS16495_E_FLAGS_CHANNEL() { \
+		.type = IIO_FLAGS, \
+		.indexed = 1, \
+		.channel = 0, \
+		.scan_index = ADIS16480_SCAN_SYS_E_FLAGS, \
+		.scan_type = { \
+			.sign = 'u', \
+			.realbits = 16, \
+			.storagebits = 16, \
+			.endianness = IIO_BE, \
+		}, \
+	}
+
 static const struct iio_chan_spec adis16480_channels[] = {
 	ADIS16480_GYRO_CHANNEL(X),
 	ADIS16480_GYRO_CHANNEL(Y),
@@ -824,6 +838,18 @@ static const struct iio_chan_spec adis16485_channels[] = {
 	ADIS16480_ACCEL_CHANNEL(Y),
 	ADIS16480_ACCEL_CHANNEL(Z),
 	ADIS16480_TEMP_CHANNEL(),
+	IIO_CHAN_SOFT_TIMESTAMP(7)
+};
+
+static const struct iio_chan_spec adis16495_channels[] = {
+	ADIS16480_GYRO_CHANNEL(X),
+	ADIS16480_GYRO_CHANNEL(Y),
+	ADIS16480_GYRO_CHANNEL(Z),
+	ADIS16480_ACCEL_CHANNEL(X),
+	ADIS16480_ACCEL_CHANNEL(Y),
+	ADIS16480_ACCEL_CHANNEL(Z),
+	ADIS16480_TEMP_CHANNEL(),
+	ADIS16495_E_FLAGS_CHANNEL(),
 	IIO_CHAN_SOFT_TIMESTAMP(7)
 };
 
@@ -895,8 +921,8 @@ static const struct adis16480_chip_info adis16480_chip_info[] = {
 		.filter_freqs = adis16480_def_filter_freqs,
 	},
 	[ADIS16495_1] = {
-		.channels = adis16485_channels,
-		.num_channels = ARRAY_SIZE(adis16485_channels),
+		.channels = adis16495_channels,
+		.num_channels = ARRAY_SIZE(adis16495_channels),
 		.gyro_max_val = IIO_RAD_TO_DEGREE(20000),
 		.gyro_max_scale = 125,
 		.accel_max_val = IIO_M_S_2_TO_G(32000),
@@ -909,8 +935,8 @@ static const struct adis16480_chip_info adis16480_chip_info[] = {
 		.burst = &adis16495_burst,
 	},
 	[ADIS16495_2] = {
-		.channels = adis16485_channels,
-		.num_channels = ARRAY_SIZE(adis16485_channels),
+		.channels = adis16495_channels,
+		.num_channels = ARRAY_SIZE(adis16495_channels),
 		.gyro_max_val = IIO_RAD_TO_DEGREE(18000),
 		.gyro_max_scale = 450,
 		.accel_max_val = IIO_M_S_2_TO_G(32000),
@@ -923,8 +949,8 @@ static const struct adis16480_chip_info adis16480_chip_info[] = {
 		.burst = &adis16495_burst,
 	},
 	[ADIS16495_3] = {
-		.channels = adis16485_channels,
-		.num_channels = ARRAY_SIZE(adis16485_channels),
+		.channels = adis16495_channels,
+		.num_channels = ARRAY_SIZE(adis16495_channels),
 		.gyro_max_val = IIO_RAD_TO_DEGREE(20000),
 		.gyro_max_scale = 2000,
 		.accel_max_val = IIO_M_S_2_TO_G(32000),
@@ -937,8 +963,8 @@ static const struct adis16480_chip_info adis16480_chip_info[] = {
 		.burst = &adis16495_burst,
 	},
 	[ADIS16497_1] = {
-		.channels = adis16485_channels,
-		.num_channels = ARRAY_SIZE(adis16485_channels),
+		.channels = adis16495_channels,
+		.num_channels = ARRAY_SIZE(adis16495_channels),
 		.gyro_max_val = IIO_RAD_TO_DEGREE(20000),
 		.gyro_max_scale = 125,
 		.accel_max_val = IIO_M_S_2_TO_G(32000),
@@ -951,8 +977,8 @@ static const struct adis16480_chip_info adis16480_chip_info[] = {
 		.burst = &adis16495_burst,
 	},
 	[ADIS16497_2] = {
-		.channels = adis16485_channels,
-		.num_channels = ARRAY_SIZE(adis16485_channels),
+		.channels = adis16495_channels,
+		.num_channels = ARRAY_SIZE(adis16495_channels),
 		.gyro_max_val = IIO_RAD_TO_DEGREE(18000),
 		.gyro_max_scale = 450,
 		.accel_max_val = IIO_M_S_2_TO_G(32000),
@@ -965,8 +991,8 @@ static const struct adis16480_chip_info adis16480_chip_info[] = {
 		.burst = &adis16495_burst,
 	},
 	[ADIS16497_3] = {
-		.channels = adis16485_channels,
-		.num_channels = ARRAY_SIZE(adis16485_channels),
+		.channels = adis16495_channels,
+		.num_channels = ARRAY_SIZE(adis16495_channels),
 		.gyro_max_val = IIO_RAD_TO_DEGREE(20000),
 		.gyro_max_scale = 2000,
 		.accel_max_val = IIO_M_S_2_TO_G(32000),
@@ -1017,7 +1043,7 @@ static irqreturn_t adis16480_trigger_handler(int irq, void *p)
 	d = (__be16 *)adis->buffer;
 	for (offset = 0; offset < 3; offset++) {
 		if (d[offset] == ADIS16495_BURST_ID) {
-			offset += 2; /* TEMP_OUT */
+			offset += 1; /* SYS_E_FLAG */
 			break;
 		}
 	}
@@ -1029,14 +1055,22 @@ static irqreturn_t adis16480_trigger_handler(int irq, void *p)
 		 * channel in the sequence, but the temperature scan index
 		 * is 10.
 		 */
-		if (bit == ADIS16480_SCAN_TEMP) {
-			data[2 * i] = d[offset];
-		} else {
+		switch (bit) {
+		case ADIS16480_SCAN_TEMP:
+			data[i] = d[offset + 1];
+			i += 1;
+			break;
+		case ADIS16480_SCAN_SYS_E_FLAGS:
+			data[i] = d[offset];
+			i += 1;
+			break;
+		case ADIS16480_SCAN_GYRO_X ... ADIS16480_SCAN_ACCEL_Z:
 			/* The lower register data is sequenced first */
-			data[2 * i] = d[2 * bit + offset + 2];
-			data[2 * i + 1] = d[2 * bit + offset + 1];
+			data[i] = d[2 * bit + offset + 3];
+			data[i + 1] = d[2 * bit + offset + 2];
+			i += 2;
+			break;
 		}
-		i++;
 	}
 
 	buffer = data;

--- a/drivers/iio/imu/adis16480.c
+++ b/drivers/iio/imu/adis16480.c
@@ -9,6 +9,8 @@
  *
  */
 
+#include <asm/unaligned.h>
+#include <linux/crc32.h>
 #include <linux/clk.h>
 #include <linux/bitfield.h>
 #include <linux/of_irq.h>
@@ -455,6 +457,7 @@ enum {
 	ADIS16480_SCAN_BARO,
 	ADIS16480_SCAN_TEMP,
 	ADIS16480_SCAN_SYS_E_FLAGS,
+	ADIS16480_SCAN_CRC_FAILURE,
 };
 
 static const unsigned int adis16480_calibbias_regs[] = {
@@ -815,6 +818,20 @@ static int adis16480_write_raw(struct iio_dev *indio_dev,
 		}, \
 	}
 
+#define ADIS16495_CRC_CHANNEL() { \
+		.type = IIO_FLAGS, \
+		.indexed = 1, \
+		.channel = 1, \
+		.scan_index = ADIS16480_SCAN_CRC_FAILURE, \
+		.scan_type = { \
+			.sign = 'u', \
+			.realbits = 16, \
+			.storagebits = 16, \
+			.endianness = IIO_BE, \
+		}, \
+		.extend_name = "crc", \
+	}
+
 static const struct iio_chan_spec adis16480_channels[] = {
 	ADIS16480_GYRO_CHANNEL(X),
 	ADIS16480_GYRO_CHANNEL(Y),
@@ -850,6 +867,7 @@ static const struct iio_chan_spec adis16495_channels[] = {
 	ADIS16480_ACCEL_CHANNEL(Z),
 	ADIS16480_TEMP_CHANNEL(),
 	ADIS16495_E_FLAGS_CHANNEL(),
+	ADIS16495_CRC_CHANNEL(),
 	IIO_CHAN_SOFT_TIMESTAMP(7)
 };
 
@@ -1006,6 +1024,23 @@ static const struct adis16480_chip_info adis16480_chip_info[] = {
 	},
 };
 
+static bool adis16480_validate_crc(__be16 *buf, u8 size, u32 crc)
+{
+	u32 crc_calc;
+	u8 crc_buf[34];
+	int j;
+
+	for (j = 0; j < size; j++) {
+		crc_buf[2 * j] = (buf[j] >> 8) & 0xFF;
+		crc_buf[2 * j + 1] = buf[j] & 0xFF;
+	}
+
+	crc_calc = crc32(~0, crc_buf, size * 2);
+	crc_calc ^= ~0;
+
+	return (crc != crc_calc);
+}
+
 static irqreturn_t adis16480_trigger_handler(int irq, void *p)
 {
 	struct iio_poll_func *pf = p;
@@ -1014,6 +1049,7 @@ static irqreturn_t adis16480_trigger_handler(int irq, void *p)
 	struct adis *adis = &st->adis;
 	int ret, bit, offset, i = 0;
 	__be16 data[ADIS16495_BURST_MAX_DATA], *buffer, *d;
+	u32 crc;
 
 	if (!adis->buffer)
 		return -ENOMEM;
@@ -1062,6 +1098,17 @@ static irqreturn_t adis16480_trigger_handler(int irq, void *p)
 			break;
 		case ADIS16480_SCAN_SYS_E_FLAGS:
 			data[i] = d[offset];
+			i += 1;
+			break;
+		case ADIS16480_SCAN_CRC_FAILURE:
+			/*
+			 * The data consists of 17 sequences of 16-bits each.
+			 * The last two sequences represent the CRC lower and
+			 * upper word
+			 */
+			crc = (get_unaligned_be16(&d[17]) << 16) |
+			       get_unaligned_be16(&d[16]);
+			data[i] = adis16480_validate_crc(&d[offset], 15, crc);
 			i += 1;
 			break;
 		case ADIS16480_SCAN_GYRO_X ... ADIS16480_SCAN_ACCEL_Z:

--- a/drivers/iio/industrialio-core.c
+++ b/drivers/iio/industrialio-core.c
@@ -86,6 +86,7 @@ static const char * const iio_chan_type_name_spec[] = {
 	[IIO_COUNT] = "count",
 	[IIO_INDEX] = "index",
 	[IIO_GRAVITY]  = "gravity",
+	[IIO_FLAGS] = "flags",
 };
 
 static const char * const iio_modifier_names[] = {

--- a/include/uapi/linux/iio/types.h
+++ b/include/uapi/linux/iio/types.h
@@ -45,6 +45,7 @@ enum iio_chan_type {
 	IIO_COUNT,
 	IIO_INDEX,
 	IIO_GRAVITY,
+	IIO_FLAGS,
 };
 
 enum iio_modifier {


### PR DESCRIPTION
This PR implements a new channel type called IIO_FLAGS which is further used to push SYS_E_FLAG data and CRC validation result to buffers.