### PR TITLE
Dev ad9162 refactor

### DIFF
--- a/drivers/iio/frequency/ad9162.c
+++ b/drivers/iio/frequency/ad9162.c
@@ -118,7 +118,7 @@ static int ad9162_setup(struct ad9162_state *st)
 	dac_rate_Hz = clk_get_rate_scaled(st->conv.clk[CLK_DAC],
 					  &st->conv.clkscale[CLK_DAC]);
 
-	ad916x_dac_set_clk_frequency(ad916x_h, dac_rate_Hz);
+	ret = ad916x_dac_set_clk_frequency(ad916x_h, dac_rate_Hz);
 	if (ret != 0)
 		return ret;
 
@@ -135,12 +135,12 @@ static int ad9162_setup(struct ad9162_state *st)
 	if (appJesdConfig.jesd_M == 2)
 		st->conv.id = ID_AD9162_COMPLEX;
 
-	ad916x_jesd_config_datapath(ad916x_h, appJesdConfig,
+	ret = ad916x_jesd_config_datapath(ad916x_h, appJesdConfig,
 				    st->interpolation, &jesdLaneRate);
 	if (ret != 0)
 		return ret;
 
-	ad916x_jesd_enable_datapath(ad916x_h, 0xFF, 0x1, 0x1);
+	ret = ad916x_jesd_enable_datapath(ad916x_h, 0xFF, 0x1, 0x1);
 	if (ret != 0)
 		return ret;
 

--- a/drivers/iio/frequency/ad9162.c
+++ b/drivers/iio/frequency/ad9162.c
@@ -28,6 +28,9 @@
 #include "ad916x/AD916x.h"
 
 
+#define to_ad916x_state(__conv)	\
+	container_of(__conv, struct ad9162_state, conv)
+
 enum chip_id {
 	CHIPID_AD9162 = 0x62,
 };
@@ -52,7 +55,7 @@ static const char * const clk_names[] = {
 static int ad9162_read(struct spi_device *spi, unsigned reg)
 {
 	struct cf_axi_converter *conv = spi_get_drvdata(spi);
-	struct ad9162_state *st = container_of(conv, struct ad9162_state, conv);
+	struct ad9162_state *st = to_ad916x_state(conv);
 	unsigned int val;
 	int ret = regmap_read(st->map, reg, &val);
 
@@ -62,7 +65,7 @@ static int ad9162_read(struct spi_device *spi, unsigned reg)
 static int ad9162_write(struct spi_device *spi, unsigned reg, unsigned val)
 {
 	struct cf_axi_converter *conv = spi_get_drvdata(spi);
-	struct ad9162_state *st = container_of(conv, struct ad9162_state, conv);
+	struct ad9162_state *st = to_ad916x_state(conv);
 
 	return regmap_write(st->map, reg, val);
 }
@@ -74,7 +77,7 @@ static int ad9162_get_temperature_code(struct cf_axi_converter *conv)
 
 static unsigned long long ad9162_get_data_clk(struct cf_axi_converter *conv)
 {
-	struct ad9162_state *st = container_of(conv, struct ad9162_state, conv);
+	struct ad9162_state *st = to_ad916x_state(conv);
 
 	return div_u64(clk_get_rate_scaled(conv->clk[CLK_DAC], &conv->clkscale[CLK_DAC]), st->interpolation);
 }
@@ -281,7 +284,7 @@ static int ad9162_write_raw(struct iio_dev *indio_dev,
 static int ad9162_prepare(struct cf_axi_converter *conv)
 {
 	struct cf_axi_dds_state *st = iio_priv(conv->indio_dev);
-	struct ad9162_state *ad9162 = container_of(conv, struct ad9162_state, conv);
+	struct ad9162_state *ad9162 = to_ad916x_state(conv);
 
 	/* FIXME This needs documenation */
 	dds_write(st, 0x428, (ad9162->complex_mode ? 0x1 : 0x0) |
@@ -319,7 +322,7 @@ static ssize_t ad9162_attr_store(struct device *dev,
 	struct iio_dev *indio_dev = dev_to_iio_dev(dev);
 	struct iio_dev_attr *this_attr = to_iio_dev_attr(attr);
 	struct cf_axi_converter *conv = iio_device_get_drvdata(indio_dev);
-	struct ad9162_state *st = container_of(conv, struct ad9162_state, conv);
+	struct ad9162_state *st = to_ad916x_state(conv);
 	ad916x_handle_t *ad916x_h = &st->dac_h;
 	unsigned long long readin;
 	int ret;
@@ -353,7 +356,7 @@ static ssize_t ad9162_attr_show(struct device *dev,
 	struct iio_dev *indio_dev = dev_to_iio_dev(dev);
 	struct iio_dev_attr *this_attr = to_iio_dev_attr(attr);
 	struct cf_axi_converter *conv = iio_device_get_drvdata(indio_dev);
-	struct ad9162_state *st = container_of(conv, struct ad9162_state, conv);
+	struct ad9162_state *st = to_ad916x_state(conv);
 	ad916x_handle_t *ad916x_h = &st->dac_h;
 	int ret = 0;
 	u64 freq;

--- a/drivers/iio/frequency/ad9162.c
+++ b/drivers/iio/frequency/ad9162.c
@@ -407,6 +407,7 @@ static int ad9162_probe(struct spi_device *spi)
 	struct cf_axi_converter *conv;
 	struct ad9162_state *st;
 	int ret;
+	bool spi3wire = false;
 
 	st = devm_kzalloc(&spi->dev, sizeof(*st), GFP_KERNEL);
 	if (st == NULL)
@@ -444,8 +445,12 @@ static int ad9162_probe(struct spi_device *spi)
 		goto out;
 	}
 
+	if (device_property_read_bool(&spi->dev, "adi,spi-3wire-enable"))
+		spi3wire = true;
+
 	st->dac_h.user_data = st->map;
-	st->dac_h.sdo = SPI_SDIO;
+	st->dac_h.sdo = ((spi->mode & SPI_3WIRE) || spi3wire) ? SPI_SDIO :
+			SPI_SDO;
 	st->dac_h.dev_xfer = spi_xfer_dummy;
 	st->dac_h.delay_us = delay_us;
 	st->dac_h.event_handler = NULL;


### PR DESCRIPTION
ad9162 refactor. This is part of the work on splitting #448 in smaller patches. This is now applied to master since it makes more sense (it needs to be ported to the rpi-4.14.y branch).