### PR TITLE
build,ci: install libssl-dev for 4.19 kernel builds

### DIFF
--- a/ci/travis/run-build.sh
+++ b/ci/travis/run-build.sh
@@ -37,7 +37,7 @@ adjust_kcflags_against_gcc() {
 	export KCFLAGS
 }
 
-APT_LIST="build-essential bc u-boot-tools flex bison"
+APT_LIST="build-essential bc u-boot-tools flex bison libssl-dev"
 
 if [ "$ARCH" == "arm64" ] ; then
 	APT_LIST="$APT_LIST gcc-aarch64-linux-gnu"


### PR DESCRIPTION
Some 4.19 kernel builds require libssl-dev to be installed on the host.
This isn't required on current 4.14. The reason this is showing up, is
because we're using vanilla Ubuntu docker images, which have few things
installed and now we're finding what to install.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>