### PR TITLE
iio: adc: mykonos: mykonos: Add some sleep to relax this busy loop.

### DIFF
--- a/drivers/iio/adc/mykonos/mykonos.c
+++ b/drivers/iio/adc/mykonos/mykonos.c
@@ -16179,6 +16179,9 @@ mykonosErr_t MYKONOS_waitArmCmdStatus(mykonosDevice_t *device, uint8_t opCode, u
         {
             return MYKONOS_ERR_WAITARMCMDSTATUS_TIMEOUT;
         }
+
+        CMB_wait_ms(1);
+
     } while (*cmdStatByte & 0x01);
 
     return MYKONOS_ERR_OK;


### PR DESCRIPTION
This was reported in issue #368

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>