### PR TITLE
iio: adc: ad9361: Expose max TX attenuation value in header

### DIFF
--- a/drivers/iio/adc/ad9361.c
+++ b/drivers/iio/adc/ad9361.c
@@ -1243,7 +1243,7 @@ static int ad9361_set_tx_atten(struct ad9361_rf_phy *phy, u32 atten_mdb,
 	dev_dbg(&phy->spi->dev, "%s : attenuation %u mdB tx1=%d tx2=%d",
 		__func__, atten_mdb, tx1, tx2);
 
-	if (atten_mdb > 89750) /* 89.75 dB */
+	if (atten_mdb > MAX_TX_ATTENUATION_DB) /* 89.75 dB */
 		return -EINVAL;
 
 	atten_mdb /= 250; /* Scale to 0.25dB / LSB */

--- a/drivers/iio/adc/ad9361_regs.h
+++ b/drivers/iio/adc/ad9361_regs.h
@@ -2826,4 +2826,6 @@
 #define MAX_GAIN_TABLE_SIZE		90
 #define MAX_NUM_GAIN_TABLES		16 /* randomly picked */
 
+#define MAX_TX_ATTENUATION_DB		89750
+
 #endif


### PR DESCRIPTION
This patch exposes the maximum TX attenuation inside the header file. The
new macro will be used to verify the desired attenuation
(MAX_TX_ATTENUATION_DB). The maximum TX attenuation value can be found
on page 55 in UG-570.

Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>