### PR TITLE
 iio: jesd204: xilinx_transceiver: add more debug/err print message on error paths

### DIFF
--- a/drivers/iio/jesd204/xilinx_transceiver.c
+++ b/drivers/iio/jesd204/xilinx_transceiver.c
@@ -179,6 +179,8 @@ static int xilinx_xcvr_gtx2_configure_cdr(struct xilinx_xcvr *xcvr,
 			cfg1 = 0x1008;
 			break;
 		default:
+			dev_err(xcvr->dev, "Invalid out_div value %u in '%s'\n",
+				out_div, __func__);
 			return -EINVAL;
 		}
 
@@ -219,6 +221,8 @@ static int xilinx_xcvr_gtx2_configure_cdr(struct xilinx_xcvr *xcvr,
 			cfg1 = 0x4008;
 			break;
 		default:
+			dev_err(xcvr->dev, "Invalid out_div value %u in '%s'\n",
+				out_div, __func__);
 			return -EINVAL;
 		}
 	}
@@ -624,6 +628,8 @@ static int xilinx_xcvr_gth34_cpll_write_config(struct xilinx_xcvr *xcvr,
 		val = 0x3;
 		break;
 	default:
+		dev_err(xcvr->dev, "Invalid fb_div_N2 value %u in '%s'\n",
+			conf->fb_div_N2, __func__);
 		return -EINVAL;
 	}
 
@@ -636,6 +642,8 @@ static int xilinx_xcvr_gth34_cpll_write_config(struct xilinx_xcvr *xcvr,
 		val |= CPLL_FB_DIV_45_N1_MASK;
 		break;
 	default:
+		dev_err(xcvr->dev, "Invalid fb_div_N1 value %u in '%s'\n",
+			conf->fb_div_N1, __func__);
 		return -EINVAL;
 	}
 
@@ -652,6 +660,8 @@ static int xilinx_xcvr_gth34_cpll_write_config(struct xilinx_xcvr *xcvr,
 		val = 0;
 		break;
 	default:
+		dev_err(xcvr->dev, "Invalid refclk_div value %u in '%s'\n",
+			conf->refclk_div, __func__);
 		return -EINVAL;
 	}
 
@@ -673,6 +683,8 @@ static int xilinx_xcvr_gtx2_cpll_write_config(struct xilinx_xcvr *xcvr,
 		val |= CPLL_FB_DIV_45_N1_MASK;
 		break;
 	default:
+		dev_err(xcvr->dev, "Invalid fb_div_N1 value %u in '%s'\n",
+			conf->fb_div_N1, __func__);
 		return -EINVAL;
 	}
 
@@ -692,6 +704,8 @@ static int xilinx_xcvr_gtx2_cpll_write_config(struct xilinx_xcvr *xcvr,
 		val |= 0x3;
 		break;
 	default:
+		dev_err(xcvr->dev, "Invalid fb_div_N2 value %u in '%s'\n",
+			conf->fb_div_N2, __func__);
 		return -EINVAL;
 	}
 
@@ -702,6 +716,8 @@ static int xilinx_xcvr_gtx2_cpll_write_config(struct xilinx_xcvr *xcvr,
 	case 2:
 		break;
 	default:
+		dev_err(xcvr->dev, "Invalid ref_clk_div value %u in '%s'\n",
+			conf->refclk_div, __func__);
 		return -EINVAL;
 	}
 
