### PR TITLE
[rpi-4.19.y] build: fix/disable GCC-9 errors/warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ env:
   - DEFCONFIG=adi_bcm2709_defconfig ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf-
   - DEFCONFIG=adi_bcm2711_defconfig ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf-
   - DEFCONFIG=adi_bcmrpi_defconfig ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf-
-  - BUILD_TYPE=compile_test DEFCONFIG=adi_bcm2709_defconfig ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf-
 
 script:
   - ./ci/travis/run-build-docker.sh

--- a/drivers/net/wireless/mediatek/mt76/mt76x2_eeprom.c
+++ b/drivers/net/wireless/mediatek/mt76/mt76x2_eeprom.c
@@ -503,7 +503,7 @@ mt76x2_get_power_info_2g(struct mt76x2_dev *dev, struct mt76x2_tx_power_info *t,
 {
 	int channel = chan->hw_value;
 	int delta_idx;
-	u8 data[6];
+	u8 data[6] = {};
 	u16 val;
 
 	if (channel < 6)
@@ -532,7 +532,7 @@ mt76x2_get_power_info_5g(struct mt76x2_dev *dev, struct mt76x2_tx_power_info *t,
 	enum mt76x2_cal_channel_group group;
 	int delta_idx;
 	u16 val;
-	u8 data[5];
+	u8 data[5] = {};
 
 	group = mt76x2_get_cal_channel_group(channel);
 	offset += group * MT_TX_POWER_GROUP_SIZE_5G;

--- a/drivers/net/wireless/realtek/rtl8192cu/include/drv_conf.h
+++ b/drivers/net/wireless/realtek/rtl8192cu/include/drv_conf.h
@@ -21,6 +21,8 @@
 #define __DRV_CONF_H__
 #include "autoconf.h"
 
+#pragma GCC diagnostic ignored "-Wmisleading-indentation"
+
 #if defined (PLATFORM_LINUX) && defined (PLATFORM_WINDOWS)
 
 #error "Shall be Linux or Windows, but not both!\n"

--- a/drivers/usb/host/dwc_otg/dwc_otg_hcd.h
+++ b/drivers/usb/host/dwc_otg/dwc_otg_hcd.h
@@ -34,6 +34,9 @@
 #ifndef __DWC_HCD_H__
 #define __DWC_HCD_H__
 
+#pragma GCC diagnostic ignored "-Wint-to-pointer-cast"
+#pragma GCC diagnostic ignored "-Wpointer-to-int-cast"
+
 #include "dwc_otg_os_dep.h"
 #include "usb.h"
 #include "dwc_otg_hcd_if.h"

--- a/drivers/video/fbdev/bcm2708_fb.c
+++ b/drivers/video/fbdev/bcm2708_fb.c
@@ -40,6 +40,9 @@
 #include <soc/bcm2835/raspberrypi-firmware.h>
 #include <linux/mutex.h>
 
+#pragma GCC diagnostic ignored "-Wint-to-pointer-cast"
+#pragma GCC diagnostic ignored "-Wpointer-to-int-cast"
+
 //#define BCM2708_FB_DEBUG
 #define MODULE_NAME "bcm2708_fb"
 

--- a/sound/soc/bcm/hifiberry_dacplusadc.c
+++ b/sound/soc/bcm/hifiberry_dacplusadc.c
@@ -17,6 +17,8 @@
  * General Public License for more details.
  */
 
+#pragma GCC diagnostic ignored "-Warray-bounds"
+
 #include <linux/module.h>
 #include <linux/platform_device.h>
 #include <linux/kernel.h>


### PR DESCRIPTION
Since warnings are treated as errors, and the compiler has been updated to GCC-9, we need to address/fix some of them, which are upstream in the RPi Linux.

This changeset does that.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>