### PR TITLE
 media: imageon-loopback: Fix imageon bridge example

### DIFF
--- a/arch/arm/boot/dts/zynq-zed-adv7511-imageon-loopback.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-imageon-loopback.dts
@@ -54,11 +54,11 @@
 						};
 
 						video-output {
-							hdmi-mode = <0>;
-							output-format = <0>;
-							output-color-space = <0>;
+							hdmi-mode = <1>;
+							output-format = <1>;
+							output-color-space = <1>;
 							up-conversion = <0>;
-							csc-enable = <1>;
+							csc-enable = <0>;
 							csc-scaling-factor = <2>;
 							csc-coefficients {
 								a1 = <0x0B37>;

--- a/drivers/media/platform/imageon-bridge.c
+++ b/drivers/media/platform/imageon-bridge.c
@@ -210,6 +210,8 @@ static int imageon_bridge_probe(struct platform_device *pdev)
 		sizeof(bridge->media_dev.model));
 	bridge->media_dev.hw_revision = 0;
 
+	media_device_init(&bridge->media_dev);
+
 	ret = media_device_register(&bridge->media_dev);
 	if (ret < 0) {
 		dev_err(&pdev->dev, "failed to register media_device\n");


### PR DESCRIPTION
This PR address a problem in imageon-bridge media platform driver.
Due changes implementd by commit 9832e155f1ed3030fdfaa19e72c06472dc2ecb1d probing of 
imageon-bridge.c resulted in a NULL pointer dereference. 

Also in DT the ADV7511 HDMI output was configured for RGB and not YCbCr 4:2:2.