### PR TITLE
build,travis: build adi-4.19.0 branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ branches:
   except:
   - xcomm_zynq
   - adi-4.14.0 # current rebased versions of master; change this when updating kernel ver
-  - adi-4.19.0
 
 os: linux
 


### PR DESCRIPTION
Branch `master-xilinx-4.19` is built when updating.

Signed-off-by: Beniamin Bia <beniamin.bia@analog.com>