### PR TITLE
Master adf4372 support

### DIFF
--- a/Documentation/devicetree/bindings/iio/frequency/adf4371.yaml
+++ b/Documentation/devicetree/bindings/iio/frequency/adf4371.yaml
@@ -33,6 +33,12 @@ properties:
       Must be "clkin"
     maxItems: 1
 
+  adi,mute-till-lock-en:
+    description:
+      If this property is present, then the supply current to RF8P and RF8N
+      output stage will shut down until the ADF4371/ADF4372 achieves lock as
+      measured by the digital lock detect circuitry.
+
 required:
   - compatible
   - reg

--- a/Documentation/devicetree/bindings/iio/frequency/adf4371.yaml
+++ b/Documentation/devicetree/bindings/iio/frequency/adf4371.yaml
@@ -4,19 +4,21 @@
 $id: http://devicetree.org/schemas/iio/frequency/adf4371.yaml#
 $schema: http://devicetree.org/meta-schemas/core.yaml#
 
-title: Analog Devices ADF4371 Wideband Synthesizer
+title: Analog Devices ADF4371/ADF4372 Wideband Synthesizers
 
 maintainers:
   - Popa Stefan <stefan.popa@analog.com>
 
 description: |
-  Analog Devices ADF4371 SPI Wideband Synthesizer
+  Analog Devices ADF4371/ADF4372 SPI Wideband Synthesizers
   https://www.analog.com/media/en/technical-documentation/data-sheets/adf4371.pdf
+  https://www.analog.com/media/en/technical-documentation/data-sheets/adf4372.pdf
 
 properties:
   compatible:
     enum:
       - adi,adf4371
+      - adi,adf4372
 
   reg:
     maxItems: 1

--- a/drivers/iio/frequency/Kconfig
+++ b/drivers/iio/frequency/Kconfig
@@ -159,12 +159,12 @@ config ADF5355
 	  module will be called adf5355.
 
 config ADF4371
-	tristate "Analog Devices ADF4371 Wideband Synthesizer"
+	tristate "Analog Devices ADF4371/ADF4372 Wideband Synthesizers"
 	depends on SPI
 	select REGMAP_SPI
 	help
-	  Say yes here to build support for Analog Devices  ADF4371
-	  Wideband Synthesizer. The driver provides direct access via sysfs.
+	  Say yes here to build support for Analog Devices ADF4371 and ADF4372
+	  Wideband Synthesizers. The driver provides direct access via sysfs.
 
 	  To compile this driver as a module, choose M here: the
 	  module will be called adf4371.

