### PR TITLE
Fix initial bank selection for IS25WP256D

### DIFF
--- a/drivers/mtd/spi-nor/spi-nor.c
+++ b/drivers/mtd/spi-nor/spi-nor.c
@@ -320,7 +320,7 @@ static inline int set_4byte(struct spi_nor *nor, const struct flash_info *info,
  *
  * Return:	Negative if error occured.
  */
-static int read_ear(struct spi_nor *nor, struct flash_info *info)
+static int read_ear(struct spi_nor *nor, const struct flash_info *info)
 {
 	int ret;
 	u8 val;
@@ -2898,6 +2898,16 @@ static int spi_nor_init_params(struct spi_nor *nor,
 		} else {
 			memcpy(params, &sfdp_params, sizeof(*params));
 		}
+	}
+
+	/* Fix bank selection for IS25WP256D (0x9d7019) by explicitly reading the hardware state. */
+	if (!strcmp(info->name, "is25wp256d")) {
+		int status = read_ear(nor, info);
+
+		if (status < 0)
+			dev_warn(nor->dev, "failed to read ear reg\n");
+		else
+			nor->curbank = status & EAR_SEGMENT_MASK;
 	}
 
 	return 0;

--- a/drivers/mtd/spi-nor/spi-nor.c
+++ b/drivers/mtd/spi-nor/spi-nor.c
@@ -320,7 +320,7 @@ static inline int set_4byte(struct spi_nor *nor, const struct flash_info *info,
  *
  * Return:	Negative if error occured.
  */
-static int read_ear(struct spi_nor *nor, const struct flash_info *info)
+static int read_ear(struct spi_nor *nor, struct flash_info *info)
 {
 	int ret;
 	u8 val;
@@ -2902,7 +2902,7 @@ static int spi_nor_init_params(struct spi_nor *nor,
 
 	/* Fix bank selection for IS25WP256D (0x9d7019) by explicitly reading the hardware state. */
 	if (!strcmp(info->name, "is25wp256d")) {
-		int status = read_ear(nor, info);
+		int status = read_ear(nor,  (struct flash_info*)info);
 
 		if (status < 0)
 			dev_warn(nor->dev, "failed to read ear reg\n");


### PR DESCRIPTION
This change causes the spi-nor driver to query the hardware for the currently selected bank.