### PR TITLE
ci,build: don't cherry-pick commit if already up-to-date

### DIFF
--- a/ci/travis/run-build.sh
+++ b/ci/travis/run-build.sh
@@ -98,6 +98,10 @@ __handle_sync_with_master() {
 			echo_red "Commit '$cm' is not in branch master"
 			return 1
 		}
+		# Make sure that we are adding something new, or cherry-pick complains
+		if git diff --quiet "$cm" "${ORIGIN}/master" ; then
+			return 0
+		fi
 
 		tmpfile=$(mktemp)
 


### PR DESCRIPTION
This only fixes the cases when doing branch-sync with master locally.

`git cherry-pick` fails with:
```
Failed to cherry-pick commits '<commit>..adi/master'
error: empty commit set passed
fatal: cherry-pick failed
```
when trying to cherry-pick something that was already cherry-picked.

In this case, the commit was already cherry-picked, so, doing
`git cherry-pick <commit>..adi/master` will error out.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>