### PR TITLE
treewide: remove `adi,spi-3wire-enable` dt property ; use upstream `spi-3wire`

### DIFF
--- a/arch/arm/boot/dts/adi-ad9265-fmc-125ebz.dtsi
+++ b/arch/arm/boot/dts/adi-ad9265-fmc-125ebz.dtsi
@@ -19,7 +19,7 @@
 		reg = <0>;
 
 		spi-max-frequency = <10000000>;
-		adi,spi-3wire-enable;
+		spi-3wire;
 
 		clocks = <&clk_ad9517 3>;
 		clock-names = "adc_clk";
@@ -30,7 +30,7 @@
 		reg = <1>;
 
 		spi-max-frequency = <10000000>;
-		adi,spi-3wire-enable;
+		spi-3wire;
 
 		clocks = <&ad9517_ref_clk>, <&ad9517_ref_clk>;
 		clock-names = "refclk", "clkin";

--- a/arch/arm/boot/dts/adi-ad9434-fmc-500ebz.dtsi
+++ b/arch/arm/boot/dts/adi-ad9434-fmc-500ebz.dtsi
@@ -19,7 +19,7 @@
 		reg = <0>;
 
 		spi-max-frequency = <10000000>;
-		adi,spi-3wire-enable;
+		spi-3wire;
 
 		clocks = <&clk_ad9517 3>;
 		clock-names = "adc_clk";
@@ -30,7 +30,7 @@
 		reg = <1>;
 
 		spi-max-frequency = <10000000>;
-		adi,spi-3wire-enable;
+		spi-3wire;
 
 		clocks = <&ad9517_ref_clk>, <&ad9517_ref_clk>;
 		clock-names = "refclk", "clkin";

--- a/arch/arm/boot/dts/adi-ad9467-fmc-250ebz.dtsi
+++ b/arch/arm/boot/dts/adi-ad9467-fmc-250ebz.dtsi
@@ -16,7 +16,7 @@
 		reg = <0>;
 
 		spi-max-frequency = <10000000>;
-		adi,spi-3wire-enable;
+		spi-3wire;
 
 		clocks = <&clk_ad9517 3>;
 		clock-names = "adc_clk";
@@ -27,7 +27,7 @@
 		reg = <1>;
 
 		spi-max-frequency = <10000000>;
-		adi,spi-3wire-enable;
+		spi-3wire;
 
 		clocks = <&ad9517_ref_clk>, <&ad9517_ref_clk>;
 		clock-names = "refclk", "clkin";

--- a/arch/arm/boot/dts/adi-adrv9009.dtsi
+++ b/arch/arm/boot/dts/adi-adrv9009.dtsi
@@ -25,7 +25,6 @@
 		#size-cells = <0>;
 
 		spi-max-frequency = <10000000>;
-		//adi,spi-3wire-enable;
 
 		clock-output-names = "ad9528-1_out0", "ad9528-1_out1", "ad9528-1_out2",
 			"ad9528-1_out3", "ad9528-1_out4", "ad9528-1_out5", "ad9528-1_out6",

--- a/arch/arm/boot/dts/adi-adrv9371.dtsi
+++ b/arch/arm/boot/dts/adi-adrv9371.dtsi
@@ -11,7 +11,6 @@
 		#size-cells = <0>;
 
 		spi-max-frequency = <10000000>;
-		//adi,spi-3wire-enable;
 
 		clock-output-names = "ad9528-1_out0", "ad9528-1_out1", "ad9528-1_out2", "ad9528-1_out3", "ad9528-1_out4", "ad9528-1_out5", "ad9528-1_out6", "ad9528-1_out7", "ad9528-1_out8", "ad9528-1_out9", "ad9528-1_out10", "ad9528-1_out11", "ad9528-1_out12", "ad9528-1_out13";
 		#clock-cells = <1>;

--- a/arch/arm/boot/dts/adi-daq1.dtsi
+++ b/arch/arm/boot/dts/adi-daq1.dtsi
@@ -23,7 +23,7 @@
 			reg = <2>;
 
 			spi-max-frequency = <1000000>;
