### PR TITLE
iio: adc: ad7606: fix reading unnecessary data from device

### DIFF
--- a/drivers/iio/adc/ad7606.c
+++ b/drivers/iio/adc/ad7606.c
@@ -84,7 +84,7 @@ err_unlock:
 }
 static int ad7606_read_samples(struct ad7606_state *st)
 {
-	unsigned int num = st->chip_info->num_channels;
+	unsigned int num = st->chip_info->num_channels - 1;
 	u16 *data = st->data;
 	int ret;
 


### PR DESCRIPTION
When a conversion result is being read from ADC, the driver reads the number
of channels + 1 because it thinks that IIO_CHAN_SOFT_TIMESTAMP is also a
physical channel. This patch fixes this issue.

Fixes: 552a21f35477 ("staging: iio: adc: ad7606: Move out of staging")

Signed-off-by: Beniamin Bia <beniamin.bia@analog.com>