### PR TITLE
Dev ad9162 standalone mode

### DIFF
--- a/drivers/iio/frequency/ad9162.c
+++ b/drivers/iio/frequency/ad9162.c
@@ -31,13 +31,8 @@
 #define to_ad916x_state(__conv)	\
 	container_of(__conv, struct ad9162_state, conv)
 
-enum chip_id {
-	CHIPID_AD9162 = 0x62,
-};
-
 struct ad9162_state {
 	struct cf_axi_converter conv;
-	enum chip_id id;
 	struct regmap *map;
 	ad916x_handle_t dac_h;
 	bool complex_mode;
@@ -429,7 +424,6 @@ static const struct attribute_group ad9162_attribute_group = {
 
 static int ad9162_probe(struct spi_device *spi)
 {
-	const struct spi_device_id *dev_id = spi_get_device_id(spi);
 	struct cf_axi_converter *conv;
 	struct ad9162_state *st;
 	int ret;
@@ -439,7 +433,6 @@ static int ad9162_probe(struct spi_device *spi)
 	if (st == NULL)
 		return -ENOMEM;
 
-	st->id = (enum chip_id) dev_id->driver_data;
 	conv = &st->conv;
 
 	conv->reset_gpio = devm_gpiod_get_optional(&spi->dev, "reset", GPIOD_OUT_HIGH);
@@ -525,7 +518,7 @@ static const struct of_device_id ad916x_dt_id[] = {
 MODULE_DEVICE_TABLE(of, ad916x_dt_id);
 
 static const struct spi_device_id ad9162_id[] = {
-	{ "ad9162", CHIPID_AD9162 },
+	{ "ad9162", 0 },
 	{}
 };
 

--- a/drivers/iio/frequency/ad9162.c
+++ b/drivers/iio/frequency/ad9162.c
@@ -518,6 +518,12 @@ static int ad9162_remove(struct spi_device *spi)
 	return 0;
 }
 
+static const struct of_device_id ad916x_dt_id[] = {
+	{ .compatible = "adi,ad9162" },
+	{},
+};
+MODULE_DEVICE_TABLE(of, ad916x_dt_id);
+
 static const struct spi_device_id ad9162_id[] = {
 	{ "ad9162", CHIPID_AD9162 },
 	{}
@@ -528,6 +534,7 @@ MODULE_DEVICE_TABLE(spi, ad9162_id);
 static struct spi_driver ad9162_driver = {
 	.driver = {
 		   .name = "ad9162",
+		   .of_match_table = ad916x_dt_id,
 		   .owner = THIS_MODULE,
 		   },
 	.probe = ad9162_probe,


### PR DESCRIPTION
This PR adds support for standalone mode in which the driver can work independent of cf_axi_dds. It also adds support for DC_TEST_EN mode. A chip_info structure is defined as a preliminary step to add support for more devices of the ad916x family.