### PR TITLE
build: dockerize builds to use newer ubuntu versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,5 @@ env:
   - BUILD_TYPE=compile_test DEFCONFIG=zynq_xcomm_adv7511_defconfig ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf-
   - BUILD_TYPE=compile_test DEFCONFIG=adi_zynqmp_defconfig ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu-
 
-before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -y build-essential bc u-boot-tools gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu
-
 script:
   - ./ci/travis/run-build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,12 @@ notifications:
 
 env:
   matrix:
-  - BUILD_TYPE=sync_branches_with_master_travis
-  - BUILD_TYPE=checkpatch
-  - BUILD_TYPE=dtb_build_test ARCH=arm DTS_FILES=arch/arm/boot/dts/zynq-*.dts CROSS_COMPILE=arm-linux-gnueabihf-
-  - BUILD_TYPE=dtb_build_test ARCH=arm64 DTS_FILES=arch/arm64/boot/dts/xilinx/zynqmp-*.dts CROSS_COMPILE=aarch64-linux-gnu-
+  - BUILD_TYPE=sync_branches_with_master_travis DO_NOT_DOCKERIZE=1
+  - BUILD_TYPE=checkpatch DO_NOT_DOCKERIZE=1
+  - BUILD_TYPE=dtb_build_test ARCH=arm DTS_FILES=arch/arm/boot/dts/zynq-*.dts
+    CROSS_COMPILE=arm-linux-gnueabihf- DO_NOT_DOCKERIZE=1
+  - BUILD_TYPE=dtb_build_test ARCH=arm64 DTS_FILES=arch/arm64/boot/dts/xilinx/zynqmp-*.dts
+    CROSS_COMPILE=aarch64-linux-gnu- DO_NOT_DOCKERIZE=1
   - DEFCONFIG=zynq_xcomm_adv7511_defconfig ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- IMAGE=uImage
   - DEFCONFIG=zynq_pluto_defconfig ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- IMAGE=uImage
   - DEFCONFIG=zynq_sidekiqz2_defconfig ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- IMAGE=uImage
@@ -27,4 +29,4 @@ env:
   - BUILD_TYPE=compile_test DEFCONFIG=adi_zynqmp_defconfig ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu-
 
 script:
-  - ./ci/travis/run-build.sh
+  - ./ci/travis/run-build-docker.sh

--- a/ci/travis/lib.sh
+++ b/ci/travis/lib.sh
@@ -31,12 +31,13 @@ ensure_command_exists wget
 ensure_command_exists sudo
 
 LOCAL_BUILD_DIR="patches-build"
+FULL_BUILD_DIR="${TRAVIS_BUILD_DIR}/${LOCAL_BUILD_DIR}"
 
 # Get the common stuff from libiio
-[ -f ${TRAVIS_BUILD_DIR}/${LOCAL_BUILD_DIR}/lib.sh ] || {
-	mkdir -p ${TRAVIS_BUILD_DIR}/${LOCAL_BUILD_DIR}
+[ -f "${FULL_BUILD_DIR}/lib.sh" ] || {
+	mkdir -p "${FULL_BUILD_DIR}"
 	wget https://raw.githubusercontent.com/analogdevicesinc/libiio/master/CI/travis/lib.sh \
-		-O ${TRAVIS_BUILD_DIR}/${LOCAL_BUILD_DIR}/lib.sh
+		-O "${FULL_BUILD_DIR}/lib.sh"
 }
 
-. ${TRAVIS_BUILD_DIR}/${LOCAL_BUILD_DIR}/lib.sh
+. "${FULL_BUILD_DIR}/lib.sh"

--- a/ci/travis/run-build-docker.sh
+++ b/ci/travis/run-build-docker.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+. ./ci/travis/lib.sh
+
+ENV_VARS="BUILD_TYPE DEFCONFIG ARCH CROSS_COMPILE DTS_FILES IMAGE"
+
+if [ "$DO_NOT_DOCKERIZE" = "1" ] ; then
+	. ./ci/travis/run-build.sh
+else
+	cat /dev/null > "${FULL_BUILD_DIR}/env"
+	BUILD_TYPE=${BUILD_TYPE:-default}
+	for env in $ENV_VARS ; do
+		val="$(eval echo "\$${env}")"
+		if [ -n "$val" ] ; then
+			echo "export ${env}=${val}" >> "${FULL_BUILD_DIR}/env"
+		fi
+	done
+	prepare_docker_image "ubuntu:rolling"
+	run_docker_script run-build.sh "ubuntu:rolling"
+fi

--- a/ci/travis/run-build.sh
+++ b/ci/travis/run-build.sh
@@ -1,7 +1,18 @@
 #!/bin/bash
 set -e
 
+# cd to docker build dir if it exists
+if [ -d /docker_build_dir ] ; then
+	cd /docker_build_dir
+fi
+
 . ./ci/travis/lib.sh
+
+if [ -f "${FULL_BUILD_DIR}/env" ] ; then
+	echo_blue "Loading environment variables"
+	cat "${FULL_BUILD_DIR}/env"
+	. "${FULL_BUILD_DIR}/env"
+fi
 
 KCFLAGS="-Werror -Wno-error=frame-larger-than="
 export KCFLAGS


### PR DESCRIPTION
This changeset wraps all builds (except for checkpatch & dtb_build_test) in
the docker scripts that were also added for libiio.

The main reason/advantage for this, is to support newer Ubuntu versions
which come with newer compilers & tools. In this day-n-age, things move
so fast, that even Ubuntu 16.04 (from almost 4 years ago) is super-old.
We send patches upstream, only to get hit back by warnings/errors that
newer compilers catch, but older ones don't.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>