### PR TITLE
.travis.yml: extend cherry-pick sync

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ env:
   - BUILD_TYPE=sync_branches_with_master
     BRANCH1="xcomm_zynq:fast-forward"
     BRANCH2="adi-4.14.0:cherry-pick"
+    BRANCH3="adi-4.19.0:cherry-pick"
+    BRANCH4="rpi-4.19.y:cherry-pick"
+    BRANCH5="rpi-4.14.y:cherry-pick"
   - BUILD_TYPE=checkpatch
   - BUILD_TYPE=dtb_build_test
   - DEFCONFIG_NAME=zynq_xcomm_adv7511_defconfig ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf-


### PR DESCRIPTION
Change adds sync-ing support via cherry-picking to branches:
* adi-4.19.0
* rpi-4.14.y
* rpi-4.19.y

rpi-4.14.y will be obsoleted soon, but we may still want to keep it for a
while longer also to test the auto-sync-ing.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>