### PR TITLE
arch: arm: boot: dts: Fix pluto DMA data width

### DIFF
--- a/arch/arm/boot/dts/zynq-pluto-sdr.dtsi
+++ b/arch/arm/boot/dts/zynq-pluto-sdr.dtsi
@@ -128,7 +128,7 @@
 
 				dma-channel@0 {
 					reg = <0>;
-					adi,source-bus-width = <64>;
+					adi,source-bus-width = <32>;
 					adi,source-bus-type = <2>;
 					adi,destination-bus-width = <64>;
 					adi,destination-bus-type = <0>;
@@ -151,7 +151,7 @@
 					reg = <0>;
 					adi,source-bus-width = <64>;
 					adi,source-bus-type = <0>;
-					adi,destination-bus-width = <64>;
+					adi,destination-bus-width = <32>;
 					adi,destination-bus-type = <2>;
 				};
 			};


### PR DESCRIPTION
Fix the destination and source bus width for DMA transfers.This is in
accordance with the HDL design here:

https://github.com/analogdevicesinc/hdl/blob/master/projects/pluto/system_bd.tcl#L185
https://github.com/analogdevicesinc/hdl/blob/master/projects/pluto/system_bd.tcl#L198

Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>