### PR TITLE
iio: m2k-logic-analyzer: fix uninitialized variable usage

### DIFF
--- a/drivers/iio/logic/m2k-logic-analyzer.c
+++ b/drivers/iio/logic/m2k-logic-analyzer.c
@@ -873,7 +873,6 @@ static int m2k_la_probe(struct platform_device *pdev)
 	indio_dev_rx->info = &m2k_la_txrx_iio_info;
 	indio_dev_rx->channels = m2k_la_rx_chan_spec,
 	indio_dev_rx->num_channels = ARRAY_SIZE(m2k_la_rx_chan_spec);
-	iio_device_attach_buffer(indio_dev_rx, buffer_rx);
 
 	buffer_rx = iio_dmaengine_buffer_alloc(&pdev->dev, "rx",
 			&m2k_la_dma_buffer_ops, indio_dev_rx);


### PR DESCRIPTION
Found by x86_64 compiler, and Raspberry Pi's build. The `build_rx` is
attached to the IIO buffer, before initialized. It's re-attached also after
it's initialized, so it seems to work. But from the looks of things, this
could potentially corrupt memory and go un-noticed.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>