### PR TITLE
drivers: mathworks: fix -Werror=int-to-pointer-cast cases

### DIFF
--- a/drivers/misc/mathworks/mathworks_ip_common.c
+++ b/drivers/misc/mathworks/mathworks_ip_common.c
@@ -86,7 +86,7 @@ static int	mathworks_ip_dma_info(struct mathworks_ip_info *thisIpcore, void *arg
 	
 	/* Populate the struct with information */
 	dinfo.size = thisIpcore->dma_info.size;
-	dinfo.phys = (void *)thisIpcore->dma_info.phys;
+	dinfo.phys = (void *)((uintptr_t)thisIpcore->dma_info.phys);
 	
 	/* Copy the struct back to user space */
 	if( copy_to_user((struct mathworks_ip_dma_info*)arg, &dinfo, sizeof(struct mathworks_ip_dma_info)) ) {
@@ -108,7 +108,7 @@ static int	mathworks_ip_reg_info(struct mathworks_ip_info *thisIpcore, void *arg
 
 	/* Populate the struct with information */
 	rinfo.size = resource_size(thisIpcore->mem);
-	rinfo.phys = (void *)thisIpcore->mem->start;
+	rinfo.phys = (void *)((uintptr_t)thisIpcore->mem->start);
 
 	/* Copy the struct back to user space */
 	if( copy_to_user((struct mathworks_ip_reg_info*)arg, &rinfo, sizeof(struct mathworks_ip_reg_info)) ) {
@@ -448,7 +448,9 @@ struct mathworks_ip_info *devm_mathworks_ip_of_init(
 	ipDev->mem = platform_get_resource(pdev, IORESOURCE_MEM,0);
 	if(ipDev->mem)
 	{
-		dev_info(&pdev->dev, "Dev memory resource found at %p %08lX. \n", (void *)ipDev->mem->start, (unsigned long)resource_size(ipDev->mem));
+		dev_info(&pdev->dev, "Dev memory resource found at %p %08lX. \n",
+			 (void *)((uintptr_t)ipDev->mem->start),
+			 (unsigned long)resource_size(ipDev->mem));
 		ipDev->mem  = devm_request_mem_region(&pdev->dev, ipDev->mem->start, resource_size(ipDev->mem), pdev->name);
 
 		if (!ipDev->mem)

--- a/drivers/misc/mathworks/mw_stream_channel.c
+++ b/drivers/misc/mathworks/mw_stream_channel.c
@@ -879,7 +879,8 @@ static int mw_axidma_alloc(struct mwadma_dev *mwdev, size_t bufferSize)
 
     else {
         dev_info(IP2DEVP(mwdev), "Address of buffer = 0x%p, Length = %u Bytes\n",\
-                (void *)MWDEV_TO_MWIP(mwdev)->dma_info.phys,(unsigned int)bufferSize);
+                (void *)((uintptr_t)MWDEV_TO_MWIP(mwdev)->dma_info.phys),
+		(unsigned int)bufferSize);
         MWDEV_TO_MWIP(mwdev)->dma_info.size = bufferSize;
     }
     return 0;


### PR DESCRIPTION
This seems to fail on the Raspberry Pi branch 4.19. It's probable that some
CFLAG has been enabled on the 4.19 kernel that appears in the RPi kernel
but not in Xilinx's.

This change fixes them for the mathworks driver.
The fix is to first cast the value of the int-type to `uintptr_t`. This
matches the size of `void *`. From there-on the value can be cast to
`void *`.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>