-			adi,spi-3wire-enable;
+			spi-3wire;
 
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/arch/arm/boot/dts/adi-daq2.dtsi
+++ b/arch/arm/boot/dts/adi-daq2.dtsi
@@ -16,7 +16,7 @@
 		spi-max-frequency = <10000000>;
 		clock-output-names = "ad9523-1_out0", "ad9523-1_out1", "ad9523-1_out2", "ad9523-1_out3", "ad9523-1_out4", "ad9523-1_out5", "ad9523-1_out6", "ad9523-1_out7", "ad9523-1_out8", "ad9523-1_out9", "ad9523-1_out10", "ad9523-1_out11", "ad9523-1_out12", "ad9523-1_out13";
 		adi,vcxo-freq = <125000000>;
-		adi,spi-3wire-enable;
+		spi-3wire;
 		adi,pll1-bypass-enable;
 		adi,osc-in-diff-enable;
 

--- a/arch/arm/boot/dts/adi-daq3.dtsi
+++ b/arch/arm/boot/dts/adi-daq3.dtsi
@@ -8,7 +8,7 @@
 		spi-cpol;
 		spi-cpha;
 		spi-max-frequency = <10000000>;
-		adi,spi-3wire-enable;
+		spi-3wire;
 
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -125,7 +125,7 @@
 		spi-cpol;
 		spi-cpha;
 		spi-max-frequency = <10000000>;
-		adi,spi-3wire-enable;
+		spi-3wire;
 
 		clocks = <&axi_ad9152_jesd>, <&clk0_ad9528 2>, <&clk0_ad9528 8>;
 		clock-names = "jesd_dac_clk", "dac_clk", "dac_sysref";
@@ -141,7 +141,7 @@
 		spi-cpol;
 		spi-cpha;
 		spi-max-frequency = <10000000>;
-		adi,spi-3wire-enable;
+		spi-3wire;
 
 		/* Content of Registers: 0x16, 0x18, 0x19, 0x1A, 0x30, 0x11A, 0x934, 0x935 */
 		adi,sfdr-optimization-config = <0xE 0xA0 0x50 0x09 0x18 0x00 0x1F 0x04>;

--- a/arch/arm/boot/dts/adi-fmcadc4.dtsi
+++ b/arch/arm/boot/dts/adi-fmcadc4.dtsi
@@ -8,7 +8,7 @@
 		spi-cpol;
 		spi-cpha;
 		spi-max-frequency = <1000000>;
-		adi,spi-3wire-enable;
+		spi-3wire;
 
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/arch/arm/boot/dts/adi-fmcjesdadc1.dtsi
+++ b/arch/arm/boot/dts/adi-fmcjesdadc1.dtsi
@@ -32,7 +32,7 @@
 			reg = <1>;
 
 			spi-max-frequency = <10000000>;
-			adi,spi-3wire-enable;
+			spi-3wire;
 
 			clocks = <&ad9517_ref_clk>, <&ad9517_clkin>;
 			clock-names = "refclk", "clkin";

--- a/arch/arm/boot/dts/adi-fmcomms11-RevA.dtsi
+++ b/arch/arm/boot/dts/adi-fmcomms11-RevA.dtsi
@@ -27,7 +27,7 @@
 
 		spi-max-frequency = <10000000>;
 		clock-output-names = "ad9508-1_out0", "ad9508-1_out1", "ad9508-1_out2", "ad9508-1_out3";
