### PR TITLE
iio: accel: adxl372: Fix FIFO number of samples limitation

### DIFF
--- a/drivers/iio/accel/adxl372.c
+++ b/drivers/iio/accel/adxl372.c
@@ -799,15 +799,6 @@ static int adxl372_buffer_postenable(struct iio_dev *indio_dev)
 	st->fifo_format = adxl372_axis_lookup_table[i].fifo_format;
 	st->fifo_set_size = bitmap_weight(indio_dev->active_scan_mask,
 					  indio_dev->masklength);
-	/*
-	 * The 512 FIFO samples can be allotted in several ways, such as:
-	 * 170 sample sets of concurrent 3-axis data
-	 * 256 sample sets of concurrent 2-axis data (user selectable)
-	 * 512 sample sets of single-axis data
-	 */
-	if ((st->watermark * st->fifo_set_size) > ADXL372_FIFO_SIZE)
-		st->watermark = (ADXL372_FIFO_SIZE  / st->fifo_set_size);
-
 	st->fifo_mode = ADXL372_FIFO_STREAMED;
 
 	ret = adxl372_configure_fifo(st);


### PR DESCRIPTION
Currently, the driver sets the FIFO_SAMPLES register with the number of
sample sets (maximum of 170 for 3 axis data, 256 for 2-axis and 512 for
single axis). However, the FIFO_SAMPLES register should store the number
of samples, regardless of how the FIFO format is configured.

This issue was reported in this EZ thread: https://ez.analog.com/linux-device-drivers/linux-software-drivers/f/q-a/113234/adxl372-setting-of-water-mark-level-not-clear