### PR TITLE
include: iio: buffer-dma: Include buffer_impl.h

### DIFF
--- a/include/linux/iio/buffer-dma.h
+++ b/include/linux/iio/buffer-dma.h
@@ -13,6 +13,7 @@
 #include <linux/spinlock.h>
 #include <linux/mutex.h>
 #include <linux/iio/buffer.h>
+#include <linux/iio/buffer_impl.h>
 
 struct iio_dma_buffer_queue;
 struct iio_dma_buffer_ops;


### PR DESCRIPTION
Mainline kernel splitted buffer.h into buffer.h and buffer_impl.h. The
latter is supposed to be used by the iio core. For driver's wanting to
include buffer-dma.h, we need buffer_impl.h in order to compile (since
buffer-dma.h directly references structs defined in buffer_impl).
Including it here, avoids nasty #include dependencies in driver's
wanting to use buffer-dma.

Signed-off-by: Nuno Sa <Nuno.Sa@analog.com>
(cherry picked from commit df99ea39afd2e4d28646fda5fc675cf9547bc374)

Fixes #600 