### PR TITLE
arm: dts: Fix fmcomms11 ad9162 3wire spi

### DIFF
--- a/arch/arm/boot/dts/adi-fmcomms11-RevA.dtsi
+++ b/arch/arm/boot/dts/adi-fmcomms11-RevA.dtsi
@@ -109,6 +109,7 @@
 		clock-names = "jesd_dac_clk", "dac_clk", "dac_sysref";
 		dac_clk-clock-scales = <2 1>;
 		adi,full-scale-current-microamp = <20000>;
+		adi,spi-3wire-enable;
 	};
 
 	adc0_ad9625: ad9625@1 {

--- a/arch/arm/boot/dts/adi-fmcomms11.dtsi
+++ b/arch/arm/boot/dts/adi-fmcomms11.dtsi
@@ -75,6 +75,7 @@
 		clock-names = "jesd_dac_clk", "dac_clk";
 		dac_clk-clock-scales = <2 1>;
 		adi,full-scale-current-microamp = <20000>;
+		adi,spi-3wire-enable;
 	};
 
 	adc0_ad9625: ad9625@1 {


### PR DESCRIPTION
Due to 798ddf889813, the 3wire SPI mode is configurable through
devicetree. On fmcomms11, ad9162 is using 3wire spi mode, so that,
the devicetree has to be updated accordingly.

Signed-off-by: Nuno Sá <nuno.sa@analog.com>