### PR TITLE
[rpi-4.14.y] build: fix/disable GCC-9 warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ env:
   matrix:
   - BUILD_TYPE=checkpatch DO_NOT_DOCKERIZE=1
   - DEFCONFIG=adi_bcm2709_defconfig ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf-
-  - BUILD_TYPE=compile_test DEFCONFIG=adi_bcm2709_defconfig ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf-
 
 script:
   - ./ci/travis/run-build-docker.sh

--- a/drivers/net/wireless/realtek/rtl8192cu/core/rtw_ap.c
+++ b/drivers/net/wireless/realtek/rtl8192cu/core/rtw_ap.c
@@ -211,7 +211,7 @@ void rtw_add_bcn_ie(_adapter *padapter, WLAN_BSSID_EX *pnetwork, u8 index, u8 *d
 	u8	bmatch = _FALSE;
 	u8	*pie = pnetwork->IEs;
 	u8	*p=NULL, *dst_ie=NULL, *premainder_ie=NULL, *pbackup_remainder_ie=NULL;
-	u32	i, offset, ielen, ie_offset, remainder_ielen = 0;
+	u32	i, offset, ielen = 0, ie_offset, remainder_ielen = 0;
 
 	for (i = sizeof(NDIS_802_11_FIXED_IEs); i < pnetwork->IELength;)
 	{

--- a/drivers/net/wireless/realtek/rtl8192cu/core/rtw_br_ext.c
+++ b/drivers/net/wireless/realtek/rtl8192cu/core/rtw_br_ext.c
@@ -19,6 +19,8 @@
  ******************************************************************************/
 #define _RTW_BR_EXT_C_
 
+#pragma GCC diagnostic ignored "-Wcast-function-type"
+
 #ifdef __KERNEL__
 #include <linux/if_arp.h>
 #include <net/ip.h>

--- a/drivers/net/wireless/realtek/rtl8192cu/include/drv_conf.h
+++ b/drivers/net/wireless/realtek/rtl8192cu/include/drv_conf.h
@@ -21,6 +21,8 @@
 #define __DRV_CONF_H__
 #include "autoconf.h"
 
+#pragma GCC diagnostic ignored "-Wcast-function-type"
+
 #if defined (PLATFORM_LINUX) && defined (PLATFORM_WINDOWS)
 
 #error "Shall be Linux or Windows, but not both!\n"

--- a/drivers/net/wireless/realtek/rtl8192cu/include/osdep_service.h
+++ b/drivers/net/wireless/realtek/rtl8192cu/include/osdep_service.h
@@ -20,6 +20,8 @@
 #ifndef __OSDEP_SERVICE_H_
 #define __OSDEP_SERVICE_H_
 
+#pragma GCC diagnostic ignored "-Wcast-function-type"
+
 #include <drv_conf.h>
 #include <basic_types.h>
 //#include <rtl871x_byteorder.h>

--- a/drivers/net/wireless/realtek/rtl8192cu/os_dep/linux/rtw_android.c
+++ b/drivers/net/wireless/realtek/rtl8192cu/os_dep/linux/rtw_android.c
@@ -18,6 +18,8 @@
  *
  ******************************************************************************/
 
+#pragma GCC diagnostic ignored "-Wcast-function-type"
+
 #include <linux/module.h>
 #include <linux/netdevice.h>
 

--- a/fs/proc/task_mmu.c
+++ b/fs/proc/task_mmu.c
@@ -24,6 +24,8 @@
 #include <asm/tlbflush.h>
 #include "internal.h"
 
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+
 void task_mem(struct seq_file *m, struct mm_struct *mm)
 {
 	unsigned long text, lib, swap, ptes, pmds, anon, file, shmem;


### PR DESCRIPTION
The only upstream issue is fs/proc/task_mmu.c.

The other issue is the rtl8192cu driver which looks to be present only in
the RPi branch. Errors on this code are ignored.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>