### PR TITLE
iio: use common FPGA defs

### DIFF
--- a/drivers/iio/adc/ad9361_conv.c
+++ b/drivers/iio/adc/ad9361_conv.c
@@ -344,7 +344,7 @@ int ad9361_hdl_loopback(struct ad9361_rf_phy *phy, bool enable)
 	version = axiadc_read(st, 0x4000);
 
 	/* Still there but implemented a bit different */
-	if (PCORE_VERSION_MAJOR(version) > 7)
+	if (ADI_AXI_PCORE_VER_MAJOR(version) > 7)
 		addr = 0x4418;
 	else
 		addr = 0x4414;
@@ -352,7 +352,7 @@ int ad9361_hdl_loopback(struct ad9361_rf_phy *phy, bool enable)
 	for (chan = 0; chan < conv->chip_info->num_channels; chan++) {
 		reg = axiadc_read(st, addr + (chan) * 0x40);
 
-		if (PCORE_VERSION_MAJOR(version) > 7) {
+		if (ADI_AXI_PCORE_VER_MAJOR(version) > 7) {
 			if (enable && reg != 0x8) {
 				conv->scratch_reg[chan] = reg;
 				reg = 0x8;
@@ -377,7 +377,7 @@ static int ad9361_iodelay_set(struct axiadc_state *st, unsigned lane,
 			      unsigned val, bool tx)
 {
 	if (tx) {
-		if (PCORE_VERSION_MAJOR(st->pcore_version) > 8)
+		if (ADI_AXI_PCORE_VER_MAJOR(st->pcore_version) > 8)
 			axiadc_write(st, 0x4000 + ADI_REG_DELAY(lane), val);
 		else
 			return -ENODEV;
@@ -563,7 +563,7 @@ static int ad9361_dig_tune_tx(struct ad9361_rf_phy *phy, unsigned long max_freq,
 			ADI_ENABLE | ADI_IQCOR_ENB);
 		axiadc_set_pnsel(st, chan, ADC_PN_CUSTOM);
 		saved_chan_ctrl6[chan] = axiadc_read(st, 0x4414 + (chan) * 0x40);
-		if (PCORE_VERSION_MAJOR(hdl_dac_version) > 7) {
+		if (ADI_AXI_PCORE_VER_MAJOR(hdl_dac_version) > 7) {
 			saved_dsel[chan] = axiadc_read(st, 0x4418 + (chan) * 0x40);
 			axiadc_write(st, 0x4418 + (chan) * 0x40, 9);
 			axiadc_write(st, 0x4414 + (chan) * 0x40, 0); /* !IQCOR_ENB */
@@ -572,7 +572,7 @@ static int ad9361_dig_tune_tx(struct ad9361_rf_phy *phy, unsigned long max_freq,
 			axiadc_write(st, 0x4414 + (chan) * 0x40, 1); /* DAC_PN_ENB */
 		}
 	}
-	if (PCORE_VERSION_MAJOR(hdl_dac_version) < 8) {
+	if (ADI_AXI_PCORE_VER_MAJOR(hdl_dac_version) < 8) {
 		saved = tmp = axiadc_read(st, 0x4048);
 		tmp &= ~0xF;
 		tmp |= 1;
@@ -583,14 +583,14 @@ static int ad9361_dig_tune_tx(struct ad9361_rf_phy *phy, unsigned long max_freq,
 	if (flags & DO_ODELAY)
 		ad9361_dig_tune_iodelay(phy, true);
 
-	if (PCORE_VERSION_MAJOR(hdl_dac_version) < 8)
+	if (ADI_AXI_PCORE_VER_MAJOR(hdl_dac_version) < 8)
 		axiadc_write(st, 0x4048, saved);
 
 	for (chan = 0; chan < num_chan; chan++) {
 		axiadc_write(st, ADI_REG_CHAN_CNTRL(chan),
 			     saved_chan_ctrl0[chan]);
 		axiadc_set_pnsel(st, chan, ADC_PN9);
-		if (PCORE_VERSION_MAJOR(hdl_dac_version) > 7) {
+		if (ADI_AXI_PCORE_VER_MAJOR(hdl_dac_version) > 7) {
 			axiadc_write(st, 0x4418 + chan * 0x40,
 				     saved_dsel[chan]);
 			axiadc_write(st, 0x4044, 1);
@@ -709,13 +709,13 @@ static int ad9361_post_setup(struct iio_dev *indio_dev)
 
 	flags = 0;
 
-	ret = ad9361_dig_tune(phy, (axiadc_read(st, ADI_REG_ID)) ?
+	ret = ad9361_dig_tune(phy, (axiadc_read(st, ADI_AXI_REG_ID)) ?
 		0 : 61440000, flags);
 	if (ret < 0)
 		goto error;
 
 	if (flags & (DO_IDELAY | DO_ODELAY)) {
-		ret = ad9361_dig_tune(phy, (axiadc_read(st, ADI_REG_ID)) ?
+		ret = ad9361_dig_tune(phy, (axiadc_read(st, ADI_AXI_REG_ID)) ?
 			0 : 61440000, flags & BE_VERBOSE);
 		if (ret < 0)
 			goto error;

--- a/drivers/iio/adc/ad9371_conv.c
+++ b/drivers/iio/adc/ad9371_conv.c
@@ -138,7 +138,7 @@ int ad9371_hdl_loopback(struct ad9371_rf_phy *phy, bool enable)
 	version = axiadc_read(st, 0x4000);
 
 	/* Still there but implemented a bit different */
-	if (PCORE_VERSION_MAJOR(version) > 7)
+	if (ADI_AXI_PCORE_VER_MAJOR(version) > 7)
 		addr = 0x4418;
 	else
 		addr = 0x4414;
@@ -146,7 +146,7 @@ int ad9371_hdl_loopback(struct ad9371_rf_phy *phy, bool enable)
 	for (chan = 0; chan < conv->chip_info->num_channels; chan++) {
 		reg = axiadc_read(st, addr + (chan) * 0x40);
 
-		if (PCORE_VERSION_MAJOR(version) > 7) {
+		if (ADI_AXI_PCORE_VER_MAJOR(version) > 7) {
 			if (enable && reg != 0x8) {
 				conv->scratch_reg[chan] = reg;
 				reg = 0x8;

--- a/drivers/iio/adc/ad_adc.c
+++ b/drivers/iio/adc/ad_adc.c
@@ -557,7 +557,7 @@ static int adc_probe(struct platform_device *pdev)
 	adc_write(st, ADI_REG_RSTN, 0);
 	adc_write(st, ADI_REG_RSTN, ADI_RSTN);
 
-	st->pcore_version = adc_read(st, ADI_REG_VERSION);
+	st->pcore_version = adc_read(st, ADI_AXI_REG_VERSION);
 
 	if (info->has_frontend) {
 		st->frontend = iio_hw_consumer_alloc(&pdev->dev);

--- a/drivers/iio/adc/admc_adc.c
+++ b/drivers/iio/adc/admc_adc.c
@@ -125,7 +125,7 @@ static int axiadc_probe(struct platform_device *pdev)
 	axiadc_write(st, ADI_REG_RSTN, 0);
 	axiadc_write(st, ADI_REG_RSTN, ADI_RSTN);
 
-	st->pcore_version = axiadc_read(st, ADI_REG_VERSION);
+	st->pcore_version = axiadc_read(st, ADI_AXI_REG_VERSION);
 
 	indio_dev->dev.parent = &pdev->dev;
 	indio_dev->name = pdev->dev.of_node->name;
@@ -148,7 +148,7 @@ static int axiadc_probe(struct platform_device *pdev)
 	dev_info(&pdev->dev, "ADI AIM (0x%X) at 0x%08llX mapped to 0x%p, probed ADC %s as %s\n",
 		 st->pcore_version,
 		 (unsigned long long)mem->start, st->regs, chip_info->name,
-		 axiadc_read(st, ADI_REG_ID) ? "SLAVE" : "MASTER");
+		 axiadc_read(st, ADI_AXI_REG_ID) ? "SLAVE" : "MASTER");
 
 	return 0;
 

--- a/drivers/iio/adc/admc_ctrl.c
+++ b/drivers/iio/adc/admc_ctrl.c
@@ -482,7 +482,7 @@ static int mc_ctrl_probe(struct platform_device *pdev)
 	mc_ctrl_write(st, ADI_REG_RSTN, 0);
 	mc_ctrl_write(st, ADI_REG_RSTN, ADI_RSTN);
 
-	st->pcore_version = axiadc_read(st, ADI_REG_VERSION);
+	st->pcore_version = axiadc_read(st, ADI_AXI_REG_ID);
 
 	ret = iio_device_register(indio_dev);
 

--- a/drivers/iio/adc/admc_speed.c
+++ b/drivers/iio/adc/admc_speed.c
@@ -121,7 +121,7 @@ static int axiadc_probe(struct platform_device *pdev)
 	axiadc_write(st, ADI_REG_RSTN, 0);
 	axiadc_write(st, ADI_REG_RSTN, ADI_RSTN);
 
-	st->pcore_version = axiadc_read(st, ADI_REG_VERSION);
+	st->pcore_version = axiadc_read(st, ADI_AXI_REG_VERSION);
 
 	indio_dev->dev.parent = &pdev->dev;
 	indio_dev->name = pdev->dev.of_node->name;
@@ -143,7 +143,7 @@ static int axiadc_probe(struct platform_device *pdev)
 
 	dev_info(&pdev->dev, "ADI AIM (0x%X) at 0x%08llX mapped to 0x%p, probed ADC %s as %s\n",
 		 st->pcore_version, (unsigned long long)mem->start, st->regs,
-		 chip_info->name, axiadc_read(st, ADI_REG_ID) ? "SLAVE" : "MASTER");
+		 chip_info->name, axiadc_read(st, ADI_AXI_REG_ID) ? "SLAVE" : "MASTER");
 
 	return 0;
 

--- a/drivers/iio/adc/adrv9009_conv.c
+++ b/drivers/iio/adc/adrv9009_conv.c
@@ -168,7 +168,7 @@ int adrv9009_hdl_loopback(struct adrv9009_rf_phy *phy, bool enable)
 	version = axiadc_read(st, 0x4000);
 
 	/* Still there but implemented a bit different */
-	if (PCORE_VERSION_MAJOR(version) > 7)
+	if (ADI_AXI_PCORE_VER_MAJOR(version) > 7)
 		addr = 0x4418;
 	else
 		addr = 0x4414;
@@ -176,7 +176,7 @@ int adrv9009_hdl_loopback(struct adrv9009_rf_phy *phy, bool enable)
 	for (chan = 0; chan < conv->chip_info->num_channels; chan++) {
 		reg = axiadc_read(st, addr + (chan) * 0x40);
 
-		if (PCORE_VERSION_MAJOR(version) > 7) {
+		if (ADI_AXI_PCORE_VER_MAJOR(version) > 7) {
 			if (enable && reg != 0x8) {
 				conv->scratch_reg[chan] = reg;
 				reg = 0x8;

--- a/drivers/iio/adc/cf_axi_adc.h
+++ b/drivers/iio/adc/cf_axi_adc.h
@@ -11,18 +11,7 @@
 #ifndef ADI_AXI_ADC_H_
 #define ADI_AXI_ADC_H_
 
-#define ADI_REG_VERSION		0x0000				/*Version and Scratch Registers */
-#define ADI_VERSION(x)		(((x) & 0xffffffff) << 0)	/* RO, Version number. */
-#define VERSION_IS(x,y,z)	((x) << 16 | (y) << 8 | (z))
-#define ADI_REG_ID		0x0004			 	/*Version and Scratch Registers */
-#define ADI_ID(x)		(((x) & 0xffffffff) << 0)   	/* RO, Instance identifier number. */
-#define ADI_REG_SCRATCH		0x0008			 	/*Version and Scratch Registers */
-#define ADI_SCRATCH(x)		(((x) & 0xffffffff) << 0)	/* RW, Scratch register. */
-
-#define PCORE_VERSION(major, minor, letter) ((major << 16) | (minor << 8) | letter)
-#define PCORE_VERSION_MAJOR(version) (version >> 16)
-#define PCORE_VERSION_MINOR(version) ((version >> 8) & 0xff)
-#define PCORE_VERSION_LETTER(version) (version & 0xff)
+#include <linux/fpga/adi-axi-common.h>
 
 /* ADC COMMON */
 
@@ -337,7 +326,7 @@ static inline unsigned int axiadc_slave_read(struct axiadc_state *st, unsigned r
 static inline void axiadc_idelay_set(struct axiadc_state *st,
 				unsigned lane, unsigned val)
 {
-	if (PCORE_VERSION_MAJOR(st->pcore_version) > 8) {
+	if (ADI_AXI_PCORE_VER_MAJOR(st->pcore_version) > 8) {
 		axiadc_write(st, ADI_REG_DELAY(lane), val);
 	} else {
 		axiadc_write(st, ADI_REG_DELAY_CNTRL, 0);

--- a/drivers/iio/adc/cf_axi_adc_core.c
+++ b/drivers/iio/adc/cf_axi_adc_core.c
@@ -48,7 +48,7 @@ int axiadc_set_pnsel(struct axiadc_state *st, int channel, enum adc_pn_sel sel)
 {
 	unsigned reg;
 
-	if (PCORE_VERSION_MAJOR(st->pcore_version) > 7) {
+	if (ADI_AXI_PCORE_VER_MAJOR(st->pcore_version) > 7) {
 		reg = axiadc_read(st, ADI_REG_CHAN_CNTRL_3(channel));
 		reg &= ~ADI_ADC_PN_SEL(~0);
 		reg |= ADI_ADC_PN_SEL(sel);
@@ -78,7 +78,7 @@ enum adc_pn_sel axiadc_get_pnsel(struct axiadc_state *st,
 {
 	unsigned val;
 
-	if (PCORE_VERSION_MAJOR(st->pcore_version) > 7) {
+	if (ADI_AXI_PCORE_VER_MAJOR(st->pcore_version) > 7) {
 		const char *ident[] = {"PN9", "PN23A", "UNDEF", "UNDEF",
 				"PN7", "PN15", "PN23", "PN31", "UNDEF", "PN_CUSTOM"};
 
@@ -686,19 +686,19 @@ static int axiadc_attach_spi_client(struct device *dev, void *data)
 }
 
 static const struct axiadc_core_info ad9467_core_1_00_a_info = {
-	.version = PCORE_VERSION(10, 0, 'a'),
+	.version = ADI_AXI_PCORE_VER(10, 0, 'a'),
 };
 
 static const struct axiadc_core_info ad9361_6_00_a_info = {
-	.version = PCORE_VERSION(10, 0, 'a'),
+	.version = ADI_AXI_PCORE_VER(10, 0, 'a'),
 };
 
 static const struct axiadc_core_info ad9643_6_00_a_info = {
-	.version = PCORE_VERSION(10, 0, 'a'),
+	.version = ADI_AXI_PCORE_VER(10, 0, 'a'),
 };
 
 static const struct axiadc_core_info ad9680_6_00_a_info = {
-	.version = PCORE_VERSION(10, 0, 'a'),
+	.version = ADI_AXI_PCORE_VER(10, 0, 'a'),
 };
 
 /* Match table for of_platform binding */
@@ -820,17 +820,17 @@ static int axiadc_probe(struct platform_device *pdev)
 	mdelay(10);
 	axiadc_write(st, ADI_REG_RSTN, ADI_RSTN | ADI_MMCM_RSTN);
 
-	st->pcore_version = axiadc_read(st, ADI_REG_VERSION);
+	st->pcore_version = axiadc_read(st, ADI_AXI_REG_VERSION);
 
-	if (PCORE_VERSION_MAJOR(st->pcore_version) >
-		PCORE_VERSION_MAJOR(info->version)) {
+	if (ADI_AXI_PCORE_VER_MAJOR(st->pcore_version) >
+		ADI_AXI_PCORE_VER_MAJOR(info->version)) {
 		dev_err(&pdev->dev, "Major version mismatch between PCORE and driver. Driver expected %d.%.2d.%c, PCORE reported %d.%.2d.%c\n",
-			PCORE_VERSION_MAJOR(info->version),
-			PCORE_VERSION_MINOR(info->version),
-			PCORE_VERSION_LETTER(info->version),
-			PCORE_VERSION_MAJOR(st->pcore_version),
-			PCORE_VERSION_MINOR(st->pcore_version),
-			PCORE_VERSION_LETTER(st->pcore_version));
+			ADI_AXI_PCORE_VER_MAJOR(info->version),
+			ADI_AXI_PCORE_VER_MINOR(info->version),
+			ADI_AXI_PCORE_VER_PATCH(info->version),
+			ADI_AXI_PCORE_VER_MAJOR(st->pcore_version),
+			ADI_AXI_PCORE_VER_MINOR(st->pcore_version),
+			ADI_AXI_PCORE_VER_PATCH(st->pcore_version));
 		ret = -ENODEV;
 		goto err_put_converter;
 	}
@@ -853,7 +853,7 @@ static int axiadc_probe(struct platform_device *pdev)
 			goto err_put_converter;
 	}
 
-	if (!st->dp_disable && !axiadc_read(st, ADI_REG_ID) &&
+	if (!st->dp_disable && !axiadc_read(st, ADI_AXI_REG_ID) &&
 		of_find_property(pdev->dev.of_node, "dmas", NULL)) {
 		ret = axiadc_configure_ring_stream(indio_dev, NULL);
 		if (ret < 0)
@@ -872,12 +872,12 @@ static int axiadc_probe(struct platform_device *pdev)
 
 	dev_info(&pdev->dev, "ADI AIM (%d.%.2d.%c) at 0x%08llX mapped to 0x%p,"
 		 " probed ADC %s as %s\n",
-		PCORE_VERSION_MAJOR(st->pcore_version),
-		PCORE_VERSION_MINOR(st->pcore_version),
-		PCORE_VERSION_LETTER(st->pcore_version),
+		ADI_AXI_PCORE_VER_MAJOR(st->pcore_version),
+		ADI_AXI_PCORE_VER_MINOR(st->pcore_version),
+		ADI_AXI_PCORE_VER_PATCH(st->pcore_version),
 		 (unsigned long long)mem->start, st->regs,
 		 conv->chip_info->name,
-		 axiadc_read(st, ADI_REG_ID) ? "SLAVE" : "MASTER");
+		 axiadc_read(st, ADI_AXI_REG_ID) ? "SLAVE" : "MASTER");
 
 	if (iio_get_debugfs_dentry(indio_dev))
 		debugfs_create_file("pseudorandom_err_check", 0644,
@@ -917,7 +917,7 @@ static int axiadc_remove(struct platform_device *pdev)
 	struct axiadc_state *st = iio_priv(indio_dev);
 
 	iio_device_unregister(indio_dev);
-	if (!st->dp_disable && !axiadc_read(st, ADI_REG_ID) &&
+	if (!st->dp_disable && !axiadc_read(st, ADI_AXI_REG_ID) &&
 		of_find_property(pdev->dev.of_node, "dmas", NULL))
 		axiadc_unconfigure_ring_stream(indio_dev);
 

--- a/drivers/iio/adc/cf_axi_tdd.c
+++ b/drivers/iio/adc/cf_axi_tdd.c
@@ -26,21 +26,9 @@
 
 #include <linux/iio/iio.h>
 #include <linux/iio/sysfs.h>
+#include <linux/fpga/adi-axi-common.h>
 
 /* Transceiver TDD Control (axi_ad*) */
-
-#define ADI_REG_VERSION		0x0000						/*Version and Scratch Registers */
-#define ADI_VERSION(x)		(((x) & 0xffffffff) << 0)	/* RO, Version number. */
-#define VERSION_IS(x,y,z)	((x) << 16 | (y) << 8 | (z))
-#define ADI_REG_ID			0x0004			 			/*Version and Scratch Registers */
-#define ADI_ID(x)			(((x) & 0xffffffff) << 0)   /* RO, Instance identifier number. */
-#define ADI_REG_SCRATCH		0x0008			 			/*Version and Scratch Registers */
-#define ADI_SCRATCH(x)		(((x) & 0xffffffff) << 0)	/* RW, Scratch register. */
-
-#define PCORE_VERSION(major, minor, letter)	((major << 16) | (minor << 8) | letter)
-#define PCORE_VERSION_MAJOR(version)		(version >> 16)
-#define PCORE_VERSION_MINOR(version)		((version >> 8) & 0xff)
-#define PCORE_VERSION_LETTER(version)		(version & 0xff)
 
 #define ADI_REG_TDD_CONTROL_0		0x0040
 #define ADI_TDD_DMA_GATE_TX_EN		(1 << 5)
@@ -449,18 +437,18 @@ static int cf_axi_tdd_probe(struct platform_device *pdev)
 	if (!st->regs)
 		return -ENOMEM;
 
-	st->version = tdd_read(st, ADI_REG_VERSION);
-	expected_version = PCORE_VERSION(1, 0, 'a');
+	st->version = tdd_read(st, ADI_AXI_REG_VERSION);
+	expected_version = ADI_AXI_PCORE_VER(1, 0, 'a');
 
-	if (PCORE_VERSION_MAJOR(st->version) !=
-		PCORE_VERSION_MAJOR(expected_version)) {
+	if (ADI_AXI_PCORE_VER_MAJOR(st->version) !=
+		ADI_AXI_PCORE_VER_MAJOR(expected_version)) {
 		dev_err(&pdev->dev, "Major version mismatch between PCORE and driver. Driver expected %d.%.2d.%c, PCORE reported %d.%.2d.%c\n",
-			PCORE_VERSION_MAJOR(expected_version),
-			PCORE_VERSION_MINOR(expected_version),
-			PCORE_VERSION_LETTER(expected_version),
-			PCORE_VERSION_MAJOR(st->version),
-			PCORE_VERSION_MINOR(st->version),
-			PCORE_VERSION_LETTER(st->version));
+			ADI_AXI_PCORE_VER_MAJOR(expected_version),
+			ADI_AXI_PCORE_VER_MINOR(expected_version),
+			ADI_AXI_PCORE_VER_PATCH(expected_version),
+			ADI_AXI_PCORE_VER_MAJOR(st->version),
+			ADI_AXI_PCORE_VER_MINOR(st->version),
+			ADI_AXI_PCORE_VER_PATCH(st->version));
 		return -ENODEV;
 	}
 
@@ -478,10 +466,10 @@ static int cf_axi_tdd_probe(struct platform_device *pdev)
 
 	dev_info(&pdev->dev, "Analog Devices CF_AXI_TDD %s (%d.%.2d.%c) at 0x%08llX mapped"
 		" to 0x%p\n",
-		tdd_read(st, ADI_REG_ID) ? "SLAVE" : "MASTER",
-		PCORE_VERSION_MAJOR(st->version),
-		PCORE_VERSION_MINOR(st->version),
-		PCORE_VERSION_LETTER(st->version),
+		tdd_read(st, ADI_AXI_REG_ID) ? "SLAVE" : "MASTER",
+		ADI_AXI_PCORE_VER_MAJOR(st->version),
+		ADI_AXI_PCORE_VER_MINOR(st->version),
+		ADI_AXI_PCORE_VER_PATCH(st->version),
 		(unsigned long long)res->start, st->regs);
 
 	platform_set_drvdata(pdev, indio_dev);

--- a/drivers/iio/frequency/cf_axi_dds.c
+++ b/drivers/iio/frequency/cf_axi_dds.c
@@ -160,7 +160,7 @@ static int cf_axi_get_parent_sampling_frequency(struct cf_axi_dds_state *st, uns
 int cf_axi_dds_datasel(struct cf_axi_dds_state *st,
 			       int channel, enum dds_data_select sel)
 {
-	if (PCORE_VERSION_MAJOR(st->version) > 7) {
+	if (ADI_AXI_PCORE_VER_MAJOR(st->version) > 7) {
 		if (channel < 0) { /* ALL */
 			unsigned i;
 			for (i = 0; i < st->chip_info->num_buf_channels; i++) {
@@ -203,7 +203,7 @@ EXPORT_SYMBOL_GPL(cf_axi_dds_datasel);
 static enum dds_data_select cf_axi_dds_get_datasel(struct cf_axi_dds_state *st,
 			       int channel)
 {
-	if (PCORE_VERSION_MAJOR(st->version) > 7) {
+	if (ADI_AXI_PCORE_VER_MAJOR(st->version) > 7) {
 		if (channel < 0)
 			channel = 0;
 
@@ -251,14 +251,14 @@ static int cf_axi_dds_sync_frame(struct iio_dev *indio_dev)
 
 void cf_axi_dds_stop(struct cf_axi_dds_state *st)
 {
-	if (PCORE_VERSION_MAJOR(st->version) < 8)
+	if (ADI_AXI_PCORE_VER_MAJOR(st->version) < 8)
 		dds_write(st, ADI_REG_CNTRL_1, 0);
 }
 EXPORT_SYMBOL_GPL(cf_axi_dds_stop);
 
 void cf_axi_dds_start_sync(struct cf_axi_dds_state *st, bool force_on)
 {
-	if (PCORE_VERSION_MAJOR(st->version) < 8) {
+	if (ADI_AXI_PCORE_VER_MAJOR(st->version) < 8) {
 		dds_write(st, ADI_REG_CNTRL_1, (st->enable || force_on) ? ADI_ENABLE : 0);
 	} else {
 		dds_write(st, ADI_REG_CNTRL_1, ADI_SYNC);
@@ -340,7 +340,7 @@ static int cf_axi_dds_default_setup(struct cf_axi_dds_state *st, u32 chan,
 	dds_write(st, ADI_REG_CHAN_CNTRL_1_IIOCHAN(chan), ADI_DDS_SCALE(scale));
 	dds_write(st, ADI_REG_CHAN_CNTRL_2_IIOCHAN(chan), val);
 
-	if (PCORE_VERSION_MAJOR(st->version) > 7) {
+	if (ADI_AXI_PCORE_VER_MAJOR(st->version) > 7) {
 		if (chan % 2)
 			dds_write(st, ADI_REG_CHAN_CNTRL_8(chan),
 				ADI_IQCOR_COEFF_2(0x4000) |
@@ -484,7 +484,7 @@ static int cf_axi_dds_read_raw(struct iio_dev *indio_dev,
 		}
 
 		reg = ADI_TO_DDS_SCALE(dds_read(st, ADI_REG_CHAN_CNTRL_1_IIOCHAN(chan->channel)));
-		if (PCORE_VERSION_MAJOR(st->version) > 6) {
+		if (ADI_AXI_PCORE_VER_MAJOR(st->version) > 6) {
 			cf_axi_dds_signed_mag_fmt_to_iio(reg, val, val2);
 		} else {
 			if (!reg) {
@@ -527,7 +527,7 @@ static int cf_axi_dds_read_raw(struct iio_dev *indio_dev,
 		phase = 1;
 	case IIO_CHAN_INFO_CALIBSCALE:
 
-		if (PCORE_VERSION_MAJOR(st->version) < 8) {
+		if (ADI_AXI_PCORE_VER_MAJOR(st->version) < 8) {
 			ret = -ENODEV;
 			break;
 		}
@@ -598,7 +598,7 @@ static int cf_axi_dds_write_raw(struct iio_dev *indio_dev,
 			}
 		}
 
-		if (PCORE_VERSION_MAJOR(st->version) > 6) {
+		if (ADI_AXI_PCORE_VER_MAJOR(st->version) > 6) {
 			/*  format is 1.1.14 (sign, integer and fractional bits) */
 			switch (val) {
 			case 1:
@@ -708,7 +708,7 @@ static int cf_axi_dds_write_raw(struct iio_dev *indio_dev,
 		phase = 1;
 	case IIO_CHAN_INFO_CALIBSCALE:
 
-		if (PCORE_VERSION_MAJOR(st->version) < 7) {
+		if (ADI_AXI_PCORE_VER_MAJOR(st->version) < 7) {
 			ret = -ENODEV;
 			break;
 		}
@@ -839,7 +839,7 @@ static void cf_axi_dds_update_chan_spec(struct cf_axi_dds_state *st,
 			struct iio_chan_spec *channels, unsigned num)
 {
 
-	if (PCORE_VERSION_MAJOR(st->version) > 6) {
+	if (ADI_AXI_PCORE_VER_MAJOR(st->version) > 6) {
 		int i;
 		for (i = 0; i < num; i++) {
 			if (channels[i].type == IIO_ALTVOLTAGE)
@@ -1369,13 +1369,13 @@ struct axidds_core_info {
 };
 
 static const struct axidds_core_info ad9122_6_00_a_info = {
-	.version = PCORE_VERSION(9, 0, 'a'),
+	.version = ADI_AXI_PCORE_VER(9, 0, 'a'),
 	.rate = 1,
 	.data_format = ADI_DATA_FORMAT,
 };
 
 static const struct axidds_core_info ad9361_6_00_a_info = {
-	.version = PCORE_VERSION(9, 0, 'a'),
+	.version = ADI_AXI_PCORE_VER(9, 0, 'a'),
 	.standalone = true,
 	.rate_format_skip_en = true, /* Set by the ad936x_conv driver */
 	.rate = 3,
@@ -1383,7 +1383,7 @@ static const struct axidds_core_info ad9361_6_00_a_info = {
 };
 
 static const struct axidds_core_info ad9364_6_00_a_info = {
-	.version = PCORE_VERSION(9, 0, 'a'),
+	.version = ADI_AXI_PCORE_VER(9, 0, 'a'),
 	.standalone = true,
 	.rate_format_skip_en = true, /* Set by the ad936x_conv driver */
 	.rate = 1,
@@ -1391,7 +1391,7 @@ static const struct axidds_core_info ad9364_6_00_a_info = {
 };
 
 static const struct axidds_core_info ad9361x2_6_00_a_info = {
-	.version = PCORE_VERSION(9, 0, 'a'),
+	.version = ADI_AXI_PCORE_VER(9, 0, 'a'),
 	.standalone = true,
 	.rate_format_skip_en = true, /* Set by the ad936x_conv driver */
 	.rate = 3,
@@ -1399,37 +1399,37 @@ static const struct axidds_core_info ad9361x2_6_00_a_info = {
 };
 
 static const struct axidds_core_info ad9144_7_00_a_info = {
-	.version = PCORE_VERSION(9, 0, 'a'),
+	.version = ADI_AXI_PCORE_VER(9, 0, 'a'),
 	.rate = 1,
 };
 
 static const struct axidds_core_info ad9739a_8_00_b_info = {
-	.version = PCORE_VERSION(9, 0, 'b'),
+	.version = ADI_AXI_PCORE_VER(9, 0, 'b'),
 	.rate = 1,
 	.data_format = ADI_DATA_FORMAT,
 };
 
 static const struct axidds_core_info ad9371_6_00_a_info = {
-	.version = PCORE_VERSION(9, 0, 'a'),
+	.version = ADI_AXI_PCORE_VER(9, 0, 'a'),
 	.standalone = true,
 	.rate = 3,
 	.chip_info = &cf_axi_dds_chip_info_ad9371,
 };
 
 static const struct axidds_core_info adrv9009_x2_9_00_a_info = {
-	.version = PCORE_VERSION(9, 0, 'a'),
+	.version = ADI_AXI_PCORE_VER(9, 0, 'a'),
 	.standalone = true,
 	.rate = 3,
 	.chip_info = &cf_axi_dds_chip_info_adrv9009_x2,
 };
 
 static const struct axidds_core_info ad9162_1_00_a_info = {
-	.version = PCORE_VERSION(9, 0, 'a'),
+	.version = ADI_AXI_PCORE_VER(9, 0, 'a'),
 	.rate = 1,
 };
 
 static const struct axidds_core_info ad9963_1_00_a_info = {
-	.version = PCORE_VERSION(9, 0, 'a'),
+	.version = ADI_AXI_PCORE_VER(9, 0, 'a'),
 	.standalone = true,
 	.rate = 0,
 	.chip_info = &cf_axi_dds_chip_info_ad9936,
@@ -1553,18 +1553,18 @@ static int cf_axi_dds_probe(struct platform_device *pdev)
 	}
 
 	st->standalone = info->standalone;
-	st->version = dds_read(st, ADI_REG_VERSION);
+	st->version = dds_read(st, ADI_AXI_REG_VERSION);
 	st->dp_disable = dds_read(st, ADI_REG_DAC_DP_DISABLE);
 
-	if (PCORE_VERSION_MAJOR(st->version) >
-		PCORE_VERSION_MAJOR(info->version)) {
+	if (ADI_AXI_PCORE_VER_MAJOR(st->version) >
+		ADI_AXI_PCORE_VER_MAJOR(info->version)) {
 		dev_err(&pdev->dev, "Major version mismatch between PCORE and driver. Driver expected %d.%.2d.%c, PCORE reported %d.%.2d.%c\n",
-			PCORE_VERSION_MAJOR(info->version),
-			PCORE_VERSION_MINOR(info->version),
-			PCORE_VERSION_LETTER(info->version),
-			PCORE_VERSION_MAJOR(st->version),
-			PCORE_VERSION_MINOR(st->version),
-			PCORE_VERSION_LETTER(st->version));
+			ADI_AXI_PCORE_VER_MAJOR(info->version),
+			ADI_AXI_PCORE_VER_MINOR(info->version),
+			ADI_AXI_PCORE_VER_PATCH(info->version),
+			ADI_AXI_PCORE_VER_MAJOR(st->version),
+			ADI_AXI_PCORE_VER_MINOR(st->version),
+			ADI_AXI_PCORE_VER_PATCH(st->version));
 		ret = -ENODEV;
 		goto err_converter_put;
 	}
@@ -1583,7 +1583,7 @@ static int cf_axi_dds_probe(struct platform_device *pdev)
 	indio_dev->info = &st->iio_info;
 
 	dds_write(st, ADI_REG_RSTN, 0x0);
-	if (PCORE_VERSION_MAJOR(st->version) > 7) {
+	if (ADI_AXI_PCORE_VER_MAJOR(st->version) > 7) {
 		dds_write(st, ADI_REG_RSTN, ADI_MMCM_RSTN);
 		do {
 			drp_status = dds_read(st, ADI_REG_DRP_STATUS);
@@ -1635,7 +1635,7 @@ static int cf_axi_dds_probe(struct platform_device *pdev)
 
 	if (!st->dp_disable) {
 		unsigned scale, frequency;
-		if (PCORE_VERSION_MAJOR(st->version) > 6)
+		if (ADI_AXI_PCORE_VER_MAJOR(st->version) > 6)
 			scale = 0x1000; /* 0.250 */
 		else
 			scale = 2; /* 0.250 */
@@ -1688,7 +1688,7 @@ static int cf_axi_dds_probe(struct platform_device *pdev)
 	cf_axi_dds_start_sync(st, 0);
 	cf_axi_dds_sync_frame(indio_dev);
 
-	if (!st->dp_disable && !dds_read(st, ADI_REG_ID)) {
+	if (!st->dp_disable && !dds_read(st, ADI_AXI_REG_ID)) {
 
 		if (st->chip_info->num_shadow_slave_channels) {
 			u32 regs[2];
@@ -1714,7 +1714,7 @@ static int cf_axi_dds_probe(struct platform_device *pdev)
 			indio_dev->available_scan_masks = st->chip_info->scan_masks;
 		}
 
-	} else if (dds_read(st, ADI_REG_ID)){
+	} else if (dds_read(st, ADI_AXI_REG_ID)) {
 		u32 regs[2];
 		ret = of_property_read_u32_array(pdev->dev.of_node,
 				"mastercore-reg", regs, ARRAY_SIZE(regs));
@@ -1729,10 +1729,10 @@ static int cf_axi_dds_probe(struct platform_device *pdev)
 
 	dev_info(&pdev->dev, "Analog Devices CF_AXI_DDS_DDS %s (%d.%.2d.%c) at 0x%08llX mapped"
 		" to 0x%p, probed DDS %s\n",
-		dds_read(st, ADI_REG_ID) ? "SLAVE" : "MASTER",
-		PCORE_VERSION_MAJOR(st->version),
-		PCORE_VERSION_MINOR(st->version),
-		PCORE_VERSION_LETTER(st->version),
+		dds_read(st, ADI_AXI_REG_ID) ? "SLAVE" : "MASTER",
+		ADI_AXI_PCORE_VER_MAJOR(st->version),
+		ADI_AXI_PCORE_VER_MINOR(st->version),
+		ADI_AXI_PCORE_VER_PATCH(st->version),
 		(unsigned long long)res->start, st->regs, st->chip_info->name);
 
 	st->plddrbypass_gpio = devm_gpiod_get(&pdev->dev, "plddrbypass", GPIOD_ASIS);
@@ -1767,7 +1767,7 @@ static int cf_axi_dds_remove(struct platform_device *pdev)
 
 	iio_device_unregister(indio_dev);
 
-	if (!st->dp_disable && !dds_read(st, ADI_REG_ID) &&
+	if (!st->dp_disable && !dds_read(st, ADI_AXI_REG_ID) &&
 		of_find_property(pdev->dev.of_node, "dmas", NULL))
 		cf_axi_dds_unconfigure_buffer(indio_dev);
 

--- a/drivers/iio/frequency/cf_axi_dds.h
+++ b/drivers/iio/frequency/cf_axi_dds.h
@@ -11,19 +11,7 @@
 
 #include <linux/spi/spi.h>
 #include <linux/clk/clkscale.h>
-
-#define ADI_REG_VERSION		0x0000				/*Version and Scratch Registers */
-#define ADI_VERSION(x)		(((x) & 0xffffffff) << 0)	/* RO, Version number. */
-#define VERSION_IS(x,y,z)	((x) << 16 | (y) << 8 | (z))
-#define ADI_REG_ID		0x0004			 	/*Version and Scratch Registers */
-#define ADI_ID(x)		(((x) & 0xffffffff) << 0)   	/* RO, Instance identifier number. */
-#define ADI_REG_SCRATCH		0x0008			 	/*Version and Scratch Registers */
-#define ADI_SCRATCH(x)		(((x) & 0xffffffff) << 0)	/* RW, Scratch register. */
-
-#define PCORE_VERSION(major, minor, letter) ((major << 16) | (minor << 8) | letter)
-#define PCORE_VERSION_MAJOR(version) (version >> 16)
-#define PCORE_VERSION_MINOR(version) ((version >> 8) & 0xff)
-#define PCORE_VERSION_LETTER(version) (version & 0xff)
+#include <linux/fpga/adi-axi-common.h>
 
 /* DAC COMMON */
 


### PR DESCRIPTION
The ADI AXI common register definitions have been added in `include/linux/fpga/adi-axi-common.h` some time ago. Some small parts have also been upstreamed.

These changes makes use of these definitions for the AXI IIO drivers.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>