### PR TITLE
iio: iio-regmap: New driver for generic regmap

### DIFF
--- a/drivers/iio/Kconfig
+++ b/drivers/iio/Kconfig
@@ -86,6 +86,7 @@ source "drivers/iio/light/Kconfig"
 source "drivers/iio/logic/Kconfig"
 source "drivers/iio/magnetometer/Kconfig"
 source "drivers/iio/multiplexer/Kconfig"
+source "drivers/iio/regmap/Kconfig"
 source "drivers/iio/orientation/Kconfig"
 if IIO_TRIGGER
    source "drivers/iio/trigger/Kconfig"

--- a/drivers/iio/Makefile
+++ b/drivers/iio/Makefile
@@ -32,6 +32,7 @@ obj-y += light/
 obj-y += logic/
 obj-y += magnetometer/
 obj-y += multiplexer/
+obj-y += regmap/
 obj-y += orientation/
 obj-y += potentiometer/
 obj-y += potentiostat/
@@ -39,3 +40,4 @@ obj-y += pressure/
 obj-y += proximity/
 obj-y += temperature/
 obj-y += trigger/
+

--- a/drivers/iio/regmap/Kconfig
+++ b/drivers/iio/regmap/Kconfig
@@ -1,0 +1,32 @@
+#
+# Industrial I/O Generic Regmap Access drivers
+#
+# When adding new entries keep the list in alphabetical order
+
+menu "IIO Regmap Access Drivers"
+
+config IIO_REGMAP
+	tristate
+
+config IIO_REGMAP_I2C
+	tristate "IIO Regmap Access Driver via I2C"
+	depends on REGMAP_I2C
+	select IIO_REGMAP
+	help
+	  Say Y to build support for IIO Regmap Access Driver via I2C used
+	  in order to access registers of devices connected through I2C.
+
+	  To compile this driver as a module, say M here: the module will
+	  be called iio-regmap-i2c.
+
+config IIO_REGMAP_SPI
+	tristate "IIO Regmap Access Driver via SPI"
+	depends on REGMAP_SPI
+	select IIO_REGMAP
+	help
+	  Say Y to build support for IIO Regmap Access Driver via SPI used
+	  in order to access registers of devices connected through SPI.
+
+	  To compile this driver as a module, say M here: the module will
+	  be called iio-regmap-spi.
+endmenu

--- a/drivers/iio/regmap/Makefile
+++ b/drivers/iio/regmap/Makefile
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0
+#
+# Makefile for Industrial I/O Generic Regmap Access Drivers
+#
+
+# When adding new entries keep the list in alphabetical order
+obj-$(CONFIG_IIO_REGMAP) += iio-regmap.o
+obj-$(CONFIG_IIO_REGMAP_I2C) += iio-regmap-i2c.o
+obj-$(CONFIG_IIO_REGMAP_SPI) += iio-regmap-spi.o

--- a/drivers/iio/regmap/iio-regmap-i2c.c
+++ b/drivers/iio/regmap/iio-regmap-i2c.c
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Generic IIO access driver via I2C
+ *
+ * Copyright 2019 Analog Devices Inc.
+ */
+
+#include <linux/device.h>
+#include <linux/err.h>
+#include <linux/i2c.h>
+#include <linux/iio/iio.h>
+#include <linux/module.h>
+#include <linux/regmap.h>
+
+#include "iio-regmap.h"
+
+static const struct regmap_config iio_regmap_config = {
+};
+
+static int iio_regmap_i2c_probe(struct i2c_client *client,
+				const struct i2c_device_id *id)
+{
+	struct regmap *regmap;
+
+	regmap = devm_regmap_init_i2c(client, &iio_regmap_config);
+	if (IS_ERR(regmap)) {
+		dev_err(&client->dev, "devm_regmap_init_i2c failed!\n");
+		return PTR_ERR(regmap);
+	}
+
+	return iio_regmap_probe(&client->dev, regmap, client->name);
+}
+
+static const struct i2c_device_id iio_regmap_i2c_id[] = {
+	{
+		.name = "iio-regmap-i2c",
+	},
+	{}
+};
+
+static struct i2c_driver iio_regmap_i2c_driver = {
+	.driver = {
+		.name	= "iio-regmap-i2c",
+	},
+	.probe	       = iio_regmap_i2c_probe,
+	.id_table      = iio_regmap_i2c_id
+};
+
+module_i2c_driver(iio_regmap_i2c_driver);
+
+MODULE_AUTHOR("Alexandru Tachici <alexandru.tachici@analog.com>");
+MODULE_DESCRIPTION("IIO Regmap I2C");
+MODULE_LICENSE("GPL v2");

