### PR TITLE
[RFC] iio: jesd204: adxcvr: AD9680 error fix

### DIFF
--- a/drivers/iio/jesd204/axi_adxcvr.c
+++ b/drivers/iio/jesd204/axi_adxcvr.c
@@ -318,8 +318,10 @@ static long adxcvr_clk_round_rate(struct clk_hw *hw,
 	dev_dbg(st->dev, "%s: Rate %lu Hz Parent Rate %lu Hz",
 		__func__, rate, *prate);
 
-	/* Just check if we can support the requested rate */
-	if (st->cpll_enable)
+	/* Just check if we can support the requested rate
+	 * CPLL allows rates of up to 6.6 Gbps
+	 */
+	if (st->cpll_enable && rate < 6600000)
 		ret = xilinx_xcvr_calc_cpll_config(&st->xcvr, *prate, rate,
 			NULL, NULL);
 	else


### PR DESCRIPTION
This patch fixes the error:
ad9680 spi0.2: Failed to initialize: -22

This error appears when trying to set the lane rate
over 6,60 Gbps in:
ad9680_setup_jesd204_link(), ad9680.c:823

On ZC706, CPLL allows rates of up to 6.6 Gbps. In this patch
we use a QPLL configuration for higher rates.

Signed-off-by: Alexandru Tachici <alexandru.tachici@analog.com>