### PR TITLE
Fixes adis16480

### DIFF
--- a/drivers/iio/imu/adis16480.c
+++ b/drivers/iio/imu/adis16480.c
@@ -697,9 +697,13 @@ static int adis16480_read_raw(struct iio_dev *indio_dev,
 			*val2 = (st->chip_info->temp_scale % 1000) * 1000;
 			return IIO_VAL_INT_PLUS_MICRO;
 		case IIO_PRESSURE:
-			*val = 0;
-			*val2 = 4000; /* 40ubar = 0.004 kPa */
-			return IIO_VAL_INT_PLUS_MICRO;
+			/*
+			 * max scale is 1310 mbar
+			 * max raw value is 32767 shifted for 32bits
+			 */
+			*val = 131; /* 1310mbar = 131 kPa */
+			*val2 = 32767 << 16;
+			return IIO_VAL_FRACTIONAL;
 		default:
 			return -EINVAL;
 		}
@@ -901,13 +905,14 @@ static const struct adis16480_chip_info adis16480_chip_info[] = {
 		.channels = adis16485_channels,
 		.num_channels = ARRAY_SIZE(adis16485_channels),
 		/*
-		 * storing the value in rad/degree and the scale in degree
-		 * gives us the result in rad and better precession than
-		 * storing the scale directly in rad.
+		 * Typically we do IIO_RAD_TO_DEGREE in the denominator, which
+		 * is exactly the same as IIO_DEGREE_TO_RAD in numerator, since
+		 * it gives better approximation. However, in this case we
+		 * cannot do it since it would not fit in a 32bit variable.
 		 */
-		.gyro_max_val = IIO_RAD_TO_DEGREE(22887),
-		.gyro_max_scale = 300,
-		.accel_max_val = IIO_M_S_2_TO_G(21973),
+		.gyro_max_val = 22887 << 16,
+		.gyro_max_scale = IIO_DEGREE_TO_RAD(300),
+		.accel_max_val = IIO_M_S_2_TO_G(21973 << 16),
 		.accel_max_scale = 18,
 		.temp_scale = 5650, /* 5.65 milli degree Celsius */
 		.int_clk = 2460000,
@@ -920,9 +925,9 @@ static const struct adis16480_chip_info adis16480_chip_info[] = {
 	[ADIS16480] = {
 		.channels = adis16480_channels,
 		.num_channels = ARRAY_SIZE(adis16480_channels),
-		.gyro_max_val = IIO_RAD_TO_DEGREE(22500),
-		.gyro_max_scale = 450,
-		.accel_max_val = IIO_M_S_2_TO_G(12500),
+		.gyro_max_val = 22500 << 16,
+		.gyro_max_scale = IIO_DEGREE_TO_RAD(450),
+		.accel_max_val = IIO_M_S_2_TO_G(12500 << 16),
 		.accel_max_scale = 10,
 		.temp_scale = 5650, /* 5.65 milli degree Celsius */
 		.int_clk = 2460000,
@@ -936,9 +941,9 @@ static const struct adis16480_chip_info adis16480_chip_info[] = {
 	[ADIS16485] = {
 		.channels = adis16485_channels,
 		.num_channels = ARRAY_SIZE(adis16485_channels),
-		.gyro_max_val = IIO_RAD_TO_DEGREE(22500),
-		.gyro_max_scale = 450,
-		.accel_max_val = IIO_M_S_2_TO_G(20000),
+		.gyro_max_val = 22500 << 16,
+		.gyro_max_scale = IIO_DEGREE_TO_RAD(450),
+		.accel_max_val = IIO_M_S_2_TO_G(20000 << 16),
 		.accel_max_scale = 5,
 		.temp_scale = 5650, /* 5.65 milli degree Celsius */
 		.int_clk = 2460000,
@@ -951,9 +956,9 @@ static const struct adis16480_chip_info adis16480_chip_info[] = {
 	[ADIS16488] = {
 		.channels = adis16480_channels,
 		.num_channels = ARRAY_SIZE(adis16480_channels),
-		.gyro_max_val = IIO_RAD_TO_DEGREE(22500),
-		.gyro_max_scale = 450,
-		.accel_max_val = IIO_M_S_2_TO_G(22500),
+		.gyro_max_val = 22500 << 16,
+		.gyro_max_scale = IIO_DEGREE_TO_RAD(450),
+		.accel_max_val = IIO_M_S_2_TO_G(22500 << 16),
 		.accel_max_scale = 18,
 		.temp_scale = 5650, /* 5.65 milli degree Celsius */
 		.int_clk = 2460000,
@@ -966,9 +971,9 @@ static const struct adis16480_chip_info adis16480_chip_info[] = {
 	[ADIS16490] = {
 		.channels = adis16485_channels,
 		.num_channels = ARRAY_SIZE(adis16485_channels),
-		.gyro_max_val = IIO_RAD_TO_DEGREE(20000),
-		.gyro_max_scale = 100,
-		.accel_max_val = IIO_M_S_2_TO_G(16000),
+		.gyro_max_val = 20000 << 16,
+		.gyro_max_scale = IIO_DEGREE_TO_RAD(100),
+		.accel_max_val = IIO_M_S_2_TO_G(16000 << 16),
 		.accel_max_scale = 8,
 		.temp_scale = 14285, /* 14.285 milli degree Celsius */
 		.int_clk = 4250000,
@@ -982,9 +987,9 @@ static const struct adis16480_chip_info adis16480_chip_info[] = {
 	[ADIS16495_1] = {
 		.channels = adis16495_channels,
 		.num_channels = ARRAY_SIZE(adis16495_channels),
-		.gyro_max_val = IIO_RAD_TO_DEGREE(20000),
-		.gyro_max_scale = 125,
-		.accel_max_val = IIO_M_S_2_TO_G(32000),
+		.gyro_max_val = 20000 << 16,
+		.gyro_max_scale = IIO_DEGREE_TO_RAD(125),
+		.accel_max_val = IIO_M_S_2_TO_G(32000 << 16),
 		.accel_max_scale = 8,
 		.temp_scale = 12500, /* 12.5 milli degree Celsius */
 		.int_clk = 4250000,
@@ -999,9 +1004,9 @@ static const struct adis16480_chip_info adis16480_chip_info[] = {
 	[ADIS16495_2] = {
 		.channels = adis16495_channels,
 		.num_channels = ARRAY_SIZE(adis16495_channels),
-		.gyro_max_val = IIO_RAD_TO_DEGREE(18000),
-		.gyro_max_scale = 450,
-		.accel_max_val = IIO_M_S_2_TO_G(32000),
+		.gyro_max_val = 18000 << 16,
+		.gyro_max_scale = IIO_DEGREE_TO_RAD(450),
+		.accel_max_val = IIO_M_S_2_TO_G(32000 << 16),
 		.accel_max_scale = 8,
 		.temp_scale = 12500, /* 12.5 milli degree Celsius */
 		.int_clk = 4250000,
@@ -1016,9 +1021,9 @@ static const struct adis16480_chip_info adis16480_chip_info[] = {
 	[ADIS16495_3] = {
 		.channels = adis16495_channels,
 		.num_channels = ARRAY_SIZE(adis16495_channels),
-		.gyro_max_val = IIO_RAD_TO_DEGREE(20000),
-		.gyro_max_scale = 2000,
-		.accel_max_val = IIO_M_S_2_TO_G(32000),
+		.gyro_max_val = 20000 << 16,
+		.gyro_max_scale = IIO_DEGREE_TO_RAD(2000),
+		.accel_max_val = IIO_M_S_2_TO_G(32000 << 16),
 		.accel_max_scale = 8,
 		.temp_scale = 12500, /* 12.5 milli degree Celsius */
 		.int_clk = 4250000,
@@ -1033,9 +1038,9 @@ static const struct adis16480_chip_info adis16480_chip_info[] = {
 	[ADIS16497_1] = {
 		.channels = adis16495_channels,
 		.num_channels = ARRAY_SIZE(adis16495_channels),
-		.gyro_max_val = IIO_RAD_TO_DEGREE(20000),
-		.gyro_max_scale = 125,
-		.accel_max_val = IIO_M_S_2_TO_G(32000),
+		.gyro_max_val = 20000 << 16,
+		.gyro_max_scale = IIO_DEGREE_TO_RAD(125),
+		.accel_max_val = IIO_M_S_2_TO_G(32000 << 16),
 		.accel_max_scale = 40,
 		.temp_scale = 12500, /* 12.5 milli degree Celsius */
 		.int_clk = 4250000,
@@ -1050,9 +1055,9 @@ static const struct adis16480_chip_info adis16480_chip_info[] = {
 	[ADIS16497_2] = {
 		.channels = adis16495_channels,
 		.num_channels = ARRAY_SIZE(adis16495_channels),
-		.gyro_max_val = IIO_RAD_TO_DEGREE(18000),
-		.gyro_max_scale = 450,
-		.accel_max_val = IIO_M_S_2_TO_G(32000),
+		.gyro_max_val = 18000 << 16,
+		.gyro_max_scale = IIO_DEGREE_TO_RAD(450),
+		.accel_max_val = IIO_M_S_2_TO_G(32000 << 16),
 		.accel_max_scale = 40,
 		.temp_scale = 12500, /* 12.5 milli degree Celsius */
 		.int_clk = 4250000,
@@ -1067,9 +1072,9 @@ static const struct adis16480_chip_info adis16480_chip_info[] = {
 	[ADIS16497_3] = {
 		.channels = adis16495_channels,
 		.num_channels = ARRAY_SIZE(adis16495_channels),
-		.gyro_max_val = IIO_RAD_TO_DEGREE(20000),
-		.gyro_max_scale = 2000,
-		.accel_max_val = IIO_M_S_2_TO_G(32000),
+		.gyro_max_val = 20000 << 16,
+		.gyro_max_scale = IIO_DEGREE_TO_RAD(2000),
+		.accel_max_val = IIO_M_S_2_TO_G(32000 << 16),
 		.accel_max_scale = 40,
 		.temp_scale = 12500, /* 12.5 milli degree Celsius */
 		.int_clk = 4250000,

--- a/drivers/iio/imu/adis16480.c
+++ b/drivers/iio/imu/adis16480.c
@@ -1200,6 +1200,7 @@ static const struct iio_info adis16480_info = {
 	.write_raw = &adis16480_write_raw,
 	.update_scan_mode = adis_update_scan_mode,
 	.driver_module = THIS_MODULE,
+	.debugfs_reg_access = adis_debugfs_reg_access,
 };
 
 static const struct iio_info adis16495_info = {
@@ -1208,6 +1209,7 @@ static const struct iio_info adis16495_info = {
 	.write_raw = &adis16480_write_raw,
 	.update_scan_mode = adis_update_scan_mode,
 	.driver_module = THIS_MODULE,
+	.debugfs_reg_access = adis_debugfs_reg_access,
 };
 
 static int adis16480_stop_device(struct iio_dev *indio_dev)

--- a/drivers/iio/imu/adis16480.c
+++ b/drivers/iio/imu/adis16480.c
@@ -23,6 +23,7 @@
 #include <linux/slab.h>
 #include <linux/sysfs.h>
 #include <linux/module.h>
+#include <linux/gpio/consumer.h>
 
 #include <linux/iio/iio.h>
 #include <linux/iio/sysfs.h>
@@ -151,6 +152,9 @@ struct adis16480_chip_info {
 	const unsigned int *filter_freqs;
 	bool has_pps_clk_mode;
 	struct adis_burst *burst;
+	u16 reset_ms;
+	u16 sw_reset_ms;
+	u16 self_test_ms;
 };
 
 enum adis16480_int_pin {
@@ -909,6 +913,9 @@ static const struct adis16480_chip_info adis16480_chip_info[] = {
 		.int_clk = 2460000,
 		.max_dec_rate = 2048,
 		.filter_freqs = adis16480_def_filter_freqs,
+		.reset_ms = 500,
+		.sw_reset_ms = 74,
+		.self_test_ms = 10,
 	},
 	[ADIS16480] = {
 		.channels = adis16480_channels,
@@ -921,6 +928,10 @@ static const struct adis16480_chip_info adis16480_chip_info[] = {
 		.int_clk = 2460000,
 		.max_dec_rate = 2048,
 		.filter_freqs = adis16480_def_filter_freqs,
+		.reset_ms = 560,
+		.sw_reset_ms = 560,
+		.self_test_ms = 12,
+
 	},
 	[ADIS16485] = {
 		.channels = adis16485_channels,
@@ -933,6 +944,9 @@ static const struct adis16480_chip_info adis16480_chip_info[] = {
 		.int_clk = 2460000,
 		.max_dec_rate = 2048,
 		.filter_freqs = adis16480_def_filter_freqs,
+		.reset_ms = 560,
+		.sw_reset_ms = 120,
+		.self_test_ms = 12,
 	},
 	[ADIS16488] = {
 		.channels = adis16480_channels,
@@ -945,6 +959,9 @@ static const struct adis16480_chip_info adis16480_chip_info[] = {
 		.int_clk = 2460000,
 		.max_dec_rate = 2048,
 		.filter_freqs = adis16480_def_filter_freqs,
+		.reset_ms = 500,
+		.sw_reset_ms = 120,
+		.self_test_ms = 12,
 	},
 	[ADIS16490] = {
 		.channels = adis16485_channels,
@@ -958,6 +975,9 @@ static const struct adis16480_chip_info adis16480_chip_info[] = {
 		.max_dec_rate = 4250,
 		.filter_freqs = adis16495_def_filter_freqs,
 		.has_pps_clk_mode = true,
+		.reset_ms = 170,
+		.sw_reset_ms = 130,
+		.self_test_ms = 40,
 	},
 	[ADIS16495_1] = {
 		.channels = adis16495_channels,
@@ -972,6 +992,9 @@ static const struct adis16480_chip_info adis16480_chip_info[] = {
 		.filter_freqs = adis16495_def_filter_freqs,
 		.has_pps_clk_mode = true,
 		.burst = &adis16495_burst,
+		.reset_ms = 250,
+		.sw_reset_ms = 210,
+		.self_test_ms = 20,
 	},
 	[ADIS16495_2] = {
 		.channels = adis16495_channels,
@@ -986,6 +1009,9 @@ static const struct adis16480_chip_info adis16480_chip_info[] = {
 		.filter_freqs = adis16495_def_filter_freqs,
 		.has_pps_clk_mode = true,
 		.burst = &adis16495_burst,
+		.reset_ms = 250,
+		.sw_reset_ms = 210,
+		.self_test_ms = 20,
 	},
 	[ADIS16495_3] = {
 		.channels = adis16495_channels,
@@ -1000,6 +1026,9 @@ static const struct adis16480_chip_info adis16480_chip_info[] = {
 		.filter_freqs = adis16495_def_filter_freqs,
 		.has_pps_clk_mode = true,
 		.burst = &adis16495_burst,
+		.reset_ms = 250,
+		.sw_reset_ms = 210,
+		.self_test_ms = 20,
 	},
 	[ADIS16497_1] = {
 		.channels = adis16495_channels,
@@ -1014,6 +1043,9 @@ static const struct adis16480_chip_info adis16480_chip_info[] = {
 		.filter_freqs = adis16495_def_filter_freqs,
 		.has_pps_clk_mode = true,
 		.burst = &adis16495_burst,
+		.reset_ms = 250,
+		.sw_reset_ms = 210,
+		.self_test_ms = 20,
 	},
 	[ADIS16497_2] = {
 		.channels = adis16495_channels,
@@ -1028,6 +1060,9 @@ static const struct adis16480_chip_info adis16480_chip_info[] = {
 		.filter_freqs = adis16495_def_filter_freqs,
 		.has_pps_clk_mode = true,
 		.burst = &adis16495_burst,
+		.reset_ms = 250,
+		.sw_reset_ms = 210,
+		.self_test_ms = 20,
 	},
 	[ADIS16497_3] = {
 		.channels = adis16495_channels,
@@ -1042,6 +1077,9 @@ static const struct adis16480_chip_info adis16480_chip_info[] = {
 		.filter_freqs = adis16495_def_filter_freqs,
 		.has_pps_clk_mode = true,
 		.burst = &adis16495_burst,
+		.reset_ms = 250,
+		.sw_reset_ms = 210,
+		.self_test_ms = 20,
 	},
 };
 
@@ -1203,12 +1241,12 @@ static int adis16480_initial_setup(struct iio_dev *indio_dev)
 	int ret;
 
 	adis_reset(&st->adis);
-	msleep(70);
+	msleep(st->chip_info->sw_reset_ms);
 
 	ret = adis_write_reg_16(&st->adis, ADIS16480_REG_GLOB_CMD, BIT(1));
 	if (ret)
 		return ret;
-	msleep(30);
+	msleep(st->chip_info->self_test_ms);
 
 	ret = adis_check_status(&st->adis);
 	if (ret)
@@ -1432,6 +1470,7 @@ static int adis16480_probe(struct spi_device *spi)
 	struct iio_dev *indio_dev;
 	struct adis16480 *st;
 	int ret;
+	struct gpio_desc *gpio;
 
 	indio_dev = devm_iio_device_alloc(&spi->dev, sizeof(*st));
 	if (indio_dev == NULL)
@@ -1448,6 +1487,12 @@ static int adis16480_probe(struct spi_device *spi)
 	indio_dev->num_channels = st->chip_info->num_channels;
 	indio_dev->info = &adis16480_info;
 	indio_dev->modes = INDIO_DIRECT_MODE;
+
+	gpio = devm_gpiod_get_optional(&spi->dev, "reset", GPIOD_OUT_LOW);
+	if (IS_ERR(gpio))
+		return PTR_ERR(gpio);
+	else if (gpio)
+		msleep(st->chip_info->reset_ms);
 
 	ret = adis_init(&st->adis, indio_dev, spi, &adis16480_data);
 	if (ret)


### PR DESCRIPTION
This series adds somes major and minor fixes to the adis16480 driver. The first one is related with wait times, which can be different from device to device. Furthermore, some of those times were not being respected which could lead to issues. The major fix for this series is related with the scales which were wrong and giving bad values. Devices tested:

- adis16480;

- adis16485;

- adis16375.