### PR TITLE
ci/travis/run-build.sh: limit git fetch depth to 50 

### DIFF
--- a/ci/travis/run-build.sh
+++ b/ci/travis/run-build.sh
@@ -40,7 +40,11 @@ branch_contains_commit() {
 
 __update_git_ref() {
 	local ref="$1"
-	git fetch origin +refs/heads/${ref}:${ref}
+	local depth
+	[ "$GIT_FETCH_DEPTH" == "disabled" ] || {
+		depth="--depth=${GIT_FETCH_DEPTH:-50}"
+	}
+	git fetch $depth origin +refs/heads/${ref}:${ref}
 }
 
 __push_back_to_github() {

--- a/ci/travis/run-build.sh
+++ b/ci/travis/run-build.sh
@@ -16,7 +16,7 @@ build_compile_test() {
 
 build_checkpatch() {
 	if [ -n "$TRAVIS_BRANCH" ]; then
-		git fetch origin +refs/heads/${TRAVIS_BRANCH}:${TRAVIS_BRANCH}
+		__update_git_ref ${TRAVIS_BRANCH}
 	fi
 	COMMIT_RANGE=$([ "$TRAVIS_PULL_REQUEST" == "false" ] &&  echo HEAD || echo ${TRAVIS_BRANCH}..)
 	scripts/checkpatch.pl --git ${COMMIT_RANGE} \


### PR DESCRIPTION
Without any parameter, `git fetch` pulls the entire branch history, which
can take a while and takes up internet bandwidth needlessly.
Also, if we bump the number of branches to sync, the time for this branch
can increase quite a bit [20-30+ minutes].

This patch limits the git fetch depth to 50.
This can be configurable by providing a `GIT_FETCH_DEPTH` parameter, with
the option of doing `GIT_FETCH_DEPTH=disabled` to disable this.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>