### PR TITLE
ARM: dtb: m2k: Set out of ADF4360 to 100MHz and CPI to 2.5mA

### DIFF
--- a/arch/arm/boot/dts/zynq-m2k-reva.dts
+++ b/arch/arm/boot/dts/zynq-m2k-reva.dts
@@ -131,6 +131,7 @@
 
 		adi,loop-filter-charge-pump-current-microamp = <2500>;
 		adi,loop-filter-pfd-frequency-hz = <5000000>;
+		adi,power-up-frequency-hz = <100000000>;
 	};
 
 	converter@1 {

--- a/arch/arm/boot/dts/zynq-m2k-reva.dts
+++ b/arch/arm/boot/dts/zynq-m2k-reva.dts
@@ -129,7 +129,7 @@
 		clock-names = "clkin";
 		clock-output-names = "ADF4360-9";
 
-		adi,loop-filter-charge-pump-current-microamp = <1870>;
+		adi,loop-filter-charge-pump-current-microamp = <2500>;
 		adi,loop-filter-pfd-frequency-hz = <5000000>;
 	};
 


### PR DESCRIPTION
On M2K the output freq of ADF4360 PLL should be 100MHz. If out freq is
not set explicitly in DT a default value equal with vco_min will be
used.
Also according to already validated M2K setup the CPI should be 
set to 2.5mA.
​
Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>