### PR TITLE
iio: accel: adxl372: Add support for FIFO peak mode

### DIFF
--- a/Documentation/ABI/testing/sysfs-bus-iio-accel-adxl372
+++ b/Documentation/ABI/testing/sysfs-bus-iio-accel-adxl372
@@ -1,0 +1,10 @@
+What:		/sys/bus/iio/devices/iio:deviceX/peak_fifo_mode_enable
+KernelVersion:
+Contact:	linux-iio@vger.kernel.org
+Description:
+		This attribute allows to configure the FIFO to store sample
+		sets of impact event peak (x, y, z). As a precondition, all
+		three channels (x, y, z) need to be enabled.
+		Writing 1, peak fifo mode will be enabled, if cleared and
+		all three channels are enabled, sample sets of concurrent
+		3-axis data will be stored in the FIFO.


### PR DESCRIPTION
By default, if all three channels (x, y, z) are enabled, sample sets of
concurrent 3-axis data is stored in the FIFO. This patch adds the option
to configure the FIFO to store peak acceleration (x, y and z) of every
over-threshold event. Since we cannot store 1 or 2 axis peak acceleration
data in the FIFO, then all three axis need to be enabled in order for this
mode to work.

Signed-off-by: Stefan Popa <stefan.popa@analog.com>