### PR TITLE
net: gmii2rgmii: backport patches/fixes for Xilinx master

### DIFF
--- a/drivers/net/phy/xilinx_gmii2rgmii.c
+++ b/drivers/net/phy/xilinx_gmii2rgmii.c
@@ -91,6 +91,11 @@ static int xgmiitorgmii_probe(struct mdio_device *mdiodev)
 		return -EPROBE_DEFER;
 	}
 
+	if (priv->phy_dev->priv) {
+		dev_err(dev, "phydev has a priv field, cannot attach\n");
+		return -EFAULT;
+	}
+
 	priv->mdio = mdiodev;
 	priv->phy_drv = priv->phy_dev->drv;
 	memcpy(&priv->conv_phy_drv, priv->phy_dev->drv,

--- a/drivers/net/phy/xilinx_gmii2rgmii.c
+++ b/drivers/net/phy/xilinx_gmii2rgmii.c
@@ -38,7 +38,7 @@ struct gmii2rgmii {
 
 static int xgmiitorgmii_read_status(struct phy_device *phydev)
 {
-	struct gmii2rgmii *priv = phydev->priv;
+	struct gmii2rgmii *priv = phydev->mdio.priv;
 	struct mii_bus *bus = priv->mdio->bus;
 	int addr = priv->mdio->addr;
 	u16 val = 0;
@@ -91,17 +91,12 @@ static int xgmiitorgmii_probe(struct mdio_device *mdiodev)
 		return -EPROBE_DEFER;
 	}
 
-	if (priv->phy_dev->priv) {
-		dev_err(dev, "phydev has a priv field, cannot attach\n");
-		return -EFAULT;
-	}
-
 	priv->mdio = mdiodev;
 	priv->phy_drv = priv->phy_dev->drv;
 	memcpy(&priv->conv_phy_drv, priv->phy_dev->drv,
 	       sizeof(struct phy_driver));
 	priv->conv_phy_drv.read_status = xgmiitorgmii_read_status;
-	priv->phy_dev->priv = priv;
+	priv->phy_dev->mdio.priv = priv;
 	priv->phy_dev->drv = &priv->conv_phy_drv;
 
 	return 0;

--- a/include/linux/mdio.h
+++ b/include/linux/mdio.h
@@ -39,6 +39,9 @@ struct mdio_device {
 	/* Bus address of the MDIO device (0-31) */
 	int addr;
 	int flags;
+
+	/* private data pointer for use by MDIO devices */
+	void *priv;
 };
 #define to_mdio_device(d) container_of(d, struct mdio_device, dev)
 


### PR DESCRIPTION
The gmii2rgmii driver had a bug when the PHY driver would have a private field/data.
This was fixed via `net: gmii2rgmii: do not attach if phy has a priv field `, but that only helped to avoid the memory corruption.

Xilinx fixed the issue by adding a `priv` field to `struct mdio_device`.
Not sure if that's the best fix, but since Xilinx is our upstream, we will get it anyway at some point in time.

We need this to make the ADIN dual-phy board to work with the GMII2RGMII converter.
The `gmii2rgmii` driver overrides the `read_status` hook of the PHY driver, because it also needs to update link status to the gmii2rgmii HDL converter.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>