### PR TITLE
arch: arm: boot: dts: Move adgs1408 dt to its own overlay

### DIFF
--- a/arch/arm/boot/dts/bcm2710-rpi-3-b.dts
+++ b/arch/arm/boot/dts/bcm2710-rpi-3-b.dts
@@ -2,7 +2,6 @@
 
 #include "bcm2710.dtsi"
 #include "bcm283x-rpi-smsc9514.dtsi"
-#include "../../../../include/dt-bindings/mux/mux.h"
 
 / {
 	compatible = "raspberrypi,3-model-b", "brcm,bcm2837";
@@ -15,16 +14,6 @@
 	aliases {
 		serial0 = &uart1;
 		serial1 = &uart0;
-	};
-	adc-mux@3 {
-		compatible = "io-channel-mux";
-		io-channels = <&adc 1>;
-		io-channel-names = "parent";
-		mux-controls = <&mux>;
-
-		channels = "out_a0", "out_a1", "test0", "test1",
-			"out_b0", "out_b1", "testb0", "testb1";
-
 	};
 
 };
@@ -128,7 +117,6 @@
 	pinctrl-names = "default";
 	pinctrl-0 = <&spi0_pins &spi0_cs_pins>;
 	cs-gpios = <&gpio 8 1>, <&gpio 7 1>;
-	status = "okay";
 
 	spidev0: spidev@0{
 		compatible = "spidev";
@@ -145,27 +133,12 @@
 		#size-cells = <0>;
 		spi-max-frequency = <125000000>;
 	};
-	mux: mux-controller@2 {
-		compatible = "adi,adgs1408";
-		reg = <0>;
-		spi-max-frequency = <1000000>;
-		#mux-control-cells = <0>;
-	};
-
-	adc: ad7298@3 {
-		compatible = "ad7298";
-		#io-channel-cells = <1>;
-		spi-max-frequency = <1000000>;
-		reg = <1>;
-	};
-
 };
 
 &i2c0 {
 	pinctrl-names = "default";
 	pinctrl-0 = <&i2c0_pins>;
 	clock-frequency = <100000>;
-	status = "okay";
 };
 
 &i2c1 {

--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -101,6 +101,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	rpi-ad738x.dtbo \
 	rpi-ad7768.dtbo \
 	rpi-ad9834.dtbo \
+	rpi-adgs1408.dtbo \
 	rpi-adxl372.dtbo \
 	rpi-adxl375.dtbo \
 	rpi-ad5770r.dtbo \

--- a/arch/arm/boot/dts/overlays/rpi-adgs1408-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-adgs1408-overlay.dts
@@ -1,0 +1,46 @@
+/dts-v1/;
+/plugin/;
+
+#include "../../../include/dt-bindings/mux/mux.h"
+
+/ {
+	compatible = "brcm,bcm2708";
+
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			adc-mux@3 {
+				compatible = "io-channel-mux";
+				io-channels = <&adc 1>;
+				io-channel-names = "parent";
+				mux-controls = <&mux>;
+
+				channels = "out_a0", "out_a1", "test0", "test1",
+				"out_b0", "out_b1", "testb0", "testb1";
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&spi0>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			mux: mux-controller@2 {
+				compatible = "adi,adgs1408";
+				reg = <0>;
+				spi-max-frequency = <1000000>;
+				#mux-control-cells = <0>;
+			};
+
+			adc: ad7298@3 {
+				compatible = "ad7298";
+				#io-channel-cells = <1>;
+				spi-max-frequency = <1000000>;
+				reg = <1>;
+			};
+		};
+	};
+};


### PR DESCRIPTION
This patch removes the adgs1408 device tree entries from
bcm2710-rpi-3-b.dts and moves them to a new overlay file.

Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>