### PR TITLE
build,travis: use FETCH_HEAD when sync-ing

### DIFF
--- a/ci/travis/run-build.sh
+++ b/ci/travis/run-build.sh
@@ -71,7 +71,7 @@ __handle_sync_with_master() {
 	}
 
 	if [ "$method" == "fast-forward" ] ; then
-		git checkout ${ORIGIN}/${dst_branch}
+		git checkout FETCH_HEAD
 		git merge --ff-only ${ORIGIN}/master || {
 			echo_red "Failed while syncing ${ORIGIN}/master over '$dst_branch'"
 			return 1
@@ -89,7 +89,7 @@ __handle_sync_with_master() {
 			depth=$((GIT_FETCH_DEPTH - 1))
 		fi
 		# FIXME: kind of dumb, the code below; maybe do this a bit neater
-		local cm="$(git log "${ORIGIN}/${dst_branch}~${depth}..${ORIGIN}/${dst_branch}" | grep "cherry picked from commit" | head -1 | awk '{print $5}' | cut -d')' -f1)"
+		local cm="$(git log "FETCH_HEAD~${depth}..FETCH_HEAD" | grep "cherry picked from commit" | head -1 | awk '{print $5}' | cut -d')' -f1)"
 		[ -n "$cm" ] || {
 			echo_red "Top commit in branch '${dst_branch}' is not cherry-picked"
 			return 1
@@ -101,7 +101,7 @@ __handle_sync_with_master() {
 
 		tmpfile=$(mktemp)
 
-		git checkout ${ORIGIN}/${dst_branch}
+		git checkout FETCH_HEAD
 		# cherry-pick until all commits; if we get a merge-commit, handle it
 		git cherry-pick -x "${cm}..${ORIGIN}/master" 1>/dev/null 2>$tmpfile || {
 			was_a_merge=0


### PR DESCRIPTION
Because on Travis-CI, the repo is cloned with 50 commits-depth, and
git-fetch is also done at around 50 commits-depth, and because (when doing
git-fetch) we don't keep a local reference to the fetch, we need to use
FETCH_HEAD.

Otherwise the error is something like:
```
From github.com:analogdevicesinc/linux
 * branch                xcomm_zynq -> FETCH_HEAD
error: pathspec 'origin/xcomm_zynq' did not match any file(s) known to git.
The command "./ci/travis/run-build.sh" exited with 1.
```

A reason this fails, is related to commit
c76a5209408fc37753a3d2f21dcf9f35078b7059 ("build: use detached versions of
the remote branches"). We still want detached versions of the git-fetch-ed
stuff, and the only reference there exists when doing a git-fetch is
`FETCH_HEAD`.

Tested locally, with a cloned-repo of 50 commits (just like Travis-CI
does). This wasn't caught earlier, because it was tested on a repo that
has many local git-refs.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>