-		adi,spi-3wire-enable;
+		spi-3wire;
 
 		ad9508_0_c0:channel@0 {
 			reg = <0>;

--- a/arch/arm/boot/dts/adi-fmcomms6.dtsi
+++ b/arch/arm/boot/dts/adi-fmcomms6.dtsi
@@ -30,7 +30,7 @@
 		reg = <0>;
 
 		spi-max-frequency = <10000000>;
-		adi,spi-3wire-enable;
+		spi-3wire;
 
 		clocks = <&ad9517_ref_clk>, <&ad9517_clkin>;
 		clock-names = "refclk", "clkin";

--- a/arch/arm64/boot/dts/xilinx/adi-adrv9009.dtsi
+++ b/arch/arm64/boot/dts/xilinx/adi-adrv9009.dtsi
@@ -25,7 +25,6 @@
 		#size-cells = <0>;
 
 		spi-max-frequency = <10000000>;
-		//adi,spi-3wire-enable;
 
 		clock-output-names = "ad9528-1_out0", "ad9528-1_out1", "ad9528-1_out2",
 			"ad9528-1_out3", "ad9528-1_out4", "ad9528-1_out5", "ad9528-1_out6",

--- a/arch/arm64/boot/dts/xilinx/adi-adrv9371.dtsi
+++ b/arch/arm64/boot/dts/xilinx/adi-adrv9371.dtsi
@@ -11,7 +11,6 @@
 		#size-cells = <0>;
 
 		spi-max-frequency = <10000000>;
-		//adi,spi-3wire-enable;
 
 		clock-output-names = "ad9528-1_out0", "ad9528-1_out1", "ad9528-1_out2", "ad9528-1_out3", "ad9528-1_out4", "ad9528-1_out5", "ad9528-1_out6", "ad9528-1_out7", "ad9528-1_out8", "ad9528-1_out9", "ad9528-1_out10", "ad9528-1_out11", "ad9528-1_out12", "ad9528-1_out13";
 		#clock-cells = <1>;

--- a/arch/arm64/boot/dts/xilinx/adi-daq2.dtsi
+++ b/arch/arm64/boot/dts/xilinx/adi-daq2.dtsi
@@ -18,7 +18,7 @@
 		#clock-cells = <1>;
 
 		adi,vcxo-freq = <125000000>;
-		adi,spi-3wire-enable;
+		spi-3wire;
 		adi,pll1-bypass-enable;
 		adi,osc-in-diff-enable;
 

--- a/arch/arm64/boot/dts/xilinx/adi-daq3.dtsi
+++ b/arch/arm64/boot/dts/xilinx/adi-daq3.dtsi
@@ -10,7 +10,7 @@
 		spi-cpol;
 		spi-cpha;
 		spi-max-frequency = <10000000>;
-		adi,spi-3wire-enable;
+		spi-3wire;
 		reg = <0>;
 
 		clock-output-names = "ad9528_out0", "ad9528_out1", "ad9528_out2", "ad9528_out3", "ad9528_out4", "ad9528_out5", "ad9528_out6", "ad9528_out7", "ad9528_out8", "ad9528_out9", "ad9528_out10", "ad9528_out11", "ad9528_out12", "ad9528_out13";
@@ -117,7 +117,7 @@
 		spi-cpol;
 		spi-cpha;
 		spi-max-frequency = <10000000>;
-		adi,spi-3wire-enable;
+		spi-3wire;
 		reg = <1>;
 
 		clocks = <&axi_ad9152_jesd>, <&clk0_ad9528 2>, <&clk0_ad9528 5>;
@@ -130,7 +130,7 @@
 		spi-cpol;
 		spi-cpha;
 		spi-max-frequency = <10000000>;
-		adi,spi-3wire-enable;
+		spi-3wire;
 		reg = <2>;
 
 		/* Content of Registers: 0x16, 0x18, 0x19, 0x1A, 0x30, 0x11A, 0x934, 0x935 */

--- a/arch/microblaze/boot/dts/adi-ad9467-fmc-250ebz.dtsi
+++ b/arch/microblaze/boot/dts/adi-ad9467-fmc-250ebz.dtsi
@@ -19,7 +19,7 @@
 		clocks = <&clk_ad9517 3>;
 		clock-names = "adc_clk";
 
-		adi,spi-3wire-enable;
+		spi-3wire;
 	};
 
 	clk_ad9517: ad9517@1 {
@@ -34,6 +34,6 @@
 		clock-output-names = "out0", "out1", "out2", "out3", "out4", "out5", "out6", "out7";
 		firmware = "ad9467_intbypass_ad9517.stp";
 
-		adi,spi-3wire-enable;
+		spi-3wire;
 	};
 };

--- a/arch/microblaze/boot/dts/adi-adrv9371.dtsi
+++ b/arch/microblaze/boot/dts/adi-adrv9371.dtsi
@@ -10,7 +10,6 @@
 		compatible = "ad9528";
 
 		spi-max-frequency = <10000000>;
-		//adi,spi-3wire-enable;
 		reg = <0>;
 
 		clock-output-names = "ad9528-1_out0", "ad9528-1_out1", "ad9528-1_out2", "ad9528-1_out3", "ad9528-1_out4", "ad9528-1_out5", "ad9528-1_out6", "ad9528-1_out7", "ad9528-1_out8", "ad9528-1_out9", "ad9528-1_out10", "ad9528-1_out11", "ad9528-1_out12", "ad9528-1_out13";

