### PR TITLE
arch: arm64: adi-adin1300-dual.dtsi: move eeprom defintion to FMC1

### DIFF
--- a/arch/arm64/boot/dts/xilinx/adi-adin1300-dual.dtsi
+++ b/arch/arm64/boot/dts/xilinx/adi-adin1300-dual.dtsi
@@ -1,9 +1,9 @@
 &i2c1 {
 	i2c-mux@75 {
-		i2c@0 { /* HPC0 */
+		i2c@1 { /* HPC1 */
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <0>;
+			reg = <1>;
 
 			eeprom@50 {
 				compatible = "at24,24c02";


### PR DESCRIPTION
The design for the dual-PHY for ZCU102 has been done for it to be setup on
FMC1. However, the EEPROM was initially setup for FMC0 and the EEPROM was
written when connected to FMC0.

This change moves the EEPROM to FMC1, so that the FMC-swap is not needed.
The final design for ZCU102 will be done on FMC1.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>