### PR TITLE
iio: adc: ad9361: remove commented MIN_ADC_CLK def

### DIFF
--- a/drivers/iio/adc/ad9361_regs.h
+++ b/drivers/iio/adc/ad9361_regs.h
@@ -2793,7 +2793,6 @@
  */
 
 #define MIN_ADC_CLK			25000000UL /* 25 MHz */
-//#define MIN_ADC_CLK			(MIN_BBPLL_FREQ / MAX_BBPLL_DIV) /* 11.17MHz */
 #define MAX_ADC_CLK			640000000UL /* 640 MHz */
 #define MAX_DAC_CLK			(MAX_ADC_CLK / 2)
 


### PR DESCRIPTION
Fixes #486

Remove it. If it's there it may encourage customers to use it:
 https://ez.analog.com/linux-device-drivers/linux-software-drivers/f/q-a/113808/ad9361-not-transmitting-when-configured-for-low-sampling-rates

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>