--- a/arch/microblaze/boot/dts/adi-daq2.dtsi
+++ b/arch/microblaze/boot/dts/adi-daq2.dtsi
@@ -13,7 +13,7 @@
 		spi-max-frequency = <10000000>;
 		clock-output-names = "ad9523-1_out0", "ad9523-1_out1", "ad9523-1_out2", "ad9523-1_out3", "ad9523-1_out4", "ad9523-1_out5", "ad9523-1_out6", "ad9523-1_out7", "ad9523-1_out8", "ad9523-1_out9", "ad9523-1_out10", "ad9523-1_out11", "ad9523-1_out12", "ad9523-1_out13";
 		adi,vcxo-freq = <125000000>;
-		adi,spi-3wire-enable;
+		spi-3wire;
 		adi,pll1-bypass-enable;
 		adi,osc-in-diff-enable;
 

--- a/arch/microblaze/boot/dts/adi-daq3.dtsi
+++ b/arch/microblaze/boot/dts/adi-daq3.dtsi
@@ -10,7 +10,7 @@
 		spi-cpol;
 		spi-cpha;
 		spi-max-frequency = <10000000>;
-		adi,spi-3wire-enable;
+		spi-3wire;
 		reg = <0>;
 
 		clock-output-names = "ad9528_out0", "ad9528_out1", "ad9528_out2", "ad9528_out3", "ad9528_out4", "ad9528_out5", "ad9528_out6", "ad9528_out7", "ad9528_out8", "ad9528_out9", "ad9528_out10", "ad9528_out11", "ad9528_out12", "ad9528_out13";
@@ -119,7 +119,7 @@
 		spi-cpol;
 		spi-cpha;
 		spi-max-frequency = <10000000>;
-		adi,spi-3wire-enable;
+		spi-3wire;
 		reg = <1>;
 
 		clocks = <&axi_ad9152_jesd>, <&clk0_ad9528 2>, <&clk0_ad9528 5>;
@@ -134,7 +134,7 @@
 		spi-cpol;
 		spi-cpha;
 		spi-max-frequency = <10000000>;
-		adi,spi-3wire-enable;
+		spi-3wire;
 		reg = <2>;
 
 		/* Content of Registers: 0x16, 0x18, 0x19, 0x1A, 0x30, 0x11A, 0x934, 0x935 */

--- a/arch/microblaze/boot/dts/adi-fmcjesdadc1.dtsi
+++ b/arch/microblaze/boot/dts/adi-fmcjesdadc1.dtsi
@@ -28,7 +28,7 @@
 			compatible = "ad9517-1";
 			reg = <1>;
 			spi-max-frequency = <10000000>;
-			adi,spi-3wire-enable;
+			spi-3wire;
 			clocks = <&ad9517_ref_clk>, <&ad9517_clkin>;
 			clock-names = "refclk", "clkin";
 			clock-output-names = "out0", "out1", "out2", "out3", "out4", "out5", "out6", "out7";

--- a/drivers/iio/adc/ad6676.c
+++ b/drivers/iio/adc/ad6676.c
@@ -69,7 +69,6 @@ struct ad6676_platform_data {
 	struct ad6676_jesd_conf jesd;
 	struct ad6676_agc_conf agc;
 	struct ad6676_shuffler_conf shuffler;
-	bool spi3wire;
 };
 
 struct ad6676_phy {
@@ -510,7 +509,7 @@ static int ad6676_setup(struct axiadc_converter *conv)
 		phy->ref_clk = clk_get_rate(clk);
 	}
 
-	ret = ad6676_reset(conv, (spi->mode & SPI_3WIRE) || pdata->spi3wire);
+	ret = ad6676_reset(conv, (spi->mode & SPI_3WIRE));
 	if (ret < 0)
 		return ret;
 
@@ -1078,8 +1077,6 @@ static struct ad6676_platform_data *ad6676_parse_dt(struct device *dev)
 	pdata = devm_kzalloc(dev, sizeof(*pdata), GFP_KERNEL);
 	if (!pdata)
 		return NULL;
