### PR TITLE
Fix linux warnings

### DIFF
--- a/drivers/iio/adc/ad9680.c
+++ b/drivers/iio/adc/ad9680.c
@@ -1179,7 +1179,7 @@ static int ad9694_setup(struct spi_device *spi)
 
 	ret |= ad9680_spi_write(spi, 0x108, 0x00); /* Clock divider = 1 */
 
-	memset(&link_config, sizeof(link_config), 0x00);
+	memset(&link_config, 0x00, sizeof(link_config));
 	link_config.did = 0;
 	link_config.bid = 0;
 	link_config.num_lanes = 2;

--- a/drivers/iio/adc/cf_axi_tdd.c
+++ b/drivers/iio/adc/cf_axi_tdd.c
@@ -310,7 +310,7 @@ static ssize_t cf_axi_tdd_show(struct device *dev,
 		case ADI_TDD_DMA_GATE_TX_EN:
 			ret = sprintf(buf, "%s\n", "tx_only");
 			break;
-		case 0:
+		default:
 			ret = sprintf(buf, "%s\n", "none");
 			break;
 		}

--- a/drivers/iio/adc/talise/talise.c
+++ b/drivers/iio/adc/talise/talise.c
@@ -1770,7 +1770,6 @@ uint32_t TALISE_programFir(taliseDevice_t *device, talisefirName_t filterToProgr
 uint32_t TALISE_calculateDigitalClocks(taliseDevice_t *device, taliseDigClocks_t *digClocks)
 {
     talRecoveryActions_t retVal = TALACT_NO_ACTION;
-    adiHalErr_t halError = ADIHAL_OK;
     uint8_t hsDivTimes10 = 25;
     uint8_t hsClkDivHsDigClk4or5 = 20;
     uint32_t localHsDigClkDiv2_Hz = 0;
@@ -3186,7 +3185,6 @@ uint32_t TALISE_setRxPfirSyncClk(taliseDevice_t *device, taliseRxProfile_t *rxPr
 uint32_t TALISE_getApiVersion (taliseDevice_t *device, uint32_t *siVer, uint32_t *majorVer, uint32_t *minorVer, uint32_t *buildVer)
 {
     talRecoveryActions_t retVal = TALACT_NO_ACTION;
-    adiHalErr_t halError = ADIHAL_OK;
 
 #if TALISE_VERBOSE
     halError = talWriteToLog(device->devHalInfo, ADIHAL_LOG_MSG, TAL_ERR_OK, "TALISE_getApiVersion()\n");

--- a/drivers/iio/adc/talise/talise_arm.c
+++ b/drivers/iio/adc/talise/talise_arm.c
@@ -114,7 +114,6 @@ uint32_t TALISE_initArm(taliseDevice_t *device, taliseInit_t *init)
 
 uint32_t TALISE_writeArmProfile(taliseDevice_t *device, taliseInit_t *init)
 {
-    adiHalErr_t halError = ADIHAL_OK;
     talRecoveryActions_t retVal = TALACT_NO_ACTION;
     talRecoveryActions_t retValWarn = TALACT_NO_ACTION;
     int32_t i = 0;
@@ -555,7 +554,6 @@ static void talFormatAdcProfileByteArray(uint8_t *armMemByteArray, uint16_t *adc
 uint32_t TALISE_loadAdcProfiles(taliseDevice_t *device, uint16_t *rxAdcProfile, uint16_t *orxLowPassAdcProfile,
         uint16_t *orxBandPassAdcProfile, uint16_t *loopBackAdcProfile, int16_t *orxMergeFilter)
 {
-    adiHalErr_t halError = ADIHAL_OK;
     talRecoveryActions_t retVal = TALACT_NO_ACTION;
     talRecoveryActions_t retValWarn = TALACT_NO_ACTION;
     uint8_t i = 0;
@@ -864,7 +862,6 @@ uint32_t TALISE_writeArmMem(taliseDevice_t *device, uint32_t address, uint8_t *d
 
 uint32_t TALISE_writeArmConfig(taliseDevice_t *device, uint8_t objectId, uint16_t offset, uint8_t *data, uint8_t byteCount)
 {
-    adiHalErr_t halError = ADIHAL_OK;
     talRecoveryActions_t retVal = TALACT_NO_ACTION;
     talRecoveryActions_t retValWarn = TALACT_NO_ACTION;
     uint8_t extendedData[4] = {0};
@@ -911,7 +908,6 @@ uint32_t TALISE_writeArmConfig(taliseDevice_t *device, uint8_t objectId, uint16_
 
 uint32_t TALISE_readArmConfig(taliseDevice_t *device, uint8_t objectId, uint16_t offset, uint8_t *data, uint8_t byteCount)
 {
-    adiHalErr_t halError = ADIHAL_OK;
     talRecoveryActions_t retVal = TALACT_NO_ACTION;
     talRecoveryActions_t retValWarn = TALACT_NO_ACTION;
     uint8_t extendedData[4] = {0};
@@ -1193,7 +1189,6 @@ uint32_t TALISE_sendArmCommand(taliseDevice_t *device, uint8_t opCode, const uin
 uint32_t TALISE_getArmVersion_v2(taliseDevice_t *device, taliseArmVersionInfo_t *talArmVersionInfo)
 {
     talRecoveryActions_t retVal = TALACT_NO_ACTION;
-    adiHalErr_t halError = ADIHAL_OK;
     uint8_t ver[5] = {0};
     uint32_t fullVersion = 0;
 
@@ -1239,7 +1234,6 @@ uint32_t TALISE_getArmVersion_v2(taliseDevice_t *device, taliseArmVersionInfo_t 
 uint32_t TALISE_getArmVersion(taliseDevice_t *device, uint8_t *majorVer, uint8_t *minorVer, uint8_t *rcVer)
 {
     talRecoveryActions_t retVal = TALACT_NO_ACTION;
-    adiHalErr_t halError = ADIHAL_OK;
     uint8_t ver[4] = {0};
     uint32_t fullVersion = 0;
 

--- a/drivers/iio/frequency/ad917x/ad917x_nco_api.c
+++ b/drivers/iio/frequency/ad917x/ad917x_nco_api.c
@@ -263,13 +263,12 @@ int ad917x_nco_set_phase_offset(ad917x_handle_t *h,
 					const ad917x_channel_select_t channels, const uint16_t ch_po)
 {
 	int err;
-	uint8_t tmp_reg;
+	uint8_t tmp_reg = 0;
 
 	if (h == NULL)
 		return API_ERROR_INVALID_HANDLE_PTR;
 	if (dacs != 0) {
 		/* DAC PAGE */
-		tmp_reg = 0;
 		if (dacs & AD917X_DAC0)
 			tmp_reg |= AD917X_MAINDAC_PAGE_0;
 		if (dacs & AD917X_DAC1)

--- a/drivers/iio/frequency/ad9517.c
+++ b/drivers/iio/frequency/ad9517.c
@@ -304,7 +304,7 @@ static int ad9517_calc_divider_hi_lo(unsigned ratio, unsigned *hi, unsigned *lo)
 
 static int ad9517_calc_d12_dividers(unsigned vco, unsigned out,  unsigned *d1_val, unsigned *d2_val)
 {
-	unsigned d1, d2, _d2, _d1, ratio;
+	unsigned d1, d2, _d2 = 0, _d1 = 0, ratio;
 	unsigned err, min = UINT_MAX;
 
 	ratio = DIV_ROUND_CLOSEST(vco, out);


### PR DESCRIPTION
This series is intended to fix compilation warnings related with ADI drivers/code. The config file used was adi_zynqmp_defconfig.