### PR TITLE
build,travis: don't build adi-4.19.0 branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ branches:
   except:
   - xcomm_zynq
   - adi-4.14.0 # current rebased versions of master; change this when updating kernel ver
+  - adi-4.19.0
 
 os: linux
 dist: trusty


### PR DESCRIPTION
Branch `master-xilinx-4.19` is built when updating.
This branch is a mirror of that, so don't run un-necessary builds.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>