### PR TITLE
fix: hwmon: axi_fan_control: Set tacho parameters

### DIFF
--- a/drivers/hwmon/axi_fan_control.c
+++ b/drivers/hwmon/axi_fan_control.c
@@ -279,7 +279,7 @@ static irqreturn_t axi_fan_control_irq_handler(int irq, void *data)
 			axi_fan_control_iowrite(new_tach,
 					ADI_REG_TACH_PERIOD, ctl);
 			axi_fan_control_iowrite(tach_tol,
-					ADI_REG_TACH_MEASUR, ctl);
+					ADI_REG_TACH_TOLERANCE, ctl);
 			ctl->update_tacho_params = false;
 		}
 


### PR DESCRIPTION
The driver was writting on the wrong register to set the tacho
parameters. For the core to start monitoring the signal, the driver has
to set the TACH_TOLERANCE register. This has to be done after writting
on TACH_PERIOD.

Signed-off-by: Nuno Sá <nuno.sa@analog.com>