-
-	pdata->spi3wire = of_property_read_bool(np, "adi,spi-3wire-enable");
 
 	pdata->base.f_adc_hz = ad6676_of_property_read_u32(np, "adi,adc-frequency-hz", 320000000UL);
 	pdata->base.fadc_fixed = of_property_read_bool(np, "adi,adc-frequency-fixed-enable");

--- a/drivers/iio/frequency/ad9122.c
+++ b/drivers/iio/frequency/ad9122.c
@@ -901,8 +901,6 @@ static int ad9122_probe(struct spi_device *spi)
 	struct cf_axi_converter *conv;
 	unsigned id, rate, datapath_ctrl, tmp;
 	int ret, conf;
-	bool spi3wire = of_property_read_bool(
-			spi->dev.of_node, "adi,spi-3wire-enable");
 
 	conv = devm_kzalloc(&spi->dev, sizeof(*conv), GFP_KERNEL);
 	if (conv == NULL)
@@ -910,7 +908,7 @@ static int ad9122_probe(struct spi_device *spi)
 
 	conv->reset_gpio = devm_gpiod_get(&spi->dev, "reset", GPIOD_OUT_HIGH);
 
-	conf = (spi->mode & SPI_3WIRE || spi3wire) ? AD9122_COMM_SDIO : 0;
+	conf = (spi->mode & SPI_3WIRE) ? AD9122_COMM_SDIO : 0;
 	ret = ad9122_write(spi, AD9122_REG_COMM, conf | AD9122_COMM_RESET);
 	if (ret < 0)
 		return ret;

--- a/drivers/iio/frequency/ad9508.c
+++ b/drivers/iio/frequency/ad9508.c
@@ -466,7 +466,7 @@ static int ad9508_setup(struct iio_dev *indio_dev)
 
 	ret = ad9508_write(indio_dev, AD9508_SERIAL_PORT_CONFIG,
 			AD9508_SER_CONF_SOFT_RESET |
-			((st->spi->mode & SPI_3WIRE || pdata->spi3wire)? 0 :
+			((st->spi->mode & SPI_3WIRE) ? 0 :
 			 AD9508_SER_CONF_SDO_ACTIVE));
 	if (ret < 0)
 		return ret;
@@ -549,8 +549,6 @@ static struct ad9508_platform_data *ad9508_parse_dt(struct device *dev)
 	pdata = devm_kzalloc(dev, sizeof(*pdata), GFP_KERNEL);
 	if (!pdata)
 		return NULL;
-
-	pdata->spi3wire = of_property_read_bool(np, "adi,spi-3wire-enable");
 
 	strncpy(&pdata->name[0], np->name, SPI_NAME_SIZE - 1);
 

--- a/drivers/iio/frequency/ad9517.c
+++ b/drivers/iio/frequency/ad9517.c
@@ -1041,8 +1041,6 @@ static int ad9517_probe(struct spi_device *spi)
 	const struct firmware *fw;
 	struct ad9517_state *st;
 	struct clk *clk, *ref_clk, *clkin;
-	bool spi3wire = of_property_read_bool(
-			spi->dev.of_node, "adi,spi-3wire-enable");
 	unsigned int device_type, part_id;
 
 	id = spi_get_device_id(spi);
@@ -1067,7 +1065,7 @@ static int ad9517_probe(struct spi_device *spi)
 	    GPIOD_OUT_HIGH);
 
 	conf = AD9517_LONG_INSTR |
-		((spi->mode & SPI_3WIRE || spi3wire) ? 0 : AD9517_SDO_ACTIVE);
+		((spi->mode & SPI_3WIRE) ? 0 : AD9517_SDO_ACTIVE);
 
 	ret = ad9517_write(spi, AD9517_SERCONF,  conf | AD9517_SOFT_RESET);
 	if (ret < 0)

