### PR TITLE
[RFC] .github: add issue template recommending EZ

### DIFF
--- a/.github/issue_template
+++ b/.github/issue_template
@@ -1,0 +1,15 @@
+Thank you for reporting an issue with us for this repository.
+
+We typically recommend using our forum (EngineerZone) for reporting issues.
+That is where you may also find some resolutions to some questions you may have.
+
+The link is:
+   https://ez.analog.com/linux-device-drivers/linux-software-drivers
+
+You are still free to open an issue on Github, in case you prefer it here.
+There are various other use-cases where this issue tracker is better suited than
+the forum, such as punctual issues/items related to driver code, or keeping track
+of certain tasks/items related to a particular driver changeset.
+
+Thank you
+Analog Devices, Inc. Linux Group


### PR DESCRIPTION
Github allows issues & pull-request templates.
For PRs we don't have stuff to recommend for PR descriptions.
Typically things get addressed in the review process.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>