### PR TITLE
spi: bcm2835: Fix 3-wire mode if DMA is enabled

### DIFF
--- a/drivers/spi/spi-bcm2835.c
+++ b/drivers/spi/spi-bcm2835.c
@@ -555,7 +555,8 @@ static int bcm2835_spi_transfer_one(struct spi_master *master,
 	bcm2835_wr(bs, BCM2835_SPI_CLK, cdiv);
 
 	/* handle all the 3-wire mode */
-	if ((spi->mode & SPI_3WIRE) && (tfr->rx_buf))
+	if (spi->mode & SPI_3WIRE && tfr->rx_buf &&
+	    tfr->rx_buf != master->dummy_rx)
 		cs |= BCM2835_SPI_CS_REN;
 	else
 		cs &= ~BCM2835_SPI_CS_REN;


### PR DESCRIPTION
This is a backport of the pacth in
https://patchwork.kernel.org/patch/11029323/. However, this
patch does not apply directly since the driver is still using
struct spi_master *master instead of struct spi_controller *ctlr
as in the original patch.

Signed-off-by: Nuno Sá <nuno.sa@analog.com>