### PR TITLE
build: move branches to script and allow it to be run locally 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ notifications:
 
 env:
   matrix:
-  - BUILD_TYPE=sync_branches_with_master
+  - BUILD_TYPE=sync_branches_with_master_travis
     GIT_FETCH_DEPTH=50
     BRANCH1="xcomm_zynq:fast-forward"
     BRANCH2="adi-4.14.0:cherry-pick"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ notifications:
 env:
   matrix:
   - BUILD_TYPE=sync_branches_with_master
+    GIT_FETCH_DEPTH=50
     BRANCH1="xcomm_zynq:fast-forward"
     BRANCH2="adi-4.14.0:cherry-pick"
     BRANCH3="adi-4.19.0:cherry-pick"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,6 @@ notifications:
 env:
   matrix:
   - BUILD_TYPE=sync_branches_with_master_travis
-    GIT_FETCH_DEPTH=50
-    BRANCH1="xcomm_zynq:fast-forward"
-    BRANCH2="adi-4.14.0:cherry-pick"
-    BRANCH3="adi-4.19.0:cherry-pick"
-    BRANCH4="rpi-4.19.y:cherry-pick"
-    BRANCH5="rpi-4.14.y:cherry-pick"
   - BUILD_TYPE=checkpatch
   - BUILD_TYPE=dtb_build_test
   - DEFCONFIG_NAME=zynq_xcomm_adv7511_defconfig ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf-

--- a/ci/travis/run-build.sh
+++ b/ci/travis/run-build.sh
@@ -88,6 +88,7 @@ __handle_sync_with_master() {
 		if [ "$GIT_FETCH_DEPTH" == "disabled" ] ; then
 			depth=50
 		else
+			GIT_FETCH_DEPTH=${GIT_FETCH_DEPTH:-50}
 			depth=$((GIT_FETCH_DEPTH - 1))
 		fi
 		# FIXME: kind of dumb, the code below; maybe do this a bit neater

--- a/ci/travis/run-build.sh
+++ b/ci/travis/run-build.sh
@@ -44,13 +44,13 @@ __update_git_ref() {
 	[ "$GIT_FETCH_DEPTH" == "disabled" ] || {
 		depth="--depth=${GIT_FETCH_DEPTH:-50}"
 	}
-	git fetch $depth origin +refs/heads/${ref}:${ref}
+	git fetch $depth $ORIGIN +refs/heads/${ref}:${ref}
 }
 
 __push_back_to_github() {
 	local dst_branch="$1"
 
-	git push --quiet -u origin "$dst_branch" || {
+	git push --quiet -u $ORIGIN "$dst_branch" || {
 		echo_red "Failed to push back '$dst_branch'"
 		return 1
 	}
@@ -122,6 +122,13 @@ __handle_sync_with_master() {
 }
 
 build_sync_branches_with_master() {
+	GIT_FETCH_DEPTH=50
+	BRANCH1="xcomm_zynq:fast-forward"
+	BRANCH2="adi-4.14.0:cherry-pick"
+	BRANCH3="adi-4.19.0:cherry-pick"
+	BRANCH4="rpi-4.19.y:cherry-pick"
+	BRANCH5="rpi-4.14.y:cherry-pick"
+
 	# support sync-ing up to 100 branches; should be enough
 	for iter in $(seq 1 100) ; do
 		local branch="$(eval "echo \$BRANCH${iter}")"
@@ -140,7 +147,7 @@ build_sync_branches_with_master_travis() {
 	[ "$TRAVIS_PULL_REQUEST" == "false" ] || return 0
 	[ "$TRAVIS_BRANCH" == "master" ] || return 0
 
-	git remote set-url origin "git@github.com:analogdevicesinc/linux.git"
+	git remote set-url $ORIGIN "git@github.com:analogdevicesinc/linux.git"
 	openssl aes-256-cbc -d -in ci/travis/deploy_key.enc -out /tmp/deploy_key -base64 -K $encrypt_key -iv $encrypt_iv
 	eval "$(ssh-agent -s)"
 	chmod 600 /tmp/deploy_key
@@ -149,6 +156,9 @@ build_sync_branches_with_master_travis() {
 	build_sync_branches_with_master
 }
 
+ORIGIN=${ORIGIN:-origin}
+
+BUILD_TYPE=${BUILD_TYPE:-${1}}
 BUILD_TYPE=${BUILD_TYPE:-default}
 
 build_${BUILD_TYPE}

--- a/ci/travis/run-build.sh
+++ b/ci/travis/run-build.sh
@@ -67,8 +67,8 @@ __handle_sync_with_master() {
 
 	if [ "$method" == "fast-forward" ] ; then
 		git checkout ${dst_branch}
-		git merge --ff-only master || {
-			echo_red "Failed while syncing master over '$dst_branch'"
+		git merge --ff-only ${ORIGIN}/master || {
+			echo_red "Failed while syncing ${ORIGIN}/master over '$dst_branch'"
 			return 1
 		}
 		__push_back_to_github "$dst_branch" || return 1
@@ -89,7 +89,7 @@ __handle_sync_with_master() {
 			echo_red "Top commit in branch '${dst_branch}' is not cherry-picked"
 			return 1
 		}
-		branch_contains_commit "$cm" "master" || {
+		branch_contains_commit "$cm" "${ORIGIN}/master" || {
 			echo_red "Commit '$cm' is not in branch master"
 			return 1
 		}
@@ -98,7 +98,7 @@ __handle_sync_with_master() {
 
 		git checkout ${dst_branch}
 		# cherry-pick until all commits; if we get a merge-commit, handle it
-		git cherry-pick -x "${cm}..master" 1>/dev/null 2>$tmpfile || {
+		git cherry-pick -x "${cm}..${ORIGIN}/master" 1>/dev/null 2>$tmpfile || {
 			was_a_merge=0
 			while grep -q "is a merge" $tmpfile ; do
 				was_a_merge=1
@@ -111,7 +111,7 @@ __handle_sync_with_master() {
 				}
 			done
 			if [ "$was_a_merge" != "0" ]; then
-				echo_red "Failed to cherry-pick commits '$cm..master'"
+				echo_red "Failed to cherry-pick commits '$cm..${ORIGIN}/master'"
 				echo_red "$(cat $tmpfile)"
 				return 1
 			fi


### PR DESCRIPTION
This change allows branches to be sync-ed also locally via:
```
ORIGIN=adi ./ci/travis/run-build.sh sync_branches_with_master
```

ORIGIN is optional, in case it is not named `origin`

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>