### PR TITLE
iio: adc: ad9361: Fix ad9361_get_temp() coefficient

### DIFF
--- a/drivers/iio/adc/ad9361.c
+++ b/drivers/iio/adc/ad9361.c
@@ -3699,7 +3699,7 @@ static int ad9361_get_temp(struct ad9361_rf_phy *phy)
 	val = (s8) ad9361_spi_read(phy->spi, REG_TEMPERATURE);
 	ad9361_spi_writef(phy->spi, REG_AUXADC_CONFIG, AUXADC_POWER_DOWN, 0);
 
-	return DIV_ROUND_CLOSEST(val * 1000000, 1140);
+	return DIV_ROUND_CLOSEST(val * 1000000, 1160);
 }
 
 static int ad9361_get_auxadc(struct ad9361_rf_phy *phy)


### PR DESCRIPTION
The issue was reported here:
https://github.com/analogdevicesinc/linux/issues/360

Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>