### PR TITLE
iio: jesd204: adxcvr: remove fixed sleep when enabling clock

### DIFF
--- a/drivers/iio/jesd204/axi_adxcvr.c
+++ b/drivers/iio/jesd204/axi_adxcvr.c
@@ -236,8 +236,6 @@ static int adxcvr_clk_enable(struct clk_hw *hw)
 
 	adxcvr_write(st, ADXCVR_REG_RESETN, ADXCVR_RESETN);
 
-	mdelay(100);
-
 	ret = adxcvr_status_error(st->dev);
 
 	return ret;


### PR DESCRIPTION
There's a fixed `mdelay(100)` call right before calling
`adxcvr_status_error()`.

The `adxcvr_status_error()` does a busy loop checking the status reg, which
is 100 x 1mS. Technically that alone should be sufficient.

This change removes the fixed delay before the busy loop.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>