### PR TITLE
Fix clkscale

### DIFF
--- a/arch/arm/boot/dts/adi-fmcomms11-RevA.dtsi
+++ b/arch/arm/boot/dts/adi-fmcomms11-RevA.dtsi
@@ -107,7 +107,7 @@
 		spi-max-frequency = <1000000>;
 		clocks = <&axi_ad9162_jesd>, <&adf4355_clk>, <&clk0_ad9508 0>;
 		clock-names = "jesd_dac_clk", "dac_clk", "dac_sysref";
-		dac_clk-clock-scales = <2 1>;
+		dac_clk-clock-scales = <1 2>;
 		adi,full-scale-current-microamp = <20000>;
 		adi,spi-3wire-enable;
 	};
@@ -122,7 +122,7 @@
 		spi-cpha;
 		clocks = <&axi_ad9625_jesd>, <&adc_clk_div>, <&clk0_ad9508 0>;
 		clock-names = "jesd_adc_clk", "adc_clk", "adc_sysref";
-		adc_clk-clock-scales = <2 1>;
+		adc_clk-clock-scales = <1 2>;
 	};
 
 	dga0_adl5240: adl5240@4 {

--- a/arch/arm/boot/dts/adi-fmcomms11.dtsi
+++ b/arch/arm/boot/dts/adi-fmcomms11.dtsi
@@ -73,7 +73,7 @@
 
 		clocks = <&axi_ad9162_jesd>, <&adf4355_clk>;
 		clock-names = "jesd_dac_clk", "dac_clk";
-		dac_clk-clock-scales = <2 1>;
+		dac_clk-clock-scales = <1 2>;
 		adi,full-scale-current-microamp = <20000>;
 		adi,spi-3wire-enable;
 	};
@@ -88,7 +88,7 @@
 
 		clocks = <&axi_ad9625_jesd>, <&adc_clk_div>;
 		clock-names = "jesd_adc_clk", "adc_clk";
-		adc_clk-clock-scales = <2 1>;
+		adc_clk-clock-scales = <1 2>;
 	};
 
 	dga0_adl5240: adl5240@4 {

--- a/include/linux/clk/clkscale.h
+++ b/include/linux/clk/clkscale.h
@@ -35,7 +35,7 @@ static inline int of_clk_get_scale(struct device_node *np, const char *name, str
 
 static inline unsigned long long clk_get_rate_scaled(struct clk *clk, struct clock_scale *scale)
 {
-	return div_u64((u64)clk_get_rate(clk) * scale->mult, scale->div);
+	return div_u64((u64)clk_get_rate(clk) * scale->div, scale->mult);
 
 }
 


### PR DESCRIPTION
clk_get_rate_scaled() and clk_set_rate_scaled() were doing the same operation, which is obviously wrong. Also update the devicetrees which were using this property.