### PR TITLE
treewide,include: fpga: adi-axi-common.h: update header/sync upstream

### DIFF
--- a/drivers/clk/clk-axi-clkgen.c
+++ b/drivers/clk/clk-axi-clkgen.c
@@ -233,31 +233,31 @@ static void axi_clkgen_setup_ranges(struct axi_clkgen *axi_clkgen)
 	unsigned int reg_value;
 	unsigned int tech, family, speed_grade, voltage;
 
-	axi_clkgen_read(axi_clkgen, AXI_REG_FPGA_INFO, &reg_value);
-	tech = AXI_INFO_FPGA_TECH(reg_value);
-	family = AXI_INFO_FPGA_FAMILY(reg_value);
-	speed_grade = AXI_INFO_FPGA_SPEED_GRADE(reg_value);
+	axi_clkgen_read(axi_clkgen, ADI_AXI_REG_FPGA_INFO, &reg_value);
+	tech = ADI_AXI_INFO_FPGA_TECH(reg_value);
+	family = ADI_AXI_INFO_FPGA_FAMILY(reg_value);
+	speed_grade = ADI_AXI_INFO_FPGA_SPEED_GRADE(reg_value);
 
-	axi_clkgen_read(axi_clkgen, AXI_REG_FPGA_VOLTAGE, &reg_value);
-	voltage = AXI_INFO_FPGA_VOLTAGE(reg_value);
+	axi_clkgen_read(axi_clkgen, ADI_AXI_REG_FPGA_VOLTAGE, &reg_value);
+	voltage = ADI_AXI_INFO_FPGA_VOLTAGE(reg_value);
 
 	switch (speed_grade) {
-	case AXI_FPGA_SPEED_1 ... AXI_FPGA_SPEED_1LV:
+	case ADI_AXI_FPGA_SPEED_1 ... ADI_AXI_FPGA_SPEED_1LV:
 		fvco_max = 1200000;
 		fpfd_max = 450000;
 		break;
-	case AXI_FPGA_SPEED_2 ... AXI_FPGA_SPEED_2LV:
+	case ADI_AXI_FPGA_SPEED_2 ... ADI_AXI_FPGA_SPEED_2LV:
 		fvco_max = 1440000;
 		fpfd_max = 500000;
-		if ((family == AXI_FPGA_FAMILY_KINTEX) |
-		    (family == AXI_FPGA_FAMILY_ARTIX)) {
+		if ((family == ADI_AXI_FPGA_FAMILY_KINTEX) |
+		    (family == ADI_AXI_FPGA_FAMILY_ARTIX)) {
 			if (voltage < 950) {
 				fvco_max = 1200000;
 				fpfd_max = 450000;
 			}
 		}
 		break;
-	case AXI_FPGA_SPEED_3:
+	case ADI_AXI_FPGA_SPEED_3:
 		fvco_max = 1600000;
 		fpfd_max = 550000;
 		break;
@@ -265,7 +265,7 @@ static void axi_clkgen_setup_ranges(struct axi_clkgen *axi_clkgen)
 		break;
 	};
 
-	if (tech == AXI_FPGA_TECH_ULTRASCALE_PLUS) {
+	if (tech == ADI_AXI_FPGA_TECH_ULTRASCALE_PLUS) {
 		fvco_max = 1600000;
 		fvco_min = 800000;
 	}
@@ -566,9 +566,10 @@ static int axi_clkgen_probe(struct platform_device *pdev)
 	if (IS_ERR(axi_clkgen->base))
 		return PTR_ERR(axi_clkgen->base);
 
-	axi_clkgen_read(axi_clkgen, AXI_REG_VERSION, &axi_clkgen->pcore_version);
+	axi_clkgen_read(axi_clkgen, ADI_AXI_REG_VERSION,
+			&axi_clkgen->pcore_version);
 
-	if (AXI_PCORE_VER_MAJOR(axi_clkgen->pcore_version) > 0x04)
+	if (ADI_AXI_PCORE_VER_MAJOR(axi_clkgen->pcore_version) > 0x04)
 		axi_clkgen_setup_ranges(axi_clkgen);
 
 	init.num_parents = of_clk_get_parent_count(pdev->dev.of_node);

--- a/drivers/dma/dma-axi-dmac.c
+++ b/drivers/dma/dma-axi-dmac.c
@@ -21,6 +21,7 @@
 #include <linux/platform_device.h>
 #include <linux/regmap.h>
 #include <linux/slab.h>
+#include <linux/fpga/adi-axi-common.h>
 
 #include <dt-bindings/dma/axi-dmac.h>
 
@@ -44,8 +45,6 @@
  * device side is a dedicated data bus only connected to a single peripheral
  * there is no address than can or needs to be configured for the device side.
  */
-
-#define AXI_DMAC_REG_VERSION		0x00
 
 #define AXI_DMAC_REG_IRQ_MASK		0x80
 #define AXI_DMAC_REG_IRQ_PENDING	0x84
@@ -827,7 +826,7 @@ static int axi_dmac_detect_caps(struct axi_dmac *dmac)
 	struct axi_dmac_chan *chan = &dmac->chan;
 	unsigned int version, version_minor;
 
-	version = axi_dmac_read(dmac, AXI_DMAC_REG_VERSION);
+	version = axi_dmac_read(dmac, ADI_AXI_REG_VERSION);
 	version_minor = version & 0xff00;
 
 	axi_dmac_write(dmac, AXI_DMAC_REG_FLAGS, AXI_DMAC_FLAG_CYCLIC);

--- a/drivers/iio/jesd204/axi_adxcvr.c
+++ b/drivers/iio/jesd204/axi_adxcvr.c
@@ -515,14 +515,14 @@ static void adxcvr_get_info(struct adxcvr_state *st)
 {
 	unsigned int reg_value;
 
-	reg_value = adxcvr_read(st, AXI_REG_FPGA_INFO);
-	st->xcvr.tech = AXI_INFO_FPGA_TECH(reg_value);
-	st->xcvr.family = AXI_INFO_FPGA_FAMILY(reg_value);
-	st->xcvr.speed_grade = AXI_INFO_FPGA_SPEED_GRADE(reg_value);
-	st->xcvr.dev_package = AXI_INFO_FPGA_DEV_PACKAGE(reg_value);
+	reg_value = adxcvr_read(st, ADI_AXI_REG_FPGA_INFO);
+	st->xcvr.tech = ADI_AXI_INFO_FPGA_TECH(reg_value);
+	st->xcvr.family = ADI_AXI_INFO_FPGA_FAMILY(reg_value);
+	st->xcvr.speed_grade = ADI_AXI_INFO_FPGA_SPEED_GRADE(reg_value);
+	st->xcvr.dev_package = ADI_AXI_INFO_FPGA_DEV_PACKAGE(reg_value);
 
-	reg_value = adxcvr_read(st, AXI_REG_FPGA_VOLTAGE);
-	st->xcvr.voltage = AXI_INFO_FPGA_VOLTAGE(reg_value);
+	reg_value = adxcvr_read(st, ADI_AXI_REG_FPGA_VOLTAGE);
+	st->xcvr.voltage = ADI_AXI_INFO_FPGA_VOLTAGE(reg_value);
 }
 
 static const char *adxcvr_gt_names[] = {
@@ -584,8 +584,8 @@ static int adxcvr_probe(struct platform_device *pdev)
 	}
 
 	st->dev = &pdev->dev;
-	st->xcvr.version = adxcvr_read(st, AXI_REG_VERSION);
-	if (AXI_PCORE_VER_MAJOR(st->xcvr.version) > 0x10)
+	st->xcvr.version = adxcvr_read(st, ADI_AXI_REG_VERSION);
+	if (ADI_AXI_PCORE_VER_MAJOR(st->xcvr.version) > 0x10)
 		adxcvr_get_info(st);
 	platform_set_drvdata(pdev, st);
 
@@ -596,7 +596,7 @@ static int adxcvr_probe(struct platform_device *pdev)
 	xcvr_type = (synth_conf >> 16) & 0xf;
 
 	/* Ensure compliance with legacy xcvr type */
-	if (AXI_PCORE_VER_MAJOR(st->xcvr.version) <= 0x10) {
+	if (ADI_AXI_PCORE_VER_MAJOR(st->xcvr.version) <= 0x10) {
 		switch (xcvr_type) {
 		case XILINX_XCVR_LEGACY_TYPE_S7_GTX2:
 			st->xcvr.type = XILINX_XCVR_TYPE_S7_GTX2;
@@ -660,9 +660,9 @@ static int adxcvr_probe(struct platform_device *pdev)
 
 	dev_info(&pdev->dev, "AXI-ADXCVR-%s (%d.%.2d.%c) using %s at 0x%08llX mapped to 0x%p. Number of lanes: %d.",
 		st->tx_enable ? "TX" : "RX",
-		AXI_PCORE_VER_MAJOR(st->xcvr.version),
-		AXI_PCORE_VER_MINOR(st->xcvr.version),
-		AXI_PCORE_VER_LETTER(st->xcvr.version),
+		ADI_AXI_PCORE_VER_MAJOR(st->xcvr.version),
+		ADI_AXI_PCORE_VER_MINOR(st->xcvr.version),
+		ADI_AXI_PCORE_VER_PATCH(st->xcvr.version),
 		adxcvr_gt_names[st->xcvr.type],
 		(unsigned long long)mem->start, st->regs,
 		st->num_lanes);

--- a/drivers/iio/jesd204/xilinx_transceiver.c
+++ b/drivers/iio/jesd204/xilinx_transceiver.c
@@ -295,8 +295,8 @@ static void xilinx_xcvr_setup_qpll_vco_range(struct xilinx_xcvr *xcvr,
 {
 	switch (xcvr->type) {
 	case XILINX_XCVR_TYPE_S7_GTX2:
-		if ((xcvr->dev_package == AXI_FPGA_DEV_FB) |
-		    (xcvr->dev_package == AXI_FPGA_DEV_SB))
+		if ((xcvr->dev_package == ADI_AXI_FPGA_DEV_FB) |
+		    (xcvr->dev_package == ADI_AXI_FPGA_DEV_SB))
 			*vco0_max = 6600000;
 		if ((xcvr->speed_grade / 10) == 2)
 			*vco1_max = 10312500;
@@ -347,7 +347,7 @@ int xilinx_xcvr_calc_cpll_config(struct xilinx_xcvr *xcvr,
 		return -EINVAL;
 	}
 
-	if (AXI_PCORE_VER_MAJOR(xcvr->version) > 0x10)
+	if (ADI_AXI_PCORE_VER_MAJOR(xcvr->version) > 0x10)
 		xilinx_xcvr_setup_cpll_vco_range(xcvr, &vco_max);
 
 	for (m = 1; m <= 2; m++) {
@@ -424,7 +424,7 @@ int xilinx_xcvr_calc_qpll_config(struct xilinx_xcvr *xcvr,
 		return -EINVAL;
 	}
 
-	if (AXI_PCORE_VER_MAJOR(xcvr->version) > 0x10)
+	if (ADI_AXI_PCORE_VER_MAJOR(xcvr->version) > 0x10)
 		xilinx_xcvr_setup_qpll_vco_range(xcvr,
 						 &vco0_min, &vco0_max,
 						 &vco1_min, &vco1_max);

--- a/drivers/iio/jesd204/xilinx_transceiver.h
+++ b/drivers/iio/jesd204/xilinx_transceiver.h
@@ -51,10 +51,10 @@ struct xilinx_xcvr {
 	enum xilinx_xcvr_refclk_ppm refclk_ppm;
 	unsigned int encoding;
 	unsigned int version;
-	enum axi_fgpa_technology tech;
-	enum axi_fpga_family family;
-	enum axi_fpga_speed_grade speed_grade;
-	enum axi_fpga_dev_pack dev_package;
+	enum adi_axi_fgpa_technology tech;
+	enum adi_axi_fpga_family family;
+	enum adi_axi_fpga_speed_grade speed_grade;
+	enum adi_axi_fpga_dev_pack dev_package;
 	unsigned int voltage;
 };
 

--- a/include/linux/fpga/adi-axi-common.h
+++ b/include/linux/fpga/adi-axi-common.h
@@ -1,85 +1,84 @@
-// SPDX-License-Identifier: GPL-2.0
+/* SPDX-License-Identifier: GPL-2.0 */
 /*
- * ADI AXI-COMMON Module
+ * Analog Devices AXI common registers & definitions
  *
  * Copyright 2019 Analog Devices Inc.
  *
  * https://wiki.analog.com/resources/fpga/docs/axi_ip
+ * https://wiki.analog.com/resources/fpga/docs/hdl/regmap
  */
 
 #ifndef ADI_AXI_COMMON_H_
 #define ADI_AXI_COMMON_H_
 
-#define AXI_PCORE_VER(major, minor, letter)	((major << 16) | (minor << 8) | letter)
-#define AXI_PCORE_VER_MAJOR(version)	(version >> 16)
-#define AXI_PCORE_VER_MINOR(version)	((version >> 8) & 0xff)
-#define AXI_PCORE_VER_LETTER(version)	(version & 0xff)
+#define	ADI_AXI_REG_VERSION			0x0000
+#define ADI_AXI_REG_ID				0x0004
+#define ADI_AXI_REG_SCRATCH			0x0008
+#define ADI_AXI_REG_CONFIG			0x000c
 
-#define	AXI_REG_VERSION			0x0000
-#define AXI_VERSION(x)			(((x) & 0xffffffff) << 0)
-#define AXI_VERSION_IS(x, y, z)		((x) << 16 | (y) << 8 | (z))
-#define AXI_VERSION_MAJOR(x)		((x) >> 16)
+#define ADI_AXI_REG_FPGA_INFO			0x001C
+#define ADI_AXI_REG_FPGA_VOLTAGE		0x0140
 
-#define AXI_REG_FPGA_INFO		0x001C
-#define AXI_REG_FPGA_VOLTAGE		0x0140
+#define ADI_AXI_PCORE_VER(major, minor, patch)	\
+	(((major) << 16) | ((minor) << 8) | (patch))
 
-#define AXI_INFO_FPGA_TECH(info)        ((info) >> 24)
-#define AXI_INFO_FPGA_FAMILY(info)      (((info) >> 16) & 0xff)
-#define AXI_INFO_FPGA_SPEED_GRADE(info)	(((info) >> 8) & 0xff)
-#define AXI_INFO_FPGA_DEV_PACKAGE(info)	((info) & 0xff)
-#define AXI_INFO_FPGA_VOLTAGE(val)      ((val) & 0xffff)
+#define ADI_AXI_PCORE_VER_MAJOR(version)	(((version) >> 16) & 0xff)
+#define ADI_AXI_PCORE_VER_MINOR(version)	(((version) >> 8) & 0xff)
+#define ADI_AXI_PCORE_VER_PATCH(version)	((version) & 0xff)
 
-#define AXI_REG_ID			0x0004
-#define AXI_REG_SCRATCH			0x0008
-#define AXI_REG_CONFIG			0x000c
+#define ADI_AXI_INFO_FPGA_TECH(info)		(((info) >> 24) & 0xff)
+#define ADI_AXI_INFO_FPGA_FAMILY(info)		(((info) >> 16) & 0xff)
+#define ADI_AXI_INFO_FPGA_SPEED_GRADE(info)	(((info) >> 8) & 0xff)
+#define ADI_AXI_INFO_FPGA_DEV_PACKAGE(info)	((info) & 0xff)
+#define ADI_AXI_INFO_FPGA_VOLTAGE(val)		((val) & 0xffff)
 
-enum axi_fgpa_technology {
-	AXI_FPGA_TECH_UNKNOWN = 0,
-	AXI_FPGA_TECH_SERIES7,
-	AXI_FPGA_TECH_ULTRASCALE,
-	AXI_FPGA_TECH_ULTRASCALE_PLUS,
+enum adi_axi_fgpa_technology {
+	ADI_AXI_FPGA_TECH_UNKNOWN = 0,
+	ADI_AXI_FPGA_TECH_SERIES7,
+	ADI_AXI_FPGA_TECH_ULTRASCALE,
+	ADI_AXI_FPGA_TECH_ULTRASCALE_PLUS,
 };
 
-enum axi_fpga_family {
-	AXI_FPGA_FAMILY_UNKNOWN = 0,
-	AXI_FPGA_FAMILY_ARTIX,
-	AXI_FPGA_FAMILY_KINTEX,
-	AXI_FPGA_FAMILY_VIRTEX,
-	AXI_FPGA_FAMILY_ZYNQ,
+enum adi_axi_fpga_family {
+	ADI_AXI_FPGA_FAMILY_UNKNOWN = 0,
+	ADI_AXI_FPGA_FAMILY_ARTIX,
+	ADI_AXI_FPGA_FAMILY_KINTEX,
+	ADI_AXI_FPGA_FAMILY_VIRTEX,
+	ADI_AXI_FPGA_FAMILY_ZYNQ,
 };
 
-enum axi_fpga_speed_grade {
-	AXI_FPGA_SPEED_UNKNOWN	= 0,
-	AXI_FPGA_SPEED_1	= 10,
-	AXI_FPGA_SPEED_1L	= 11,
-	AXI_FPGA_SPEED_1H	= 12,
-	AXI_FPGA_SPEED_1HV	= 13,
-	AXI_FPGA_SPEED_1LV	= 14,
-	AXI_FPGA_SPEED_2	= 20,
-	AXI_FPGA_SPEED_2L	= 21,
-	AXI_FPGA_SPEED_2LV	= 22,
-	AXI_FPGA_SPEED_3	= 30,
+enum adi_axi_fpga_speed_grade {
+	ADI_AXI_FPGA_SPEED_UNKNOWN	= 0,
+	ADI_AXI_FPGA_SPEED_1	= 10,
+	ADI_AXI_FPGA_SPEED_1L	= 11,
+	ADI_AXI_FPGA_SPEED_1H	= 12,
+	ADI_AXI_FPGA_SPEED_1HV	= 13,
+	ADI_AXI_FPGA_SPEED_1LV	= 14,
+	ADI_AXI_FPGA_SPEED_2	= 20,
+	ADI_AXI_FPGA_SPEED_2L	= 21,
+	ADI_AXI_FPGA_SPEED_2LV	= 22,
+	ADI_AXI_FPGA_SPEED_3	= 30,
 };
 
-enum axi_fpga_dev_pack {
-	AXI_FPGA_DEV_UNKNOWN = 0,
-	AXI_FPGA_DEV_RF,
-	AXI_FPGA_DEV_FL,
-	AXI_FPGA_DEV_FF,
-	AXI_FPGA_DEV_FB,
-	AXI_FPGA_DEV_HC,
-	AXI_FPGA_DEV_FH,
-	AXI_FPGA_DEV_CS,
-	AXI_FPGA_DEV_CP,
-	AXI_FPGA_DEV_FT,
-	AXI_FPGA_DEV_FG,
-	AXI_FPGA_DEV_SB,
-	AXI_FPGA_DEV_RB,
-	AXI_FPGA_DEV_RS,
-	AXI_FPGA_DEV_CL,
-	AXI_FPGA_DEV_SF,
-	AXI_FPGA_DEV_BA,
-	AXI_FPGA_DEV_FA,
+enum adi_axi_fpga_dev_pack {
+	ADI_AXI_FPGA_DEV_UNKNOWN = 0,
+	ADI_AXI_FPGA_DEV_RF,
+	ADI_AXI_FPGA_DEV_FL,
+	ADI_AXI_FPGA_DEV_FF,
+	ADI_AXI_FPGA_DEV_FB,
+	ADI_AXI_FPGA_DEV_HC,
+	ADI_AXI_FPGA_DEV_FH,
+	ADI_AXI_FPGA_DEV_CS,
+	ADI_AXI_FPGA_DEV_CP,
+	ADI_AXI_FPGA_DEV_FT,
+	ADI_AXI_FPGA_DEV_FG,
+	ADI_AXI_FPGA_DEV_SB,
+	ADI_AXI_FPGA_DEV_RB,
+	ADI_AXI_FPGA_DEV_RS,
+	ADI_AXI_FPGA_DEV_CL,
+	ADI_AXI_FPGA_DEV_SF,
+	ADI_AXI_FPGA_DEV_BA,
+	ADI_AXI_FPGA_DEV_FA,
 };
 
 #endif /* ADI_AXI_COMMON_H_ */


### PR DESCRIPTION
The adi-axi-common.h header was partially upstreamed, via the DMAEngine
subsystem. The definitions were prefixed with ADI_, to avoid any potential
collisions with other FPGA providers/vendors that may use AXI FPGA
elements.

This change updates the header and the places where the definitions are
used.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>