### PR TITLE
 media: adi-fb: Add ADI FB AXI driver

### DIFF
--- a/Documentation/devicetree/bindings/media/adi,adi-axi-fb.yaml
+++ b/Documentation/devicetree/bindings/media/adi,adi-axi-fb.yaml
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright 2019 Analog Devices Inc.
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/bindings/media/adi,adi-fb.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
+
+title: Analog Devices AXI Frame Buffer Device Tree Bindings
+
+maintainers:
+  - Bogdan Togorean <bogdan.togorean@analog.com>
+
+description: |
+  Bindings for the Analog Devices Frame Buffer core. Spefications of the
+  core can be found in:
+  https://wiki.analog.com/resources/fpga/docs/axi_dmac
+
+properties:
+  compatible:
+    enum:
+        - adi,axi-framebuffer-1.00.a
+
+  memory-region:
+    description:
+      Phandle to a node used to specify reserved memory for video frame buffers.
+    allOf:
+      - $ref: /schemas/types.yaml#/definitions/phandle-array
+
+  reg:
+    minItems: 2
+    maxItems: 2
+
+  adi,flock-resolution:
+    description:
+      (u32, u32) tuple setting resolution of input/output image in pixels.
+      <horizontal> <vertical>
+    allOf:
+      - $ref: /schemas/types.yaml#/definitions/uint32-array
+    minItems: 2
+    maxItems: 2
+
+  adi,flock-mode:
+    description:
+      Select operating mode of the framebuffer.
+      0 -> Frame rate conversion mode
+      1 -> Output delay mode
+    enum: [ 0, 1 ]
+    maxItems: 1
+
+  adi,flock-frm-buf-nr:
+    description:
+      The total number of video frame buffers.
+      Related to NUM_BUF synthesys parameter.
+    minimum: 3
+    maxItems: 1
+
+  adi,flock-distance:
+    description:
+      Applicable only in output delay mode. Set the output delay in frames.
+      Should be set in interval 0 to flock,frm-buf-nr - 2
+    minimum: 0
+    maxItems: 1
+
+  adi,flock-dwidth:
+    description:
+      Represent the number of bytes per pixel according to used color space.
+    enum: [ 1, 2, 4 ]
+    maxItems: 1
+
+required:
+  - compatible
+  - memory-region
+  - reg
+
+examples:
+  - |
+    adi-fb {
+            compatible = "adi,axi-framebuffer-1.00.a";
+            memory-region = <&reserved>;
+            reg = <0x43000000 0x1000>, <0x43c20000 0x1000>;
+            reg-names = "tx_dma", "rx_dma";
+            adi,flock-resolution = <1920>, <1080>;
+            adi,flock-distance = <0>;
+            adi,flock-mode = <0>;
+            adi,flock-dwidth = <4>;
+            adi,flock-frm-buf-nr = <3>;
+    };
+
+    reserved-memory {
+            #address-cells = <1>;
+            #size-cells = <1>;
+            ranges;
+
+            reserved: buffer@0 {
+                    no-map;
+                    reg = <0x1C000000 0x2000000>;
+            };
+    };

--- a/drivers/media/platform/Kconfig
+++ b/drivers/media/platform/Kconfig
@@ -526,6 +526,13 @@ config VIDEO_TI_SC
 config VIDEO_TI_CSC
 	tristate
 
+config ADI_AXI_VIDEO_FRAME_BUFFER
+	tristate "ADI AXI frame buffer"
+	depends on MEDIA_SUPPORT
+	---help---
+	  To compile this driver as a module, choose M here: the
+	  module will be called adi-axi-fb.
+
 menuconfig V4L_TEST_DRIVERS
 	bool "Media test drivers"
 	depends on MEDIA_CAMERA_SUPPORT

--- a/drivers/media/platform/Makefile
+++ b/drivers/media/platform/Makefile
@@ -56,6 +56,7 @@ obj-y					+= davinci/
 obj-$(CONFIG_VIDEO_SH_VOU)		+= sh_vou.o
 obj-$(CONFIG_VIDEO_AXI_HDMI_RX)		+= axi-hdmi-rx.o
 obj-$(CONFIG_VIDEO_IMAGEON_BRIDGE)	+= imageon-bridge.o
