### PR TITLE
 iio: amplifiers: ad8366: sync with upstream version (part 1)

### DIFF
--- a/drivers/iio/amplifiers/Kconfig
+++ b/drivers/iio/amplifiers/Kconfig
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0
 #
 # Gain Amplifiers, etc.
 #

--- a/drivers/iio/amplifiers/Kconfig
+++ b/drivers/iio/amplifiers/Kconfig
@@ -9,6 +9,7 @@ menu "Amplifiers"
 config AD8366
 	tristate "Analog Devices AD8366 VGA"
 	depends on SPI
+	depends on GPIOLIB
 	select BITREVERSE
 	help
 	  Say yes here to build support for Analog Devices AD8366

--- a/drivers/iio/amplifiers/ad8366.c
+++ b/drivers/iio/amplifiers/ad8366.c
@@ -1,9 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0
 /*
  * AD8366 SPI Dual-Digital Variable Gain Amplifier (VGA)
  *
- * Copyright 2012 Analog Devices Inc.
- *
- * Licensed under the GPL-2.
+ * Copyright 2012-2019 Analog Devices Inc.
  */
 
 #include <linux/device.h>

--- a/drivers/iio/amplifiers/ad8366.c
+++ b/drivers/iio/amplifiers/ad8366.c
@@ -31,6 +31,7 @@ struct ad8366_state {
 	struct spi_device	*spi;
 	struct regulator		*reg;
 	struct gpio_desc		*reset_gpio;
+	struct mutex            lock; /* protect sensor state */
 	unsigned char		ch[2];
 	enum ad8366_type	type;
 
@@ -86,7 +87,7 @@ static int ad8366_read_raw(struct iio_dev *indio_dev,
 	int ret;
 	int code;
 
-	mutex_lock(&indio_dev->mlock);
+	mutex_lock(&st->lock);
 	switch (m) {
 	case IIO_CHAN_INFO_HARDWAREGAIN:
 		code = st->ch[chan->channel];
@@ -119,7 +120,7 @@ static int ad8366_read_raw(struct iio_dev *indio_dev,
 	default:
 		ret = -EINVAL;
 	}
-	mutex_unlock(&indio_dev->mlock);
+	mutex_unlock(&st->lock);
 
 	return ret;
 };
@@ -167,7 +168,7 @@ static int ad8366_write_raw(struct iio_dev *indio_dev,
 		break;
 	}
 
-	mutex_lock(&indio_dev->mlock);
+	mutex_lock(&st->lock);
 	switch (mask) {
 	case IIO_CHAN_INFO_HARDWAREGAIN:
 		st->ch[chan->channel] = code;
@@ -176,7 +177,7 @@ static int ad8366_write_raw(struct iio_dev *indio_dev,
 	default:
 		ret = -EINVAL;
 	}
-	mutex_unlock(&indio_dev->mlock);
+	mutex_unlock(&st->lock);
 
 	return ret;
 }
@@ -224,6 +225,7 @@ static int ad8366_probe(struct spi_device *spi)
 	}
 
 	spi_set_drvdata(spi, indio_dev);
+	mutex_init(&st->lock);
 	st->spi = spi;
 
 	indio_dev->dev.parent = &spi->dev;

--- a/drivers/iio/amplifiers/ad8366.c
+++ b/drivers/iio/amplifiers/ad8366.c
@@ -257,7 +257,8 @@ static int ad8366_probe(struct spi_device *spi)
 		break;
 	default:
 		dev_err(&spi->dev, "Invalid device ID\n");
-		return -EINVAL;
+		ret = -EINVAL;
+		goto error_disable_reg;
 	}
 
 	indio_dev->info = &ad8366_info;


### PR DESCRIPTION
The ad8366 driver has been updated upstream.
This change backports some of the changes that went upstream, but are not in the ADI tree.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>