### PR TITLE
hwmon: ltc2947: New features

### DIFF
--- a/Documentation/devicetree/bindings/hwmon/adi,ltc2947.yaml
+++ b/Documentation/devicetree/bindings/hwmon/adi,ltc2947.yaml
@@ -52,6 +52,30 @@ properties:
     maxItems: 1
     default: 0
 
+    adi,gpio-out-pol:
+      description:
+        This property controls the GPIO polarity. Setting it to one makes the GPIO active high, setting it
+        to zero makets it active low. When this property is present, the GPIO is automatically configured
+        as output and set to control a fan as a function of measured temperature.
+      allOf:
+        - $ref: /schemas/types.yaml#/definitions/uint32
+        - enum: [0, 1]
+      maxItems: 1
+      default: 0
+
+      adi,gpio-in-accum:
+        description:
+          When set, this property sets the GPIO as input. It is then used to control the accumulation of
+          charge, energy and time. This function can be enabled/configured separately for each of the
+          two sets of accumulation registers. Check table 13 of the datasheet for more information on the
+          supported options. This property cannot be used together with adi,gpio-out-pol.
+        allOf:
+          - $ref: /schemas/types.yaml#/definitions/uint32
+          - enum: [0, 1, 2]
+        minItems: 2
+        maxItems: 2
+        default: {0 0}
+
 required:
   - compatible
   - reg

--- a/Documentation/devicetree/bindings/hwmon/adi,ltc2947.yaml
+++ b/Documentation/devicetree/bindings/hwmon/adi,ltc2947.yaml
@@ -28,6 +28,30 @@ properties:
       an external clock is used, this property must be set accordingly.
     maxItems: 1
 
+  adi,accumulator-ctl-pol:
+    description:
+      This property controls the polarity of current that is accumulatred to calculate charge and
+      energy so that, they can be only accumulated for positive current for example. Since there are
+      two sets of registers for the accumulated values, this entry can also have two items which sets
+      energy1/charge1 and energy2/charger2 respectively. Check table 12 of the datasheet for more
+      information on the supported options.
+    allOf:
+      - $ref: /schemas/types.yaml#/definitions/uint32
+      - enum: [0, 1, 2, 3]
+    minItems: 2
+    maxItems: 2
+    default: {0 0}
+
+  adi,accumulation-deadband-microamp:
+    description:
+      This property controls the Accumulation Dead band which allows to set the level of current below which
+      no accumulation takes place.
+    allOf:
+      - $ref: /schemas/types.yaml#/definitions/uint32
+      - maximum: 255
+    maxItems: 1
+    default: 0
+
 required:
   - compatible
   - reg
@@ -42,6 +66,9 @@ examples:
            ltc2947_spi: ltc2947@0 {
                    compatible = "adi,ltc2947";
                    reg = <0>;
+                   /* accumulation takes place always for energ1/charge1. */
+                   /* accumulation only on positive current for energy2/charge2. */
+                   adi,accumulator-ctl-pol = <0 1>;
            };
     };
 ...

--- a/drivers/hwmon/ltc2947-core.c
+++ b/drivers/hwmon/ltc2947-core.c
@@ -1133,9 +1133,6 @@ static const struct hwmon_chip_info ltc2947_chip_info = {
 	.info = ltc2947_info,
 };
 
-static SENSOR_DEVICE_ATTR(test1, 0644, ltc2947_show_value,
-			  ltc2947_set_value, 0xFF);
-
 /* power attributes */
 static SENSOR_DEVICE_ATTR(power1_input, 0444, ltc2947_show_value,
 			  ltc2947_set_value, LTC2947_POWER_INPUT);
@@ -1198,7 +1195,6 @@ static SENSOR_DEVICE_ATTR(power1_fault, 0444, ltc2947_show_alert,
 			  NULL, LTC2947_FAULT);
 
 static struct attribute *ltc2947_attrs[] = {
-	&sensor_dev_attr_test1.dev_attr.attr,
 	&sensor_dev_attr_in0_fault.dev_attr.attr,
 	&sensor_dev_attr_in1_fault.dev_attr.attr,
 	&sensor_dev_attr_curr1_fault.dev_attr.attr,

--- a/drivers/hwmon/ltc2947-i2c.c
+++ b/drivers/hwmon/ltc2947-i2c.c
@@ -38,6 +38,7 @@ static struct i2c_driver ltc2947_driver = {
 	.driver = {
 		.name = "ltc2947",
 		.of_match_table = ltc2947_of_match,
+		.pm = &ltc2947_pm_ops,
 	},
 	.probe = ltc2947_probe,
 	.id_table = ltc2947_id,

--- a/drivers/hwmon/ltc2947-spi.c
+++ b/drivers/hwmon/ltc2947-spi.c
@@ -38,6 +38,7 @@ static struct spi_driver ltc2947_driver = {
 	.driver = {
 		.name = "ltc2947",
 		.of_match_table = ltc2947_of_match,
+		.pm = &ltc2947_pm_ops,
 	},
 	.probe = ltc2947_probe,
 	.id_table = ltc2947_id,

--- a/drivers/hwmon/ltc2947.h
+++ b/drivers/hwmon/ltc2947.h
@@ -5,6 +5,7 @@
 struct regmap;
 
 extern const struct of_device_id ltc2947_of_match[];
+extern const struct dev_pm_ops ltc2947_pm_ops;
 
 int ltc2947_core_probe(struct regmap *map, const char *name);
 


### PR DESCRIPTION
This patch series adds support for:

- Power management;

- Support Accumulator control;

- Support GPIO configuration.

The devicetree bindings are also updated according with the added features.