--- a/drivers/iio/frequency/adf4371.c
+++ b/drivers/iio/frequency/adf4371.c
@@ -427,7 +427,6 @@ static const struct iio_chan_spec adf4371_chan[] = {
 	ADF4371_CHANNEL(ADF4371_CH_RFAUX8),
 	ADF4371_CHANNEL(ADF4371_CH_RF16),
 	ADF4371_CHANNEL(ADF4371_CH_RF32),
-	ADF4371_CHANNEL(ADF4371_CH_RFAUX8),
 };
 
 static int adf4371_reg_access(struct iio_dev *indio_dev,

--- a/drivers/iio/frequency/adf4371.c
+++ b/drivers/iio/frequency/adf4371.c
@@ -87,6 +87,11 @@ enum {
 	ADF4371_CH_RF32
 };
 
+enum adf4371_variant {
+	ADF4371,
+	ADF4372
+};
+
 struct adf4371_pwrdown {
 	unsigned int reg;
 	unsigned int bit;
@@ -140,6 +145,11 @@ static const struct regmap_config adf4371_regmap_config = {
 	.read_flag_mask = BIT(7),
 };
 
+struct adf4371_chip_info {
+	unsigned int num_channels;
+	const struct iio_chan_spec *channels;
+};
+
 struct adf4371_state {
 	struct spi_device *spi;
 	struct regmap *regmap;
@@ -152,6 +162,7 @@ struct adf4371_state {
 	 * writes.
 	 */
 	struct mutex lock;
+	const struct adf4371_chip_info *chip_info;
 	unsigned long clkin_freq;
 	unsigned long fpfd;
 	unsigned int integer;
@@ -429,6 +440,17 @@ static const struct iio_chan_spec adf4371_chan[] = {
 	ADF4371_CHANNEL(ADF4371_CH_RF32),
 };
 
+static const struct adf4371_chip_info adf4371_chip_info[] = {
+	[ADF4371] = {
+		.channels = adf4371_chan,
+		.num_channels = 4,
+	},
+	[ADF4372] = {
+		.channels = adf4371_chan,
+		.num_channels = 3,
+	}
+};
+
 static int adf4371_reg_access(struct iio_dev *indio_dev,
 			      unsigned int reg,
 			      unsigned int writeval,
@@ -537,12 +559,13 @@ static int adf4371_probe(struct spi_device *spi)
 	st->spi = spi;
 	mutex_init(&st->lock);
 
+	st->chip_info = &adf4371_chip_info[id->driver_data];
 	indio_dev->dev.parent = &spi->dev;
 	indio_dev->name = id->name;
 	indio_dev->info = &adf4371_info;
 	indio_dev->modes = INDIO_DIRECT_MODE;
-	indio_dev->channels = adf4371_chan;
-	indio_dev->num_channels = ARRAY_SIZE(adf4371_chan);
+	indio_dev->channels = st->chip_info->channels;
+	indio_dev->num_channels = st->chip_info->num_channels;
 
 	st->clkin = devm_clk_get(&spi->dev, "clkin");
 	if (IS_ERR(st->clkin))
@@ -568,13 +591,15 @@ static int adf4371_probe(struct spi_device *spi)
 }
 
 static const struct spi_device_id adf4371_id_table[] = {
-	{ "adf4371", 0 },
+	{ "adf4371", ADF4371 },
+	{ "adf4372", ADF4372 },
 	{}
 };
 MODULE_DEVICE_TABLE(spi, adf4371_id_table);
 
 static const struct of_device_id adf4371_of_match[] = {
 	{ .compatible = "adi,adf4371" },
+	{ .compatible = "adi,adf4372" },
 	{ },
 };
 MODULE_DEVICE_TABLE(of, adf4371_of_match);

--- a/drivers/iio/frequency/adf4371.c
+++ b/drivers/iio/frequency/adf4371.c
@@ -45,6 +45,10 @@
 #define ADF4371_RF_DIV_SEL_MSK		GENMASK(6, 4)
 #define ADF4371_RF_DIV_SEL(x)		FIELD_PREP(ADF4371_RF_DIV_SEL_MSK, x)
 
+/* ADF4371_REG25 */
+#define ADF4371_MUTE_LD_MSK		BIT(7)
+#define ADF4371_MUTE_LD(x)		FIELD_PREP(ADF4371_MUTE_LD_MSK, x)
+
 /* ADF4371_REG32 */
 #define ADF4371_TIMEOUT_MSK		GENMASK(1, 0)
 #define ADF4371_TIMEOUT(x)		FIELD_PREP(ADF4371_TIMEOUT_MSK, x)
@@ -483,6 +487,15 @@ static int adf4371_setup(struct adf4371_state *st)
 				     ARRAY_SIZE(adf4371_reg_defaults));
 	if (ret < 0)
 		return ret;
+
+	/* Mute to Lock Detect */
+	if (device_property_read_bool(&st->spi->dev, "adi,mute-till-lock-en")) {
+		ret = regmap_update_bits(st->regmap, ADF4371_REG(0x25),
+					 ADF4371_MUTE_LD_MSK,
+					 ADF4371_MUTE_LD(1));
+		if (ret < 0)
+			return ret;
+	}
 
 	/* Set address in ascending order, so the bulk_write() will work */
 	ret = regmap_update_bits(st->regmap, ADF4371_REG(0x0),

--- a/drivers/iio/frequency/adf4371.c
+++ b/drivers/iio/frequency/adf4371.c
@@ -535,6 +535,7 @@ static int adf4371_probe(struct spi_device *spi)
 	st = iio_priv(indio_dev);
 	spi_set_drvdata(spi, indio_dev);
 	st->regmap = regmap;
+	st->spi = spi;
 	mutex_init(&st->lock);
 
 	indio_dev->dev.parent = &spi->dev;


### PR DESCRIPTION
This PR adds support for ADF4372 and the output stage mute feature.
Common Clock Framework provider will follow in a different PR