### PR TITLE
iio: adc: talise-api: ignore ISO C90 vla warnings

### DIFF
--- a/drivers/iio/adc/talise/adi_hal.h
+++ b/drivers/iio/adc/talise/adi_hal.h
@@ -9,6 +9,8 @@
 #ifndef _ADI_HAL_H_
 #define _ADI_HAL_H_
 
+#pragma GCC diagnostic ignored "-Wvla"
+
 /* include standard types and definitions */
 #include <linux/kernel.h>
 #include <linux/math64.h>


### PR DESCRIPTION
On newer kernels warning/error is:
```
drivers/iio/adc/talise/talise_gpio.c:2032:5: error: ISO C90 forbids array 'gpioStatus' whose size can't be evaluated [-Werror=vla]
 2032 |     uint8_t gpioStatus[GPIO_STATUS_CMD_SIZE_BYTES];
```

It's probable that upstream kernel decided to enforce some C90 stuff [vs
C99]. We won't fix this code, but we will ignore it so that it builds on
the adi-iio branch.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>