### PR TITLE
build,travis: adjust cherry-pick sync depth to GIT_FETCH_DEPTH level

### DIFF
--- a/ci/travis/run-build.sh
+++ b/ci/travis/run-build.sh
@@ -84,8 +84,14 @@ __handle_sync_with_master() {
 	fi
 
 	if [ "$method" == "cherry-pick" ] ; then
+		local depth
+		if [ "$GIT_FETCH_DEPTH" == "disabled" ] ; then
+			depth=50
+		else
+			depth=$((GIT_FETCH_DEPTH - 1))
+		fi
 		# FIXME: kind of dumb, the code below; maybe do this a bit neater
-		local cm="$(git log "${dst_branch}~50..${dst_branch}" | grep "cherry picked from commit" | head -1 | awk '{print $5}' | cut -d')' -f1)"
+		local cm="$(git log "${dst_branch}~${depth}..${dst_branch}" | grep "cherry picked from commit" | head -1 | awk '{print $5}' | cut -d')' -f1)"
 		[ -n "$cm" ] || {
 			echo_red "Top commit in branch '${dst_branch}' is not cherry-picked"
 			return 1


### PR DESCRIPTION
I forgot that branches are sync-ed up-to GIT_FETCH_DEPTH level (which is
50), so trying to sync via cherry-pick at that level needs to be adjusted
to `GIT_FETCH_DEPTH - 1`.

This change does that.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>