### PR TITLE
build,travis: fix cherry-pick syncing when merge commits found

### DIFF
--- a/ci/travis/run-build.sh
+++ b/ci/travis/run-build.sh
@@ -115,7 +115,7 @@ __handle_sync_with_master() {
 					continue
 				}
 			done
-			if [ "$was_a_merge" != "0" ]; then
+			if [ "$was_a_merge" != "1" ]; then
 				echo_red "Failed to cherry-pick commits '$cm..${ORIGIN}/master'"
 				echo_red "$(cat $tmpfile)"
 				return 1


### PR DESCRIPTION
When the code was written initially some pre-vacation logic was used.

The initial mechanism for cherry-picking (from mater) when merge commits
was sound, except for the last error check when `was_a_merge` variable was
checked.

If `was_a_merge` is 0, it means that no merge commits were found, but an
error occurred, so it should be checked if `was_a_merge` is 1 (not 0).

The last couple of merges contained some merge commits, and that's how this
issue was identified.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>