### PR TITLE
drivers: iio: jesd204: axi_adxcvr: Fix QPLL1 register write

### DIFF
--- a/drivers/iio/jesd204/axi_adxcvr.c
+++ b/drivers/iio/jesd204/axi_adxcvr.c
@@ -355,6 +355,14 @@ static int adxcvr_clk_set_rate(struct clk_hw *hw,
 	if (ret < 0)
 		return ret;
 
+	if ((st->xcvr.type == XILINX_XCVR_TYPE_US_GTH3) ||
+	    (st->xcvr.type == XILINX_XCVR_TYPE_US_GTH4)) {
+		if (st->sys_clk_sel == ADXCVR_GTH_SYSCLK_QPLL1)
+			qpll_conf.qpll = 1;
+		else
+			qpll_conf.qpll = 0;
+	}
+
 	for (i = 0; i < st->num_lanes; i++) {
 
 		if (st->cpll_enable)


### PR DESCRIPTION
This patch adds a sys clock check inside adxcvr_clk_set_rate. Previously
this function did not verify the sys clock source and it was always
writing the configuration to QPLL0 register.

Fixes: 439daa8 ("iio: jesd204: axi_adxcvr: Add support GTH3/4 QPLL1
support")

Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>