### PR TITLE
iio: adc: ad7606: Fix software scale selection

### DIFF
--- a/drivers/iio/adc/ad7606.c
+++ b/drivers/iio/adc/ad7606.c
@@ -264,7 +264,9 @@ static int ad7606_write_raw(struct iio_dev *indio_dev,
 	case IIO_CHAN_INFO_SCALE:
 		mutex_lock(&st->lock);
 		i = find_closest(val2, st->scale_avail, st->num_scales);
-		ret = st->write_scale(indio_dev, chan->address, i);
+		if (st->sw_mode_en)
+			ch = chan->address;
+		ret = st->write_scale(indio_dev, ch, i);
 		if (ret < 0) {
 			mutex_unlock(&st->lock);
 			return ret;


### PR DESCRIPTION
This fix is only needed on adi repo, upstream it is fixed.

When device is used in software mode, writing scale wasn't updating the
scale property from iio.

Signed-off-by: Beniamin Bia <beniamin.bia@analog.com>