### PR TITLE
Fix sgmii when rgmmii down

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-adrv2crr-fmc.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-adrv2crr-fmc.dts
@@ -145,6 +145,7 @@
 	phy1: phy@1 {
 		device_type = "ethernet-phy";
 		reg = <1>;
+		reset-gpios = <&gpio 31 GPIO_ACTIVE_HIGH>;
 	};
 };
 /*

--- a/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg.dts
@@ -55,6 +55,7 @@
 		device_type = "ethernet-phy";
 		reg = <0x0>;
 		marvell,reg-init = <3 16 0xff00 0x1e 3 17 0xfff0 0x00>;
+		reset-gpios = <&gpio 25 GPIO_ACTIVE_HIGH>;
 	};
 };
 

--- a/drivers/net/ethernet/cadence/macb.h
+++ b/drivers/net/ethernet/cadence/macb.h
@@ -1084,6 +1084,11 @@ struct macb {
 	struct ptp_clock_info ptp_clock_info;
 	struct tsu_incr tsu_incr;
 	struct hwtstamp_config tstamp_config;
+	/* special flag for when the connection between
+	 * the phy and the MAC fails, but, there are more
+	 * phys on the mdio bus...
+	 */
+	bool keep_mac_around;
 };
 
 #ifdef CONFIG_MACB_USE_HWSTAMP

--- a/drivers/of/of_mdio.c
+++ b/drivers/of/of_mdio.c
@@ -228,7 +228,12 @@ int of_mdiobus_register(struct mii_bus *mdio, struct device_node *np)
 			rc = of_mdiobus_register_phy(mdio, child, addr);
 		else
 			rc = of_mdiobus_register_device(mdio, child, addr);
-		if (rc)
+
+		if (rc == -ENODEV)
+			dev_err(&mdio->dev,
+				"MDIO device at address %d is missing.\n",
+				addr);
+		else if (rc)
 			goto unregister;
 	}
 
@@ -252,7 +257,7 @@ int of_mdiobus_register(struct mii_bus *mdio, struct device_node *np)
 
 			if (of_mdiobus_child_is_phy(child)) {
 				rc = of_mdiobus_register_phy(mdio, child, addr);
-				if (rc)
+				if (rc && rc != -ENODEV)
 					goto unregister;
 			}
 		}


### PR DESCRIPTION
This PR allows the sgmii interface to still work even if the the rgmii interface is down. The [of_mdio: avoid MDIO bus removal when a PHY is missing](https://github.com/torvalds/linux/commit/95f566de0269a0c59fd6a737a147731302136429) patch was cherry-picked from upstream. Also, some merge from the upstream macb driver was done here. 
The last patch also adds reset-gpios to the device tree so that, the driver can enable the phy if it boots disabled (for some reason).