### PR TITLE
arm: dts: Fix fmcomms11 ad9162 fsc settings

### DIFF
--- a/arch/arm/boot/dts/adi-fmcomms11-RevA.dtsi
+++ b/arch/arm/boot/dts/adi-fmcomms11-RevA.dtsi
@@ -108,6 +108,7 @@
 		clocks = <&axi_ad9162_jesd>, <&adf4355_clk>, <&clk0_ad9508 0>;
 		clock-names = "jesd_dac_clk", "dac_clk", "dac_sysref";
 		dac_clk-clock-scales = <2 1>;
+		adi,full-scale-current-microamp = <20000>;
 	};
 
 	adc0_ad9625: ad9625@1 {

--- a/arch/arm/boot/dts/adi-fmcomms11.dtsi
+++ b/arch/arm/boot/dts/adi-fmcomms11.dtsi
@@ -74,6 +74,7 @@
 		clocks = <&axi_ad9162_jesd>, <&adf4355_clk>;
 		clock-names = "jesd_dac_clk", "dac_clk";
 		dac_clk-clock-scales = <2 1>;
+		adi,full-scale-current-microamp = <20000>;
 	};
 
 	adc0_ad9625: ad9625@1 {


### PR DESCRIPTION
Due to 2234963b5cba, the ad9162 full scale current is now configured
through devicetree, defaulting to 40mA if no property is set. Since
fmcomms11 needs a configuration of 20mA, this has to be done in the
devicetree.

Signed-off-by: Nuno Sá <nuno.sa@analog.com>