### PR TITLE
arm64: dts: xilinx: zynqmp-adrv9009-zu11eg.dts: Split phy1 definition

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-adrv2crr-fmc.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-adrv2crr-fmc.dts
@@ -141,6 +141,12 @@
 	phys = <&lane0 PHY_TYPE_SGMII 0 1 125000000>;
 };
 
+&gem3 {
+	phy1: phy@1 {
+		device_type = "ethernet-phy";
+		reg = <1>;
+	};
+};
 /*
  * DisplayPort: P2
  * Using: GTR Lane3, Lane2

--- a/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg.dts
@@ -56,10 +56,6 @@
 		reg = <0x0>;
 		marvell,reg-init = <3 16 0xff00 0x1e 3 17 0xfff0 0x00>;
 	};
-	phy1: phy@1 {
-		device_type = "ethernet-phy";
-		reg = <1>;
-	};
 };
 
 &gpio {


### PR DESCRIPTION
Since phy1 is only available in the carrier board, it should be only
defined in zynqmp-adrv9009-zu11eg-adrv2crr-fmc.

Signed-off-by: Nuno Sá <nuno.sa@analog.com>