### PR TITLE
iio: ad9361: fix double-free when parsing DT for filter-band settings

### DIFF
--- a/drivers/iio/adc/ad9361_ext_band_ctrl.c
+++ b/drivers/iio/adc/ad9361_ext_band_ctrl.c
@@ -176,8 +176,6 @@ static int ad9361_parse_setting_seq(struct device *dev,
 		nseq->delay = args[0]; /* delay to wait after this setting */
 
 		list_add_tail(&nseq->list, lst);
-
-		of_node_put(it.node);
 	};
 
 out:


### PR DESCRIPTION
Reported via:
  https://ez.analog.com/linux-device-drivers/linux-software-drivers/f/q-a/114085/kernel-panic-with-e310/340287

When looping with of_for_each_phandle(), the only time that is recommended
to use `of_node_put()` is on error-paths (which is already being done).

Otherwise, the of_for_each_phandle() call should handle free-ing the
`it.node` if the loop finishes successfully.

This type of API design (with `of_for_each_phandle()`) is a bit error prone
when being used. And in this case it was causing double-free.

Also, ARM is not the most consistent architecture with regards to Linux
panic-ing on access violations. Sometimes it lets you get away with 1-2-3,
which could be one reason why we didn't catch this in our testing.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>