### PR TITLE
iio: adc: adrv9009: GPIO3v3 control via debugfs

### DIFF
--- a/drivers/iio/adc/adrv9009.c
+++ b/drivers/iio/adc/adrv9009.c
@@ -1033,6 +1033,17 @@ static int adrv9009_do_setup(struct adrv9009_rf_phy *phy)
 		goto out_disable_obs_rx_clk;
 	}
 
+	if (phy->gpio3v3SrcCtrl) {
+		ret = TALISE_setGpio3v3SourceCtrl(phy->talDevice, phy->gpio3v3SrcCtrl);
+		if (ret != TALACT_NO_ACTION) {
+			dev_err(&phy->spi->dev, "%s:%d (ret %d)", __func__, __LINE__, ret);
+			ret = -EFAULT;
+			goto out_disable_obs_rx_clk;
+		}
+		TALISE_setGpio3v3PinLevel(phy->talDevice, phy->gpio3v3PinLevel);
+		TALISE_setGpio3v3Oe(phy->talDevice, phy->gpio3v3OutEn, 0xFFF);
+	}
+
 	if (has_tx(phy)) {
 		ret = TALISE_setPaProtectionCfg(phy->talDevice, &phy->tx_pa_protection);
 		if (ret != TALACT_NO_ACTION) {
@@ -3361,6 +3372,7 @@ static ssize_t adrv9009_debugfs_write(struct file *file,
 	taliseTxNcoTestToneCfg_t nco_config;
 	u32 val2, val3, val4;
 	s64 val;
+	u16 level;
 	char buf[80];
 	int ret;
 
@@ -3370,7 +3382,7 @@ static ssize_t adrv9009_debugfs_write(struct file *file,
 
 	buf[count] = 0;
 
-	ret = sscanf(buf, "%lld %i %i %i", &val, &val2, &val3, &val4);
+	ret = sscanf(buf, "%lli %i %i %i", &val, &val2, &val3, &val4);
 	if (ret < 1)
 		return -EINVAL;
 
@@ -3428,6 +3440,48 @@ static ssize_t adrv9009_debugfs_write(struct file *file,
 
 		entry->val = val;
 		return count;
+	case DBGFS_GPIO3V3:
+		mutex_lock(&phy->indio_dev->mlock);
+		if (ret == 1) {
+			ret = TALISE_getGpio3v3PinLevel(phy->talDevice, &level);
+			if (ret < 0) {
+				mutex_unlock(&phy->indio_dev->mlock);
+				return ret;
+			}
+			if (val == 0xFFF)
+				entry->val = level;
+			else if (val >= 0 && val < 12)
+				entry->val = !!(level & BIT(val));
+			else
+				ret = -EINVAL;
+		} else if (ret == 2) {
+			if (val == 0xFFF) {
+				level = val2;
+				entry->val = val2;
+				ret = TALISE_setGpio3v3PinLevel(phy->talDevice, level);
+			} else if (val >= 0 && val < 12) {
+				ret = TALISE_getGpio3v3PinLevel(phy->talDevice, &level);
+				if (ret < 0) {
+					mutex_unlock(&phy->indio_dev->mlock);
+					return ret;
+				}
+
+				if (val2)
+					level |= BIT(val);
+				else
+					level &= ~BIT(val);
+
+				entry->val = !!val2;
+				ret = TALISE_setGpio3v3PinLevel(phy->talDevice, level);
+			} else {
+				ret = -EINVAL;
+			}
+
+		} else {
+			ret = -EINVAL;
+		}
+		mutex_unlock(&phy->indio_dev->mlock);
+		break;
 	default:
 		break;
 	}
@@ -3493,6 +3547,7 @@ static int adrv9009_register_debugfs(struct iio_dev *indio_dev)
 	adrv9009_add_debugfs_entry(phy, "bist_framer_a_loopback", DBGFS_BIST_FRAMER_A_LOOPBACK);
 	adrv9009_add_debugfs_entry(phy, "bist_framer_b_loopback", DBGFS_BIST_FRAMER_B_LOOPBACK);
 	adrv9009_add_debugfs_entry(phy, "bist_tone", DBGFS_BIST_TONE);
+	adrv9009_add_debugfs_entry(phy, "gpio3v3", DBGFS_GPIO3V3);
 
 	for (i = 0; i < phy->adrv9009_debugfs_entry_index; i++)
 		d = debugfs_create_file(
@@ -3967,6 +4022,12 @@ static int adrv9009_phy_parse_dt(struct iio_dev *iodev, struct device *dev)
 	ADRV9009_OF_PROP("adi,arm-gpio-config-en-tx-tracking-cals-enable",
 			 &phy->arm_gpio_config.enTxTrackingCals.enable, 0);
 
+	ADRV9009_OF_PROP("adi,gpio3v3-source-control",
+			 &phy->gpio3v3SrcCtrl, 0);
+	ADRV9009_OF_PROP("adi,gpio3v3-output-enable-mask",
+			 &phy->gpio3v3OutEn, 0);
+	ADRV9009_OF_PROP("adi,gpio3v3-output-level-mask",
+			 &phy->gpio3v3PinLevel, 0);
 
 	ADRV9009_OF_PROP("adi,orx-lo-cfg-disable-aux-pll-relocking",
 			 &phy->orx_lo_cfg.disableAuxPllRelocking, 0);

--- a/drivers/iio/adc/adrv9009.h
+++ b/drivers/iio/adc/adrv9009.h
@@ -38,6 +38,7 @@ enum debugfs_cmd {
 	DBGFS_BIST_FRAMER_A_LOOPBACK,
 	DBGFS_BIST_FRAMER_B_LOOPBACK,
 	DBGFS_BIST_TONE,
+	DBGFS_GPIO3V3,
 };
 
 
@@ -180,6 +181,9 @@ struct adrv9009_rf_phy {
 	taliseTxAttenCtrlPin_t	tx2_atten_ctrl_pin;
 	taliseTxPaProtectCfg_t	tx_pa_protection;
 	taliseRxHd2Config_t	rx_hd2_config;
+	uint16_t		gpio3v3SrcCtrl;
+	uint16_t 		gpio3v3PinLevel;
+	uint16_t 		gpio3v3OutEn;
 
 	int16_t rxFirCoefs[72];
 	int16_t obsrxFirCoefs[72];
@@ -204,7 +208,7 @@ struct adrv9009_rf_phy {
 	struct clk 		*clks[NUM_ADRV9009_CLKS];
 	struct adrv9009_clock	clk_priv[NUM_ADRV9009_CLKS];
 	struct clk_onecell_data	clk_data;
-	struct adrv9009_debugfs_entry debugfs_entry[338];
+	struct adrv9009_debugfs_entry debugfs_entry[342];
 	struct bin_attribute 	bin;
 	struct bin_attribute 	bin_gt;
 	struct iio_dev 		*indio_dev;


### PR DESCRIPTION
This patch adds support for controlling the 12 GPIO3v3 via debugfs.
In order to use these pins, the adi,gpio3v3-source-control attribute
must be set. Please refer to the Rerefer to the reference manual UG-1295.
In addition, dedicated output pins must be masked via
adi,gpio3v3-output-enable-mask.

adi,gpio3v3-source-control = <0x333>;
adi,gpio3v3-output-enable-mask = <0xFFF>;
adi,gpio3v3-output-level-mask = <0x0>;

For test purposes these attributes can be also set via debugfs.

cd /sys/kernel/debug/iio/iio\:device3
echo 0x333 > adi,gpio3v3-source-control
echo 0xFFF > adi,gpio3v3-output-enable-mask
echo 1 > initialize

The gpio3v3 debugfs control allows setting individual gpios by
number 0…11. Or altogether using the 0xFFF mask.
GPIOs masked as inputs can also be read.

root@analog:/sys/kernel/debug/iio/iio:device3# echo 0 1 > gpio3v3
root@analog:/sys/kernel/debug/iio/iio:device3# echo 0xFFF 0x123 > gpio3v3
root@analog:/sys/kernel/debug/iio/iio:device3# echo 0xFFF 0x0 > gpio3v3

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>