### PR TITLE
arch: arm{64}: fix broken device-trees & dtb_build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,19 +17,15 @@ env:
   matrix:
   - BUILD_TYPE=sync_branches_with_master_travis
   - BUILD_TYPE=checkpatch
-  - BUILD_TYPE=dtb_build_test
-  - DEFCONFIG_NAME=zynq_xcomm_adv7511_defconfig ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf-
-    DTS_FILES=arch/arm/boot/dts/zynq-*.dts IMAGE=uImage
-  - DEFCONFIG_NAME=zynq_pluto_defconfig ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf-
-    DTS_FILES=arch/arm/boot/dts/zynq-*.dts IMAGE=uImage
-  - DEFCONFIG_NAME=zynq_sidekiqz2_defconfig ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf-
-    DTS_FILES=arch/arm/boot/dts/zynq-*.dts IMAGE=uImage
-  - DEFCONFIG_NAME=adi_zynqmp_defconfig ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu-
-    DTS_FILES=arch/arm64/boot/dts/xilinx/zynqmp-*.dts DTS_PREFIX=xilinx/ IMAGE=Image
-  - DEFCONFIG_NAME=zynq_m2k_defconfig ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf-
-    DTS_FILES=arch/arm/boot/dts/zynq-*.dts IMAGE=uImage
-  - BUILD_TYPE=compile_test DEFCONFIG_NAME=zynq_xcomm_adv7511_defconfig ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf-
-  - BUILD_TYPE=compile_test DEFCONFIG_NAME=adi_zynqmp_defconfig ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu-
+  - BUILD_TYPE=dtb_build_test ARCH=arm DTS_FILES=arch/arm/boot/dts/zynq-*.dts CROSS_COMPILE=arm-linux-gnueabihf-
+  - BUILD_TYPE=dtb_build_test ARCH=arm64 DTS_FILES=arch/arm64/boot/dts/xilinx/zynqmp-*.dts CROSS_COMPILE=aarch64-linux-gnu-
+  - DEFCONFIG=zynq_xcomm_adv7511_defconfig ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- IMAGE=uImage
+  - DEFCONFIG=zynq_pluto_defconfig ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- IMAGE=uImage
+  - DEFCONFIG=zynq_sidekiqz2_defconfig ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- IMAGE=uImage
+  - DEFCONFIG=adi_zynqmp_defconfig ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- IMAGE=Image
+  - DEFCONFIG=zynq_m2k_defconfig ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- IMAGE=uImage
+  - BUILD_TYPE=compile_test DEFCONFIG=zynq_xcomm_adv7511_defconfig ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf-
+  - BUILD_TYPE=compile_test DEFCONFIG=adi_zynqmp_defconfig ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu-
 
 before_install:
   - sudo apt-get update -qq

--- a/arch/arm/boot/dts/adi-ad9265-fmc-125ebz.dtsi
+++ b/arch/arm/boot/dts/adi-ad9265-fmc-125ebz.dtsi
@@ -32,8 +32,6 @@
 		spi-max-frequency = <10000000>;
 		adi,spi-3wire-enable;
 
-		firmware = "ad9517.stp";
-
 		clocks = <&ad9517_ref_clk>, <&ad9517_ref_clk>;
 		clock-names = "refclk", "clkin";
 

--- a/arch/arm/boot/dts/adi-ad9434-fmc-500ebz.dtsi
+++ b/arch/arm/boot/dts/adi-ad9434-fmc-500ebz.dtsi
@@ -32,8 +32,6 @@
 		spi-max-frequency = <10000000>;
 		adi,spi-3wire-enable;
 
-		firmware = "ad9517.stp";
-
 		clocks = <&ad9517_ref_clk>, <&ad9517_ref_clk>;
 		clock-names = "refclk", "clkin";
 

--- a/arch/arm/boot/dts/adi-fmcomms6.dtsi
+++ b/arch/arm/boot/dts/adi-fmcomms6.dtsi
@@ -32,8 +32,6 @@
 		spi-max-frequency = <10000000>;
 		adi,spi-3wire-enable;
 
-		firmware = "ad9517.stp";
-
 		clocks = <&ad9517_ref_clk>, <&ad9517_clkin>;
 		clock-names = "refclk", "clkin";
 

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-cn0506-rgmii.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-cn0506-rgmii.dts
@@ -2,4 +2,4 @@
 
 /include/ "zynq-zc706.dtsi"
 /include/ "zynq-zc706-adv7511.dtsi"
