### PR TITLE
media: adi-axi-fb: Add check for reserved memory size and split dts examples

### DIFF
--- a/Documentation/devicetree/bindings/media/adi,adi-axi-fb.yaml
+++ b/Documentation/devicetree/bindings/media/adi,adi-axi-fb.yaml
@@ -14,6 +14,7 @@ description: |
   Bindings for the Analog Devices Frame Buffer core. Spefications of the
   core can be found in:
   https://wiki.analog.com/resources/fpga/docs/axi_dmac
+  First example is used when FB is stored in PS RAM and second for PL RAM.
 
 properties:
   compatible:
@@ -90,8 +91,8 @@ examples:
     adi-fb {
             compatible = "adi,axi-framebuffer-1.00.a";
             memory-region = <&reserved>;
-            reg = <0x1C000000 0x2000>, <0x43000000 0x1000>, <0x43c20000 0x1000>;
-            reg-names = "fb_mem", "tx_dma", "rx_dma";
+            reg = <0x43000000 0x1000>, <0x43c20000 0x1000>;
+            reg-names = "tx_dma", "rx_dma";
             adi,flock-resolution = <1920>, <1080>;
             adi,flock-distance = <0>;
             adi,flock-mode = <0>;
@@ -108,4 +109,16 @@ examples:
                     no-map;
                     reg = <0x1C000000 0x2000000>;
             };
+    };
+
+  - |
+    adi-fb {
+            compatible = "adi,axi-framebuffer-1.00.a";
+            reg = <0x1C000000 0x2000>, <0x43000000 0x1000>, <0x43c20000 0x1000>;
+            reg-names = "fb_mem", "tx_dma", "rx_dma";
+            adi,flock-resolution = <1920>, <1080>;
+            adi,flock-distance = <0>;
+            adi,flock-mode = <0>;
+            adi,flock-dwidth = <4>;
+            adi,flock-frm-buf-nr = <3>;
     };

--- a/drivers/media/platform/adi-axi-fb.c
+++ b/drivers/media/platform/adi-axi-fb.c
@@ -262,6 +262,12 @@ static int frame_buffer_probe(struct platform_device *pdev)
 			frm_buff->frame_stride = tmp;
 	}
 
+	if ((frm_buff->video_ram_buf.end - frm_buff->video_ram_buf.start) <
+			frm_buff->frame_stride * frm_buff->num_frames) {
+		dev_err(&pdev->dev, "FB does not fit in reserved memory\n");
+		return -ENOMEM;
+	}
+
 	adi_fb_init(frm_buff, TX_DMA);
 	adi_fb_init(frm_buff, RX_DMA);
 


### PR DESCRIPTION
This patch set add check for reserved memory size. If the reserved memory is not big enough to accommodate frame buffer size times number of frames return with error to avoid memory corruption.

Also split the dts example to avoid confusion between case when FB is stored in PS RAM and FB is stored in PL RAM.

Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