--- a/drivers/iio/frequency/ad9523.c
+++ b/drivers/iio/frequency/ad9523.c
@@ -1011,7 +1011,7 @@ static int ad9523_setup(struct iio_dev *indio_dev)
 
 	ret = ad9523_write(indio_dev, AD9523_SERIAL_PORT_CONFIG,
 			   AD9523_SER_CONF_SOFT_RESET |
-			  ((st->spi->mode & SPI_3WIRE || pdata->spi3wire)? 0 :
+			  ((st->spi->mode & SPI_3WIRE) ? 0 :
 			  AD9523_SER_CONF_SDO_ACTIVE));
 	if (ret < 0)
 		return ret;
@@ -1278,8 +1278,6 @@ static struct ad9523_platform_data *ad9523_parse_dt(struct device *dev)
 	pdata = devm_kzalloc(dev, sizeof(*pdata), GFP_KERNEL);
 	if (!pdata)
 		return ERR_PTR(-ENOMEM);
-
-	pdata->spi3wire = of_property_read_bool(np, "adi,spi-3wire-enable");
 
 	tmp = 0;
 	of_property_read_u32(np, "adi,vcxo-freq", &tmp);

--- a/drivers/iio/frequency/ad9528.c
+++ b/drivers/iio/frequency/ad9528.c
@@ -904,7 +904,7 @@ static int ad9528_setup(struct iio_dev *indio_dev)
 
 	ret = ad9528_write(indio_dev, AD9528_SERIAL_PORT_CONFIG,
 			AD9528_SER_CONF_SOFT_RESET |
-			((st->spi->mode & SPI_3WIRE || pdata->spi3wire)? 0 :
+			((st->spi->mode & SPI_3WIRE) ? 0 :
 			 AD9528_SER_CONF_SDO_ACTIVE));
 	if (ret < 0)
 		return ret;
@@ -1213,8 +1213,6 @@ static struct ad9528_platform_data *ad9528_parse_dt(struct device *dev)
 	pdata = devm_kzalloc(dev, sizeof(*pdata), GFP_KERNEL);
 	if (!pdata)
 		return NULL;
-
-	pdata->spi3wire = of_property_read_bool(np, "adi,spi-3wire-enable");
 
 	tmp = 0;
 	of_property_read_u32(np, "adi,vcxo-freq", &tmp);

--- a/include/linux/iio/frequency/ad9508.h
+++ b/include/linux/iio/frequency/ad9508.h
@@ -35,16 +35,12 @@ struct ad9508_channel_spec {
 /**
  * struct ad9528_platform_data - platform specific information
  *
- * @spi3wire: SPI 3-Wire mode enable;
-
  * @num_channels: Array size of struct ad9528_channel_spec.
  * @channels: Pointer to channel array.
  * @name: Optional alternative iio device name.
  */
 
 struct ad9508_platform_data {
-	bool				spi3wire;
-
 	/* Output Channel Configuration */
 	int				num_channels;
 	struct ad9508_channel_spec	*channels;

--- a/include/linux/iio/frequency/ad9523.h
+++ b/include/linux/iio/frequency/ad9523.h
@@ -107,7 +107,6 @@ enum cpole1_capacitor {
  * struct ad9523_platform_data - platform specific information
  *
  * @vcxo_freq: External VCXO frequency in Hz
- * @spi3wire: SPI 3-Wire mode enable;
  * @refa_diff_rcv_en: REFA differential/single-ended input selection.
  * @refb_diff_rcv_en: REFB differential/single-ended input selection.
  * @zd_in_diff_en: Zero Delay differential/single-ended input selection.
@@ -144,7 +143,6 @@ enum cpole1_capacitor {
 
 struct ad9523_platform_data {
 	unsigned long 			vcxo_freq;
-	bool				spi3wire;
 
 	/* Differential/ Single-Ended Input Configuration */
 	bool				refa_diff_rcv_en;

--- a/include/linux/iio/frequency/ad9528.h
+++ b/include/linux/iio/frequency/ad9528.h
@@ -38,7 +38,6 @@ struct ad9528_channel_spec {
  * struct ad9528_platform_data - platform specific information
  *
  * @vcxo_freq: External VCXO frequency in Hz
- * @spi3wire: SPI 3-Wire mode enable;
  * @refa_en: REFA input enable.
  * @refb_en: REFB input enable.
  * @refa_diff_rcv_en: REFA differential/single-ended input selection.
@@ -78,7 +77,6 @@ struct ad9528_channel_spec {
 
 struct ad9528_platform_data {
 	unsigned long			vcxo_freq;
-	bool				spi3wire;
 
 	/* REFA / REFB input configuration */
 	bool				refa_en;


### PR DESCRIPTION
All drivers support upstream 3wire mode by using the upstream `spi-3wire`
property. All device-trees have been updated to use this property.
    
This change removes all usage/handling of the old/special
adi,spi-3wire-enable.
    
Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>