### PR TITLE
ci,travis: add altera_4.14 to the cherry-pick sync

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ branches:
   - adi-4.19.0
 
 os: linux
-dist: trusty
 
 notifications:
   email:

--- a/ci/travis/run-build.sh
+++ b/ci/travis/run-build.sh
@@ -133,6 +133,7 @@ build_sync_branches_with_master() {
 	BRANCH3="adi-4.19.0:cherry-pick"
 	BRANCH4="rpi-4.19.y:cherry-pick"
 	BRANCH5="rpi-4.14.y:cherry-pick"
+	BRANCH6="altera_4.14:cherry-pick"
 
 	# support sync-ing up to 100 branches; should be enough
 	for iter in $(seq 1 100) ; do


### PR DESCRIPTION
At this point in time, cherry-pick sync-ing has been validated by the
`adi-4.Y.0` and `rpi-4.Y.y` branches.
    
Time to add `altera_4.Y` and relieve some sync-ing duties to automation.
    
This brings Intel/Altera reference designs closer to Xilinx level, making
them a first-class citizen.
We will need to change the Linux methodology of merging stuff to altera
branches from now on: i.e. merge drivers in master ALL-THE-TIME, and merge
only DT/board/branch specific-stuff in `altera_x.y` branches.
    
Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>