### PR TITLE
nvmem: adi_axi_sysid: remove unused variable

### DIFF
--- a/drivers/nvmem/adi_axi_sysid.c
+++ b/drivers/nvmem/adi_axi_sysid.c
@@ -182,7 +182,6 @@ static int axi_sysid_probe(struct platform_device *pdev)
 	struct axi_sysid *st;
 	struct resource *res;
 	u32 version;
-	int ret;
 
 	id = of_match_node(axi_sysid_of_match, pdev->dev.of_node);
 	if (!id)


### PR DESCRIPTION
Build complains with a warning:
```
drivers/nvmem/adi_axi_sysid.c: In function ‘axi_sysid_probe’:
drivers/nvmem/adi_axi_sysid.c:185:6: warning: unused variable ‘ret’ [-Wunused-variable]
  int ret;
      ^
```

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>