### PR TITLE
build,ci: treat warnings as errors

### DIFF
--- a/ci/travis/run-build.sh
+++ b/ci/travis/run-build.sh
@@ -3,6 +3,9 @@ set -e
 
 . ./ci/travis/lib.sh
 
+KCFLAGS="-Werror -Wno-error=frame-larger-than="
+export KCFLAGS
+
 build_default() {
 	make ${DEFCONFIG}
 	make -j`getconf _NPROCESSORS_ONLN` $IMAGE UIMAGE_LOADADDR=0x8000

--- a/drivers/dma/dmatest.c
+++ b/drivers/dma/dmatest.c
@@ -1182,13 +1182,16 @@ static int param_set_dmatest_type(const char *val,
 	unsigned int mask;
 	char val_buf[32], *p;
 	int ret, en = 1;
+	int err;
 
 	strlcpy(val_buf, val, sizeof(val_buf));
 
 	if ((p = strchr(val_buf, '='))) {
 		*p = 0;
 		p++;
-		kstrtoint(p, 10, &en);
+		err = kstrtoint(p, 10, &en);
+		if (err)
+			return err;
 	}
 
 	ret = find_string(strim(val_buf), transaction_type_names,

--- a/drivers/gpu/drm/adi_axi_hdmi/axi_hdmi_crtc.c
+++ b/drivers/gpu/drm/adi_axi_hdmi/axi_hdmi_crtc.c
@@ -41,13 +41,12 @@ static struct dma_async_tx_descriptor *axi_hdmi_vdma_prep_interleaved_desc(
 {
 	struct axi_hdmi_crtc *axi_hdmi_crtc = plane_to_axi_hdmi_crtc(plane);
 	struct drm_framebuffer *fb = plane->state->fb;
-	struct xilinx_vdma_config vdma_config;
 	size_t offset, hw_row_size;
 	struct drm_gem_cma_object *obj;
 
-	obj = drm_fb_cma_get_gem_obj(plane->state->fb, 0);
-
 #if IS_ENABLED(CONFIG_XILINX_DMA)
+	struct xilinx_vdma_config vdma_config;
+
 	if (!strncmp(axi_hdmi_crtc->dma->device->dev->driver->name, "xilinx-vdma", 11)) {
 		memset(&vdma_config, 0, sizeof(vdma_config));
 		vdma_config.park = 1;
@@ -55,6 +54,8 @@ static struct dma_async_tx_descriptor *axi_hdmi_vdma_prep_interleaved_desc(
 		xilinx_vdma_channel_set_config(axi_hdmi_crtc->dma, &vdma_config);
 	}
 #endif
+
+	obj = drm_fb_cma_get_gem_obj(plane->state->fb, 0);
 
 	offset = plane->state->crtc_x * fb->format->cpp[0] +
 		plane->state->crtc_y * fb->pitches[0];

--- a/drivers/gpu/drm/xlnx/zynqmp_disp.c
+++ b/drivers/gpu/drm/xlnx/zynqmp_disp.c
@@ -2475,7 +2475,6 @@ static int zynqmp_disp_plane_mode_set(struct drm_plane *plane,
 {
 	struct zynqmp_disp_layer *layer = plane_to_layer(plane);
 	const struct drm_format_info *info = fb->format;
-	struct drm_format_name_buf format_name;
 	struct device *dev = layer->disp->dev;
 	dma_addr_t paddr;
 	unsigned int i;

--- a/drivers/iio/frequency/ad917x/ad917x_nco_api.c
+++ b/drivers/iio/frequency/ad917x/ad917x_nco_api.c
@@ -312,7 +312,7 @@ int ad917x_nco_get_phase_offset(ad917x_handle_t *h,
 					const ad917x_channel_select_t channels, uint16_t *ch_po)
 {
 	int err;
-	uint8_t tmp_reg;
+	uint8_t tmp_reg = 0;
 	if (h == NULL)
 		return API_ERROR_INVALID_HANDLE_PTR;
 	if ((dacs_po == NULL) || (ch_po == NULL))

--- a/drivers/media/i2c/adv7604.c
+++ b/drivers/media/i2c/adv7604.c
@@ -1632,7 +1632,7 @@ static int adv76xx_query_dv_timings(struct v4l2_subdev *sd,
 
 		bt->width = w;
 		bt->height = h;
-		bt->pixelclock = info->read_hdmi_pixelclock(sd);
+		bt->pixelclock = adv76xx_read_hdmi_pixelclock(sd);
 		bt->hfrontporch = hdmi_read16(sd, 0x20, info->hfrontporch_mask);
 		bt->hsync = hdmi_read16(sd, 0x22, info->hsync_mask);
 		bt->hbackporch = hdmi_read16(sd, 0x24, info->hbackporch_mask);

--- a/drivers/misc/mathworks/mw_stream_channel.c
+++ b/drivers/misc/mathworks/mw_stream_channel.c
@@ -1047,7 +1047,8 @@ static ssize_t mw_stream_chan_store(struct device *dev, struct device_attribute 
 static ssize_t mw_stream_chan_show(struct device *dev, struct device_attribute *attr,
         char *buf)
 {
-    return sprintf(buf, "%llu\n", atomic64_read(&rxcount)); 
+	return sprintf(buf, "%llu\n",
+		       (unsigned long long)atomic64_read(&rxcount));
 }
 
 static DEVICE_ATTR(dma_irq, S_IRUGO, mw_stream_chan_show, mw_stream_chan_store);

--- a/drivers/staging/iio/adc/ad7192.c
+++ b/drivers/staging/iio/adc/ad7192.c
@@ -485,8 +485,9 @@ static unsigned int ad7192_get_temp_scale(bool unipolar)
 static int ad7192_set_3db_filter_freq(struct ad7192_state *st,
 				      int val, int val2)
 {
-	int freq_avail[4], i, ret, idx, freq;
+	int freq_avail[4], i, ret, freq;
 	unsigned int diff_new, diff_old;
+	int idx = 0;
 
 	diff_old = U32_MAX;
 	freq = val * 1000 + val2;


### PR DESCRIPTION
Sometimes we don't catch warnings, and they go upstream.
We should catch warnings as early as possible and fix them. Otherwise they
slip and get caught by Greg, which isn't the best thing.

This change treats all (except `-Werror=frame-larger-than=`) warnings as
errors. Some Talise & Mykonos codes use more than 1024 bytes on the stack
and converting/reworking them is unsafe.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>