### PR TITLE
iio: adc: ad7292: Add analog input channels and suport for voltage regulator

### DIFF
--- a/Documentation/devicetree/bindings/iio/adc/adi,ad7292.yaml
+++ b/Documentation/devicetree/bindings/iio/adc/adi,ad7292.yaml
@@ -22,6 +22,23 @@ properties:
   reg:
     maxItems: 1
 
+  spi-cpha:
+    description: |
+      See Documentation/devicetree/bindings/spi/spi-bus.txt
+    maxItems: 1
+
+  diff-channels:
+    description: |
+      Empty property to tell whether VIN0 and VIN1 shall work as differential
+      inputs.
+    maxItems: 1
+
+  '#address-cells':
+    const: 1
+
+  '#size-cells':
+    const: 0
+
 required:
   - compatible
   - reg
@@ -32,4 +49,6 @@ examples:
       compatible = "adi,ad7292";
       reg = <0>;
       spi-max-frequency = <16000000>;
+      spi-cpha;
+      diff-channels;
     };

--- a/Documentation/devicetree/bindings/iio/adc/adi,ad7292.yaml
+++ b/Documentation/devicetree/bindings/iio/adc/adi,ad7292.yaml
@@ -12,6 +12,8 @@ maintainers:
 description: |
   Analog Devices AD7292 10-Bit Monitor and Control System with ADC, DACs,
   Temperature Sensor, and GPIOs
+
+  Specifications about the part can be found at:
     https://www.analog.com/en/products/ad7292.html
 
 properties:
@@ -20,6 +22,11 @@ properties:
       - adi,ad7292
 
   reg:
+    maxItems: 1
+
+  vref-supply:
+    description: |
+      The regulator supply for ADC and DAC reference voltage.
     maxItems: 1
 
   spi-cpha:
@@ -49,6 +56,7 @@ examples:
       compatible = "adi,ad7292";
       reg = <0>;
       spi-max-frequency = <16000000>;
+      vref-supply = <&adc_vref>;
       spi-cpha;
       diff-channels;
     };

--- a/arch/arm/boot/dts/overlays/rpi-ad7292-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ad7292-overlay.dts
@@ -15,6 +15,11 @@
 				compatible = "adi,ad7292";
 				reg = <0>;
 				spi-max-frequency = <16000000>;
+				spi-cpha;
+				diff-channels;
+
+				#address-cells = <1>;
+				#size-cells = <0>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/overlays/rpi-ad7292-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ad7292-overlay.dts
@@ -5,6 +5,19 @@
 	compatible = "brcm,bcm2708";
 
 	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			adc_vref: fixedregulator@0 {
+				compatible = "regulator-fixed";
+				regulator-name = "fixed-supply";
+				regulator-min-microvolt = <1250000>;
+				regulator-max-microvolt = <1250000>;
+				regulator-boot-on;
+			};
+		};
+	};
+
+	fragment@1 {
 		target = <&spi0>;
 		__overlay__ {
 			#address-cells = <1>;
@@ -15,6 +28,7 @@
 				compatible = "adi,ad7292";
 				reg = <0>;
 				spi-max-frequency = <16000000>;
+				vref-supply = <&adc_vref>;
 				spi-cpha;
 				diff-channels;
 


### PR DESCRIPTION
This pull request adds IIO channels for the eight multiplexed analog input channels included in the AD7292 part. It also adds a voltage regulator to handle its internal voltage reference.