### PR TITLE
arch: arm: zynq-adrv9361-z7035-fmc.dts: fix M2 port not working

### DIFF
--- a/arch/arm/boot/dts/zynq-adrv9361-z7035-fmc.dts
+++ b/arch/arm/boot/dts/zynq-adrv9361-z7035-fmc.dts
@@ -135,7 +135,7 @@
 &gem1 {
 	status = "okay";
 
-	phy-handle = <&gmiitorgmii>;
+	phy-handle = <&phy1>;
 	phy-mode = "gmii";
 
 	phy1: phy@1 {

--- a/arch/arm/boot/dts/zynq-adrv9361-z7035-fmc.dts
+++ b/arch/arm/boot/dts/zynq-adrv9361-z7035-fmc.dts
@@ -138,17 +138,18 @@
 	phy-handle = <&gmiitorgmii>;
 	phy-mode = "gmii";
 
+	phy1: phy@1 {
+		device_type = "ethernet-phy";
+		reg = <0x1>;
+		marvell,reg-init = <3 16 0xff00 0x1e 3 17 0xfff0 0x00>;
+	};
+
 	gmiitorgmii: gmiitorgmii@8 {
 		compatible = "xlnx,gmii-to-rgmii-1.0";
 		reg = <0x8>;
 		phy-handle = <&phy1>;
 	};
 
-	phy1: phy@1 {
-		device_type = "ethernet-phy";
-		reg = <0x1>;
-		marvell,reg-init = <3 16 0xff00 0x1e 3 17 0xfff0 0x00>;
-	};
 };
 
 / {


### PR DESCRIPTION
Not sure if (and why) this worked before, but when attaching the PHY to the
`macb` MAC driver via `phy-handle`, the actual PHY node should be passed,
and not the `gmii2rgmii` node.

The `gmii2rgmii` driver is an MDIO driver, not a PHY driver, so it never
made sense to attach them like this, and it probably worked due to some
fluke.

This change attaches the phy1 node to the gem1 (MAC) node, and the M2 port
works.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>