### PR TITLE
iio: adis16475: Fix of_device_id

### DIFF
--- a/drivers/iio/imu/adis16475.c
+++ b/drivers/iio/imu/adis16475.c
@@ -1021,7 +1021,7 @@ static const struct of_device_id adis16475_of_match[] = {
 	{ .compatible = "adi,adis16477-3" },
 	{ },
 };
-MODULE_DEVICE_TABLE(of, adis16480_of_match);
+MODULE_DEVICE_TABLE(of, adis16475_of_match);
 
 static struct spi_driver adis16475_driver = {
 	.driver = {


### PR DESCRIPTION
The wrong table was being passed to MODULE_DEVICE_TABLE. Hence,
compiling as module would fail.

Fixes: 699730d5d930 (iio: imu: Add support for adis16475)
Signed-off-by: Nuno Sá <nuno.sa@analog.com>