### PR TITLE
 iio: cf_axi_dds: make cf_axi_dds_state struct opaque

### DIFF
--- a/drivers/iio/frequency/cf_axi_dds.c
+++ b/drivers/iio/frequency/cf_axi_dds.c
@@ -39,6 +39,32 @@
 
 static const unsigned int interpolation_factors_available[] = {1, 8};
 
+struct cf_axi_dds_state {
+	struct device			*dev_spi;
+	struct clk			*clk;
+	struct cf_axi_dds_chip_info	*chip_info;
+	struct gpio_desc		*plddrbypass_gpio;
+
+	bool				standalone;
+	bool				dp_disable;
+	bool				enable;
+	bool				pl_dma_fifo_en;
+	enum fifo_ctrl			gpio_dma_fifo_ctrl;
+
+	struct iio_info			iio_info;
+	size_t				regs_size;
+	void __iomem			*regs;
+	void __iomem			*slave_regs;
+	void __iomem			*master_regs;
+	u64				dac_clk;
+	unsigned int			ddr_dds_interp_en;
+	unsigned int			cached_freq[16];
+	unsigned int			version;
+	unsigned int			have_slave_channels;
+	unsigned int			interpolation_factor;
+	struct notifier_block		clk_nb;
+};
+
 bool cf_axi_dds_dma_fifo_en(struct cf_axi_dds_state *st)
 {
 	return st->pl_dma_fifo_en;

--- a/drivers/iio/frequency/cf_axi_dds.c
+++ b/drivers/iio/frequency/cf_axi_dds.c
@@ -39,6 +39,12 @@
 
 static const unsigned int interpolation_factors_available[] = {1, 8};
 
+bool cf_axi_dds_dma_fifo_en(struct cf_axi_dds_state *st)
+{
+	return st->pl_dma_fifo_en;
+}
+EXPORT_SYMBOL(cf_axi_dds_dma_fifo_en);
+
 void dds_write(struct cf_axi_dds_state *st,
 	       unsigned int reg, unsigned int val)
 {

--- a/drivers/iio/frequency/cf_axi_dds.c
+++ b/drivers/iio/frequency/cf_axi_dds.c
@@ -39,6 +39,40 @@
 
 static const unsigned int interpolation_factors_available[] = {1, 8};
 
+void dds_write(struct cf_axi_dds_state *st,
+	       unsigned int reg, unsigned int val)
+{
+	iowrite32(val, st->regs + reg);
+}
+EXPORT_SYMBOL(dds_write);
+
+int dds_read(struct cf_axi_dds_state *st, unsigned int reg)
+{
+	return ioread32(st->regs + reg);
+}
+EXPORT_SYMBOL(dds_read);
+
+void dds_slave_write(struct cf_axi_dds_state *st,
+		     unsigned int reg, unsigned int val)
+{
+	iowrite32(val, st->slave_regs + reg);
+}
+EXPORT_SYMBOL(dds_slave_write);
+
+unsigned int dds_slave_read(struct cf_axi_dds_state *st, unsigned int reg)
+{
+	return ioread32(st->slave_regs + reg);
+}
+EXPORT_SYMBOL(dds_slave_read);
+
+void dds_master_write(struct cf_axi_dds_state *st,
+		      unsigned int reg, unsigned int val)
+{
+	if (st->master_regs)
+		iowrite32(val, st->master_regs + reg);
+}
+EXPORT_SYMBOL(dds_master_write);
+
 static int cf_axi_dds_to_signed_mag_fmt(int val, int val2, unsigned int *res)
 {
 	unsigned i;

--- a/drivers/iio/frequency/cf_axi_dds.h
+++ b/drivers/iio/frequency/cf_axi_dds.h
@@ -200,31 +200,7 @@ struct cf_axi_dds_chip_info {
 	struct iio_chan_spec channel[24];
 };
 
-struct cf_axi_dds_state {
-	struct device 		*dev_spi;
-	struct clk 		*clk;
-	struct cf_axi_dds_chip_info	*chip_info;
-	struct gpio_desc		*plddrbypass_gpio;
-
-	bool			standalone;
-	bool			dp_disable;
-	bool			enable;
-	bool			pl_dma_fifo_en;
-	enum fifo_ctrl		gpio_dma_fifo_ctrl;
-
-	struct iio_info		iio_info;
-	size_t			regs_size;
-	void __iomem		*regs;
-	void __iomem		*slave_regs;
-	void __iomem		*master_regs;
-	u64			dac_clk;
-	unsigned 		ddr_dds_interp_en;
-	unsigned		cached_freq[16];
-	unsigned		version;
-	unsigned		have_slave_channels;
-	unsigned		interpolation_factor;
-	struct notifier_block   clk_nb;
-};
+struct cf_axi_dds_state;
 
 enum {
 	CLK_DATA,

--- a/drivers/iio/frequency/cf_axi_dds.h
+++ b/drivers/iio/frequency/cf_axi_dds.h
@@ -305,4 +305,6 @@ unsigned int dds_slave_read(struct cf_axi_dds_state *st, unsigned int reg);
 void dds_master_write(struct cf_axi_dds_state *st,
 		      unsigned int reg, unsigned int val);
 
+bool cf_axi_dds_dma_fifo_en(struct cf_axi_dds_state *st);
+
 #endif /* ADI_AXI_DDS_H_ */

--- a/drivers/iio/frequency/cf_axi_dds.h
+++ b/drivers/iio/frequency/cf_axi_dds.h
@@ -296,33 +296,13 @@ int cf_axi_dds_pl_ddr_fifo_ctrl(struct cf_axi_dds_state *st, bool enable);
  * IO accessors
  */
 
-static inline void dds_write(struct cf_axi_dds_state *st,
-			     unsigned reg, unsigned val)
-{
-	iowrite32(val, st->regs + reg);
-}
-
-static inline unsigned int dds_read(struct cf_axi_dds_state *st, unsigned reg)
-{
-	return ioread32(st->regs + reg);
-}
-
-static inline void dds_slave_write(struct cf_axi_dds_state *st,
-			     unsigned reg, unsigned val)
-{
-	iowrite32(val, st->slave_regs + reg);
-}
-
-static inline unsigned int dds_slave_read(struct cf_axi_dds_state *st, unsigned reg)
-{
-	return ioread32(st->slave_regs + reg);
-}
-
-static inline void dds_master_write(struct cf_axi_dds_state *st,
-			     unsigned reg, unsigned val)
-{
-	if (st->master_regs)
-		iowrite32(val, st->master_regs + reg);
-}
+void dds_write(struct cf_axi_dds_state *st,
+	       unsigned int reg, unsigned int val);
+int dds_read(struct cf_axi_dds_state *st, unsigned int reg);
+void dds_slave_write(struct cf_axi_dds_state *st,
+		     unsigned int reg, unsigned int val);
+unsigned int dds_slave_read(struct cf_axi_dds_state *st, unsigned int reg);
+void dds_master_write(struct cf_axi_dds_state *st,
+		      unsigned int reg, unsigned int val);
 
 #endif /* ADI_AXI_DDS_H_ */

--- a/drivers/iio/frequency/cf_axi_dds_buffer_stream.c
+++ b/drivers/iio/frequency/cf_axi_dds_buffer_stream.c
@@ -29,7 +29,7 @@ static int dds_buffer_submit_block(struct iio_dma_buffer_queue *queue,
 	if (block->block.bytes_used) {
 		bool enable_fifo = false;
 
-		if (st->pl_dma_fifo_en &&
+		if (cf_axi_dds_dma_fifo_en(st) &&
 			(block->block.flags & IIO_BUFFER_BLOCK_FLAG_CYCLIC)) {
 			block->block.flags &= ~IIO_BUFFER_BLOCK_FLAG_CYCLIC;
 			enable_fifo = true;

--- a/drivers/iio/frequency/cf_axi_dds_buffer_stream.c
+++ b/drivers/iio/frequency/cf_axi_dds_buffer_stream.c
@@ -57,11 +57,9 @@ static int dds_buffer_state_set(struct iio_dev *indio_dev, bool state)
 		return cf_axi_dds_datasel(st, -1, DATA_SEL_DDS);
 
 	cf_axi_dds_stop(st);
-	st->enable = false;
 
 	dds_write(st, ADI_REG_VDMA_STATUS, ADI_VDMA_OVF | ADI_VDMA_UNF);
 
-	st->enable = true;
 	cf_axi_dds_start_sync(st, 1);
 
 	return 0;


### PR DESCRIPTION
The state of the cf_axi_dds does not need to be exposed outside of the
`cf_axi_dds.c` file. This change moves it inside the C file.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>