+obj-$(CONFIG_ADI_AXI_VIDEO_FRAME_BUFFER)	+= adi-axi-fb.o
 
 obj-$(CONFIG_SOC_CAMERA)		+= soc_camera/
 

--- a/drivers/media/platform/adi-axi-fb.c
+++ b/drivers/media/platform/adi-axi-fb.c
@@ -1,0 +1,278 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Copyright 2019 Analog Devices Inc.
+ * ADI Frame Buffer Driver
+ *
+ */
+
+#include <linux/device.h>
+#include <linux/module.h>
+#include <linux/of_address.h>
+#include <linux/platform_device.h>
+#include <media/media-device.h>
+#include <linux/fpga/adi-axi-common.h>
+
+/* DMA defines */
+#define DMAC_REG_CTRL				0x400
+#define DMAC_REG_START_TRANSFER			0x408
+#define DMAC_REG_FLAGS				0x40c
+#define DMAC_REG_DEST_ADDRESS			0x410
+#define DMAC_REG_SRC_ADDRESS			0x414
+#define DMAC_REG_X_LENGTH			0x418
+#define DMAC_REG_Y_LENGTH			0x41c
+#define DMAC_REG_DEST_STRIDE			0x420
+#define DMAC_REG_SRC_STRIDE			0x424
+#define DMAC_REG_FRAME_LOCK_CONFIG		0x454
+#define DMAC_REG_FRAME_LOCK_STRIDE		0x458
+
+#define DMAC_CTRL_ENABLE			BIT(0)
+#define DMAC_TRANSFER_SUBMIT			BIT(0)
+#define DMAC_FLOCK_WAIT_WRITER			BIT(9)
+
+#define DMAC_FLAGS_CYCLIC			BIT(0)
+#define DMAC_FLAGS_TLAST			BIT(1)
+#define DMAC_FLAGS_FLOCK			BIT(3)
+
+#define DMAC_DEFAULT_FLAGS (DMAC_FLAGS_FLOCK | DMAC_FLAGS_CYCLIC | \
+			    DMAC_FLAGS_TLAST)
+
+struct hdl_subdev {
+	void __iomem *tx_dma_regs;
+	void __iomem *rx_dma_regs;
+};
+
+struct frame_buffer {
+	struct media_device media_dev;
+
+	struct resource video_ram_buf;
+	struct hdl_subdev hdl_subdev;
+	u32 num_frames;
+	u32 mode;
+	u32 distance;
+	/* resolution[0] width, resolution[1] height */
+	u32 resolution[2];
+	u32 dwidth;
+};
+
+enum {
+	TX_DMA,
+	RX_DMA
+};
+
+static u32 adi_fb_reg_read(void __iomem *base_addr, u32 addr)
+{
+	return ioread32(base_addr + addr);
+}
+
+static void adi_fb_reg_write(void __iomem *base_addr, u32 addr, u32 value)
+{
+	iowrite32(value, base_addr + addr);
+}
+
+static void adi_fb_reg_clr(void __iomem *base_addr, u32 addr, u32 clr)
+{
+	adi_fb_reg_write(base_addr, addr,
+			 adi_fb_reg_read(base_addr, addr) & ~clr);
+}
+
+static void adi_fb_reg_set(void __iomem *base_addr, u32 addr, u32 set)
+{
+	adi_fb_reg_write(base_addr, addr,
+			 adi_fb_reg_read(base_addr, addr) | set);
+}
+
+static void adi_fb_init(struct frame_buffer *buff, int dma_dir)
+{
+	void __iomem *base_addr;
+	u32 stride, dir, flock_cfg;
+
+	if (dma_dir == RX_DMA) {
+		base_addr = buff->hdl_subdev.rx_dma_regs;
+		dir = DMAC_REG_DEST_ADDRESS;
+		stride = DMAC_REG_DEST_STRIDE;
+		flock_cfg = ((buff->distance) << 16) | ((buff->mode) << 8) |
+			    (buff->num_frames);
+	} else {
+		base_addr = buff->hdl_subdev.tx_dma_regs;
+		dir = DMAC_REG_SRC_ADDRESS;
+		stride = DMAC_REG_SRC_STRIDE;
+		flock_cfg = ((buff->distance) << 16) | ((buff->mode) << 8) |
+			    DMAC_FLOCK_WAIT_WRITER | (buff->num_frames);
+	}
+
+	/* reset DMAC */
+	adi_fb_reg_clr(base_addr, DMAC_REG_CTRL, DMAC_CTRL_ENABLE);
+
+	/* Init DMAC */
+	adi_fb_reg_set(base_addr, DMAC_REG_CTRL, DMAC_CTRL_ENABLE);
+	adi_fb_reg_write(base_addr, DMAC_REG_FLAGS, DMAC_DEFAULT_FLAGS);
+
+	adi_fb_reg_write(base_addr, dir, buff->video_ram_buf.start);
+	/* h size */
+	adi_fb_reg_write(base_addr, DMAC_REG_X_LENGTH,
+			 ((buff->resolution[0] * buff->dwidth) - 1));
+	/* h offset */
+	adi_fb_reg_write(base_addr, stride,
+			 (buff->resolution[0] * buff->dwidth));
+	/* v size */
+	adi_fb_reg_write(base_addr, DMAC_REG_Y_LENGTH,
+			 (buff->resolution[1] - 1));
+
+	adi_fb_reg_write(base_addr, DMAC_REG_FRAME_LOCK_CONFIG, flock_cfg);
+	/* total active */
+	adi_fb_reg_write(base_addr,
+			 DMAC_REG_FRAME_LOCK_STRIDE,
+			 (buff->resolution[0] * buff->resolution[1] *
+			  buff->dwidth));
+	/* submit transfer */
+	adi_fb_reg_set(base_addr, DMAC_REG_START_TRANSFER,
+		       DMAC_TRANSFER_SUBMIT);
+}
+
+static void frame_buffer_media_unregister(void *data)
+{
+	struct frame_buffer *frm_buff = data;
+
+	media_device_unregister(&frm_buff->media_dev);
+}
+
+static int frame_buffer_probe(struct platform_device *pdev)
+{
+	struct frame_buffer *frm_buff;
+	struct device_node *np;
+	struct resource *res;
+	int ret;
+	u32 tmp;
+
+	frm_buff = devm_kzalloc(&pdev->dev, sizeof(struct frame_buffer),
+				GFP_KERNEL);
+	if (!frm_buff)
+		return -ENOMEM;
+
+	platform_set_drvdata(pdev, frm_buff);
+
+	/* Get reserved memory region from Device-tree */
+	np = of_parse_phandle(pdev->dev.of_node, "memory-region", 0);
+	if (!np) {
+		dev_err(&pdev->dev, "No %s specified\n", "memory-region");
+		return -ENODEV;
+	}
+
+	ret = of_address_to_resource(np, 0, &frm_buff->video_ram_buf);
+	if (ret) {
+		dev_err(&pdev->dev,
+			"No memory address assigned to the region\n");
+		return ret;
+	}
+	dev_info(&pdev->dev, "Allocated reserved memory, paddr: 0x%0X\n",
+		 frm_buff->video_ram_buf.start);
+
+	/* Get physical address of DMAs*/
+	res = platform_get_resource_byname(pdev, IORESOURCE_MEM, "tx_dma");
+	frm_buff->hdl_subdev.tx_dma_regs =
+		devm_ioremap_resource(&pdev->dev, res);
+	if (IS_ERR(frm_buff->hdl_subdev.tx_dma_regs))
+		return PTR_ERR(frm_buff->hdl_subdev.tx_dma_regs);
+
+	res = platform_get_resource_byname(pdev, IORESOURCE_MEM, "rx_dma");
+	frm_buff->hdl_subdev.rx_dma_regs =
+		devm_ioremap_resource(&pdev->dev, res);
+	if (IS_ERR(frm_buff->hdl_subdev.rx_dma_regs))
+		return PTR_ERR(frm_buff->hdl_subdev.rx_dma_regs);
+
+	/* Get frames number */
+	ret = device_property_read_u32(&pdev->dev, "adi,flock-frm-buf-nr",
+					&tmp);
+	if (ret) {
+		frm_buff->num_frames = 3;
+		dev_info(&pdev->dev, "No frames number specified. Using %d\n",
+			 frm_buff->num_frames);
+	} else {
+		frm_buff->num_frames = tmp;
+	}
+
+	/* Get frame distance */
+	ret = device_property_read_u32(&pdev->dev, "adi,flock-distance", &tmp);
+	if (ret) {
+		frm_buff->distance = 0;
+		dev_info(&pdev->dev, "No distance specified. Using %d\n",
+			 frm_buff->distance);
+	} else {
+		frm_buff->distance = tmp;
+	}
+
+	/* Get operating mode */
+	ret = device_property_read_u32(&pdev->dev, "adi,flock-mode", &tmp);
+	if (ret) {
+		frm_buff->mode = 0;
+		dev_info(&pdev->dev,
+			 "No operating mode specified. Using framelock\n");
+	} else {
+		frm_buff->mode = tmp;
+	}
+
+	/* Get data width */
+	ret = device_property_read_u32(&pdev->dev, "adi,flock-dwidth", &tmp);
+	if (ret) {
+		frm_buff->dwidth = 4;
+		dev_info(&pdev->dev, "No data width specified. Using %d byte\n",
+			 frm_buff->dwidth);
+	} else {
+		frm_buff->dwidth = tmp;
+	}
+
+	/* Get resolution mode */
+	ret = device_property_read_u32_array(&pdev->dev, "adi,flock-resolution",
+					     frm_buff->resolution, 2);
+	if (ret) {
+		frm_buff->resolution[0] = 1920;
+		frm_buff->resolution[1] = 1080;
+		dev_info(&pdev->dev,
+			 "No resolution specified. Using default %d x %d\n",
+			 frm_buff->resolution[0], frm_buff->resolution[1]);
+	}
+
+	adi_fb_init(frm_buff, TX_DMA);
+	adi_fb_init(frm_buff, RX_DMA);
+
+	frm_buff->media_dev.dev = &pdev->dev;
+
+	strlcpy(frm_buff->media_dev.model, "ADI AXI Frame Buffer",
+		sizeof(frm_buff->media_dev.model));
+
+	frm_buff->media_dev.hw_revision = 0;
+
+	media_device_init(&frm_buff->media_dev);
+
+	ret = media_device_register(&frm_buff->media_dev);
+	if (ret < 0) {
+		dev_err(&pdev->dev, "failed to register media_device\n");
+		return ret;
+	}
+
+	ret = devm_add_action_or_reset(&pdev->dev,
+		frame_buffer_media_unregister, frm_buff);
+	if (ret)
+		return ret;
+
+	return 0;
+}
+
+static const struct of_device_id frame_buffer_of_match[] = {
+	{ .compatible = "adi,axi-framebuffer-1.00.a", },
+	{},
+};
+MODULE_DEVICE_TABLE(of, frame_buffer_of_match);
+
+static struct platform_driver frame_buffer_driver = {
+	.driver			= {
+		.name		= "axi-framebuffer",
+		.of_match_table = frame_buffer_of_match,
+	},
+	.probe			= frame_buffer_probe,
+};
+module_platform_driver(frame_buffer_driver);
+
+MODULE_AUTHOR("Bogdan Togoean <bogdan.togorean@analog.com>");
+MODULE_DESCRIPTION("Analog Devices AXI Frame Buffer");
+MODULE_LICENSE("GPL");


### PR DESCRIPTION
This PR propose a new driver for control of AXI Frame Buffer HDL core.
More details here: https://wiki.analog.com/resources/fpga/docs/axi_dmac in section FrameLock Synchronization.

This is the preliminary, standalone version of driver as required by Mathworks.
Possible future integration with V4L2 framework.

