### PR TITLE
build: fix implicit fall-through statements (part 2)

### DIFF
--- a/drivers/dma/xilinx/xilinx_dpdma.c
+++ b/drivers/dma/xilinx/xilinx_dpdma.c
@@ -1744,7 +1744,9 @@ static void xilinx_dpdma_chan_handle_err(struct xilinx_dpdma_chan *chan)
 	switch (chan->active_desc->status) {
 	case ERRORED:
 		dev_dbg(dev, "repeated error on desc\n");
+		/* fall-through */
 	case ACTIVE:
+		/* fall-through */
 	case PREPARED:
 		/* Reschedule if there's no new descriptor */
 		if (!chan->pending_desc && !chan->submitted_desc) {

--- a/drivers/iio/adc/cf_axi_adc_core.c
+++ b/drivers/iio/adc/cf_axi_adc_core.c
@@ -355,6 +355,7 @@ static int axiadc_read_raw(struct iio_dev *indio_dev,
 	switch (m) {
 	case IIO_CHAN_INFO_CALIBPHASE:
 		phase = 1;
+		/* fall-through */
 	case IIO_CHAN_INFO_CALIBSCALE:
 		tmp = axiadc_read(st, ADI_REG_CHAN_CNTRL_2(channel));
 		/*  format is 1.1.14 (sign, integer and fractional bits) */
@@ -453,6 +454,7 @@ static int axiadc_write_raw(struct iio_dev *indio_dev,
 	switch (mask) {
 	case IIO_CHAN_INFO_CALIBPHASE:
 		phase = 1;
+		/* fall-through */
 	case IIO_CHAN_INFO_CALIBSCALE:
 		/*  format is 1.1.14 (sign, integer and fractional bits) */
 		switch (val) {

--- a/drivers/iio/frequency/cf_axi_dds.c
+++ b/drivers/iio/frequency/cf_axi_dds.c
@@ -549,6 +549,7 @@ static int cf_axi_dds_read_raw(struct iio_dev *indio_dev,
 		return IIO_VAL_INT;
 	case IIO_CHAN_INFO_CALIBPHASE:
 		phase = 1;
+		/* fall-through */
 	case IIO_CHAN_INFO_CALIBSCALE:
 
 		reg = dds_read(st, ADI_REG_CHAN_CNTRL_8(chan->channel));
@@ -711,6 +712,7 @@ static int cf_axi_dds_write_raw(struct iio_dev *indio_dev,
 		break;
 	case IIO_CHAN_INFO_CALIBPHASE:
 		phase = 1;
+		/* fall-through */
 	case IIO_CHAN_INFO_CALIBSCALE:
 
 		ret = cf_axi_dds_to_signed_mag_fmt(val, val2, &i);

--- a/drivers/iio/jesd204/axi_jesd204b_v51.c
+++ b/drivers/iio/jesd204/axi_jesd204b_v51.c
@@ -319,6 +319,7 @@ static int jesd204b_probe(struct platform_device *pdev)
 			device_create_file(&pdev->dev, &dev_attr_lane6_syncstat);
 			device_create_file(&pdev->dev, &dev_attr_lane7_syncstat);
 		}
+		/* fall-through */
 	case 4:
 		device_create_file(&pdev->dev, &dev_attr_lane2_info);
 		device_create_file(&pdev->dev, &dev_attr_lane3_info);
@@ -326,10 +327,12 @@ static int jesd204b_probe(struct platform_device *pdev)
 			device_create_file(&pdev->dev, &dev_attr_lane2_syncstat);
 			device_create_file(&pdev->dev, &dev_attr_lane3_syncstat);
 		}
+		/* fall-through */
 	case 2:
 		device_create_file(&pdev->dev, &dev_attr_lane1_info);
 		if (!st->transmit)
 			device_create_file(&pdev->dev, &dev_attr_lane1_syncstat);
+		/* fall-through */
 	case 1:
 		device_create_file(&pdev->dev, &dev_attr_lane0_info);
 		if (!st->transmit)


### PR DESCRIPTION
Continuation from #633 
This should be the last batch of implicit fall-through warnings fixes.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>