### PR TITLE
drm: vc4: fix uninitialized var

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_firmware_kms.c
+++ b/drivers/gpu/drm/vc4/vc4_firmware_kms.c
@@ -683,6 +683,8 @@ static struct drm_plane *vc4_fkms_plane_init(struct drm_device *dev,
 	 * other layers as requested by KMS.
 	 */
 	switch (type) {
+	default:
+	/* Fall through */
 	case DRM_PLANE_TYPE_PRIMARY:
 		default_zpos = 0;
 		break;


### PR DESCRIPTION
The switch statement needed a `default` case. Not the best fix, but it
silences the warning, and it's the best that can be done here.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>