### PR TITLE
net: phy: adin: fix logical condition in adin_get_downshift()

### DIFF
--- a/drivers/net/phy/adin.c
+++ b/drivers/net/phy/adin.c
@@ -305,7 +305,7 @@ static int adin_get_downshift(struct phy_device *phydev, u8 *data)
 	enable = FIELD_GET(ADIN1300_DOWNSPEEDS_EN, val);
 	cnt = FIELD_GET(ADIN1300_DOWNSPEED_RETRIES_MSK, cnt);
 
-	*data = enable & cnt ? cnt : DOWNSHIFT_DEV_DISABLE;
+	*data = (enable && cnt) ? cnt : DOWNSHIFT_DEV_DISABLE;
 
 	return 0;
 }


### PR DESCRIPTION
The code was merged in ADI master a bit sooner than what was sent upstream
and this slipped through.

The upstream version does not have this bug (i.e. has the fixed version).

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>