### PR TITLE
iio: jesd204: axi_adxcvr: Add support GTH3/4 QPLL1 support

### DIFF
--- a/drivers/iio/jesd204/axi_adxcvr.c
+++ b/drivers/iio/jesd204/axi_adxcvr.c
@@ -285,6 +285,14 @@ static unsigned long adxcvr_clk_recalc_rate(struct clk_hw *hw,
 	} else {
 		struct xilinx_xcvr_qpll_config qpll_conf;
 
+		if ((st->xcvr.type == XILINX_XCVR_TYPE_US_GTH3) ||
+		    (st->xcvr.type == XILINX_XCVR_TYPE_US_GTH4)) {
+			if (st->sys_clk_sel == ADXCVR_GTH_SYSCLK_QPLL1)
+				qpll_conf.qpll = 1;
+			else
+				qpll_conf.qpll = 0;
+		}
+
 		xilinx_xcvr_qpll_read_config(&st->xcvr, ADXCVR_DRP_PORT_COMMON(0),
 			&qpll_conf);
 		return xilinx_xcvr_qpll_calc_lane_rate(&st->xcvr, parent_rate,

--- a/drivers/iio/jesd204/axi_adxcvr.h
+++ b/drivers/iio/jesd204/axi_adxcvr.h
@@ -48,6 +48,9 @@
 #define ADXCVR_DRP_PORT_COMMON(x)	(x)
 #define ADXCVR_DRP_PORT_CHANNEL(x)	(0x100 + (x))
 
+#define ADXCVR_GTH_SYSCLK_CPLL		0
+#define ADXCVR_GTH_SYSCLK_QPLL1		2
+#define ADXCVR_GTH_SYSCLK_QPLL0		3
 
 struct adxcvr_state {
 	struct device		*dev;

--- a/drivers/iio/jesd204/xilinx_transceiver.c
+++ b/drivers/iio/jesd204/xilinx_transceiver.c
@@ -415,8 +415,19 @@ int xilinx_xcvr_calc_qpll_config(struct xilinx_xcvr *xcvr,
 	case XILINX_XCVR_TYPE_US_GTH4:
 	case XILINX_XCVR_TYPE_US_GTY4:
 		N = N_gth34;
-		vco0_min = 9800000;
-		vco0_max = 16375000;
+
+		if (conf != NULL) {
+			if (conf->qpll) {
+				vco0_min = 8000000;
+				vco0_max = 13000000;
+			} else {
+				vco0_min = 9800000;
+				vco0_max = 16375000;
+			}
+		} else {
+			vco0_min = 8000000;
+			vco0_max = 16375000;
+		}
 		vco1_min = vco0_min;
 		vco1_max = vco0_max;
 		break;
@@ -714,7 +725,6 @@ EXPORT_SYMBOL_GPL(xilinx_xcvr_cpll_calc_lane_rate);
 static int xilinx_xcvr_gth34_qpll_read_config(struct xilinx_xcvr *xcvr,
 	unsigned int drp_port, struct xilinx_xcvr_qpll_config *conf)
 {
-	unsigned int qpll = 0;
 	int val;
 
 	#define QPLL0_FBDIV_DIV 0x14
@@ -725,7 +735,7 @@ static int xilinx_xcvr_gth34_qpll_read_config(struct xilinx_xcvr *xcvr,
 	#define QPLL_FBDIV(x) (0x14 + (x) * 0x80)
 	#define QPLL_REFCLK_DIV(x) (0x18 + (x) * 0x80)
 
-	val = xilinx_xcvr_drp_read(xcvr, drp_port, QPLL_REFCLK_DIV(qpll));
+	val = xilinx_xcvr_drp_read(xcvr, drp_port, QPLL_REFCLK_DIV(conf->qpll));
 	if (val < 0)
 		return val;
 
@@ -747,7 +757,7 @@ static int xilinx_xcvr_gth34_qpll_read_config(struct xilinx_xcvr *xcvr,
 		break;
 	}
 
-	val = xilinx_xcvr_drp_read(xcvr, drp_port, QPLL_FBDIV(qpll));
+	val = xilinx_xcvr_drp_read(xcvr, drp_port, QPLL_FBDIV(conf->qpll));
 	if (val < 0)
 		return val;
 
@@ -872,12 +882,12 @@ static int xilinx_xcvr_gth34_qpll_write_config(struct xilinx_xcvr *xcvr,
 		return -EINVAL;
 	}
 
-	ret = xilinx_xcvr_drp_update(xcvr, drp_port, QPLL_FBDIV(0),
+	ret = xilinx_xcvr_drp_update(xcvr, drp_port, QPLL_FBDIV(conf->qpll),
 		0xff, fbdiv);
 	if (ret < 0)
 		return ret;
 
-	return xilinx_xcvr_drp_update(xcvr, drp_port, QPLL_REFCLK_DIV(0),
+	return xilinx_xcvr_drp_update(xcvr, drp_port, QPLL_REFCLK_DIV(conf->qpll),
 		0xf80, refclk << 7);
 }
 

--- a/drivers/iio/jesd204/xilinx_transceiver.h
+++ b/drivers/iio/jesd204/xilinx_transceiver.h
@@ -70,6 +70,7 @@ struct xilinx_xcvr_qpll_config {
 	unsigned int refclk_div;
 	unsigned int fb_div;
 	unsigned int band;
+	unsigned int qpll;
 };
 
 int xilinx_xcvr_configure_cdr(struct xilinx_xcvr *xcvr, unsigned int drp_port,


### PR DESCRIPTION
This patch adds support for GTH3/4 QPLL1 support. Before this only QPLL0
was supported.

QPLL1 frequency range is from 8.0 to 13.0 GHz.

Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>

The queston here do we want to set QPLL0 or QPLL1 dynamical in the driver depending on the frequency that is required ? Right now the sysclk is set inside the device tree and the user has to specify which one he wants to use, this will require him to know about the frequency ranges for QPLL0 and QPLL1.  
