### PR TITLE
build: fix implicit fall-through statements

### DIFF
--- a/drivers/iio/jesd204/axi_jesd204_rx.c
+++ b/drivers/iio/jesd204/axi_jesd204_rx.c
@@ -673,11 +673,14 @@ static int axi_jesd204_rx_probe(struct platform_device *pdev)
 		device_create_file(&pdev->dev, &dev_attr_lane5_info);
 		device_create_file(&pdev->dev, &dev_attr_lane6_info);
 		device_create_file(&pdev->dev, &dev_attr_lane7_info);
+		/* fall-through */
 	case 4:
 		device_create_file(&pdev->dev, &dev_attr_lane2_info);
 		device_create_file(&pdev->dev, &dev_attr_lane3_info);
+		/* fall-through */
 	case 2:
 		device_create_file(&pdev->dev, &dev_attr_lane1_info);
+		/* fall-through */
 	case 1:
 		device_create_file(&pdev->dev, &dev_attr_lane0_info);
 		break;

--- a/drivers/iio/jesd204/xilinx_transceiver.c
+++ b/drivers/iio/jesd204/xilinx_transceiver.c
@@ -662,6 +662,7 @@ static int xilinx_xcvr_gtx2_cpll_write_config(struct xilinx_xcvr *xcvr,
 	switch (conf->fb_div_N2) {
 	case 1:
 		val |= 0x10;
+		/* fall-through */
 	case 2:
 		val |= 0x00;
 		break;

--- a/drivers/input/keyboard/adp5589-keys.c
+++ b/drivers/input/keyboard/adp5589-keys.c
@@ -1067,6 +1067,7 @@ static int adp5589_probe(struct i2c_client *client,
 	switch (dev_id) {
 	case ADP5585_02:
 		kpad->support_row5 = true;
+		/* fall through */
 	case ADP5585_01:
 		kpad->is_adp5585 = true;
 		kpad->var = &const_adp5585;

--- a/drivers/media/platform/axi-hdmi-rx.c
+++ b/drivers/media/platform/axi-hdmi-rx.c
@@ -556,6 +556,7 @@ static int axi_hdmi_rx_try_fmt_vid_cap(struct file *file, void *priv_fh,
 		break;
 	default:
 		pix->pixelformat = V4L2_PIX_FMT_RGB24;
+		/* fall-through */
 	case V4L2_PIX_FMT_RGB24:
 	case V4L2_PIX_FMT_BGR24:
 		pix->colorspace = V4L2_COLORSPACE_SRGB;


### PR DESCRIPTION
This only occurs on the adi-iio branch, which means that the upstream kernel may have likely enabled this warning at some point in time.

This change addresses them.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>