@@ -1170,8 +1186,11 @@ int xilinx_xcvr_write_rx_clk25_div(struct xilinx_xcvr *xcvr,
 {
 	unsigned int reg, mask;
 
-	if (div == 0 || div > 32)
+	if (div == 0 || div > 32) {
+		dev_err(xcvr->dev, "Invalid div value %u in '%s'\n",
+			div, __func__);
 		return -EINVAL;
+	}
 
 	div--;
 
@@ -1203,8 +1222,11 @@ int xilinx_xcvr_write_tx_clk25_div(struct xilinx_xcvr *xcvr,
 {
 	unsigned int reg, mask;
 
-	if (div == 0 || div > 32)
+	if (div == 0 || div > 32) {
+		dev_err(xcvr->dev, "Invalid div value %u in '%s'\n",
+			div, __func__);
 		return -EINVAL;
+	}
 
 	div--;
 

--- a/drivers/iio/jesd204/xilinx_transceiver.c
+++ b/drivers/iio/jesd204/xilinx_transceiver.c
@@ -376,7 +376,7 @@ int xilinx_xcvr_calc_cpll_config(struct xilinx_xcvr *xcvr,
 		}
 	}
 
-	dev_dbg(xcvr->dev,
+	dev_err(xcvr->dev,
 		 "CPLL: failed to find setting for lane rate %u kHz with reference clock %u kHz\n",
 		lane_rate_khz, refclk_khz);
 
@@ -473,7 +473,7 @@ int xilinx_xcvr_calc_qpll_config(struct xilinx_xcvr *xcvr,
 		}
 	}
 
-	dev_dbg(xcvr->dev,
+	dev_err(xcvr->dev,
 		 "QPLL: failed to find setting for lane rate %u kHz with reference clock %u kHz\n",
 		 lane_rate_khz, refclk_khz);
 
@@ -877,7 +877,7 @@ static int xilinx_xcvr_gth34_qpll_write_config(struct xilinx_xcvr *xcvr,
 		refclk = 2;
 		break;
 	default:
-		dev_dbg(xcvr->dev, "Invalid refclk divider: %d\n",
+		dev_err(xcvr->dev, "Invalid refclk divider: %d\n",
 			conf->refclk_div);
 		return -EINVAL;
 	}
@@ -911,7 +911,7 @@ static int xilinx_xcvr_gtx2_qpll_write_config(struct xilinx_xcvr *xcvr,
 		cfg1 = QPLL_REFCLK_DIV_M(2);
 		break;
 	default:
-		dev_dbg(xcvr->dev, "Invalid refclk divider: %d\n",
+		dev_err(xcvr->dev, "Invalid refclk divider: %d\n",
 			conf->refclk_div);
 		return -EINVAL;
 	}
@@ -945,7 +945,7 @@ static int xilinx_xcvr_gtx2_qpll_write_config(struct xilinx_xcvr *xcvr,
 		fbdiv = 368;
 		break;
 	default:
-		dev_dbg(xcvr->dev, "Invalid feedback divider: %d\n",
+		dev_err(xcvr->dev, "Invalid feedback divider: %d\n",
 			conf->fb_div);
 		return -EINVAL;
 	}

--- a/drivers/iio/jesd204/xilinx_transceiver.c
+++ b/drivers/iio/jesd204/xilinx_transceiver.c
@@ -245,6 +245,8 @@ int xilinx_xcvr_configure_cdr(struct xilinx_xcvr *xcvr,
 	case XILINX_XCVR_TYPE_US_GTY4:
 		return xilinx_xcvr_gth3_configure_cdr(xcvr, drp_port, out_div);
 	default:
+		dev_err(xcvr->dev, "Unknown transceiver type %d in '%s'\n",
+			xcvr->type, __func__);
 		return -EINVAL;
 	}
 }
@@ -268,6 +270,10 @@ int xilinx_xcvr_configure_lpm_dfe_mode(struct xilinx_xcvr *xcvr,
 		else
 			xilinx_xcvr_drp_write(xcvr, drp_port, 0x029, 0x0954);
 		break;
+	default:
+		dev_err(xcvr->dev, "Unknown transceiver type %d in '%s'\n",
+			xcvr->type, __func__);
+		return -EINVAL;
 	}
 
 	return 0;
@@ -318,6 +324,11 @@ static void xilinx_xcvr_setup_qpll_vco_range(struct xilinx_xcvr *xcvr,
 				*vco0_max = 10312500;
 			*vco1_max = *vco0_max;
 		}
+		break;
+	default:
+		dev_err(xcvr->dev, "Unknown transceiver type %d in '%s'\n",
+			xcvr->type, __func__);
+		return;
 	}
 }
 
@@ -344,6 +355,8 @@ int xilinx_xcvr_calc_cpll_config(struct xilinx_xcvr *xcvr,
 		vco_max = 6250000;
 		break;
 	default:
+		dev_err(xcvr->dev, "Unknown transceiver type %d in '%s'\n",
+			xcvr->type, __func__);
 		return -EINVAL;
 	}
 
@@ -432,6 +445,8 @@ int xilinx_xcvr_calc_qpll_config(struct xilinx_xcvr *xcvr,
 		vco1_max = vco0_max;
 		break;
 	default:
+		dev_err(xcvr->dev, "Unknown transceiver type %d in '%s'\n",
+			xcvr->type, __func__);
 		return -EINVAL;
 	}
 
@@ -579,6 +594,8 @@ int xilinx_xcvr_cpll_read_config(struct xilinx_xcvr *xcvr,
 	case XILINX_XCVR_TYPE_US_GTY4:
 		return xilinx_xcvr_gth34_cpll_read_config(xcvr, drp_port, conf);
 	default:
+		dev_err(xcvr->dev, "Unknown transceiver type %d in '%s'\n",
+			xcvr->type, __func__);
 		return -EINVAL;
 	}
 }
@@ -704,6 +721,8 @@ int xilinx_xcvr_cpll_write_config(struct xilinx_xcvr *xcvr,
 	case XILINX_XCVR_TYPE_US_GTY4:
 		return xilinx_xcvr_gth34_cpll_write_config(xcvr, drp_port, conf);
 	default:
+		dev_err(xcvr->dev, "Unknown transceiver type %d in '%s'\n",
+			xcvr->type, __func__);
 		return -EINVAL;
 	}
 }
@@ -850,6 +869,8 @@ int xilinx_xcvr_qpll_read_config(struct xilinx_xcvr *xcvr,
 	case XILINX_XCVR_TYPE_US_GTY4:
 		return xilinx_xcvr_gth34_qpll_read_config(xcvr, drp_port, conf);
 	default:
+		dev_err(xcvr->dev, "Unknown transceiver type %d in '%s'\n",
+			xcvr->type, __func__);
 		return -EINVAL;
 	}
 }
@@ -989,6 +1010,8 @@ int xilinx_xcvr_qpll_write_config(struct xilinx_xcvr *xcvr,
 	case XILINX_XCVR_TYPE_US_GTY4:
 		return xilinx_xcvr_gth34_qpll_write_config(xcvr, drp_port, conf);
 	default:
+		dev_err(xcvr->dev, "Unknown transceiver type %d in '%s'\n",
+			xcvr->type, __func__);
 		return -EINVAL;
 	}
 }
