### PR TITLE
dts: Specify AD9517 firmware file

### DIFF
--- a/arch/arm/boot/dts/adi-ad9265-fmc-125ebz.dtsi
+++ b/arch/arm/boot/dts/adi-ad9265-fmc-125ebz.dtsi
@@ -32,6 +32,8 @@
 		spi-max-frequency = <10000000>;
 		adi,spi-3wire-enable;
 
+		firmware = "ad9517.stp";
+
 		clocks = <&ad9517_ref_clk>, <&ad9517_ref_clk>;
 		clock-names = "refclk", "clkin";
 

--- a/arch/arm/boot/dts/adi-ad9434-fmc-500ebz.dtsi
+++ b/arch/arm/boot/dts/adi-ad9434-fmc-500ebz.dtsi
@@ -32,6 +32,8 @@
 		spi-max-frequency = <10000000>;
 		adi,spi-3wire-enable;
 
+		firmware = "ad9517.stp";
+
 		clocks = <&ad9517_ref_clk>, <&ad9517_ref_clk>;
 		clock-names = "refclk", "clkin";
 

--- a/arch/arm/boot/dts/adi-ad9467-fmc-250ebz.dtsi
+++ b/arch/arm/boot/dts/adi-ad9467-fmc-250ebz.dtsi
@@ -29,6 +29,8 @@
 		spi-max-frequency = <10000000>;
 		adi,spi-3wire-enable;
 
+		firmware = "ad9517.stp";
+
 		clocks = <&ad9517_ref_clk>, <&ad9517_ref_clk>;
 		clock-names = "refclk", "clkin";
 

--- a/arch/arm/boot/dts/adi-fmcjesdadc1.dtsi
+++ b/arch/arm/boot/dts/adi-fmcjesdadc1.dtsi
@@ -34,6 +34,8 @@
 			spi-max-frequency = <10000000>;
 			adi,spi-3wire-enable;
 
+			firmware = "ad9517.stp";
+
 			clocks = <&ad9517_ref_clk>, <&ad9517_clkin>;
 			clock-names = "refclk", "clkin";
 

--- a/arch/arm/boot/dts/adi-fmcomms6.dtsi
+++ b/arch/arm/boot/dts/adi-fmcomms6.dtsi
@@ -32,6 +32,8 @@
 		spi-max-frequency = <10000000>;
 		adi,spi-3wire-enable;
 
+		firmware = "ad9517.stp";
+
 		clocks = <&ad9517_ref_clk>, <&ad9517_clkin>;
 		clock-names = "refclk", "clkin";
 

--- a/arch/microblaze/boot/dts/adi-ad9467-fmc-250ebz.dtsi
+++ b/arch/microblaze/boot/dts/adi-ad9467-fmc-250ebz.dtsi
@@ -29,6 +29,7 @@
 		compatible = "ad9517-4";
 		reg = <1>;
 		spi-max-frequency = <10000000>;
+		firmware = "ad9517.stp";
 		clocks = <&ad9517_ref_clk>, <&ad9517_ref_clk>;
 		clock-names = "refclk", "clkin";
 		clock-output-names = "out0", "out1", "out2", "out3", "out4", "out5", "out6", "out7";

--- a/arch/microblaze/boot/dts/adi-fmcjesdadc1.dtsi
+++ b/arch/microblaze/boot/dts/adi-fmcjesdadc1.dtsi
@@ -29,6 +29,7 @@
 			reg = <1>;
 			spi-max-frequency = <10000000>;
 			adi,spi-3wire-enable;
+			firmware = "ad9517.stp";
 			clocks = <&ad9517_ref_clk>, <&ad9517_clkin>;
 			clock-names = "refclk", "clkin";
 			clock-output-names = "out0", "out1", "out2", "out3", "out4", "out5", "out6", "out7";


### PR DESCRIPTION
Because of https://github.com/analogdevicesinc/linux/commit/3fc41fb8c53f20f7ccbe8e8e0a02e41b4b2b6aa7, the default FIRMWARE file is not automatically
loaded when the "firmware" property is missing, so it should be manually
specified, otherwise, the ad9517_default_regs values are used to configure
the clock chip.

Signed-off-by: Sergiu Cuciurean <sergiu.cuciurean@analog.com>