### PR TITLE
 iio: frequency: cf_axi_dds: remove some old PCORE code

### DIFF
--- a/drivers/iio/frequency/cf_axi_dds.c
+++ b/drivers/iio/frequency/cf_axi_dds.c
@@ -315,13 +315,6 @@ static int cf_axi_dds_sync_frame(struct iio_dev *indio_dev)
 	return 0;
 }
 
-void cf_axi_dds_stop(struct cf_axi_dds_state *st)
-{
-	if (ADI_AXI_PCORE_VER_MAJOR(st->version) < 8)
-		dds_write(st, ADI_REG_CNTRL_1, 0);
-}
-EXPORT_SYMBOL_GPL(cf_axi_dds_stop);
-
 void cf_axi_dds_start_sync(struct cf_axi_dds_state *st, bool force_on)
 {
 	if (ADI_AXI_PCORE_VER_MAJOR(st->version) < 8) {
@@ -343,15 +336,10 @@ static int cf_axi_dds_rate_change(struct notifier_block *nb,
 	unsigned reg, i;
 	unsigned long long val64;
 
-	/* Temp Workaround: stop PCORE while we reset the sink */
-	if (flags == PRE_RATE_CHANGE && cnd->new_rate == -EINVAL)
-		cf_axi_dds_stop(st);
-
 	st->dac_clk = cnd->new_rate;
 
 	if (flags == POST_RATE_CHANGE) {
 		st->dac_clk = cnd->new_rate;
-		cf_axi_dds_stop(st);
 
 		for (i = 0; i < st->chip_info->num_dds_channels; i++) {
 			reg = dds_read(st, ADI_REG_CHAN_CNTRL_2_IIOCHAN(i));
@@ -376,8 +364,6 @@ static void cf_axi_dds_set_sed_pattern(struct iio_dev *indio_dev, unsigned chan,
 
 	dds_write(st, ADI_REG_CHAN_CNTRL_5(chan),
 		ADI_TO_DDS_PATT_1(pat1) | ADI_DDS_PATT_2(pat2));
-
-	cf_axi_dds_stop(st);
 
 	cf_axi_dds_datasel(st, -1, DATA_SEL_SED);
 
@@ -697,7 +683,6 @@ static int cf_axi_dds_write_raw(struct iio_dev *indio_dev,
 						break;
 			}
 		}
-		cf_axi_dds_stop(st);
 		dds_write(st, ADI_REG_CHAN_CNTRL_1_IIOCHAN(chan->channel), ADI_DDS_SCALE(i));
 		cf_axi_dds_start_sync(st, 0);
 		break;
@@ -711,7 +696,6 @@ static int cf_axi_dds_write_raw(struct iio_dev *indio_dev,
 			break;
 		}
 
-		cf_axi_dds_stop(st);
 		reg = dds_read(st, ADI_REG_CHAN_CNTRL_2_IIOCHAN(chan->channel));
 		reg &= ~ADI_DDS_INCR(~0);
 		val64 = (u64) val * 0xFFFFULL;
@@ -734,7 +718,6 @@ static int cf_axi_dds_write_raw(struct iio_dev *indio_dev,
 		if (val == 360000)
 			val = 0;
 
-		cf_axi_dds_stop(st);
 		reg = dds_read(st, ADI_REG_CHAN_CNTRL_2_IIOCHAN(chan->channel));
 		reg &= ~ADI_DDS_INIT(~0);
 		val64 = (u64) val * 0x10000ULL + (360000 / 2);
@@ -762,7 +745,6 @@ static int cf_axi_dds_write_raw(struct iio_dev *indio_dev,
 
 		reg = dds_read(st, ADI_REG_CNTRL_2);
 		i = cf_axi_dds_get_datasel(st, -1);
-		cf_axi_dds_stop(st);
 		conv->write_raw(indio_dev, chan, val, val2, mask);
 		dds_write(st, ADI_REG_CNTRL_2, reg);
 		cf_axi_dds_datasel(st, -1, i);
@@ -1691,8 +1673,6 @@ static int cf_axi_dds_probe(struct platform_device *pdev)
 		ctrl_2 |= info->data_format;
 	else
 		ctrl_2 |= ADI_DATA_FORMAT;
-
-	cf_axi_dds_stop(st);
 
 	if (info && !info->rate_format_skip_en)
 		dds_write(st, ADI_REG_CNTRL_2, ctrl_2);

--- a/drivers/iio/frequency/cf_axi_dds.c
+++ b/drivers/iio/frequency/cf_axi_dds.c
@@ -272,7 +272,7 @@ static int cf_axi_dds_sync_frame(struct iio_dev *indio_dev)
 	int stat;
 	static int retry = 0;
 
-	mdelay(10); /* Wait until clocks are stable */
+	msleep(10); /* Wait until clocks are stable */
 
 	dds_write(st, ADI_REG_FRAME, 0);
 	dds_write(st, ADI_REG_FRAME, ADI_FRAME);
@@ -1581,7 +1581,7 @@ static int cf_axi_dds_probe(struct platform_device *pdev)
 		drp_status = dds_read(st, ADI_REG_DRP_STATUS);
 		if (drp_status & ADI_DRP_LOCKED)
 			break;
-		mdelay(1);
+		msleep(1);
 	} while (timeout--);
 
 	if (timeout == -1) {

--- a/drivers/iio/frequency/cf_axi_dds.c
+++ b/drivers/iio/frequency/cf_axi_dds.c
@@ -226,40 +226,26 @@ static int cf_axi_get_parent_sampling_frequency(struct cf_axi_dds_state *st, uns
 int cf_axi_dds_datasel(struct cf_axi_dds_state *st,
 			       int channel, enum dds_data_select sel)
 {
-	if (ADI_AXI_PCORE_VER_MAJOR(st->version) > 7) {
-		if (channel < 0) { /* ALL */
-			unsigned i;
-			for (i = 0; i < st->chip_info->num_buf_channels; i++) {
-				if (i > (st->have_slave_channels - 1))
-					dds_slave_write(st,
-						ADI_REG_CHAN_CNTRL_7(i -
-						st->have_slave_channels), sel);
-				else
-					dds_write(st,
-					ADI_REG_CHAN_CNTRL_7(i), sel);
-			}
-		} else {
-			if ((unsigned)channel > (st->have_slave_channels - 1))
+	if (channel < 0) { /* ALL */
+		unsigned int i;
+
+		for (i = 0; i < st->chip_info->num_buf_channels; i++) {
+			if (i > (st->have_slave_channels - 1))
 				dds_slave_write(st,
-					ADI_REG_CHAN_CNTRL_7(channel -
+					ADI_REG_CHAN_CNTRL_7(i -
 					st->have_slave_channels), sel);
 			else
-				dds_write(st, ADI_REG_CHAN_CNTRL_7(channel),
-					  sel);
+				dds_write(st,
+				ADI_REG_CHAN_CNTRL_7(i), sel);
 		}
 	} else {
-		unsigned reg;
-
-		switch(sel) {
-		case DATA_SEL_DDS:
-		case DATA_SEL_SED:
-		case DATA_SEL_DMA:
-			reg = dds_read(st, ADI_REG_CNTRL_2) & ~ADI_DATA_SEL(~0);
-			dds_write(st, ADI_REG_CNTRL_2, reg | ADI_DATA_SEL(sel));
-			break;
-		default:
-			return -EINVAL;
-		}
+		if ((unsigned int)channel > (st->have_slave_channels - 1))
+			dds_slave_write(st,
+				ADI_REG_CHAN_CNTRL_7(channel -
+				st->have_slave_channels), sel);
+		else
+			dds_write(st, ADI_REG_CHAN_CNTRL_7(channel),
+				  sel);
 	}
 
 	return 0;
@@ -269,18 +255,14 @@ EXPORT_SYMBOL_GPL(cf_axi_dds_datasel);
 static enum dds_data_select cf_axi_dds_get_datasel(struct cf_axi_dds_state *st,
 			       int channel)
 {
-	if (ADI_AXI_PCORE_VER_MAJOR(st->version) > 7) {
-		if (channel < 0)
-			channel = 0;
+	if (channel < 0)
+		channel = 0;
 
-		if ((unsigned)channel > (st->have_slave_channels - 1))
-			return dds_slave_read(st,
-				ADI_REG_CHAN_CNTRL_7(channel - st->have_slave_channels));
+	if ((unsigned int)channel > (st->have_slave_channels - 1))
+		return dds_slave_read(st,
+			ADI_REG_CHAN_CNTRL_7(channel - st->have_slave_channels));
 
-		return dds_read(st, ADI_REG_CHAN_CNTRL_7(channel));
-	} else {
-		return ADI_TO_DATA_SEL(dds_read(st, ADI_REG_CNTRL_2));
-	}
+	return dds_read(st, ADI_REG_CHAN_CNTRL_7(channel));
 }
 
 static int cf_axi_dds_sync_frame(struct iio_dev *indio_dev)
@@ -388,16 +370,14 @@ static int cf_axi_dds_default_setup(struct cf_axi_dds_state *st, u32 chan,
 	dds_write(st, ADI_REG_CHAN_CNTRL_1_IIOCHAN(chan), ADI_DDS_SCALE(scale));
 	dds_write(st, ADI_REG_CHAN_CNTRL_2_IIOCHAN(chan), val);
 
-	if (ADI_AXI_PCORE_VER_MAJOR(st->version) > 7) {
-		if (chan % 2)
-			dds_write(st, ADI_REG_CHAN_CNTRL_8(chan),
-				ADI_IQCOR_COEFF_2(0x4000) |
-				ADI_IQCOR_COEFF_1(0));
-		else
-			dds_write(st, ADI_REG_CHAN_CNTRL_8(chan),
-				ADI_IQCOR_COEFF_2(0) |
-				ADI_IQCOR_COEFF_1(0x4000));
-	}
+	if (chan % 2)
+		dds_write(st, ADI_REG_CHAN_CNTRL_8(chan),
+			ADI_IQCOR_COEFF_2(0x4000) |
+			ADI_IQCOR_COEFF_1(0));
+	else
+		dds_write(st, ADI_REG_CHAN_CNTRL_8(chan),
+			ADI_IQCOR_COEFF_2(0) |
+			ADI_IQCOR_COEFF_1(0x4000));
 
 	return 0;
 }
@@ -532,17 +512,7 @@ static int cf_axi_dds_read_raw(struct iio_dev *indio_dev,
 		}
 
 		reg = ADI_TO_DDS_SCALE(dds_read(st, ADI_REG_CHAN_CNTRL_1_IIOCHAN(chan->channel)));
-		if (ADI_AXI_PCORE_VER_MAJOR(st->version) > 6) {
-			cf_axi_dds_signed_mag_fmt_to_iio(reg, val, val2);
-		} else {
-			if (!reg) {
-				*val = 1;
-				*val2 = 0;
-			} else {
-				*val = 0;
-				*val2 = 1000000 >> reg;
-			}
-		}
+		cf_axi_dds_signed_mag_fmt_to_iio(reg, val, val2);
 		mutex_unlock(&indio_dev->mlock);
 		return IIO_VAL_INT_PLUS_MICRO;
 	case IIO_CHAN_INFO_FREQUENCY:
@@ -574,11 +544,6 @@ static int cf_axi_dds_read_raw(struct iio_dev *indio_dev,
 	case IIO_CHAN_INFO_CALIBPHASE:
 		phase = 1;
 	case IIO_CHAN_INFO_CALIBSCALE:
-
-		if (ADI_AXI_PCORE_VER_MAJOR(st->version) < 8) {
-			ret = -ENODEV;
-			break;
-		}
 
 		reg = dds_read(st, ADI_REG_CHAN_CNTRL_8(chan->channel));
 		/*  format is 1.1.14 (sign, integer and fractional bits) */
@@ -646,39 +611,29 @@ static int cf_axi_dds_write_raw(struct iio_dev *indio_dev,
 			}
 		}
 
-		if (ADI_AXI_PCORE_VER_MAJOR(st->version) > 6) {
-			/*  format is 1.1.14 (sign, integer and fractional bits) */
-			switch (val) {
-			case 1:
-				i = 0x4000;
-				break;
-			case -1:
-				i = 0xC000;
-				break;
-			case 0:
-				i = 0;
-				if (val2 < 0) {
-					i = 0x8000;
-					val2 *= -1;
-				}
-				break;
-			default:
-				ret = -EINVAL;
-				goto err_unlock;
+		/*  format is 1.1.14 (sign, integer and fractional bits) */
+		switch (val) {
+		case 1:
+			i = 0x4000;
+			break;
+		case -1:
+			i = 0xC000;
+			break;
+		case 0:
+			i = 0;
+			if (val2 < 0) {
+				i = 0x8000;
+				val2 *= -1;
 			}
-
-			val64 = (unsigned long long)val2 * 0x4000UL + (1000000UL / 2);
-			do_div(val64, 1000000UL);
-			i |= val64;
-		} else {
-			if (val == 1) {
-				i = 0;
-			} else {
-				for (i = 1; i < 16; i++)
-					if (val2 == (1000000 >> i))
-						break;
-			}
+			break;
+		default:
+			ret = -EINVAL;
+			goto err_unlock;
 		}
+
+		val64 = (unsigned long long)val2 * 0x4000UL + (1000000UL / 2);
+		do_div(val64, 1000000UL);
+		i |= val64;
 		dds_write(st, ADI_REG_CHAN_CNTRL_1_IIOCHAN(chan->channel), ADI_DDS_SCALE(i));
 		cf_axi_dds_start_sync(st);
 		break;
@@ -751,11 +706,6 @@ static int cf_axi_dds_write_raw(struct iio_dev *indio_dev,
 	case IIO_CHAN_INFO_CALIBPHASE:
 		phase = 1;
 	case IIO_CHAN_INFO_CALIBSCALE:
-
-		if (ADI_AXI_PCORE_VER_MAJOR(st->version) < 7) {
-			ret = -ENODEV;
-			break;
-		}
 
 		ret = cf_axi_dds_to_signed_mag_fmt(val, val2, &i);
 		if (ret < 0)
@@ -882,13 +832,11 @@ static const struct iio_chan_spec_ext_info cf_axi_dds_ext_info[] = {
 static void cf_axi_dds_update_chan_spec(struct cf_axi_dds_state *st,
 			struct iio_chan_spec *channels, unsigned num)
 {
+	unsigned int i;
 
-	if (ADI_AXI_PCORE_VER_MAJOR(st->version) > 6) {
-		int i;
-		for (i = 0; i < num; i++) {
-			if (channels[i].type == IIO_ALTVOLTAGE)
-				channels[i].ext_info = NULL;
-		}
+	for (i = 0; i < num; i++) {
+		if (channels[i].type == IIO_ALTVOLTAGE)
+			channels[i].ext_info = NULL;
 	}
 }
 
@@ -1627,20 +1575,21 @@ static int cf_axi_dds_probe(struct platform_device *pdev)
 	indio_dev->info = &st->iio_info;
 
 	dds_write(st, ADI_REG_RSTN, 0x0);
-	if (ADI_AXI_PCORE_VER_MAJOR(st->version) > 7) {
-		dds_write(st, ADI_REG_RSTN, ADI_MMCM_RSTN);
-		do {
-			drp_status = dds_read(st, ADI_REG_DRP_STATUS);
-			if (drp_status & ADI_DRP_LOCKED)
-				break;
-			mdelay(1);
-		} while(timeout--);
-		if (timeout == -1) {
-			dev_err(&pdev->dev, "DRP unlocked.\n");
-			ret = -ETIMEDOUT;
-			goto err_converter_put;
-		}
+	dds_write(st, ADI_REG_RSTN, ADI_MMCM_RSTN);
+
+	do {
+		drp_status = dds_read(st, ADI_REG_DRP_STATUS);
+		if (drp_status & ADI_DRP_LOCKED)
+			break;
+		mdelay(1);
+	} while (timeout--);
+
+	if (timeout == -1) {
+		dev_err(&pdev->dev, "DRP unlocked.\n");
+		ret = -ETIMEDOUT;
+		goto err_converter_put;
 	}
+
 	dds_write(st, ADI_REG_RSTN, ADI_RSTN | ADI_MMCM_RSTN);
 
 	if (info)
@@ -1677,11 +1626,7 @@ static int cf_axi_dds_probe(struct platform_device *pdev)
 
 	if (!st->dp_disable) {
 		unsigned scale, frequency;
-		if (ADI_AXI_PCORE_VER_MAJOR(st->version) > 6)
-			scale = 0x1000; /* 0.250 */
-		else
-			scale = 2; /* 0.250 */
-
+		scale = 0x1000; /* 0.250 */
 		frequency = 40000000;
 
 		of_property_read_u32(np, "adi,axi-dds-default-scale", &scale);

--- a/drivers/iio/frequency/cf_axi_dds.h
+++ b/drivers/iio/frequency/cf_axi_dds.h
@@ -264,7 +264,7 @@ int cf_axi_dds_configure_buffer(struct iio_dev *indio_dev);
 void cf_axi_dds_unconfigure_buffer(struct iio_dev *indio_dev);
 int cf_axi_dds_datasel(struct cf_axi_dds_state *st,
 			       int channel, enum dds_data_select sel);
-void cf_axi_dds_start_sync(struct cf_axi_dds_state *st, bool force_on);
+void cf_axi_dds_start_sync(struct cf_axi_dds_state *st);
 int cf_axi_dds_pl_ddr_fifo_ctrl(struct cf_axi_dds_state *st, bool enable);
 
 /*

--- a/drivers/iio/frequency/cf_axi_dds.h
+++ b/drivers/iio/frequency/cf_axi_dds.h
@@ -264,7 +264,6 @@ int cf_axi_dds_configure_buffer(struct iio_dev *indio_dev);
 void cf_axi_dds_unconfigure_buffer(struct iio_dev *indio_dev);
 int cf_axi_dds_datasel(struct cf_axi_dds_state *st,
 			       int channel, enum dds_data_select sel);
-void cf_axi_dds_stop(struct cf_axi_dds_state *st);
 void cf_axi_dds_start_sync(struct cf_axi_dds_state *st, bool force_on);
 int cf_axi_dds_pl_ddr_fifo_ctrl(struct cf_axi_dds_state *st, bool enable);
 

--- a/drivers/iio/frequency/cf_axi_dds_buffer_stream.c
+++ b/drivers/iio/frequency/cf_axi_dds_buffer_stream.c
@@ -56,8 +56,6 @@ static int dds_buffer_state_set(struct iio_dev *indio_dev, bool state)
 	if (!state)
 		return cf_axi_dds_datasel(st, -1, DATA_SEL_DDS);
 
-	cf_axi_dds_stop(st);
-
 	dds_write(st, ADI_REG_VDMA_STATUS, ADI_VDMA_OVF | ADI_VDMA_UNF);
 
 	cf_axi_dds_start_sync(st, 1);

--- a/drivers/iio/frequency/cf_axi_dds_buffer_stream.c
+++ b/drivers/iio/frequency/cf_axi_dds_buffer_stream.c
@@ -58,7 +58,7 @@ static int dds_buffer_state_set(struct iio_dev *indio_dev, bool state)
 
 	dds_write(st, ADI_REG_VDMA_STATUS, ADI_VDMA_OVF | ADI_VDMA_UNF);
 
-	cf_axi_dds_start_sync(st, 1);
+	cf_axi_dds_start_sync(st);
 
 	return 0;
 }


### PR DESCRIPTION
Currently, the PCORE version of the AXI DDS is at version 10.
This change removes all code that handles earlier versions.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>