@@ -1060,6 +1083,8 @@ int xilinx_xcvr_read_out_div(struct xilinx_xcvr *xcvr, unsigned int drp_port,
 		return xilinx_xcvr_gth34_read_out_div(xcvr, drp_port,
 			rx_out_div, tx_out_div);
 	default:
+		dev_err(xcvr->dev, "Unknown transceiver type %d in '%s'\n",
+			xcvr->type, __func__);
 		return -EINVAL;
 	}
 }
@@ -1133,6 +1158,8 @@ int xilinx_xcvr_write_out_div(struct xilinx_xcvr *xcvr, unsigned int drp_port,
 		return xilinx_xcvr_gth34_write_out_div(xcvr, drp_port,
 			rx_out_div, tx_out_div);
 	default:
+		dev_err(xcvr->dev, "Unknown transceiver type %d in '%s'\n",
+			xcvr->type, __func__);
 		return -EINVAL;
 	}
 }
@@ -1162,6 +1189,8 @@ int xilinx_xcvr_write_rx_clk25_div(struct xilinx_xcvr *xcvr,
 		reg = 0x6d;
 		break;
 	default:
+		dev_err(xcvr->dev, "Unknown transceiver type %d in '%s'\n",
+			xcvr->type, __func__);
 		return -EINVAL;
 	}
 
@@ -1192,6 +1221,8 @@ int xilinx_xcvr_write_tx_clk25_div(struct xilinx_xcvr *xcvr,
 		reg = 0x7a;
 		break;
 	default:
+		dev_err(xcvr->dev, "Unknown transceiver type %d in '%s'\n",
+			xcvr->type, __func__);
 		return -EINVAL;
 	}
 

--- a/drivers/iio/jesd204/xilinx_transceiver.c
+++ b/drivers/iio/jesd204/xilinx_transceiver.c
@@ -155,6 +155,8 @@ static int xilinx_xcvr_gtx2_configure_cdr(struct xilinx_xcvr *xcvr,
 		cfg3 = 0x8000;
 		break;
 	default:
+		dev_err(xcvr->dev, "Invalid refclk_ppm value %u in '%s'\n",
+			xcvr->refclk_ppm, __func__);
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
When debugging/extending stuff, some invalid values can occur.
This changeset prints messages to syslog on all error paths to make debugging easier.

The changes should be good as a general case.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>