### PR TITLE
dts: arm: overlays: Add ADIS16475 overlay

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -5,6 +5,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	adau1977-adc.dtbo \
 	adau7002-simple.dtbo \
 	adau7118-simple.dtbo \
+	adis16475.dtbo \
 	ads1015.dtbo \
 	ads1115.dtbo \
 	ads7846.dtbo \

--- a/arch/arm/boot/dts/overlays/adis16475-overlay.dts
+++ b/arch/arm/boot/dts/overlays/adis16475-overlay.dts
@@ -1,0 +1,68 @@
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/interrupt-controller/irq.h>
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target = <&spi0>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@1 {
+		target = <&spidev0>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@2 {
+		target = <&spidev1>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	 fragment@3 {
+		target = <&gpio>;
+		__overlay__ {
+			adis16475_pins: adis16475_pins {
+				brcm,pins = <4 12>; // interrupt and reset
+				brcm,function = <0 1>; // in out
+			};
+		};
+	};
+	fragment@4 {
+		target = <&spi0>;
+		__overlay__ {
+			/* needed to avoid dtc warning */
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			adis16475: adis16475@0 {
+				compatible = "adi,adis16477-1";
+				reg = <0>;
+				pinctrl-names = "default";
+				pinctrl-0 = <&adis16475_pins>;
+				spi-cpha;
+				spi-cpol;
+				reset-gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+				spi-max-frequency = <2000000>;
+				interrupts = <4 IRQ_TYPE_EDGE_RISING>;
+				interrupt-parent = <&gpio>;
+			};
+		};
+	};
+
+	__overrides__ {
+		interrupt = <&adis16475_pins>,"brcm,pins:0",
+				<&adis16475>,"interrupts:0";
+		reset = <&adis16475_pins>,"brcm,pins:4",
+				<&adis16475>,"reset-gpios:4";
+	};
+};


### PR DESCRIPTION
Add devicetree overlay for the ADIS16475 IMU.

Signed-off-by: Nuno Sá <nuno.sa@analog.com>