### PR TITLE
ci,build: install flex & bison

### DIFF
--- a/ci/travis/run-build.sh
+++ b/ci/travis/run-build.sh
@@ -37,7 +37,7 @@ adjust_kcflags_against_gcc() {
 	export KCFLAGS
 }
 
-APT_LIST="build-essential bc u-boot-tools"
+APT_LIST="build-essential bc u-boot-tools flex bison"
 
 if [ "$ARCH" == "arm64" ] ; then
 	APT_LIST="$APT_LIST gcc-aarch64-linux-gnu"


### PR DESCRIPTION
Kernel 4.19 builds fail that bison is not present during build. This change
adds both flex & bison, as the two go hand-in-hand.

This won't fix all the build errors on the 4.19 branches. Seems those still
require some work.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>