-/include/ "adi-adin1300-dual-rgmii.dtsi"
+/include/ "adi-cn0506-rgmii.dtsi"

--- a/arch/arm/boot/dts/zynq-zed-adv7511-pmod-ad1-da1.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-pmod-ad1-da1.dts
@@ -1,5 +1,6 @@
 /dts-v1/;
 
+/include/ "zynq-zed.dtsi"
 /include/ "zynq-zed-adv7511.dtsi"
 
 / {

--- a/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-revb-adrv2crr-fmc-sync.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-revb-adrv2crr-fmc-sync.dts
@@ -7,7 +7,7 @@
  */
 
 #include "zynqmp-adrv9009-zu11eg-reva-adrv2crr-fmc-sync.dts"
-#include "zynqmp-adrv9009-zu11eg-revb.dts"
+#include "zynqmp-adrv9009-zu11eg-revb.dtsi"
 
 &dwc3_0 {
 	status = "okay";

--- a/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-revb-adrv2crr-fmc.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-revb-adrv2crr-fmc.dts
@@ -7,7 +7,7 @@
  */
 
 #include "zynqmp-adrv9009-zu11eg-reva-adrv2crr-fmc.dts"
-#include "zynqmp-adrv9009-zu11eg-revb.dts"
+#include "zynqmp-adrv9009-zu11eg-revb.dtsi"
 
 &dwc3_0 {
 	status = "okay";

--- a/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-revb.dtsi
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-revb.dtsi
@@ -10,9 +10,6 @@
  * OUT 6,7	-- CML no pull-up(will be LVPECL on rev C)
  */
 
-#include "zynqmp-adrv9009-zu11eg-reva.dts"
-#include "zynqmp-adrv9009-zu11eg-revb.dtsi"
-
 / {
 	model = "Analog Devices ADRV9009-ZU11EG Rev.B";
 };

--- a/arch/microblaze/boot/dts/adi-ad9467-fmc-250ebz.dtsi
+++ b/arch/microblaze/boot/dts/adi-ad9467-fmc-250ebz.dtsi
@@ -29,7 +29,6 @@
 		compatible = "ad9517-4";
 		reg = <1>;
 		spi-max-frequency = <10000000>;
-		firmware = "ad9517.stp";
 		clocks = <&ad9517_ref_clk>, <&ad9517_ref_clk>;
 		clock-names = "refclk", "clkin";
 		clock-output-names = "out0", "out1", "out2", "out3", "out4", "out5", "out6", "out7";

--- a/ci/travis/run-build.sh
+++ b/ci/travis/run-build.sh
@@ -4,13 +4,13 @@ set -e
 . ./ci/travis/lib.sh
 
 build_default() {
-	make ${DEFCONFIG_NAME}
+	make ${DEFCONFIG}
 	make -j`getconf _NPROCESSORS_ONLN` $IMAGE UIMAGE_LOADADDR=0x8000
 }
 
 build_compile_test() {
 	export COMPILE_TEST=y
-	make ${DEFCONFIG_NAME}
+	make ${DEFCONFIG}
 	make -j`getconf _NPROCESSORS_ONLN`
 }
 
@@ -27,8 +27,10 @@ build_checkpatch() {
 }
 
 build_dtb_build_test() {
+	make ${DEFCONFIG:-defconfig}
 	for file in $DTS_FILES; do
-		make ${DTS_PREFIX}`basename $file | sed  -e 's\dts\dtb\g'` || exit 1
+		dtb_file=$(echo $file | sed 's/dts\//_/g' | cut -d'_' -f2 | sed 's\dts\dtb\g')
+		make ${dtb_file} || exit 1
 	done
 }
 


### PR DESCRIPTION
It seems that the dtb builds were not being run since the split, and we
never noticed this.
The initial commit that did the split was done in order to better identify
compiler errors from dtb errors. What happened, was that dtb's were never
compiled since then.

With this change, the matrix was simplified; the DTS_FILES variables have
been moved to separate builds, so that the `dtb_build_test` rules have
something to actually run.
Also, added a new matrix entry for ARM64; previously DTS_FILES were run for
each ARM target, and we have 4 now.

Fixes: 6827f3d ("build,travis: split builds into smaller parts")
Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>