### PR TITLE
[WIP]Add driver support for AD5940

### DIFF
--- a/Documentation/devicetree/bindings/iio/adc/adi,ad5940.yaml
+++ b/Documentation/devicetree/bindings/iio/adc/adi,ad5940.yaml
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright 2019 Analog Devices Inc.
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/bindings/iio/adc/adi,ad5940.yaml
+$schema: $schema: http://devicetree.org/meta-schemas/core.yaml#
+
+title: Analog Devices AD5940 Device Tree Bindings
+
+maintainers:
+  - Song Qiang <songqiang1304521@gmail.com>
+
+description: |
+  Analog Devices AD5940 High Precision, Impedance, and Electrochemical Front End.
+    https://www.analog.com/media/en/technical-documentation/data-sheets/AD5940.pdf
+
+properties:
+  compatible:
+    enum:
+      - adi,ad5940
+
+  reg:
+    maxItems: 1
+
+required:
+  - compatible
+  - reg
+  - interupts
+
+examples:
+  - |
+    ad5940: ad5940@0 {
+      compatible = "adi,ad5940";
+      reg = <0>;
+      spi-max-frequency = <16000000>;
+    };

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -406,6 +406,13 @@ W:	http://ez.analog.com/community/linux-device-drivers
 S:	Supported
 F:	drivers/regulator/ad5398.c
 
+AD5940 ANALOG FRONT END DRIVER
+M:	Song Qiang <songqiang1304521@gmail.com>
+W:	https://wiki.analog.com/resources/eval/user-guides/ad5940
+W:	http://ez.analog.com/community/linux-device-drivers
+S:	Supported
+F:	drivers/iio/adc/ad5940.c
+
 AD714X CAPACITANCE TOUCH SENSOR DRIVER (AD7142/3/7/8/7A)
 M:	Michael Hennerich <michael.hennerich@analog.com>
 W:	http://wiki.analog.com/AD7142

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -412,6 +412,7 @@ W:	https://wiki.analog.com/resources/eval/user-guides/ad5940
 W:	http://ez.analog.com/community/linux-device-drivers
 S:	Supported
 F:	drivers/iio/adc/ad5940.c
+F:	Documentation/devicetree/bindings/iio/adc/adi,ad5940.yaml
 
 AD714X CAPACITANCE TOUCH SENSOR DRIVER (AD7142/3/7/8/7A)
 M:	Michael Hennerich <michael.hennerich@analog.com>

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -413,6 +413,7 @@ W:	http://ez.analog.com/community/linux-device-drivers
 S:	Supported
 F:	drivers/iio/adc/ad5940.c
 F:	Documentation/devicetree/bindings/iio/adc/adi,ad5940.yaml
+F:	arch/arm/boot/dts/overlays/rpi-ad5940-overlay.dts
 
 AD714X CAPACITANCE TOUCH SENSOR DRIVER (AD7142/3/7/8/7A)
 M:	Michael Hennerich <michael.hennerich@analog.com>

--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -97,6 +97,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	rotary-encoder.dtbo \
 	rpi-adf4371.dtbo \
 	rpi-ad5686.dtbo \
+	rpi-ad5940.dtbo \
 	rpi-ad7190.dtbo \
 	rpi-ad738x.dtbo \
 	rpi-ad7768.dtbo \

--- a/arch/arm/boot/dts/overlays/rpi-ad5940-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ad5940-overlay.dts
@@ -1,0 +1,22 @@
+/dts-v1/;
+/plugin/;
+#include <dt-bindings/interrupt-controller/irq.h>
+
+/ {
+	compatible = "brcm,bcm2708";
+
+	fragment@1 {
+		target = <&spi0>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			ad5940@0{
+				compatible = "adi,ad5940";
+				reg = <0>;
+				spi-max-frequency = <16000000>;
+			};
+		};
+	};
+};

--- a/drivers/iio/adc/Kconfig
+++ b/drivers/iio/adc/Kconfig
@@ -10,6 +10,16 @@ config AD_SIGMA_DELTA
 	select IIO_BUFFER
 	select IIO_TRIGGERED_BUFFER
 
+config AD5940
+	tristate "Analog Devices AD5940 ADC Driver"
+	depends on SPI
+	help
+	  Say yes here to build support for the ADC part of Analog Devices
+	  analog front end AD5940.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called ad5940.
+
 config AD7091R5
 	tristate "Analog Devices AD7091R5 ADC Driver"
 	depends on I2C

