### PR TITLE
arch: arm: add reference zynq-zc706-adv7511-adin1300-dual.dts

### DIFF
--- a/arch/arm/boot/dts/adi-adin1300-dual.dtsi
+++ b/arch/arm/boot/dts/adi-adin1300-dual.dtsi
@@ -1,0 +1,31 @@
+&gem0 {
+	status = "okay";
+	phy-mode = "rgmii-id";
+	phy-handle = <&ethernet_gem0_phy1>;
+
+	ethernet_gem0_phy1: ethernet-phy@1 {
+		reg = <1>;
+	};
+
+	gmiitorgmii_gem0_phy1: gmiitorgmii@8 {
+		compatible = "xlnx,gmii-to-rgmii-1.0";
+		reg = <8>;
+		phy-handle = <&ethernet_gem0_phy1>;
+	};
+};
+
+&gem1 {
+	status = "okay";
+	phy-mode = "rgmii-id";
+	phy-handle = <&ethernet_gem1_phy2>;
+
+	ethernet_gem1_phy2: ethernet-phy@2 {
+		reg = <2>;
+	};
+
+	gmiitorgmii_gem1_phy2: gmiitorgmii@8 {
+		compatible = "xlnx,gmii-to-rgmii-1.0";
+		reg = <8>;
+		phy-handle = <&ethernet_gem1_phy2>;
+	};
+};

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-adin1300-dual.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-adin1300-dual.dts
@@ -1,0 +1,5 @@
+/dts-v1/;
+
+/include/ "zynq-zc706.dtsi"
+/include/ "zynq-zc706-adv7511.dtsi"
+/include/ "adi-adin1300-dual.dtsi"

--- a/arch/arm/boot/dts/zynq-zed-adv7511-adin1300-dual.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-adin1300-dual.dts
@@ -1,0 +1,5 @@
+/dts-v1/;
+
+/include/ "zynq-zed.dtsi"
+/include/ "zynq-zed-adv7511.dtsi"
+/include/ "adi-adin1300-dual.dtsi"


### PR DESCRIPTION
This change adds the example device-tree for the dual ADIN1300 reference
board.

On the ZC706, the PHYs need to be configured in RGMII-ID to work.

The reference design has a GMII2RGMII converter, which sits in-between the
PHY & MAC. This converter IP/HDL needs the `gmii2rgmii` driver to be
instantiated to do the work.

In order to properly work (with the ADIN PHY), this PR is also required:
  https://github.com/analogdevicesinc/linux/pull/556
The PR fixes some memory corruption caused by the `gmii2rgmii` when
operating with the ADIN PHY driver.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>