### PR TITLE
ci,build: use '=' as split separator instead of '_'

### DIFF
--- a/ci/travis/run-build.sh
+++ b/ci/travis/run-build.sh
@@ -29,7 +29,7 @@ build_checkpatch() {
 build_dtb_build_test() {
 	make ${DEFCONFIG:-defconfig}
 	for file in $DTS_FILES; do
-		dtb_file=$(echo $file | sed 's/dts\//_/g' | cut -d'_' -f2 | sed 's\dts\dtb\g')
+		dtb_file=$(echo $file | sed 's/dts\//=/g' | cut -d'=' -f2 | sed 's\dts\dtb\g')
 		make ${dtb_file} || exit 1
 	done
 }


### PR DESCRIPTION
'_' is a way more common separator in filenames and does not work well for
files that have underscores.
The '=' symbol is less common, so it should work.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>