### PR TITLE
build,ci: add `adi-iio` to auto cherry-pick sync

### DIFF
--- a/ci/travis/run-build.sh
+++ b/ci/travis/run-build.sh
@@ -140,6 +140,7 @@ build_sync_branches_with_master() {
 	BRANCH4="rpi-4.19.y:cherry-pick"
 	BRANCH5="rpi-4.14.y:cherry-pick"
 	BRANCH6="altera_4.14:cherry-pick"
+	BRANCH7="adi-iio:cherry-pick"
 
 	# support sync-ing up to 100 branches; should be enough
 	for iter in $(seq 1 100) ; do


### PR DESCRIPTION
Same as for the other branches, whatever we merge to master, will get
cherry-picked to this branch as well.

This should give us a good-enough set of patches on top of Jonathan's IIO
togreg branch, which should help a bit more with upstreaming over time.
i.e. what-we've-upstreamed vs what-we-still-need-to-upstream

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>