### PR TITLE
iio: imu: adis: remove forgotten lock in __adis_read_reg()

### DIFF
--- a/drivers/iio/imu/adis.c
+++ b/drivers/iio/imu/adis.c
@@ -167,7 +167,6 @@ int __adis_read_reg(struct adis *adis, unsigned int reg,
 		},
 	};
 
-	mutex_lock(&adis->state_lock);
 	spi_message_init(&msg);
 
 	if (adis->current_page != page) {


### PR DESCRIPTION
This lock was forgotten when things were reworked. It should have been
removed then. Leaving it there will cause a deadlock.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>