### PR TITLE
Ad7616 spi core

### DIFF
--- a/drivers/iio/adc/ad7606.c
+++ b/drivers/iio/adc/ad7606.c
@@ -463,36 +463,6 @@ static const struct attribute_group ad7606_attribute_group_range = {
 	.attrs = ad7606_attributes_range,
 };
 
-#define AD760X_CHANNEL(num, mask_sep, mask_type, mask_all) {	\
-		.type = IIO_VOLTAGE,				\
-		.indexed = 1,					\
-		.channel = num,					\
-		.address = num,					\
-		.info_mask_separate = mask_sep,			\
-		.info_mask_shared_by_type = mask_type,		\
-		.info_mask_shared_by_all = mask_all,		\
-		.scan_index = num,				\
-		.scan_type = {					\
-			.sign = 's',				\
-			.realbits = 16,				\
-			.storagebits = 16,			\
-			.endianness = IIO_CPU,			\
-		},						\
-}
-
-#define AD7605_CHANNEL(num)				\
-	AD760X_CHANNEL(num, BIT(IIO_CHAN_INFO_RAW),	\
-		BIT(IIO_CHAN_INFO_SCALE), 0)
-
-#define AD7606_CHANNEL(num)				\
-	AD760X_CHANNEL(num, BIT(IIO_CHAN_INFO_RAW),	\
-		BIT(IIO_CHAN_INFO_SCALE),		\
-		BIT(IIO_CHAN_INFO_OVERSAMPLING_RATIO))
-
-#define AD7606B_CHANNEL(num)	\
-	AD760X_CHANNEL(num, BIT(IIO_CHAN_INFO_RAW) | BIT(IIO_CHAN_INFO_SCALE),\
-		0, BIT(IIO_CHAN_INFO_OVERSAMPLING_RATIO))
-
 static const struct iio_chan_spec ad7605_channels[] = {
 	IIO_CHAN_SOFT_TIMESTAMP(4),
 	AD7605_CHANNEL(0),

--- a/drivers/iio/adc/ad7606.c
+++ b/drivers/iio/adc/ad7606.c
@@ -73,16 +73,6 @@ static const unsigned int ad7606B_oversampling_avail[9] = {
 	1, 2, 4, 8, 16, 32, 64, 128, 256
 };
 
-static int ad7606B_spi_rd_wr_cmd(int addr, char isWriteOp)
-{
-	return (addr & 0x3F) | (((~isWriteOp) & 0x1) << 6);
-}
-
-static int ad7616_spi_rd_wr_cmd(int addr, char isWriteOp)
-{
-	return ((addr & 0x7F) << 1) | ((isWriteOp & 0x1) << 7);
-}
-
 static int ad7606_reset(struct ad7606_state *st)
 {
 	if (st->gpio_reset) {
@@ -522,7 +512,6 @@ static const struct ad7606_chip_info ad7606_chip_info_tbl[] = {
 		.sw_mode_config = ad7606B_sw_mode_config,
 		.oversampling_avail = ad7606_oversampling_avail,
 		.oversampling_num = ARRAY_SIZE(ad7606_oversampling_avail),
-		.spi_rd_wr_cmd = ad7606B_spi_rd_wr_cmd,
 		.write_scale_sw = ad7606_write_scale_sw,
 		.write_os_sw = ad7606_write_os_sw,
 	},
@@ -533,7 +522,6 @@ static const struct ad7606_chip_info ad7606_chip_info_tbl[] = {
 		.oversampling_avail = ad7616_oversampling_avail,
 		.oversampling_num = ARRAY_SIZE(ad7616_oversampling_avail),
 		.os_req_reset = true,
-		.spi_rd_wr_cmd = ad7616_spi_rd_wr_cmd,
 		.write_scale_sw = ad7616_write_scale_sw,
 		.write_os_sw = ad7616_write_os_sw,
 	},

--- a/drivers/iio/adc/ad7606.c
+++ b/drivers/iio/adc/ad7606.c
@@ -28,21 +28,6 @@
 
 #include "ad7606.h"
 
-#define AD7606_RANGE_CH_ADDR(ch)	(0x03 + ((ch) >> 1))
-#define AD7606_OS_MODE			0x08
-#define AD7616_CONFIGURATION_REGISTER	0x02
-#define AD7616_OS_MASK			GENMASK(4,  2)
-
-#define AD7616_RANGE_CH_ADDR_OFF	0x04
-#define AD7616_RANGE_CH_ADDR(ch)	((((ch) & 0x1) << 1) + ((ch) >> 3))
-#define AD7616_RANGE_CH_MSK(ch)		(GENMASK(1, 0) << ((ch) & 0x6))
-#define AD7616_RANGE_CH_MODE(ch, mode)	((mode) << (ch & GENMASK(2, 1)))
-
-/* AD7606_RANGE_CH_X_Y */
-#define AD7606_RANGE_CH_MSK(ch)		(GENMASK(3, 0) << (4 * ((ch) % 2)))
-#define AD7606_RANGE_CH_MODE(ch, mode)	\
-	((GENMASK(3, 0) & mode) << (4 * ((ch) % 2)))
-
 /*
  * Scales are computed as 5000/32768 and 10000/32768 respectively,
  * so that when applied to the raw values they provide mV values
@@ -95,10 +80,8 @@ static int ad7606_reg_access(struct iio_dev *indio_dev,
 	}
 err_unlock:
 	mutex_unlock(&st->lock);
-
 	return ret;
 }
-
 static int ad7606_read_samples(struct ad7606_state *st)
 {
 	unsigned int num = st->chip_info->num_channels;
@@ -240,16 +223,6 @@ static ssize_t in_voltage_scale_available_show(struct device *dev,
 
 static IIO_DEVICE_ATTR_RO(in_voltage_scale_available, 0);
 
-static int ad7606_write_scale_sw(struct iio_dev *indio_dev, int ch, int val)
-{
-	struct ad7606_state *st = iio_priv(indio_dev);
-
-	return st->bops->write_mask(st,
-					AD7606_RANGE_CH_ADDR(ch),
-					AD7606_RANGE_CH_MSK(ch),
-					AD7606_RANGE_CH_MODE(ch, val));
-}
-
 static int ad7606_write_scale_hw(struct iio_dev *indio_dev, int ch, int val)
 {
 	struct ad7606_state *st = iio_priv(indio_dev);
@@ -257,13 +230,6 @@ static int ad7606_write_scale_hw(struct iio_dev *indio_dev, int ch, int val)
 	gpiod_set_value(st->gpio_range, val);
 
 	return 0;
-}
-
-static int ad7606_write_os_sw(struct iio_dev *indio_dev, int val)
-{
-	struct ad7606_state *st = iio_priv(indio_dev);
-
-	return st->bops->reg_write(st, AD7606_OS_MODE, val);
 }
 
 static int ad7606_write_os_hw(struct iio_dev *indio_dev, int val)
@@ -283,26 +249,6 @@ static int ad7606_write_os_hw(struct iio_dev *indio_dev, int val)
 		ad7606_reset(st);
 
 	return 0;
-}
-
-static int ad7616_write_scale_sw(struct iio_dev *indio_dev, int ch, int val)
-{
-	struct ad7606_state *st = iio_priv(indio_dev);
-	unsigned int ch_addr, mode;
-
-	ch_addr = AD7616_RANGE_CH_ADDR_OFF + AD7616_RANGE_CH_ADDR(ch);
-	mode = AD7616_RANGE_CH_MODE(ch, ((val + 1) & 0x3));
-
-	return st->bops->write_mask(st, ch_addr, AD7616_RANGE_CH_MSK(ch),
-				     mode);
-}
-
-static int ad7616_write_os_sw(struct iio_dev *indio_dev, int val)
-{
-	struct ad7606_state *st = iio_priv(indio_dev);
-
-	return st->bops->write_mask(st, AD7616_CONFIGURATION_REGISTER,
-				     AD7616_OS_MASK, val << 2);
 }
 
 static int ad7606_write_raw(struct iio_dev *indio_dev,
@@ -469,8 +415,6 @@ static const struct ad7606_chip_info ad7606_chip_info_tbl[] = {
 		.num_channels = 9,
 		.oversampling_avail = ad7606_oversampling_avail,
 		.oversampling_num = ARRAY_SIZE(ad7606_oversampling_avail),
-		.write_scale_sw = ad7606_write_scale_sw,
-		.write_os_sw = ad7606_write_os_sw,
 	},
 	[ID_AD7616] = {
 		.channels = ad7616_channels,
@@ -478,8 +422,6 @@ static const struct ad7606_chip_info ad7606_chip_info_tbl[] = {
 		.oversampling_avail = ad7616_oversampling_avail,
 		.oversampling_num = ARRAY_SIZE(ad7616_oversampling_avail),
 		.os_req_reset = true,
-		.write_scale_sw = ad7616_write_scale_sw,
-		.write_os_sw = ad7616_write_os_sw,
 	},
 };
 
@@ -582,6 +524,14 @@ static const struct iio_info ad7606_info_no_os_or_range = {
 };
 
 static const struct iio_info ad7606_info_os_and_range = {
+	.driver_module = THIS_MODULE,
+	.read_raw = &ad7606_read_raw,
+	.write_raw = &ad7606_write_raw,
+	.attrs = &ad7606_attribute_group_os_and_range,
+	.validate_trigger = &ad7606_validate_trigger,
+};
+
+static const struct iio_info ad7606_info_os_range_and_debug = {
 	.driver_module = THIS_MODULE,
 	.read_raw = &ad7606_read_raw,
 	.write_raw = &ad7606_write_raw,
@@ -701,33 +651,16 @@ int ad7606_probe(struct device *dev, int irq, void __iomem *base_address,
 							 "adi,sw-mode");
 
 	if (st->sw_mode_en) {
+		indio_dev->info = &ad7606_info_os_range_and_debug;
+
 		/* Scale of 0.076293 is only available in sw mode */
 		st->scale_avail = ad7606B_scale_avail;
 		st->num_scales = ARRAY_SIZE(ad7606B_scale_avail);
 
 		/* After reset, in software mode, ±10 V is set by default */
 		memset32(st->range, 2, ARRAY_SIZE(st->range));
-		indio_dev->info = &ad7606_info_os_and_range;
-
-		/*
-		 * In software mode, the range gpio has no longer its function.
-		 * Instead, the scale can be configured individually for each
-		 * channel from the RANGE_CH registers.
-		 */
-		if (st->chip_info->write_scale_sw)
-			st->write_scale = st->chip_info->write_scale_sw;
-
-		/*
-		 * In software mode, the oversampling is no longer configured
-		 * with GPIO pins. Instead, the oversampling can be configured
-		 * in configuratiion register.
-		 */
-		if (st->chip_info->write_os_sw)
-			st->write_os = st->chip_info->write_os_sw;
 
 		ret = st->bops->sw_mode_config(indio_dev);
-		if (ret < 0)
-			return ret;
 	}
 
 	init_completion(&st->completion);

--- a/drivers/iio/adc/ad7606.c
+++ b/drivers/iio/adc/ad7606.c
@@ -8,7 +8,6 @@
 #include <linux/delay.h>
 #include <linux/device.h>
 #include <linux/err.h>
-#include <linux/gpio/consumer.h>
 #include <linux/interrupt.h>
 #include <linux/kernel.h>
 #include <linux/module.h>
@@ -31,11 +30,9 @@
 
 #define AD7606_RANGE_CH_ADDR(ch)	(0x03 + ((ch) >> 1))
 #define AD7606_OS_MODE			0x08
-
 #define AD7616_CONFIGURATION_REGISTER	0x02
 #define AD7616_OS_MASK			GENMASK(4,  2)
-#define AD7616_BURST_MODE		BIT(6)
-#define AD7616_SEQEN_MODE		BIT(5)
+
 #define AD7616_RANGE_CH_ADDR_OFF	0x04
 #define AD7616_RANGE_CH_ADDR(ch)	((((ch) & 0x1) << 1) + ((ch) >> 3))
 #define AD7616_RANGE_CH_MSK(ch)		(GENMASK(1, 0) << ((ch) & 0x6))
@@ -45,9 +42,6 @@
 #define AD7606_RANGE_CH_MSK(ch)		(GENMASK(3, 0) << (4 * ((ch) % 2)))
 #define AD7606_RANGE_CH_MODE(ch, mode)	\
 	((GENMASK(3, 0) & mode) << (4 * ((ch) % 2)))
-
-static int ad7606B_sw_mode_config(struct iio_dev *indio_dev);
-static int ad7616_sw_mode_config(struct iio_dev *indio_dev);
 
 /*
  * Scales are computed as 5000/32768 and 10000/32768 respectively,
@@ -67,10 +61,6 @@ static const unsigned int ad7606_oversampling_avail[7] = {
 
 static const unsigned int ad7616_oversampling_avail[8] = {
 	1, 2, 4, 8, 16, 32, 64, 128,
-};
-
-static const unsigned int ad7606B_oversampling_avail[9] = {
-	1, 2, 4, 8, 16, 32, 64, 128, 256
 };
 
 static int ad7606_reset(struct ad7606_state *st)
@@ -420,18 +410,6 @@ static const struct iio_chan_spec ad7606_channels[] = {
 	AD7606_CHANNEL(7),
 };
 
-static const struct iio_chan_spec ad7606B_channels[] = {
-	IIO_CHAN_SOFT_TIMESTAMP(8),
-	AD7606B_CHANNEL(0),
-	AD7606B_CHANNEL(1),
-	AD7606B_CHANNEL(2),
-	AD7606B_CHANNEL(3),
-	AD7606B_CHANNEL(4),
-	AD7606B_CHANNEL(5),
-	AD7606B_CHANNEL(6),
-	AD7606B_CHANNEL(7),
-};
-
 /*
  * The current assumption that this driver makes for AD7616, is that it's
  * working in Hardware Mode with Serial, Burst and Sequencer modes activated.
@@ -462,26 +440,6 @@ static const struct iio_chan_spec ad7616_channels[] = {
 	AD7606_CHANNEL(15),
 };
 
-static const struct iio_chan_spec ad7616_soft_channels[] = {
-	IIO_CHAN_SOFT_TIMESTAMP(16),
-	AD7606B_CHANNEL(0),
-	AD7606B_CHANNEL(1),
-	AD7606B_CHANNEL(2),
-	AD7606B_CHANNEL(3),
-	AD7606B_CHANNEL(4),
-	AD7606B_CHANNEL(5),
-	AD7606B_CHANNEL(6),
-	AD7606B_CHANNEL(7),
-	AD7606B_CHANNEL(8),
-	AD7606B_CHANNEL(9),
-	AD7606B_CHANNEL(10),
-	AD7606B_CHANNEL(11),
-	AD7606B_CHANNEL(12),
-	AD7606B_CHANNEL(13),
-	AD7606B_CHANNEL(14),
-	AD7606B_CHANNEL(15),
-};
-
 static const struct ad7606_chip_info ad7606_chip_info_tbl[] = {
 	/* More devices added in future */
 	[ID_AD7605_4] = {
@@ -509,7 +467,6 @@ static const struct ad7606_chip_info ad7606_chip_info_tbl[] = {
 	[ID_AD7606B] = {
 		.channels = ad7606_channels,
 		.num_channels = 9,
-		.sw_mode_config = ad7606B_sw_mode_config,
 		.oversampling_avail = ad7606_oversampling_avail,
 		.oversampling_num = ARRAY_SIZE(ad7606_oversampling_avail),
 		.write_scale_sw = ad7606_write_scale_sw,
@@ -518,7 +475,6 @@ static const struct ad7606_chip_info ad7606_chip_info_tbl[] = {
 	[ID_AD7616] = {
 		.channels = ad7616_channels,
 		.num_channels = 17,
-		.sw_mode_config = ad7616_sw_mode_config,
 		.oversampling_avail = ad7616_oversampling_avail,
 		.oversampling_num = ARRAY_SIZE(ad7616_oversampling_avail),
 		.os_req_reset = true,
@@ -661,51 +617,6 @@ static void ad7606_regulator_disable(void *data)
 	regulator_disable(st->reg);
 }
 
-static int ad7606B_sw_mode_config(struct iio_dev *indio_dev)
-{
-	struct ad7606_state *st = iio_priv(indio_dev);
-	unsigned int buf[3];
-
-	/*
-	 * Software mode is enabled when all three oversampling
-	 * pins are set to high. If oversampling gpios are defined
-	 * in the device tree, then they need to be set to high,
-	 * otherwise, they must be hardwired to VDD
-	 */
-	if (st->gpio_os) {
-		memset32(buf, 1, ARRAY_SIZE(buf));
-		gpiod_set_array_value(ARRAY_SIZE(buf),
-				      st->gpio_os->desc, buf);
-	}
-	/* OS of 128 and 256 are available only in software mode */
-	st->oversampling_avail = ad7606B_oversampling_avail;
-	st->num_os_ratios = ARRAY_SIZE(ad7606B_oversampling_avail);
-	/*
-	 * Scale can be configured individually for each channel
-	 * in software mode.
-	 */
-	indio_dev->channels = ad7606B_channels;
-
-	return 0;
-}
-
-static int ad7616_sw_mode_config(struct iio_dev *indio_dev)
-{
-	struct ad7606_state *st = iio_priv(indio_dev);
-
-	/*
-	 * Scale can be configured individually for each channel
-	 * in software mode.
-	 */
-	indio_dev->channels = ad7616_soft_channels;
-
-	/* Activate Burst mode and SEQEN MODE */
-	return st->bops->write_mask(st,
-			      AD7616_CONFIGURATION_REGISTER,
-			      AD7616_BURST_MODE | AD7616_SEQEN_MODE,
-			      AD7616_BURST_MODE | AD7616_SEQEN_MODE);
-}
-
 int ad7606_probe(struct device *dev, int irq, void __iomem *base_address,
 		 const char *name, unsigned int id,
 		 const struct ad7606_bus_ops *bops)
@@ -785,7 +696,7 @@ int ad7606_probe(struct device *dev, int irq, void __iomem *base_address,
 	st->write_scale = ad7606_write_scale_hw;
 	st->write_os = ad7606_write_os_hw;
 
-	if (st->chip_info->sw_mode_config)
+	if (st->bops->sw_mode_config)
 		st->sw_mode_en = device_property_present(st->dev,
 							 "adi,sw-mode");
 
@@ -814,7 +725,7 @@ int ad7606_probe(struct device *dev, int irq, void __iomem *base_address,
 		if (st->chip_info->write_os_sw)
 			st->write_os = st->chip_info->write_os_sw;
 
-		ret = st->chip_info->sw_mode_config(indio_dev);
+		ret = st->bops->sw_mode_config(indio_dev);
 		if (ret < 0)
 			return ret;
 	}

--- a/drivers/iio/adc/ad7606.c
+++ b/drivers/iio/adc/ad7606.c
@@ -95,59 +95,6 @@ static int ad7606_reset(struct ad7606_state *st)
 	return -ENODEV;
 }
 
-static int ad7606_spi_reg_read(struct ad7606_state *st, unsigned int addr)
-{
-	struct spi_device *spi = to_spi_device(st->dev);
-	struct spi_transfer t[] = {
-		{
-			.tx_buf = &st->data[0],
-			.len = 2,
-			.cs_change = 0,
-		}, {
-			.rx_buf = &st->data[1],
-			.len = 2,
-		},
-	};
-	int ret;
-
-	st->data[0] = cpu_to_be16(st->chip_info->spi_rd_wr_cmd(addr, 0) << 8);
-
-	ret = spi_sync_transfer(spi, t, ARRAY_SIZE(t));
-	if (ret < 0)
-		return ret;
-
-	return be16_to_cpu(st->data[1]);
-}
-
-static int ad7606_spi_reg_write(struct ad7606_state *st,
-				unsigned int addr,
-				unsigned int val)
-{
-	struct spi_device *spi = to_spi_device(st->dev);
-
-	st->data[0] = cpu_to_be16((st->chip_info->spi_rd_wr_cmd(addr, 1) << 8) |
-				  (val & 0x1FF));
-
-	return spi_write(spi, &st->data[0], sizeof(st->data[0]));
-}
-
-static int ad7606_spi_write_mask(struct ad7606_state *st,
-				 unsigned int addr,
-				 unsigned long mask,
-				 unsigned int val)
-{
-	int readval;
-
-	readval = ad7606_spi_reg_read(st, addr);
-	if (readval < 0)
-		return readval;
-
-	readval &= ~mask;
-	readval |= val;
-
-	return ad7606_spi_reg_write(st, addr, readval);
-}
-
 static int ad7606_reg_access(struct iio_dev *indio_dev,
 			     unsigned int reg,
 			     unsigned int writeval,
@@ -158,13 +105,13 @@ static int ad7606_reg_access(struct iio_dev *indio_dev,
 
 	mutex_lock(&st->lock);
 	if (readval) {
-		ret = ad7606_spi_reg_read(st, reg);
+		ret = st->bops->reg_read(st, reg);
 		if (ret < 0)
 			goto err_unlock;
 		*readval = ret;
 		ret = 0;
 	} else {
-		ret = ad7606_spi_reg_write(st, reg, writeval);
+		ret = st->bops->reg_write(st, reg, writeval);
 	}
 err_unlock:
 	mutex_unlock(&st->lock);
@@ -317,10 +264,10 @@ static int ad7606_write_scale_sw(struct iio_dev *indio_dev, int ch, int val)
 {
 	struct ad7606_state *st = iio_priv(indio_dev);
 
-	return ad7606_spi_write_mask(st,
-				     AD7606_RANGE_CH_ADDR(ch),
-				     AD7606_RANGE_CH_MSK(ch),
-				     AD7606_RANGE_CH_MODE(ch, val));
+	return st->bops->write_mask(st,
+					AD7606_RANGE_CH_ADDR(ch),
+					AD7606_RANGE_CH_MSK(ch),
+					AD7606_RANGE_CH_MODE(ch, val));
 }
 
 static int ad7606_write_scale_hw(struct iio_dev *indio_dev, int ch, int val)
@@ -336,7 +283,7 @@ static int ad7606_write_os_sw(struct iio_dev *indio_dev, int val)
 {
 	struct ad7606_state *st = iio_priv(indio_dev);
 
-	return ad7606_spi_reg_write(st, AD7606_OS_MODE, val);
+	return st->bops->reg_write(st, AD7606_OS_MODE, val);
 }
 
 static int ad7606_write_os_hw(struct iio_dev *indio_dev, int val)
@@ -366,7 +313,7 @@ static int ad7616_write_scale_sw(struct iio_dev *indio_dev, int ch, int val)
 	ch_addr = AD7616_RANGE_CH_ADDR_OFF + AD7616_RANGE_CH_ADDR(ch);
 	mode = AD7616_RANGE_CH_MODE(ch, ((val + 1) & 0x3));
 
-	return ad7606_spi_write_mask(st, ch_addr, AD7616_RANGE_CH_MSK(ch),
+	return st->bops->write_mask(st, ch_addr, AD7616_RANGE_CH_MSK(ch),
 				     mode);
 }
 
@@ -374,7 +321,7 @@ static int ad7616_write_os_sw(struct iio_dev *indio_dev, int val)
 {
 	struct ad7606_state *st = iio_priv(indio_dev);
 
-	return ad7606_spi_write_mask(st, AD7616_CONFIGURATION_REGISTER,
+	return st->bops->write_mask(st, AD7616_CONFIGURATION_REGISTER,
 				     AD7616_OS_MASK, val << 2);
 }
 
@@ -765,7 +712,7 @@ static int ad7616_sw_mode_config(struct iio_dev *indio_dev)
 	indio_dev->channels = ad7616_soft_channels;
 
 	/* Activate Burst mode and SEQEN MODE */
-	return ad7606_spi_write_mask(st,
+	return st->bops->write_mask(st,
 			      AD7616_CONFIGURATION_REGISTER,
 			      AD7616_BURST_MODE | AD7616_SEQEN_MODE,
 			      AD7616_BURST_MODE | AD7616_SEQEN_MODE);

--- a/drivers/iio/adc/ad7606.h
+++ b/drivers/iio/adc/ad7606.h
@@ -8,6 +8,36 @@
 #ifndef IIO_ADC_AD7606_H_
 #define IIO_ADC_AD7606_H_
 
+#define AD760X_CHANNEL(num, mask_sep, mask_type, mask_all) {	\
+		.type = IIO_VOLTAGE,				\
+		.indexed = 1,					\
+		.channel = num,					\
+		.address = num,					\
+		.info_mask_separate = mask_sep,			\
+		.info_mask_shared_by_type = mask_type,		\
+		.info_mask_shared_by_all = mask_all,		\
+		.scan_index = num,				\
+		.scan_type = {					\
+			.sign = 's',				\
+			.realbits = 16,				\
+			.storagebits = 16,			\
+			.endianness = IIO_CPU,			\
+		},						\
+}
+
+#define AD7605_CHANNEL(num)				\
+	AD760X_CHANNEL(num, BIT(IIO_CHAN_INFO_RAW),	\
+		BIT(IIO_CHAN_INFO_SCALE), 0)
+
+#define AD7606_CHANNEL(num)				\
+	AD760X_CHANNEL(num, BIT(IIO_CHAN_INFO_RAW),	\
+		BIT(IIO_CHAN_INFO_SCALE),		\
+		BIT(IIO_CHAN_INFO_OVERSAMPLING_RATIO))
+
+#define AD7606B_CHANNEL(num)	\
+	AD760X_CHANNEL(num, BIT(IIO_CHAN_INFO_RAW) | BIT(IIO_CHAN_INFO_SCALE),\
+		0, BIT(IIO_CHAN_INFO_OVERSAMPLING_RATIO))
+
 /**
  * struct ad7606_chip_info - chip specific information
  * @channels:		channel specification

--- a/drivers/iio/adc/ad7606.h
+++ b/drivers/iio/adc/ad7606.h
@@ -6,6 +6,9 @@
  */
 
 #ifndef IIO_ADC_AD7606_H_
+
+#include <linux/gpio/consumer.h>
+
 #define IIO_ADC_AD7606_H_
 
 #define AD760X_CHANNEL(num, mask_sep, mask_type, mask_all) {	\
@@ -50,8 +53,6 @@
 			in software mode
  * @write_os_sw		pointer to the function which writes the os via spi
 			in software mode
- * @sw_mode_config:	pointer to a function which configured the device
- *			for software mode
  */
 struct ad7606_chip_info {
 	const struct iio_chan_spec	*channels;
@@ -61,7 +62,6 @@ struct ad7606_chip_info {
 	bool				os_req_reset;
 	int (*write_scale_sw)(struct iio_dev *indio_dev, int, int);
 	int (*write_os_sw)(struct iio_dev *indio_dev, int);
-	int (*sw_mode_config)(struct iio_dev *indio_dev);
 };
 
 /**
@@ -135,6 +135,8 @@ struct ad7606_state {
  * @reg_write	function pointer for writing spi register
  * @write_mask	function pointer for write spi register with mask
  * @rd_wr_cmd	pointer to the function which calculates the spi address
+ * @sw_mode_config	pointer to a function which configured the device
+ *			for software mode
  */
 struct ad7606_bus_ops {
 	/* more methods added in future? */
@@ -148,6 +150,7 @@ struct ad7606_bus_ops {
 				 unsigned long mask,
 				 unsigned int val);
 	u16 (*rd_wr_cmd)(int, char);
+	int (*sw_mode_config)(struct iio_dev *indio_dev);
 };
 
 int ad7606_probe(struct device *dev, int irq, void __iomem *base_address,

--- a/drivers/iio/adc/ad7606.h
+++ b/drivers/iio/adc/ad7606.h
@@ -49,10 +49,6 @@
  *			oversampling ratios.
  * @oversampling_num	number of elements stored in oversampling_avail array
  * @os_req_reset	some devices require a reset to update oversampling
- * @write_scale_sw	pointer to the function which writes the scale via spi
-			in software mode
- * @write_os_sw		pointer to the function which writes the os via spi
-			in software mode
  */
 struct ad7606_chip_info {
 	const struct iio_chan_spec	*channels;
@@ -60,8 +56,6 @@ struct ad7606_chip_info {
 	const unsigned int		*oversampling_avail;
 	unsigned int			oversampling_num;
 	bool				os_req_reset;
-	int (*write_scale_sw)(struct iio_dev *indio_dev, int, int);
-	int (*write_os_sw)(struct iio_dev *indio_dev, int);
 };
 
 /**

--- a/drivers/iio/adc/ad7606.h
+++ b/drivers/iio/adc/ad7606.h
@@ -46,7 +46,6 @@
  *			oversampling ratios.
  * @oversampling_num	number of elements stored in oversampling_avail array
  * @os_req_reset	some devices require a reset to update oversampling
- * @spi_rd_wr_cmd	pointer to the function which calculates the spi address
  * @write_scale_sw	pointer to the function which writes the scale via spi
 			in software mode
  * @write_os_sw		pointer to the function which writes the os via spi
@@ -60,7 +59,6 @@ struct ad7606_chip_info {
 	const unsigned int		*oversampling_avail;
 	unsigned int			oversampling_num;
 	bool				os_req_reset;
-	int (*spi_rd_wr_cmd)(int, char);
 	int (*write_scale_sw)(struct iio_dev *indio_dev, int, int);
 	int (*write_os_sw)(struct iio_dev *indio_dev, int);
 	int (*sw_mode_config)(struct iio_dev *indio_dev);
@@ -136,6 +134,7 @@ struct ad7606_state {
  * @reg_read	function pointer for reading spi register
  * @reg_write	function pointer for writing spi register
  * @write_mask	function pointer for write spi register with mask
+ * @rd_wr_cmd	pointer to the function which calculates the spi address
  */
 struct ad7606_bus_ops {
 	/* more methods added in future? */
@@ -148,6 +147,7 @@ struct ad7606_bus_ops {
 				 unsigned int addr,
 				 unsigned long mask,
 				 unsigned int val);
+	u16 (*rd_wr_cmd)(int, char);
 };
 
 int ad7606_probe(struct device *dev, int irq, void __iomem *base_address,

--- a/drivers/iio/adc/ad7606.h
+++ b/drivers/iio/adc/ad7606.h
@@ -133,10 +133,21 @@ struct ad7606_state {
 /**
  * struct ad7606_bus_ops - driver bus operations
  * @read_block		function pointer for reading blocks of data
+ * @reg_read	function pointer for reading spi register
+ * @reg_write	function pointer for writing spi register
+ * @write_mask	function pointer for write spi register with mask
  */
 struct ad7606_bus_ops {
 	/* more methods added in future? */
 	int (*read_block)(struct device *, int, void *);
+	int (*reg_read)(struct ad7606_state *st, unsigned int addr);
+	int (*reg_write)(struct ad7606_state *st,
+				unsigned int addr,
+				unsigned int val);
+	int (*write_mask)(struct ad7606_state *st,
+				 unsigned int addr,
+				 unsigned long mask,
+				 unsigned int val);
 };
 
 int ad7606_probe(struct device *dev, int irq, void __iomem *base_address,

--- a/drivers/iio/adc/ad7606_spi.c
+++ b/drivers/iio/adc/ad7606_spi.c
@@ -15,6 +15,46 @@
 
 #define MAX_SPI_FREQ_HZ		23500000	/* VDRIVE above 4.75 V */
 
+#define AD7616_CONFIGURATION_REGISTER	0x02
+#define AD7616_BURST_MODE		BIT(6)
+#define AD7616_SEQEN_MODE		BIT(5)
+
+static const unsigned int ad7606B_oversampling_avail[9] = {
+	1, 2, 4, 8, 16, 32, 64, 128, 256
+};
+
+static const struct iio_chan_spec ad7606B_soft_channels[] = {
+	IIO_CHAN_SOFT_TIMESTAMP(8),
+	AD7606B_CHANNEL(0),
+	AD7606B_CHANNEL(1),
+	AD7606B_CHANNEL(2),
+	AD7606B_CHANNEL(3),
+	AD7606B_CHANNEL(4),
+	AD7606B_CHANNEL(5),
+	AD7606B_CHANNEL(6),
+	AD7606B_CHANNEL(7),
+};
+
+static const struct iio_chan_spec ad7616_soft_channels[] = {
+	IIO_CHAN_SOFT_TIMESTAMP(16),
+	AD7606B_CHANNEL(0),
+	AD7606B_CHANNEL(1),
+	AD7606B_CHANNEL(2),
+	AD7606B_CHANNEL(3),
+	AD7606B_CHANNEL(4),
+	AD7606B_CHANNEL(5),
+	AD7606B_CHANNEL(6),
+	AD7606B_CHANNEL(7),
+	AD7606B_CHANNEL(8),
+	AD7606B_CHANNEL(9),
+	AD7606B_CHANNEL(10),
+	AD7606B_CHANNEL(11),
+	AD7606B_CHANNEL(12),
+	AD7606B_CHANNEL(13),
+	AD7606B_CHANNEL(14),
+	AD7606B_CHANNEL(15),
+};
+
 static u16 ad7606B_spi_rd_wr_cmd(int addr, char isWriteOp)
 {
 	return (addr & 0x3F) | (((~isWriteOp) & 0x1) << 6);
@@ -97,6 +137,51 @@ static int ad7606_spi_read_block(struct device *dev,
 	return 0;
 }
 
+static int ad7606B_sw_mode_config(struct iio_dev *indio_dev)
+{
+	struct ad7606_state *st = iio_priv(indio_dev);
+	unsigned int buf[3];
+
+	/*
+	 * Software mode is enabled when all three oversampling
+	 * pins are set to high. If oversampling gpios are defined
+	 * in the device tree, then they need to be set to high,
+	 * otherwise, they must be hardwired to VDD
+	 */
+	if (st->gpio_os) {
+		memset32(buf, 1, ARRAY_SIZE(buf));
+		gpiod_set_array_value(ARRAY_SIZE(buf),
+				      st->gpio_os->desc, buf);
+	}
+	/* OS of 128 and 256 are available only in software mode */
+	st->oversampling_avail = ad7606B_oversampling_avail;
+	st->num_os_ratios = ARRAY_SIZE(ad7606B_oversampling_avail);
+	/*
+	 * Scale can be configured individually for each channel
+	 * in software mode.
+	 */
+	indio_dev->channels = ad7606B_soft_channels;
+
+	return 0;
+}
+
+static int ad7616_sw_mode_config(struct iio_dev *indio_dev)
+{
+	struct ad7606_state *st = iio_priv(indio_dev);
+
+	/*
+	 * Scale can be configured individually for each channel
+	 * in software mode.
+	 */
+	indio_dev->channels = ad7616_soft_channels;
+
+	/* Activate Burst mode and SEQEN MODE */
+	return st->bops->write_mask(st,
+			      AD7616_CONFIGURATION_REGISTER,
+			      AD7616_BURST_MODE | AD7616_SEQEN_MODE,
+			      AD7616_BURST_MODE | AD7616_SEQEN_MODE);
+}
+
 static const struct ad7606_bus_ops ad7606_spi_bops = {
 	.read_block = ad7606_spi_read_block,
 };
@@ -107,6 +192,7 @@ static const struct ad7606_bus_ops ad7616_spi_bops = {
 	.reg_write = ad7606_spi_reg_write,
 	.write_mask = ad7606_spi_write_mask,
 	.rd_wr_cmd = ad7616_spi_rd_wr_cmd,
+	.sw_mode_config = ad7616_sw_mode_config,
 };
 
 static const struct ad7606_bus_ops ad7606B_spi_bops = {
@@ -115,6 +201,7 @@ static const struct ad7606_bus_ops ad7606B_spi_bops = {
 	.reg_write = ad7606_spi_reg_write,
 	.write_mask = ad7606_spi_write_mask,
 	.rd_wr_cmd = ad7606B_spi_rd_wr_cmd,
+	.sw_mode_config = ad7606B_sw_mode_config,
 };
 
 static int ad7606_spi_probe(struct spi_device *spi)


### PR DESCRIPTION
The part of the driver which is used only in software mode were moved in spi file.