### PR TITLE
arch: arm: polish device-trees

### DIFF
--- a/arch/arm/boot/dts/zynq-adrv9361-z7035-userspace.dts
+++ b/arch/arm/boot/dts/zynq-adrv9361-z7035-userspace.dts
@@ -9,7 +9,7 @@
 	};
 
 	chosen {
-		linux,stdout-path = "/amba@0/uart@E0001000";
+		stdout-path = "/amba@0/uart@E0001000";
 	};
 
 	clocks {

--- a/arch/arm/boot/dts/zynq-adrv9361-z7035.dtsi
+++ b/arch/arm/boot/dts/zynq-adrv9361-z7035.dtsi
@@ -15,7 +15,7 @@
 	};
 
 	chosen {
-		linux,stdout-path = "/amba@0/uart@E0001000";
+		stdout-path = "/amba@0/uart@E0001000";
 	};
 
 	clocks {

--- a/arch/arm/boot/dts/zynq-adrv9364-z7020.dtsi
+++ b/arch/arm/boot/dts/zynq-adrv9364-z7020.dtsi
@@ -15,7 +15,7 @@
 	};
 
 	chosen {
-		linux,stdout-path = "/amba@0/uart@E0001000";
+		stdout-path = "/amba@0/uart@E0001000";
 	};
 
 	clocks {

--- a/arch/arm/boot/dts/zynq-e310.dts
+++ b/arch/arm/boot/dts/zynq-e310.dts
@@ -28,7 +28,6 @@
 	};
 
 	chosen {
-		linux,stdout-path = "serial0:115200n8";
 		stdout-path = "serial0:115200n8";
 	};
 

--- a/arch/arm/boot/dts/zynq-m2k-reva.dts
+++ b/arch/arm/boot/dts/zynq-m2k-reva.dts
@@ -174,7 +174,7 @@
 		#size-cells = <0x1>;
 		ranges;
 
-		fmc_i2c: i2c@41620000 {
+		fmc_i2c: i2c@41600000 {
 			compatible = "xlnx,axi-iic-1.01.b", "xlnx,xps-iic-2.00.a";
 			interrupt-parent = <&intc>;
 			interrupts = <0 58 0x4>;
@@ -370,7 +370,7 @@
 			};
 		};
 
-		logic_analyzer@7010000 {
+		logic_analyzer@70100000 {
 			compatible = "adi,m2k-logic-analyzer";
 			reg = <0x70100000 0x10000>;
 
@@ -380,9 +380,9 @@
 			dma-names = "tx", "rx";
 		};
 
-		m2k-adc-trigger@7C4c0000 {
+		m2k-adc-trigger@7c4c0000 {
 			compatible = "adi,axi-adc-trigger";
-			reg = <0x7C4c0000 0x10000>;
+			reg = <0x7c4c0000 0x10000>;
 			clocks = <&converter_clock>;
 		};
 

--- a/arch/arm/boot/dts/zynq-m2k.dtsi
+++ b/arch/arm/boot/dts/zynq-m2k.dtsi
@@ -15,7 +15,7 @@
 	};
 
 	chosen {
-		linux,stdout-path = "/amba@0/uart@E0001000";
+		stdout-path = "/amba@0/uart@E0001000";
 	};
 
 	usb_phy0: phy0 {

--- a/arch/arm/boot/dts/zynq-microzed.dtsi
+++ b/arch/arm/boot/dts/zynq-microzed.dtsi
@@ -8,7 +8,7 @@
 	};
 
 	chosen {
-		linux,stdout-path = "/amba@0/uart@E0001000";
+		stdout-path = "/amba@0/uart@E0001000";
 	};
 
 	fpga_axi: fpga-axi@0 {

--- a/arch/arm/boot/dts/zynq-pluto-sdr.dtsi
+++ b/arch/arm/boot/dts/zynq-pluto-sdr.dtsi
@@ -15,7 +15,7 @@
 	};
 
 	chosen {
-		linux,stdout-path = "/amba@0/uart@E0001000";
+		stdout-path = "/amba@0/uart@E0001000";
 	};
 
 	clocks {

--- a/arch/arm/boot/dts/zynq-zc702.dtsi
+++ b/arch/arm/boot/dts/zynq-zc702.dtsi
@@ -11,7 +11,7 @@
 	chosen {
 //		bootargs = "console=ttyPS0,115200 root=/dev/ram rw initrd=0x1100000,33M ip=:::::eth0:dhcp earlyprintk";
 		bootargs = "console=ttyPS0,115200 root=/dev/mmcblk0p2 rw earlyprintk rootfstype=ext4 rootwait";
-		linux,stdout-path = "/amba@0/uart@E0001000";
+		stdout-path = "/amba@0/uart@E0001000";
 	};
 
 	leds {

--- a/arch/arm/boot/dts/zynq-zc706.dtsi
+++ b/arch/arm/boot/dts/zynq-zc706.dtsi
@@ -9,7 +9,7 @@
 
 	chosen {
 		bootargs = "console=ttyPS0,115200 root=/dev/mmcblk0p2 rw earlyprintk rootfstype=ext4 rootwait";
-		linux,stdout-path = "/amba@0/uart@E0001000";
+		stdout-path = "/amba@0/uart@E0001000";
 	};
 
 	leds {

--- a/arch/arm/boot/dts/zynq-zed.dtsi
+++ b/arch/arm/boot/dts/zynq-zed.dtsi
@@ -10,7 +10,7 @@
 	chosen {
 //		bootargs = "console=ttyPS0,115200 root=/dev/ram rw initrd=0x1100000,33M ip=:::::eth0:dhcp earlyprintk";
 		bootargs = "console=ttyPS0,115200 root=/dev/mmcblk0p2 rw earlyprintk rootfstype=ext4 rootwait";
-		linux,stdout-path = "/amba@0/uart@E0001000";
+		stdout-path = "/amba@0/uart@E0001000";
 	};
 };
 


### PR DESCRIPTION
Newer DTC compilers have more checks and these fail in our DTB build test.

https://travis-ci.org/analogdevicesinc/linux/jobs/597989404

These properties are fixable now in 4.14.
These changes do that.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>