--- a/drivers/iio/regmap/iio-regmap-spi.c
+++ b/drivers/iio/regmap/iio-regmap-spi.c
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Generic IIO access driver via SPI
+ *
+ * Copyright 2019 Analog Devices Inc.
+ */
+
+#include <linux/device.h>
+#include <linux/iio/iio.h>
+#include <linux/init.h>
+#include <linux/module.h>
+#include <linux/regmap.h>
+#include <linux/spi/spi.h>
+
+#include "iio-regmap.h"
+
+static const struct regmap_config iio_regmap_spi_regmap_config = {
+};
+
+static int iio_regmap_spi_probe(struct spi_device *spi)
+{
+	const struct spi_device_id *id = spi_get_device_id(spi);
+	struct regmap *regmap;
+	int ret;
+
+	regmap = devm_regmap_init_spi(spi, &iio_regmap_spi_regmap_config);
+	if (IS_ERR(regmap)) {
+		dev_err(&spi->dev, "devm_regmap_init_spi failed!\n");
+		return PTR_ERR(regmap);
+	}
+
+	return iio_regmap_probe(&spi->dev, regmap, id->name);
+}
+
+static const struct spi_device_id iio_regmap_spi_id[] = {
+	{
+		.name = "iio-regmap-spi",
+	},
+	{}
+};
+
+static struct spi_driver iio_regmap_spi_driver = {
+	.driver = {
+		.name	= "iio-regmap-spi",
+	},
+	.probe	       = iio_regmap_spi_probe,
+	.id_table      = iio_regmap_spi_id
+};
+
+module_spi_driver(iio_regmap_spi_driver);
+
+MODULE_AUTHOR("Alexandru Tachici <alexandru.tachici@analog.com>");
+MODULE_DESCRIPTION("IIO Regmap SPI");
+MODULE_LICENSE("GPL v2");

--- a/drivers/iio/regmap/iio-regmap.c
+++ b/drivers/iio/regmap/iio-regmap.c
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Generic IIO access driver
+ *
+ * Copyright 2019 Analog Devices Inc.
+ */
+
+#include <linux/iio/iio.h>
+#include <linux/module.h>
+#include <linux/spi/spi.h>
+
+#include "iio-regmap.h"
+
+struct iio_regmap {
+	struct device *dev;
+	struct regmap *regmap;
+};
+
+static const struct iio_info iio_regmap_info = {
+};
+
+int iio_regmap_probe(struct device *dev, struct regmap *regmap,
+		     const char *name)
+{
+	struct iio_dev *indio_dev;
+	struct iio_regmap *st;
+	int ret;
+
+	indio_dev = devm_iio_device_alloc(dev, sizeof(*st));
+	if (!indio_dev)
+		return -ENOMEM;
+
+	st = iio_priv(indio_dev);
+	dev_set_drvdata(dev, indio_dev);
+
+	st->dev = dev;
+	st->regmap = regmap;
+
+	indio_dev->dev.parent = dev;
+	indio_dev->name = name;
+	indio_dev->info = &iio_regmap_info;
+	indio_dev->modes = INDIO_DIRECT_MODE;
+
+	ret = devm_iio_device_register(dev, indio_dev);
+	if (ret < 0)
+		dev_err(&indio_dev->dev, "iio-regmap device register failed\n");
+
+	return ret;
+}
+EXPORT_SYMBOL_GPL(iio_regmap_probe);
+
+MODULE_AUTHOR("Alexandru Tachici <alexandru.tachici@analog.com>");
+MODULE_DESCRIPTION("Generic IIO access driver");
+MODULE_LICENSE("GPL v2");

--- a/drivers/iio/regmap/iio-regmap.h
+++ b/drivers/iio/regmap/iio-regmap.h
@@ -1,0 +1,16 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Generic IIO access driver
+ *
+ * Copyright 2019 Analog Devices Inc.
+ */
+
+#ifndef _IIO_REGMAP_H_
+#define _IIO_REGMAP_H_
+
+struct regmap;
+
+int iio_regmap_probe(struct device *dev, struct regmap *regmap,
+		     const char *name);
+
+#endif /* _IIO_REGMAP_H_ */


### PR DESCRIPTION
This change adds support for the Generic IIO access driver via
I2C and SPI. The intent for this chip is to provide a base/simple driver
for prototyping new IIO drivers and new boards by allowing regmap
sequences to be loaded at probe & remove to do chip init.

Later this may be extended to optionally configure IIO channels.

Signed-off-by: Alexandru Tachici <alexandru.tachici@analog.com>