### PR TITLE
arch: arm: socfpga: fix cn0506 mii device-tree

### DIFF
--- a/arch/arm/boot/dts/adi-cn0506-socfpga-mii.dtsi
+++ b/arch/arm/boot/dts/adi-cn0506-socfpga-mii.dtsi
@@ -8,7 +8,7 @@
 
 &gmac1 {
 	status = "okay";
-	mac-mode = "mii";
+	phy-mode = "mii";
 	phy-handle = <&ethernet_gmac1_phy1>;
 
 	mdio {
@@ -24,7 +24,7 @@
 
 &gmac2 {
 	status = "okay";
-	mac-mode = "mii";
+	phy-mode = "mii";
 	phy-handle = <&ethernet_gmac2_phy2>;
 
 	mdio {


### PR DESCRIPTION
When the split was done for MII modes, the correct property for the PHY
mode is `phy-mode` not `mac-mode`.

Fixes: 8fb262f1fdb0 ("arch: arm: socfpga: split device-trees for MII mode for CN0506")
Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>