### PR TITLE
arm: dts: adi-fmclidar1: Make it compatible with jesd-eye-scan-gtk

### DIFF
--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmclidar1.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmclidar1.dts
@@ -105,7 +105,7 @@
 		clock-output-names = "jesd_adc_lane_clk";
 	};
 
-	axi_ad9094_adxcvr: axi-ad9094-adxcvr@44a50000 {
+	axi_ad9094_adxcvr: axi-adxcvr-rx@44a50000 {
 		compatible = "adi,axi-adxcvr-1.0";
 		reg = <0x44a50000 0x1000>;
 


### PR DESCRIPTION
A naming convention allows the jesd-eye-scan-gtk application to
determine target devices.

Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>