### PR TITLE
nvmem: adi_axi_sysid: ignore return value

### DIFF
--- a/drivers/nvmem/adi_axi_sysid.c
+++ b/drivers/nvmem/adi_axi_sysid.c
@@ -234,7 +234,9 @@ static int axi_sysid_remove(struct platform_device *pdev)
 {
 	struct nvmem_device *nvmem = platform_get_drvdata(pdev);
 
-	return nvmem_unregister(nvmem);
+	nvmem_unregister(nvmem);
+
+	return 0;
 }
 
 static struct platform_driver axi_sysid_driver = {


### PR DESCRIPTION
At some point in upstream, the nvmem_unregister() function will have a void
return, which will cause a build error.
So, just ignore the return value now.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>