### PR TITLE
iio: frequency: adf4360: Fix for ADF4360 default output level on M2K

### DIFF
--- a/Documentation/devicetree/bindings/iio/frequency/adi,adf4360.yaml
+++ b/Documentation/devicetree/bindings/iio/frequency/adi,adf4360.yaml
@@ -120,6 +120,13 @@ properties:
       muxout control is set to lock detect.
     maxItems: 1
 
+  adi,power-out-level-microamp:
+    description: |
+      Chip support setting of output power level. This property is optional.
+      If it is not provided by default 11000 uA will be set.
+    allOf:
+      - enum: [3500, 5000, 7500, 11000]
+
 required:
   - compatible
   - reg

--- a/arch/arm/boot/dts/zynq-m2k-reva.dts
+++ b/arch/arm/boot/dts/zynq-m2k-reva.dts
@@ -132,6 +132,7 @@
 		adi,loop-filter-charge-pump-current-microamp = <2500>;
 		adi,loop-filter-pfd-frequency-hz = <5000000>;
 		adi,power-up-frequency-hz = <100000000>;
+		adi,power-out-level-microamp = <5000>;
 	};
 
 	converter@1 {

--- a/drivers/iio/frequency/adf4360.c
+++ b/drivers/iio/frequency/adf4360.c
@@ -168,7 +168,7 @@ static const char * const adf4360_power_level_modes[] = {
 	[ADF4360_PL_3_5] = "3500-uA",
 	[ADF4360_PL_5] = "5000-uA",
 	[ADF4360_PL_7_5] = "7500-uA",
-	[ADF4360_PL_11] = "1100-uA",
+	[ADF4360_PL_11] = "11000-uA",
 };
 
 static const unsigned int adf4360_power_lvl_microamp[] = {

--- a/drivers/iio/frequency/adf4360.c
+++ b/drivers/iio/frequency/adf4360.c
@@ -1142,7 +1142,7 @@ static int adf4360_parse_dt(struct adf4360_state *st)
 		st->power_level = find_closest(tmp, adf4360_power_lvl_microamp,
 					ARRAY_SIZE(adf4360_power_lvl_microamp));
 	else
-		st->power_level = ADF4360_PL_11;
+		st->power_level = ADF4360_PL_5;
 
 	return 0;
 }

--- a/drivers/iio/frequency/adf4360.c
+++ b/drivers/iio/frequency/adf4360.c
@@ -171,6 +171,13 @@ static const char * const adf4360_power_level_modes[] = {
 	[ADF4360_PL_11] = "1100-uA",
 };
 
+static const unsigned int adf4360_power_lvl_microamp[] = {
+	[ADF4360_PL_3_5] = 3500,
+	[ADF4360_PL_5] = 5000,
+	[ADF4360_PL_7_5] = 7500,
+	[ADF4360_PL_11] = 11000,
+};
+
 static const unsigned int adf4360_cpi_modes[] = {
 	[ADF4360_CPI_0_31] = 310,
 	[ADF4360_CPI_0_62] = 620,
@@ -1129,6 +1136,14 @@ static int adf4360_parse_dt(struct adf4360_state *st)
 	else
 		st->freq_req = st->vco_min;
 
+	ret = device_property_read_u32(dev, "adi,power-out-level-microamp",
+				       &tmp);
+	if (ret == 0)
+		st->power_level = find_closest(tmp, adf4360_power_lvl_microamp,
+					ARRAY_SIZE(adf4360_power_lvl_microamp));
+	else
+		st->power_level = ADF4360_PL_11;
+
 	return 0;
 }
 
@@ -1154,7 +1169,6 @@ static int adf4360_probe(struct spi_device *spi)
 	st->part_id = id->driver_data;
 	st->muxout_mode = ADF4360_MUXOUT_LOCK_DETECT;
 	st->mtld = true;
-	st->power_level = ADF4360_PL_11;
 
 	ret = adf4360_parse_dt(st);
 	if (ret) {


### PR DESCRIPTION
On ADALM2000 was discovered a problem related to PLL loosing lock if the ADF4360 output level is set to 11mA.

This PR add :

- DT property to allow output power level configuration

- update of M2K devicetree 

- fix of a typo in output power level enumeration.

Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>