### PR TITLE
arch: arm: m2k: remove dead-end end-points

### DIFF
--- a/arch/arm/boot/dts/zynq-m2k-reva.dts
+++ b/arch/arm/boot/dts/zynq-m2k-reva.dts
@@ -143,27 +143,6 @@
 
 		clocks = <&converter_clock>;
 		clock-names = "clk";
-
-		ports {
-			#address-cells = <1>;
-			#size-cells = <0>;
-
-			port@0 {
-				reg = <0>;
-
-				ad9963_tx: endpoint {
-					remote-endpoint = <>;
-				};
-			};
-
-			port@1 {
-				reg = <1>;
-
-				ad9963_rx: endpoint {
-					remote-endpoint = <>;
-				};
-			};
-		};
 	};
 };
 

--- a/arch/arm/boot/dts/zynq-zed-adv7511-m2k-revb.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-m2k-revb.dts
@@ -99,27 +99,6 @@
 
 		clocks = <&converter_clock>;
 		clock-names = "clk";
-
-		ports {
-			#address-cells = <1>;
-			#size-cells = <0>;
-
-			port@0 {
-				reg = <0>;
-
-				ad9963_tx: endpoint {
-					remote-endpoint = <>;
-				};
-			};
-
-			port@1 {
-				reg = <1>;
-
-				ad9963_rx: endpoint {
-					remote-endpoint = <>;
-				};
-			};
-		};
 	};
 };
 

--- a/arch/arm/boot/dts/zynq-zed-adv7511-m2k-revc.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-m2k-revc.dts
@@ -115,27 +115,6 @@
 
 		clocks = <&converter_clock>;
 		clock-names = "clk";
-
-		ports {
-			#address-cells = <1>;
-			#size-cells = <0>;
-
-			port@0 {
-				reg = <0>;
-
-				ad9963_tx: endpoint {
-					remote-endpoint = <>;
-				};
-			};
-
-			port@1 {
-				reg = <1>;
-
-				ad9963_rx: endpoint {
-					remote-endpoint = <>;
-				};
-			};
-		};
 	};
 };
 


### PR DESCRIPTION
The newer DTC compilers crash when they try to process these nodes.
The AD9963 driver does not seem to implement any code for parsing those
remote endpoint nodes, so remove them.

Error is:
```
  DTC     arch/arm/boot/dts/zynq-zed-adv7511-m2k-revb.dtb
dtc: scripts/dtc/livetree.c:438: propval_cell: Assertion `prop->val.len == sizeof(cell_t)' failed.
Aborted (core dumped)
make[1]: *** [scripts/Makefile.lib:293: arch/arm/boot/dts/zynq-zed-adv7511-m2k-revb.dtb] Error 134

```

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>