### PR TITLE
arm: dts: Change JESD pre emphasis setting for ADRV9009 on A10SOC

### DIFF
--- a/arch/arm/boot/dts/socfpga_arria10_socdk_adrv9008-1.dts
+++ b/arch/arm/boot/dts/socfpga_arria10_socdk_adrv9008-1.dts
@@ -140,6 +140,7 @@
 	clock-names = "jesd_rx_clk", "dev_clk", "fmc_clk", "sysref_dev_clk",
 		"sysref_fmc_clk";
 
+	adi,jesd204-ser-pre-emphasis = <4>;
 	reset-gpios = <&sys_gpio_out 20 0>;
 	test-gpios = <&sys_gpio_out 21 0>;
 	sysref-req-gpios = <&sys_gpio_out 26 0>;

--- a/arch/arm/boot/dts/socfpga_arria10_socdk_adrv9008-2.dts
+++ b/arch/arm/boot/dts/socfpga_arria10_socdk_adrv9008-2.dts
@@ -267,6 +267,7 @@
 	clock-names = "jesd_tx_clk", "jesd_rx_os_clk",
 		"dev_clk", "fmc_clk", "sysref_dev_clk", "sysref_fmc_clk";
 
+	adi,jesd204-ser-pre-emphasis = <4>;
 	reset-gpios = <&sys_gpio_out 20 0>;
 	test-gpios = <&sys_gpio_out 21 0>;
 	sysref-req-gpios = <&sys_gpio_out 26 0>;

--- a/arch/arm/boot/dts/socfpga_arria10_socdk_adrv9009.dts
+++ b/arch/arm/boot/dts/socfpga_arria10_socdk_adrv9009.dts
@@ -284,6 +284,7 @@
 #include "adi-adrv9009.dtsi"
 
 &trx0_adrv9009 {
+	adi,jesd204-ser-pre-emphasis = <4>;
 	reset-gpios = <&sys_gpio_out 20 0>;
 	test-gpios = <&sys_gpio_out 21 0>;
 	sysref-req-gpios = <&sys_gpio_out 26 0>;


### PR DESCRIPTION
With the previous value, there were errors on the RX/OBS links
With this change, there are no errors at maximum lane rate

Signed-off-by: Adrian Costina <adrian.costina@analog.com>