### PR TITLE
ci/travis/run-build.sh: go back 50 commits when trying to cherry-pick

### DIFF
--- a/ci/travis/run-build.sh
+++ b/ci/travis/run-build.sh
@@ -85,7 +85,7 @@ __handle_sync_with_master() {
 
 	if [ "$method" == "cherry-pick" ] ; then
 		# FIXME: kind of dumb, the code below; maybe do this a bit neater
-		local cm="$(git log "${dst_branch}~1..${dst_branch}" | grep "cherry picked from commit" | awk '{print $5}' | cut -d')' -f1)"
+		local cm="$(git log "${dst_branch}~50..${dst_branch}" | grep "cherry picked from commit" | head -1 | awk '{print $5}' | cut -d')' -f1)"
 		[ -n "$cm" ] || {
 			echo_red "Top commit in branch '${dst_branch}' is not cherry-picked"
 			return 1


### PR DESCRIPTION
The logic for cherry-picking assumed that the last commit is always
cherry-picked from master. For branches like `adi-4.14.0` & `adi-4.19.0`
this is almost always true.

However for the `rpi-4.x.y` branches we sometimes merge device-tree
overlays. And with the altera branches, we will also merge code that is
only specific to those branches.

For these cases, we will have interleaved commits that are not in master,
so we'd need to go back [automatically] further-back in history to find a
commit (that is also in master) to cherry-pick into these branches.

50 commits (back) should be sufficient. If this number needs to be higher
than 50, then (definitely) someone needs to do a manual investigation and
fix-up/cherry-pick/rebase something.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>