### PR TITLE
[2019_R1] arch: arm: zynq-adrv9361-z7035-fmc.dts: fix M2 port not working

### DIFF
--- a/arch/arm/boot/dts/zynq-adrv9361-z7035-fmc.dts
+++ b/arch/arm/boot/dts/zynq-adrv9361-z7035-fmc.dts
@@ -135,7 +135,7 @@
 &gem1 {
 	status = "okay";
 
-	phy-handle = <&gmiitorgmii>;
+	phy-handle = <&phy1>;
 	phy-mode = "gmii";
 
 	phy1: phy@1 {

--- a/arch/arm/boot/dts/zynq-adrv9361-z7035-fmc.dts
+++ b/arch/arm/boot/dts/zynq-adrv9361-z7035-fmc.dts
@@ -138,17 +138,18 @@
 	phy-handle = <&gmiitorgmii>;
 	phy-mode = "gmii";
 
+	phy1: phy@1 {
+		device_type = "ethernet-phy";
+		reg = <0x1>;
+		marvell,reg-init = <3 16 0xff00 0x1e 3 17 0xfff0 0x00>;
+	};
+
 	gmiitorgmii: gmiitorgmii@8 {
 		compatible = "xlnx,gmii-to-rgmii-1.0";
 		reg = <0x8>;
 		phy-handle = <&phy1>;
 	};
 
-	phy1: phy@1 {
-		device_type = "ethernet-phy";
-		reg = <0x1>;
-		marvell,reg-init = <3 16 0xff00 0x1e 3 17 0xfff0 0x00>;
-	};
 };
 
 / {


### PR DESCRIPTION
Backport to 2019_R1 fix from master, merged via PR #571 

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>