### PR TITLE
build,travis: add rules to build kernel Intel ARM ref boards

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,21 +16,12 @@ notifications:
 
 env:
   matrix:
-  - BUILD_TYPE=sync_branches_with_master_travis
   - BUILD_TYPE=checkpatch
   - BUILD_TYPE=dtb_build_test
-  - DEFCONFIG_NAME=zynq_xcomm_adv7511_defconfig ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf-
-    DTS_FILES=arch/arm/boot/dts/zynq-*.dts IMAGE=uImage
-  - DEFCONFIG_NAME=zynq_pluto_defconfig ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf-
-    DTS_FILES=arch/arm/boot/dts/zynq-*.dts IMAGE=uImage
-  - DEFCONFIG_NAME=zynq_sidekiqz2_defconfig ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf-
-    DTS_FILES=arch/arm/boot/dts/zynq-*.dts IMAGE=uImage
-  - DEFCONFIG_NAME=adi_zynqmp_defconfig ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu-
-    DTS_FILES=arch/arm64/boot/dts/xilinx/zynqmp-*.dts DTS_PREFIX=xilinx/ IMAGE=Image
-  - DEFCONFIG_NAME=zynq_m2k_defconfig ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf-
-    DTS_FILES=arch/arm/boot/dts/zynq-*.dts IMAGE=uImage
-  - BUILD_TYPE=compile_test DEFCONFIG_NAME=zynq_xcomm_adv7511_defconfig ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf-
-  - BUILD_TYPE=compile_test DEFCONFIG_NAME=adi_zynqmp_defconfig ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu-
+  - DEFCONFIG_NAME=socfpga_adi_defconfig ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf-
+    DTS_FILES=arch/arm/boot/dts/zynq-*.dts IMAGE=zImage
+  - BUILD_TYPE=compile_test
+    DEFCONFIG_NAME=socfpga_adi_defconfig ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf-
 
 before_install:
   - sudo apt-get update -qq


### PR DESCRIPTION
The `altera_x.y` branches need to build the kernel for Intel Arria
reference boards.
So, we just need to update the `.travis.yml` file to reflect this.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>