--- a/drivers/iio/adc/Makefile
+++ b/drivers/iio/adc/Makefile
@@ -5,6 +5,7 @@
 
 # When adding new entries keep the list in alphabetical order
 obj-$(CONFIG_AD_SIGMA_DELTA) += ad_sigma_delta.o
+obj-$(CONFIG_AD5940) += ad5940.o
 obj-$(CONFIG_AD6676) += ad6676.o
 obj-$(CONFIG_AD7091R5) += ad7091r5.o ad7091r-base.o
 obj-$(CONFIG_AD7124) += ad7124.o

--- a/drivers/iio/adc/ad5940.c
+++ b/drivers/iio/adc/ad5940.c
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL
+/*
+ * AD5940 SPI ADC driver
+ *
+ * Copyright (C) 2019 Song Qiang <songqiang1304521@gmail.com>
+ */
+
+#include <linux/device.h>
+#include <linux/module.h>
+#include <linux/spi/spi.h>
+
+#include <linux/iio/iio.h>
+
+struct ad5940_state {
+	struct spi_device *spi;
+};
+
+static int ad5940_read_raw(struct iio_dev *indio_dev,
+	const struct iio_chan_spec *chan, int *val, int *val2, long info)
+{
+	switch (info) {
+	case IIO_CHAN_INFO_RAW:
+		*val = 1000;
+
+		return IIO_VAL_INT;
+	case IIO_CHAN_INFO_SCALE:
+		*val = 1;
+		*val2 = 20;
+
+		return IIO_VAL_INT_PLUS_MICRO;
+	default:
+		return -EINVAL;
+	}
+}
+
+#define AD5940_CHANNEL(idx)						\
+	{								\
+		.type = IIO_VOLTAGE,					\
+		.indexed = 1,						\
+		.channel = idx,						\
+		.info_mask_separate = BIT(IIO_CHAN_INFO_RAW),		\
+		.info_mask_shared_by_type = BIT(IIO_CHAN_INFO_SCALE),	\
+	}
+
+static const struct iio_chan_spec ad5940_channels[] = {
+	AD5940_CHANNEL(0),
+};
+
+static const struct iio_info ad5940_info = {
+	.read_raw = &ad5940_read_raw,
+};
+
+static int ad5940_setup(struct ad5940_state *st)
+{
+	return 0;
+}
+
+static int ad5940_probe(struct spi_device *spi)
+{
+	struct iio_dev *indio_dev;
+	struct ad5940_state *st;
+	int ret;
+
+	indio_dev = devm_iio_device_alloc(&spi->dev, sizeof(*st));
+	if (!indio_dev)
+		return -ENOMEM;
+
+	st = iio_priv(indio_dev);
+
+	st->spi = spi;
+
+	indio_dev->dev.parent = &spi->dev;
+	indio_dev->dev.of_node = spi->dev.of_node;
+	indio_dev->name = spi->dev.of_node->name;
+	indio_dev->modes = INDIO_DIRECT_MODE;
+	indio_dev->channels = ad5940_channels;
+	indio_dev->num_channels = ARRAY_SIZE(ad5940_channels);
+	indio_dev->info = &ad5940_info;
+
+	ret = ad5940_setup(st);
+	if (ret)
+		return ret;
+
+	return devm_iio_device_register(&spi->dev, indio_dev);
+}
+
+static const struct of_device_id ad5940_dt_match[] = {
+	{ .compatible = "adi,ad5940" },
+	{},
+};
+MODULE_DEVICE_TABLE(of, ad5940_spi_ids);
+
+static struct spi_driver ad5940_driver = {
+	.driver = {
+		.name = "ad5940",
+		.of_match_table = ad5940_dt_match,
+	},
+	.probe = ad5940_probe,
+};
+module_spi_driver(ad5940_driver);
+
+MODULE_AUTHOR("Song Qiang <songqiang1304521@gmail.com>");
+MODULE_DESCRIPTION("Analog Device AD5940 ADC driver");
+MODULE_LICENSE("GPL");


### PR DESCRIPTION
Driver support for AD5940 for GSoC 2019. Basic driver skeleton support without any actual operations.
@stefpopa @commodo 