### PR TITLE
iio: frequency: adf4371: Add common clock framework support

### DIFF
--- a/Documentation/devicetree/bindings/iio/frequency/adf4371.yaml
+++ b/Documentation/devicetree/bindings/iio/frequency/adf4371.yaml
@@ -39,11 +39,47 @@ properties:
       output stage will shut down until the ADF4371/ADF4372 achieves lock as
       measured by the digital lock detect circuitry.
 
+  '#address-cells':
+    const: 1
+
+  '#size-cells':
+    const: 0
+
 required:
   - compatible
   - reg
   - clocks
   - clock-names
+
+  patternProperties:
+  "^channel@[01]$":
+    type: object
+    description: Represents the external channels which are connected to the device.
+
+    properties:
+      reg:
+        description: |
+          The channel number. It can have up to 3 channels on adf4372
+          and 4 channels on adf4371, numbered from 0 to 3.
+        maxItems: 1
+
+      adi,output-enable:
+        description: |
+          If this property is specified, the output channel will be enabled.
+          If left empty, the driver will initialize the defaults (RF8x, channel 0
+          will be the only one enabled).
+        maxItems: 1
+
+      adi,power-up-frequency:
+        description: |
+          Set the frequency after power up for the channel. If this property is
+          specified, it has to be in sync with the power up frequency set on the
+          other channels. This limitation is due to the fact that all the channel
+          frequencies are derived from the VCO fundamental frequency.
+        maxItems: 1
+
+    required:
+      - reg
 
 examples:
   - |
@@ -54,9 +90,36 @@ examples:
         frequency@0 {
                 compatible = "adi,adf4371";
                 reg = <0>;
+
+                #address-cells = <1>;
+                #size-cells = <0>;
+
                 spi-max-frequency = <1000000>;
                 clocks = <&adf4371_clkin>;
                 clock-names = "clkin";
+
+                channel@0 {
+                        reg = <0>;
+                        adi,output-enable;
+                        adi,power-up-frequency = /bits/ 64 <8000000000>;
+                };
+
+                channel@1 {
+                        reg = <1>;
+                        adi,output-enable;
+                };
+
+                channel@2 {
+                        reg = <2>;
+                        adi,output-enable;
+                        adi,power-up-frequency = /bits/ 64 <16000000000>;
+                };
+
+                channel@3 {
+                        reg = <3>;
+                        adi,output-enable;
+                        adi,power-up-frequency = /bits/ 64 <32000000000>;
+                };
         };
     };
 ...

--- a/Documentation/devicetree/bindings/iio/frequency/adf4371.yaml
+++ b/Documentation/devicetree/bindings/iio/frequency/adf4371.yaml
@@ -33,6 +33,19 @@ properties:
       Must be "clkin"
     maxItems: 1
 
+  clock-output-names:
+    maxItems: 1
+
+  clock-scales:
+    description:
+      The Common Clock Framework max rate is limited by MAX of unsigned long.
+      For ADF4371/ADF4372 devices this is a deficiency. If specified, this
+      property allows arbitrary scales. The first element in the array should
+      be the multiplier and the second element should be the divider.
+    allOf:
+      - $ref: /schemas/types.yaml#/definitions/uint32-array
+      - minimum: 1
+
   adi,mute-till-lock-en:
     description:
       If this property is present, then the supply current to RF8P and RF8N
@@ -44,6 +57,9 @@ properties:
 
   '#size-cells':
     const: 0
+
+  '#clock-cells':
+    const: 1
 
 required:
   - compatible
@@ -93,10 +109,12 @@ examples:
 
                 #address-cells = <1>;
                 #size-cells = <0>;
+                #clock-cells = <1>;
 
                 spi-max-frequency = <1000000>;
                 clocks = <&adf4371_clkin>;
                 clock-names = "clkin";
+                clock-scales = <1 10>;
 
                 channel@0 {
                         reg = <0>;


### PR DESCRIPTION
This patch allows the ADF4371/ADF4372 to be used as clock providers.
Because the frequency generated by adf4371 can go up to 32GHz,
clk_{get,set}_rate_scaled()` had to be used to work around the 4.2GHz
limitation imposed by the unsigned long type used by the CCF.

Signed-off-by: Stefan Popa <stefan.popa@analog.com>