### PR TITLE
spi: spi-axi-engine: Fix buffer increment

### DIFF
--- a/drivers/spi/spi-axi-spi-engine.c
+++ b/drivers/spi/spi-axi-spi-engine.c
@@ -468,8 +468,9 @@ static void spi_engine_write_buff(struct spi_engine *spi_engine, uint8_t m)
 
 	for (i = 0; i < (m * bytes_len); i += bytes_len) {
 		for (j = 0; j < bytes_len; j++)
-			val |= spi_engine->tx_buf[j] << (word_len - 8 * (j + 1));
+			val |= spi_engine->tx_buf[i + j] << (word_len - 8 * (j + 1));
 		writel_relaxed(val, addr);
+		val = 0;
 	}
 
 	spi_engine->tx_buf += i;


### PR DESCRIPTION
While using the spi engine for multiple 8 bit transmits the temporary value
used to write to the registers must be reset to 0. Also the transmission
length must be taken into account while incrementing the buffer. This patch
implements these requirements.

Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>

Port from master branch.