### PR TITLE
media: adi-axi-fb: Add stride and PL only memory space frame buffer allocation 

### DIFF
--- a/Documentation/devicetree/bindings/media/adi,adi-axi-fb.yaml
+++ b/Documentation/devicetree/bindings/media/adi,adi-axi-fb.yaml
@@ -61,6 +61,18 @@ properties:
     minimum: 0
     maxItems: 1
 
+  adi,flock-line-stride:
+    description:
+      The number of bytes between the start of one row and the next row.
+      Needs to be aligned to the bus width.
+    maxItems: 1
+
+  adi,flock-frm-stride:
+    description:
+      Stride of consecutive frames in memory in bytes. Should be at least the
+      size of one frame.
+    maxItems: 1
+
   adi,flock-dwidth:
     description:
       Represent the number of bytes per pixel according to used color space.

--- a/Documentation/devicetree/bindings/media/adi,adi-axi-fb.yaml
+++ b/Documentation/devicetree/bindings/media/adi,adi-axi-fb.yaml
@@ -23,12 +23,14 @@ properties:
   memory-region:
     description:
       Phandle to a node used to specify reserved memory for video frame buffers.
+      If not used, frame buffer address and size should be specified using reg
+      property.
     allOf:
       - $ref: /schemas/types.yaml#/definitions/phandle-array
 
   reg:
     minItems: 2
-    maxItems: 2
+    maxItems: 3
 
   adi,flock-resolution:
     description:
@@ -81,7 +83,6 @@ properties:
 
 required:
   - compatible
-  - memory-region
   - reg
 
 examples:
@@ -89,8 +90,8 @@ examples:
     adi-fb {
             compatible = "adi,axi-framebuffer-1.00.a";
             memory-region = <&reserved>;
-            reg = <0x43000000 0x1000>, <0x43c20000 0x1000>;
-            reg-names = "tx_dma", "rx_dma";
+            reg = <0x1C000000 0x2000>, <0x43000000 0x1000>, <0x43c20000 0x1000>;
+            reg-names = "fb_mem", "tx_dma", "rx_dma";
             adi,flock-resolution = <1920>, <1080>;
             adi,flock-distance = <0>;
             adi,flock-mode = <0>;

--- a/drivers/media/platform/adi-axi-fb.c
+++ b/drivers/media/platform/adi-axi-fb.c
@@ -153,15 +153,21 @@ static int frame_buffer_probe(struct platform_device *pdev)
 	/* Get reserved memory region from Device-tree */
 	np = of_parse_phandle(pdev->dev.of_node, "memory-region", 0);
 	if (!np) {
-		dev_err(&pdev->dev, "No %s specified\n", "memory-region");
-		return -ENODEV;
-	}
-
-	ret = of_address_to_resource(np, 0, &frm_buff->video_ram_buf);
-	if (ret) {
-		dev_err(&pdev->dev,
-			"No memory address assigned to the region\n");
-		return ret;
+		/* Get physical address of FB from reg property */
+		res = platform_get_resource_byname(pdev,
+						IORESOURCE_MEM, "fb_mem");
+		if (!res) {
+			dev_err(&pdev->dev, "No frame buffer memory.\n");
+			return -EFAULT;
+		}
+		frm_buff->video_ram_buf = *res;
+	} else {
+		ret = of_address_to_resource(np, 0, &frm_buff->video_ram_buf);
+		if (ret) {
+			dev_err(&pdev->dev,
+				"No memory address assigned to the region\n");
+			return ret;
+		}
 	}
 	dev_info(&pdev->dev, "Allocated reserved memory, paddr: 0x%0X\n",
 		 frm_buff->video_ram_buf.start);


### PR DESCRIPTION
This patch adds the possibility to set line and frame stride through DT but as optional property. 

Also add the possibility to specify frame buffer address but not using the Linux reserved memory framework. Is useful when the frame buffer is stored in PL RAM and not accessible to CPU and Linux.

Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>