### PR TITLE
dts: arm: overlays: Add ADDI9036 overlay

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -119,6 +119,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	pwm-ir-tx.dtbo \
 	qca7000.dtbo \
 	rotary-encoder.dtbo \
+	rpi-addi9036.dtbo \
 	rpi-adf4371.dtbo \
 	rpi-ad5686.dtbo \
 	rpi-ad7190.dtbo \

--- a/arch/arm/boot/dts/overlays/rpi-addi9036-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-addi9036-overlay.dts
@@ -1,0 +1,89 @@
+// Definitions for ADDI9036 camera module
+/dts-v1/;
+/plugin/;
+
+/{
+	compatible = "brcm,bcm2708";
+
+	fragment@0 {
+		target = <&i2c_vc>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			camera_front@64 {
+				compatible = "adi,addi9036";
+				reg = <0x64>;
+
+				reset-gpios = <&gpio 41 1>;
+
+				port {
+					addi9036_ep: endpoint {
+						remote-endpoint = <&csi1_ep>;
+						clock-lanes = <0>;
+						data-lanes = <1 2>;
+					};
+				};
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&csi1>;
+		__overlay__ {
+			status = "okay";
+
+			port {
+				csi1_ep: endpoint {
+					remote-endpoint = <&addi9036_ep>;
+				};
+			};
+		};
+	};
+
+	fragment@2 {
+		target = <&i2c0_pins>;
+		__overlay__ {
+			brcm,pins = <44 45>;
+			brcm,function = <5>; /* alt1 */
+		};
+	};
+
+	fragment@3 {
+		target = <&i2c_vc>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@4 {
+		target = <&i2c1>;
+		__overlay__ {
+			pinctrl-0 = <&i2c1_pins>;
+			status = "okay";
+		};
+	};
+
+	fragment@5 {
+		target = <&i2c1>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			eeprom: eeprom@56 {
+				compatible = "atmel,24c1024";
+				reg = <0x56>;
+				pagesize = <32>;
+			};
+		};
+	};
+
+	fragment@6 {
+		target = <&i2c1_pins>;
+		__overlay__ {
+			brcm,pins = <2 3>;
+			brcm,function = <4>; /* alt 0 */
+		};
+	};
+};


### PR DESCRIPTION
Add devicetree overlay for ADDI9036 3D Time of Flight Development 
Platform.

Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>