### PR TITLE
ADIS library refactor

### DIFF
--- a/drivers/iio/gyro/adis16136.c
+++ b/drivers/iio/gyro/adis16136.c
@@ -520,7 +520,6 @@ static struct adis_data *adis16136_adis_data_alloc(struct adis16136 *st)
 	data->glob_cmd_reg = ADIS16136_REG_GLOB_CMD;
 	data->diag_stat_reg = ADIS16136_REG_DIAG_STAT;
 	data->self_test_mask = ADIS16136_MSC_CTRL_SELF_TEST;
-	data->startup_delay = 80;
 	data->read_delay = 10;
 	data->write_delay = 10;
 	data->status_error_msgs = adis16136_status_error_msgs;

--- a/drivers/iio/gyro/adis16136.c
+++ b/drivers/iio/gyro/adis16136.c
@@ -520,6 +520,7 @@ static struct adis_data *adis16136_adis_data_alloc(struct adis16136 *st)
 	data->glob_cmd_reg = ADIS16136_REG_GLOB_CMD;
 	data->diag_stat_reg = ADIS16136_REG_DIAG_STAT;
 	data->self_test_mask = ADIS16136_MSC_CTRL_SELF_TEST;
+	data->self_test_reg = ADIS16136_REG_MSC_CTRL;
 	data->read_delay = 10;
 	data->write_delay = 10;
 	data->status_error_msgs = adis16136_status_error_msgs;

--- a/drivers/iio/gyro/adis16136.c
+++ b/drivers/iio/gyro/adis16136.c
@@ -60,6 +60,7 @@
 struct adis16136_chip_info {
 	unsigned int precision;
 	unsigned int fullscale;
+	const struct adis_timeout *timeouts;
 };
 
 struct adis16136 {
@@ -464,24 +465,6 @@ static const char * const adis16136_status_error_msgs[] = {
 	[ADIS16136_DIAG_STAT_FLASH_CHKSUM_FAIL] = "Flash checksum error",
 };
 
-static const struct adis_data adis16136_data = {
-	.diag_stat_reg = ADIS16136_REG_DIAG_STAT,
-	.glob_cmd_reg = ADIS16136_REG_GLOB_CMD,
-	.msc_ctrl_reg = ADIS16136_REG_MSC_CTRL,
-
-	.self_test_mask = ADIS16136_MSC_CTRL_SELF_TEST,
-	.startup_delay = 80,
-
-	.read_delay = 10,
-	.write_delay = 10,
-
-	.status_error_msgs = adis16136_status_error_msgs,
-	.status_error_mask = BIT(ADIS16136_DIAG_STAT_FLASH_UPDATE_FAIL) |
-		BIT(ADIS16136_DIAG_STAT_SPI_FAIL) |
-		BIT(ADIS16136_DIAG_STAT_SELF_TEST_FAIL) |
-		BIT(ADIS16136_DIAG_STAT_FLASH_CHKSUM_FAIL),
-};
-
 enum adis16136_id {
 	ID_ADIS16133,
 	ID_ADIS16135,
@@ -489,30 +472,73 @@ enum adis16136_id {
 	ID_ADIS16137,
 };
 
+static const struct adis_timeout adis16133_timeouts = {
+	.reset_ms = 75,
+	.sw_reset_ms = 75,
+	.self_test_ms = 50,
+};
+
+static const struct adis_timeout adis16136_timeouts = {
+	.reset_ms = 128,
+	.sw_reset_ms = 75,
+	.self_test_ms = 245,
+};
+
 static const struct adis16136_chip_info adis16136_chip_info[] = {
 	[ID_ADIS16133] = {
 		.precision = IIO_DEGREE_TO_RAD(1200),
 		.fullscale = 24000,
+		.timeouts = &adis16133_timeouts,
 	},
 	[ID_ADIS16135] = {
 		.precision = IIO_DEGREE_TO_RAD(300),
 		.fullscale = 24000,
+		.timeouts = &adis16133_timeouts,
 	},
 	[ID_ADIS16136] = {
 		.precision = IIO_DEGREE_TO_RAD(450),
 		.fullscale = 24623,
+		.timeouts = &adis16136_timeouts,
 	},
 	[ID_ADIS16137] = {
 		.precision = IIO_DEGREE_TO_RAD(1000),
 		.fullscale = 24609,
+		.timeouts = &adis16136_timeouts,
 	},
 };
+
+static struct adis_data *adis16136_adis_data_alloc(struct adis16136 *st)
+{
+	struct adis_data *data;
+	struct device *dev = &st->adis.spi->dev;
+
+	data = devm_kzalloc(dev, sizeof(struct adis_data), GFP_KERNEL);
+	if (!data)
+		return ERR_PTR(-ENOMEM);
+
+	data->msc_ctrl_reg = ADIS16136_REG_MSC_CTRL;
+	data->glob_cmd_reg = ADIS16136_REG_GLOB_CMD;
+	data->diag_stat_reg = ADIS16136_REG_DIAG_STAT;
+	data->self_test_mask = ADIS16136_MSC_CTRL_SELF_TEST;
+	data->startup_delay = 80;
+	data->read_delay = 10;
+	data->write_delay = 10;
+	data->status_error_msgs = adis16136_status_error_msgs;
+	data->status_error_mask = BIT(ADIS16136_DIAG_STAT_FLASH_UPDATE_FAIL) |
+				BIT(ADIS16136_DIAG_STAT_SPI_FAIL) |
+				BIT(ADIS16136_DIAG_STAT_SELF_TEST_FAIL) |
+				BIT(ADIS16136_DIAG_STAT_FLASH_CHKSUM_FAIL);
+	data->timeouts = st->chip_info->timeouts;
+
+	return data;
+}
 
 static int adis16136_probe(struct spi_device *spi)
 {
 	const struct spi_device_id *id = spi_get_device_id(spi);
 	struct adis16136 *adis16136;
 	struct iio_dev *indio_dev;
+	const struct adis_data *adis16136_data;
 	int ret;
 
 	indio_dev = devm_iio_device_alloc(&spi->dev, sizeof(*adis16136));
@@ -531,7 +557,11 @@ static int adis16136_probe(struct spi_device *spi)
 	indio_dev->info = &adis16136_info;
 	indio_dev->modes = INDIO_DIRECT_MODE;
 
-	ret = adis_init(&adis16136->adis, indio_dev, spi, &adis16136_data);
+	adis16136_data = adis16136_adis_data_alloc(adis16136);
+	if (IS_ERR(adis16136_data))
+		return PTR_ERR(adis16136_data);
+
+	ret = adis_init(&adis16136->adis, indio_dev, spi, adis16136_data);
 	if (ret)
 		return ret;
 

--- a/drivers/iio/gyro/adis16260.c
+++ b/drivers/iio/gyro/adis16260.c
@@ -348,6 +348,7 @@ static const struct adis_data adis16260_data = {
 	.diag_stat_reg = ADIS16260_DIAG_STAT,
 
 	.self_test_mask = ADIS16260_MSC_CTRL_MEM_TEST,
+	.self_test_reg = ADIS16260_MSC_CTRL,
 	.timeouts = &adis16260_timeouts,
 
 	.status_error_msgs = adis1620_status_error_msgs,

--- a/drivers/iio/gyro/adis16260.c
+++ b/drivers/iio/gyro/adis16260.c
@@ -348,7 +348,6 @@ static const struct adis_data adis16260_data = {
 	.diag_stat_reg = ADIS16260_DIAG_STAT,
 
 	.self_test_mask = ADIS16260_MSC_CTRL_MEM_TEST,
-	.startup_delay = ADIS16260_STARTUP_DELAY,
 	.timeouts = &adis16260_timeouts,
 
 	.status_error_msgs = adis1620_status_error_msgs,

--- a/drivers/iio/gyro/adis16260.c
+++ b/drivers/iio/gyro/adis16260.c
@@ -334,6 +334,12 @@ static const char * const adis1620_status_error_msgs[] = {
 	[ADIS16260_DIAG_STAT_POWER_LOW_BIT] = "Power supply below 4.75",
 };
 
+static const struct adis_timeout adis16260_timeouts = {
+	.reset_ms = ADIS16260_STARTUP_DELAY,
+	.sw_reset_ms = ADIS16260_STARTUP_DELAY,
+	.self_test_ms = ADIS16260_STARTUP_DELAY,
+};
+
 static const struct adis_data adis16260_data = {
 	.write_delay = 30,
 	.read_delay = 30,
@@ -343,6 +349,7 @@ static const struct adis_data adis16260_data = {
 
 	.self_test_mask = ADIS16260_MSC_CTRL_MEM_TEST,
 	.startup_delay = ADIS16260_STARTUP_DELAY,
+	.timeouts = &adis16260_timeouts,
 
 	.status_error_msgs = adis1620_status_error_msgs,
 	.status_error_mask = BIT(ADIS16260_DIAG_STAT_FLASH_CHK_BIT) |

--- a/drivers/iio/imu/Kconfig
+++ b/drivers/iio/imu/Kconfig
@@ -66,6 +66,7 @@ endmenu
 
 config IIO_ADIS_LIB
 	tristate
+	depends on GPIOLIB
 	help
 	  A set of IO helper functions for the Analog Devices ADIS* device family.
 

--- a/drivers/iio/imu/adis.c
+++ b/drivers/iio/imu/adis.c
@@ -340,19 +340,25 @@ EXPORT_SYMBOL_GPL(__adis_check_status);
 int __adis_reset(struct adis *adis)
 {
 	int ret;
+	const struct adis_timeout *timeouts = adis->data->timeouts;
 
 	ret = __adis_write_reg_8(adis, adis->data->glob_cmd_reg,
 			ADIS_GLOB_CMD_SW_RESET);
-	if (ret)
+	if (ret) {
 		dev_err(&adis->spi->dev, "Failed to reset device: %d\n", ret);
+		return ret;
+	}
 
-	return ret;
+	msleep(timeouts->sw_reset_ms);
+
+	return 0;
 }
 EXPORT_SYMBOL_GPL(__adis_reset);
 
 static int adis_self_test(struct adis *adis)
 {
 	int ret;
+	const struct adis_timeout *timeouts = adis->data->timeouts;
 
 	ret = __adis_write_reg_16(adis, adis->data->msc_ctrl_reg,
 			adis->data->self_test_mask);
@@ -362,7 +368,7 @@ static int adis_self_test(struct adis *adis)
 		return ret;
 	}
 
-	msleep(adis->data->startup_delay);
+	msleep(timeouts->self_test_ms);
 
 	ret = __adis_check_status(adis);
 
@@ -391,7 +397,6 @@ int adis_initial_startup(struct adis *adis)
 	if (ret) {
 		dev_err(&adis->spi->dev, "Self-test failed, trying reset.\n");
 		__adis_reset(adis);
-		msleep(adis->data->startup_delay);
 		ret = adis_self_test(adis);
 		if (ret) {
 			dev_err(&adis->spi->dev, "Second self-test failed, giving up.\n");
@@ -467,6 +472,11 @@ EXPORT_SYMBOL_GPL(adis_single_conversion);
 int adis_init(struct adis *adis, struct iio_dev *indio_dev,
 	struct spi_device *spi, const struct adis_data *data)
 {
+	if (!data || !data->timeouts) {
+		dev_err(&spi->dev, "No config data or timeouts not defined!\n");
+		return -EINVAL;
+	}
+
 	mutex_init(&adis->state_lock);
 	adis->spi = spi;
 	adis->data = data;

--- a/drivers/iio/imu/adis.c
+++ b/drivers/iio/imu/adis.c
@@ -8,6 +8,7 @@
  */
 
 #include <linux/delay.h>
+#include <linux/gpio/consumer.h>
 #include <linux/mutex.h>
 #include <linux/device.h>
 #include <linux/kernel.h>
@@ -379,36 +380,64 @@ static int adis_self_test(struct adis *adis)
 }
 
 /**
- * adis_inital_startup() - Performs device self-test
+ * __adis_initial_startup() - Device initial setup
  * @adis: The adis device
+ *
+ * This functions makes sure the device is not in reset, via rst pin.
+ * Furthermore it performs a SW reset (only in the case we are not coming from
+ * reset already) and a self test. It also compares the product id with the
+ * device id if the prod_id_reg variable is set.
  *
  * Returns 0 if the device is operational, a negative error code otherwise.
  *
  * This function should be called early on in the device initialization sequence
  * to ensure that the device is in a sane and known state and that it is usable.
  */
-int adis_initial_startup(struct adis *adis)
+int __adis_initial_startup(struct adis *adis)
 {
 	int ret;
+	struct gpio_desc *gpio;
+	const struct adis_timeout *timeouts = adis->data->timeouts;
+	const char *iio_name = spi_get_device_id(adis->spi)->name;
+	u16 prod_id, dev_id;
 
-	mutex_lock(&adis->state_lock);
-
-	ret = adis_self_test(adis);
-	if (ret) {
-		dev_err(&adis->spi->dev, "Self-test failed, trying reset.\n");
-		__adis_reset(adis);
-		ret = adis_self_test(adis);
-		if (ret) {
-			dev_err(&adis->spi->dev, "Second self-test failed, giving up.\n");
-			goto out_unlock;
-		}
+	/* check if the device has rst pin low */
+	gpio = devm_gpiod_get_optional(&adis->spi->dev, "reset", GPIOD_ASIS);
+	if (IS_ERR(gpio)) {
+		return PTR_ERR(gpio);
+	} else if (gpio && gpiod_get_value_cansleep(gpio)) {
+		/* bring device out of reset */
+		gpiod_set_value_cansleep(gpio, 0);
+		msleep(timeouts->reset_ms);
+	} else {
+		ret = __adis_reset(adis);
+		if (ret)
+			return ret;
 	}
 
-out_unlock:
-	mutex_unlock(&adis->state_lock);
-	return ret;
+	ret = adis_self_test(adis);
+	if (ret)
+		return ret;
+
+	if (!adis->data->prod_id_reg)
+		return 0;
+
+	ret = adis_read_reg_16(adis, adis->data->prod_id_reg, &prod_id);
+	if (ret)
+		return ret;
+
+	ret = sscanf(iio_name, "adis%hu\n", &dev_id);
+	if (ret != 1)
+		return -EINVAL;
+
+	if (prod_id != dev_id)
+		dev_warn(&adis->spi->dev,
+			 "Device ID(%u) and product ID(%u) do not match.",
+			 dev_id, prod_id);
+
+	return 0;
 }
-EXPORT_SYMBOL_GPL(adis_initial_startup);
+EXPORT_SYMBOL_GPL(__adis_initial_startup);
 
 /**
  * adis_single_conversion() - Performs a single sample conversion

--- a/drivers/iio/imu/adis.c
+++ b/drivers/iio/imu/adis.c
@@ -360,8 +360,8 @@ static int adis_self_test(struct adis *adis)
 	int ret;
 	const struct adis_timeout *timeouts = adis->data->timeouts;
 
-	ret = __adis_write_reg_16(adis, adis->data->msc_ctrl_reg,
-			adis->data->self_test_mask);
+	ret = __adis_write_reg_16(adis, adis->data->self_test_reg,
+				  adis->data->self_test_mask);
 	if (ret) {
 		dev_err(&adis->spi->dev, "Failed to initiate self test: %d\n",
 			ret);
@@ -373,7 +373,7 @@ static int adis_self_test(struct adis *adis)
 	ret = __adis_check_status(adis);
 
 	if (adis->data->self_test_no_autoclear)
-		__adis_write_reg_16(adis, adis->data->msc_ctrl_reg, 0x00);
+		__adis_write_reg_16(adis, adis->data->self_test_reg, 0x00);
 
 	return ret;
 }

--- a/drivers/iio/imu/adis16400.c
+++ b/drivers/iio/imu/adis16400.c
@@ -1151,6 +1151,7 @@ static struct adis_data *adis16400_adis_data_alloc(struct adis16400_state *st)
 	data->read_delay = 50;
 	data->write_delay = 50;
 	data->self_test_mask = ADIS16400_MSC_CTRL_MEM_TEST;
+	data->self_test_reg = ADIS16400_MSC_CTRL;
 	data->status_error_msgs = adis16400_status_error_msgs;
 	data->status_error_mask = BIT(ADIS16400_DIAG_STAT_ZACCL_FAIL) |
 				BIT(ADIS16400_DIAG_STAT_YACCL_FAIL) |

--- a/drivers/iio/imu/adis16400.c
+++ b/drivers/iio/imu/adis16400.c
@@ -1151,7 +1151,6 @@ static struct adis_data *adis16400_adis_data_alloc(struct adis16400_state *st)
 	data->read_delay = 50;
 	data->write_delay = 50;
 	data->self_test_mask = ADIS16400_MSC_CTRL_MEM_TEST;
-	data->startup_delay = ADIS16400_STARTUP_DELAY;
 	data->status_error_msgs = adis16400_status_error_msgs;
 	data->status_error_mask = BIT(ADIS16400_DIAG_STAT_ZACCL_FAIL) |
 				BIT(ADIS16400_DIAG_STAT_YACCL_FAIL) |

--- a/drivers/iio/imu/adis16400.c
+++ b/drivers/iio/imu/adis16400.c
@@ -160,6 +160,7 @@ struct adis16400_state;
 
 struct adis16400_chip_info {
 	const struct iio_chan_spec *channels;
+	const struct adis_timeout *timeouts;
 	const int num_channels;
 	const long flags;
 	unsigned int gyro_scale_micro;
@@ -933,6 +934,36 @@ static const struct iio_chan_spec adis16334_channels[] = {
 	IIO_CHAN_SOFT_TIMESTAMP(ADIS16400_SCAN_TIMESTAMP),
 };
 
+static const struct adis_timeout adis16300_timeouts = {
+	.reset_ms = ADIS16400_STARTUP_DELAY,
+	.sw_reset_ms = ADIS16400_STARTUP_DELAY,
+	.self_test_ms = ADIS16400_STARTUP_DELAY,
+};
+
+static const struct adis_timeout adis16362_timeouts = {
+	.reset_ms = 130,
+	.sw_reset_ms = 130,
+	.self_test_ms = 12,
+};
+
+static const struct adis_timeout adis16400_timeouts = {
+	.reset_ms = 170,
+	.sw_reset_ms = 170,
+	.self_test_ms = 12,
+};
+
+static const struct adis_timeout adis16445_timeouts = {
+	.reset_ms = 55,
+	.sw_reset_ms = 55,
+	.self_test_ms = 16,
+};
+
+static const struct adis_timeout adis16448_timeouts = {
+	.reset_ms = 90,
+	.sw_reset_ms = 90,
+	.self_test_ms = 45,
+};
+
 static struct adis16400_chip_info adis16400_chips[] = {
 	[ADIS16300] = {
 		.channels = adis16300_channels,
@@ -945,6 +976,7 @@ static struct adis16400_chip_info adis16400_chips[] = {
 		.temp_offset = 25000000 / 140000, /* 25 C = 0x00 */
 		.set_freq = adis16400_set_freq,
 		.get_freq = adis16400_get_freq,
+		.timeouts = &adis16300_timeouts,
 	},
 	[ADIS16334] = {
 		.channels = adis16334_channels,
@@ -968,6 +1000,7 @@ static struct adis16400_chip_info adis16400_chips[] = {
 		.flags = ADIS16400_NO_BURST | ADIS16400_HAS_SLOW_MODE,
 		.set_freq = adis16400_set_freq,
 		.get_freq = adis16400_get_freq,
+		.timeouts = &adis16300_timeouts,
 	},
 	[ADIS16360] = {
 		.channels = adis16350_channels,
@@ -980,6 +1013,7 @@ static struct adis16400_chip_info adis16400_chips[] = {
 		.temp_offset = 25000000 / 136000, /* 25 C = 0x00 */
 		.set_freq = adis16400_set_freq,
 		.get_freq = adis16400_get_freq,
+		.timeouts = &adis16300_timeouts,
 	},
 	[ADIS16362] = {
 		.channels = adis16350_channels,
@@ -992,6 +1026,7 @@ static struct adis16400_chip_info adis16400_chips[] = {
 		.temp_offset = 25000000 / 136000, /* 25 C = 0x00 */
 		.set_freq = adis16400_set_freq,
 		.get_freq = adis16400_get_freq,
+		.timeouts = &adis16362_timeouts,
 	},
 	[ADIS16364] = {
 		.channels = adis16350_channels,
@@ -1004,6 +1039,7 @@ static struct adis16400_chip_info adis16400_chips[] = {
 		.temp_offset = 25000000 / 136000, /* 25 C = 0x00 */
 		.set_freq = adis16400_set_freq,
 		.get_freq = adis16400_get_freq,
+		.timeouts = &adis16362_timeouts,
 	},
 	[ADIS16367] = {
 		.channels = adis16350_channels,
@@ -1016,6 +1052,7 @@ static struct adis16400_chip_info adis16400_chips[] = {
 		.temp_offset = 25000000 / 136000, /* 25 C = 0x00 */
 		.set_freq = adis16400_set_freq,
 		.get_freq = adis16400_get_freq,
+		.timeouts = &adis16300_timeouts,
 	},
 	[ADIS16400] = {
 		.channels = adis16400_channels,
@@ -1027,6 +1064,7 @@ static struct adis16400_chip_info adis16400_chips[] = {
 		.temp_offset = 25000000 / 140000, /* 25 C = 0x00 */
 		.set_freq = adis16400_set_freq,
 		.get_freq = adis16400_get_freq,
+		.timeouts = &adis16400_timeouts,
 	},
 	[ADIS16445] = {
 		.channels = adis16445_channels,
@@ -1040,6 +1078,7 @@ static struct adis16400_chip_info adis16400_chips[] = {
 		.temp_offset = 31000000 / 73860, /* 31 C = 0x00 */
 		.set_freq = adis16334_set_freq,
 		.get_freq = adis16334_get_freq,
+		.timeouts = &adis16445_timeouts,
 	},
 	[ADIS16448] = {
 		.channels = adis16448_channels,
@@ -1053,6 +1092,7 @@ static struct adis16400_chip_info adis16400_chips[] = {
 		.temp_offset = 31000000 / 73860, /* 31 C = 0x00 */
 		.set_freq = adis16334_set_freq,
 		.get_freq = adis16334_get_freq,
+		.timeouts = &adis16448_timeouts,
 	}
 };
 
@@ -1082,35 +1122,6 @@ static const char * const adis16400_status_error_msgs[] = {
 	[ADIS16400_DIAG_STAT_POWER_LOW] = "Power supply below 4.75V",
 };
 
-static const struct adis_data adis16400_data = {
-	.msc_ctrl_reg = ADIS16400_MSC_CTRL,
-	.glob_cmd_reg = ADIS16400_GLOB_CMD,
-	.diag_stat_reg = ADIS16400_DIAG_STAT,
-
-	.read_delay = 50,
-	.write_delay = 50,
-
-	.self_test_mask = ADIS16400_MSC_CTRL_MEM_TEST,
-	.startup_delay = ADIS16400_STARTUP_DELAY,
-
-	.status_error_msgs = adis16400_status_error_msgs,
-	.status_error_mask = BIT(ADIS16400_DIAG_STAT_ZACCL_FAIL) |
-		BIT(ADIS16400_DIAG_STAT_YACCL_FAIL) |
-		BIT(ADIS16400_DIAG_STAT_XACCL_FAIL) |
-		BIT(ADIS16400_DIAG_STAT_XGYRO_FAIL) |
-		BIT(ADIS16400_DIAG_STAT_YGYRO_FAIL) |
-		BIT(ADIS16400_DIAG_STAT_ZGYRO_FAIL) |
-		BIT(ADIS16400_DIAG_STAT_ALARM2) |
-		BIT(ADIS16400_DIAG_STAT_ALARM1) |
-		BIT(ADIS16400_DIAG_STAT_FLASH_CHK) |
-		BIT(ADIS16400_DIAG_STAT_SELF_TEST) |
-		BIT(ADIS16400_DIAG_STAT_OVERFLOW) |
-		BIT(ADIS16400_DIAG_STAT_SPI_FAIL) |
-		BIT(ADIS16400_DIAG_STAT_FLASH_UPT) |
-		BIT(ADIS16400_DIAG_STAT_POWER_HIGH) |
-		BIT(ADIS16400_DIAG_STAT_POWER_LOW),
-};
-
 static void adis16400_setup_chan_mask(struct adis16400_state *st)
 {
 	const struct adis16400_chip_info *chip_info = st->variant;
@@ -1125,11 +1136,49 @@ static void adis16400_setup_chan_mask(struct adis16400_state *st)
 	}
 }
 
+static struct adis_data *adis16400_adis_data_alloc(struct adis16400_state *st)
+{
+	struct adis_data *data;
+	struct device *dev = &st->adis.spi->dev;
+
+	data = devm_kzalloc(dev, sizeof(struct adis_data), GFP_KERNEL);
+	if (!data)
+		return ERR_PTR(-ENOMEM);
+
+	data->msc_ctrl_reg = ADIS16400_MSC_CTRL;
+	data->glob_cmd_reg = ADIS16400_GLOB_CMD;
+	data->diag_stat_reg = ADIS16400_DIAG_STAT;
+	data->read_delay = 50;
+	data->write_delay = 50;
+	data->self_test_mask = ADIS16400_MSC_CTRL_MEM_TEST;
+	data->startup_delay = ADIS16400_STARTUP_DELAY;
+	data->status_error_msgs = adis16400_status_error_msgs;
+	data->status_error_mask = BIT(ADIS16400_DIAG_STAT_ZACCL_FAIL) |
+				BIT(ADIS16400_DIAG_STAT_YACCL_FAIL) |
+				BIT(ADIS16400_DIAG_STAT_XACCL_FAIL) |
+				BIT(ADIS16400_DIAG_STAT_XGYRO_FAIL) |
+				BIT(ADIS16400_DIAG_STAT_YGYRO_FAIL) |
+				BIT(ADIS16400_DIAG_STAT_ZGYRO_FAIL) |
+				BIT(ADIS16400_DIAG_STAT_ALARM2) |
+				BIT(ADIS16400_DIAG_STAT_ALARM1) |
+				BIT(ADIS16400_DIAG_STAT_FLASH_CHK) |
+				BIT(ADIS16400_DIAG_STAT_SELF_TEST) |
+				BIT(ADIS16400_DIAG_STAT_OVERFLOW) |
+				BIT(ADIS16400_DIAG_STAT_SPI_FAIL) |
+				BIT(ADIS16400_DIAG_STAT_FLASH_UPT) |
+				BIT(ADIS16400_DIAG_STAT_POWER_HIGH) |
+				BIT(ADIS16400_DIAG_STAT_POWER_LOW);
+	data->timeouts = st->variant->timeouts;
+
+	return data;
+}
+
 static int adis16400_probe(struct spi_device *spi)
 {
 	struct adis16400_state *st;
 	struct iio_dev *indio_dev;
 	int ret;
+	const struct adis_data *adis16400_data;
 
 	indio_dev = devm_iio_device_alloc(&spi->dev, sizeof(*st));
 	if (indio_dev == NULL)
@@ -1156,7 +1205,11 @@ static int adis16400_probe(struct spi_device *spi)
 			st->adis.burst->extra_len = sizeof(u16);
 	}
 
-	ret = adis_init(&st->adis, indio_dev, spi, &adis16400_data);
+	adis16400_data = adis16400_adis_data_alloc(st);
+	if (IS_ERR(adis16400_data))
+		return PTR_ERR(adis16400_data);
+
+	ret = adis_init(&st->adis, indio_dev, spi, adis16400_data);
 	if (ret)
 		return ret;
 

--- a/drivers/iio/imu/adis16460.c
+++ b/drivers/iio/imu/adis16460.c
@@ -384,6 +384,12 @@ static const char * const adis16460_status_error_msgs[] = {
 	[ADIS16460_DIAG_STAT_FLASH_UPT] = "Flash update failure",
 };
 
+static const struct adis_timeout adis16460_timeouts = {
+	.reset_ms = 225,
+	.sw_reset_ms = 225,
+	.self_test_ms = 10,
+};
+
 static const struct adis_data adis16460_data = {
 	.diag_stat_reg = ADIS16460_REG_DIAG_STAT,
 	.glob_cmd_reg = ADIS16460_REG_GLOB_CMD,
@@ -399,6 +405,7 @@ static const struct adis_data adis16460_data = {
 		BIT(ADIS16460_DIAG_STAT_SPI_COMM) |
 		BIT(ADIS16460_DIAG_STAT_FLASH_UPT),
 	.enable_irq = adis16460_enable_irq,
+	.timeouts = &adis16460_timeouts,
 };
 
 static int adis16460_probe(struct spi_device *spi)

--- a/drivers/iio/imu/adis16460.c
+++ b/drivers/iio/imu/adis16460.c
@@ -334,40 +334,6 @@ static int adis16460_enable_irq(struct adis *adis, bool enable)
 	return 0;
 }
 
-static int adis16460_initial_setup(struct iio_dev *indio_dev)
-{
-	struct adis16460 *st = iio_priv(indio_dev);
-	uint16_t prod_id;
-	unsigned int device_id;
-	int ret;
-
-	adis_reset(&st->adis);
-	msleep(222);
-
-	ret = adis_write_reg_16(&st->adis, ADIS16460_REG_GLOB_CMD, BIT(1));
-	if (ret)
-		return ret;
-	msleep(75);
-
-	ret = adis_check_status(&st->adis);
-	if (ret)
-		return ret;
-
-	ret = adis_read_reg_16(&st->adis, ADIS16460_REG_PROD_ID, &prod_id);
-	if (ret)
-		return ret;
-
-	ret = sscanf(indio_dev->name, "adis%u\n", &device_id);
-	if (ret != 1)
-		return -EINVAL;
-
-	if (prod_id != device_id)
-		dev_warn(&indio_dev->dev, "Device ID(%u) and product ID(%u) do not match.",
-				device_id, prod_id);
-
-	return 0;
-}
-
 #define ADIS16460_DIAG_STAT_IN_CLK_OOS	7
 #define ADIS16460_DIAG_STAT_FLASH_MEM	6
 #define ADIS16460_DIAG_STAT_SELF_TEST	5
@@ -393,6 +359,9 @@ static const struct adis_timeout adis16460_timeouts = {
 static const struct adis_data adis16460_data = {
 	.diag_stat_reg = ADIS16460_REG_DIAG_STAT,
 	.glob_cmd_reg = ADIS16460_REG_GLOB_CMD,
+	.prod_id_reg = ADIS16460_REG_PROD_ID,
+	.self_test_mask = BIT(2),
+	.self_test_reg = ADIS16460_REG_GLOB_CMD,
 	.has_paging = false,
 	.read_delay = 5,
 	.write_delay = 5,
@@ -440,7 +409,7 @@ static int adis16460_probe(struct spi_device *spi)
 
 	adis16460_enable_irq(&st->adis, 0);
 
-	ret = adis16460_initial_setup(indio_dev);
+	ret = __adis_initial_startup(&st->adis);
 	if (ret)
 		goto error_cleanup_buffer;
 

--- a/drivers/iio/imu/adis16475.c
+++ b/drivers/iio/imu/adis16475.c
@@ -77,6 +77,7 @@ struct adis16475_clks {
 struct adis16475_chip_info {
 	const struct iio_chan_spec *channels;
 	const struct adis16475_clks *clks;
+	const struct adis_timeout *timeouts;
 	u32 num_channels;
 	u32 gyro_max_val;
 	u32 gyro_max_scale;
@@ -85,8 +86,6 @@ struct adis16475_chip_info {
 	u32 temp_scale;
 	u32 int_clk;
 	u16 max_dec;
-	u16 reset_ms;
-	u16 self_test_ms;
 	u8 num_clks;
 	bool has_burst32;
 };
@@ -557,6 +556,18 @@ static const struct adis16475_clks adis16475_ext_clks[] = {
 	{ "pulse-sync", ADIS16475_CLK_PULSE, 1000, 2100 },
 };
 
+static const struct adis_timeout adis16475_timeouts = {
+	.reset_ms = 200,
+	.sw_reset_ms = 200,
+	.self_test_ms = 20,
+};
+
+static const struct adis_timeout adis1650x_timeouts = {
+	.reset_ms = 260,
+	.sw_reset_ms = 260,
+	.self_test_ms = 30,
+};
+
 static const struct adis16475_chip_info adis16475_chip_info[] = {
 	[ADIS16475_1] = {
 		.num_channels = ARRAY_SIZE(adis16475_channels),
@@ -568,8 +579,7 @@ static const struct adis16475_chip_info adis16475_chip_info[] = {
 		.temp_scale = 100,
 		.int_clk = 2000,
 		.max_dec = 1999,
-		.reset_ms = 200,
-		.self_test_ms = 20,
+		.timeouts = &adis16475_timeouts,
 		.clks = adis16475_ext_clks,
 		.num_clks = ARRAY_SIZE(adis16475_ext_clks),
 	},
@@ -583,8 +593,7 @@ static const struct adis16475_chip_info adis16475_chip_info[] = {
 		.temp_scale = 100,
 		.int_clk = 2000,
 		.max_dec = 1999,
-		.reset_ms = 200,
-		.self_test_ms = 20,
+		.timeouts = &adis16475_timeouts,
 		.clks = adis16475_ext_clks,
 		.num_clks = ARRAY_SIZE(adis16475_ext_clks),
 	},
@@ -598,8 +607,7 @@ static const struct adis16475_chip_info adis16475_chip_info[] = {
 		.temp_scale = 100,
 		.int_clk = 2000,
 		.max_dec = 1999,
-		.reset_ms = 200,
-		.self_test_ms = 20,
+		.timeouts = &adis16475_timeouts,
 		.clks = adis16475_ext_clks,
 		.num_clks = ARRAY_SIZE(adis16475_ext_clks),
 	},
@@ -613,8 +621,7 @@ static const struct adis16475_chip_info adis16475_chip_info[] = {
 		.temp_scale = 100,
 		.int_clk = 2000,
 		.max_dec = 1999,
-		.reset_ms = 200,
-		.self_test_ms = 20,
+		.timeouts = &adis16475_timeouts,
 		.clks = adis16475_ext_clks,
 		.num_clks = ARRAY_SIZE(adis16475_ext_clks),
 	},
@@ -628,8 +635,7 @@ static const struct adis16475_chip_info adis16475_chip_info[] = {
 		.temp_scale = 100,
 		.int_clk = 2000,
 		.max_dec = 1999,
-		.reset_ms = 200,
-		.self_test_ms = 20,
+		.timeouts = &adis16475_timeouts,
 		.clks = adis16475_ext_clks,
 		.num_clks = ARRAY_SIZE(adis16475_ext_clks),
 	},
@@ -643,8 +649,7 @@ static const struct adis16475_chip_info adis16475_chip_info[] = {
 		.temp_scale = 100,
 		.int_clk = 2000,
 		.max_dec = 1999,
-		.reset_ms = 200,
-		.self_test_ms = 20,
+		.timeouts = &adis16475_timeouts,
 		.clks = adis16475_ext_clks,
 		.num_clks = ARRAY_SIZE(adis16475_ext_clks),
 	},
@@ -658,8 +663,7 @@ static const struct adis16475_chip_info adis16475_chip_info[] = {
 		.temp_scale = 100,
 		.int_clk = 2000,
 		.max_dec = 1999,
-		.reset_ms = 260,
-		.self_test_ms = 30,
+		.timeouts = &adis1650x_timeouts,
 		.clks = adis16475_ext_clks,
 		/* pulse sync not supported */
 		.num_clks = ARRAY_SIZE(adis16475_ext_clks) - 1,
@@ -675,8 +679,7 @@ static const struct adis16475_chip_info adis16475_chip_info[] = {
 		.temp_scale = 100,
 		.int_clk = 2000,
 		.max_dec = 1999,
-		.reset_ms = 260,
-		.self_test_ms = 30,
+		.timeouts = &adis1650x_timeouts,
 		.clks = adis16475_ext_clks,
 		/* pulse sync not supported */
 		.num_clks = ARRAY_SIZE(adis16475_ext_clks) - 1,
@@ -692,8 +695,7 @@ static const struct adis16475_chip_info adis16475_chip_info[] = {
 		.temp_scale = 100,
 		.int_clk = 2000,
 		.max_dec = 1999,
-		.reset_ms = 260,
-		.self_test_ms = 30,
+		.timeouts = &adis1650x_timeouts,
 		.clks = adis16475_ext_clks,
 		/* pulse sync not supported */
 		.num_clks = ARRAY_SIZE(adis16475_ext_clks) - 1,
@@ -709,8 +711,7 @@ static const struct adis16475_chip_info adis16475_chip_info[] = {
 		.temp_scale = 100,
 		.int_clk = 2000,
 		.max_dec = 1999,
-		.reset_ms = 260,
-		.self_test_ms = 30,
+		.timeouts = &adis1650x_timeouts,
 		.clks = adis16475_ext_clks,
 		/* pulse sync not supported */
 		.num_clks = ARRAY_SIZE(adis16475_ext_clks) - 1,
@@ -726,8 +727,7 @@ static const struct adis16475_chip_info adis16475_chip_info[] = {
 		.temp_scale = 100,
 		.int_clk = 2000,
 		.max_dec = 1999,
-		.reset_ms = 260,
-		.self_test_ms = 30,
+		.timeouts = &adis1650x_timeouts,
 		.clks = adis16475_ext_clks,
 		/* pulse sync not supported */
 		.num_clks = ARRAY_SIZE(adis16475_ext_clks) - 1,
@@ -743,8 +743,7 @@ static const struct adis16475_chip_info adis16475_chip_info[] = {
 		.temp_scale = 100,
 		.int_clk = 2000,
 		.max_dec = 1999,
-		.reset_ms = 260,
-		.self_test_ms = 30,
+		.timeouts = &adis1650x_timeouts,
 		.clks = adis16475_ext_clks,
 		/* pulse sync not supported */
 		.num_clks = ARRAY_SIZE(adis16475_ext_clks) - 1,
@@ -807,27 +806,6 @@ static struct adis_burst adis16475_burst = {
 	.extra_len = 3 * sizeof(u16),
 	.read_delay = 5,
 	.write_delay = 5,
-};
-
-static const struct adis_data adis16475_data = {
-	.msc_ctrl_reg = ADIS16475_REG_MSG_CTRL,
-	.glob_cmd_reg = ADIS16475_REG_GLOB_CMD,
-	.diag_stat_reg = ADIS16475_REG_DIAG_STAT,
-
-	.cs_change_delay = 16,
-	.read_delay = 5,
-	.write_delay = 5,
-
-	.status_error_msgs = adis16475_status_error_msgs,
-	.status_error_mask = BIT(ADIS16475_DIAG_STAT_DATA_PATH) |
-		BIT(ADIS16475_DIAG_STAT_FLASH_MEM) |
-		BIT(ADIS16475_DIAG_STAT_SPI) |
-		BIT(ADIS16475_DIAG_STAT_STANDBY) |
-		BIT(ADIS16475_DIAG_STAT_SENSOR) |
-		BIT(ADIS16475_DIAG_STAT_MEMORY) |
-		BIT(ADIS16475_DIAG_STAT_CLK),
-
-	.enable_irq = adis16475_enable_irq
 };
 
 static u16 adis16475_validate_crc(const u8 *buffer, const u16 crc,
@@ -1112,17 +1090,18 @@ static int adis16475_check_state(struct iio_dev *indio_dev)
 	struct adis16475 *st = iio_priv(indio_dev);
 	u16 prod_id;
 	u32 device_id;
+	const struct adis_timeout *timeouts = st->info->timeouts;
 
 	ret = __adis_reset(&st->adis);
 	if (ret)
 		return ret;
 
-	msleep(st->info->reset_ms);
+	msleep(timeouts->reset_ms);
 	ret = __adis_write_reg_16(&st->adis, ADIS16475_REG_GLOB_CMD, BIT(2));
 	if (ret)
 		return ret;
 
-	msleep(st->info->self_test_ms);
+	msleep(timeouts->self_test_ms);
 	ret = __adis_check_status(&st->adis);
 	if (ret)
 		return ret;
@@ -1143,12 +1122,42 @@ static int adis16475_check_state(struct iio_dev *indio_dev)
 	return 0;
 }
 
+static struct adis_data *adis16475_adis_data_alloc(struct adis16475 *st)
+{
+	struct adis_data *data;
+	struct device *dev = &st->adis.spi->dev;
+
+	data = devm_kzalloc(dev, sizeof(struct adis_data), GFP_KERNEL);
+	if (!data)
+		return ERR_PTR(-ENOMEM);
+
+	data->msc_ctrl_reg = ADIS16475_REG_MSG_CTRL;
+	data->glob_cmd_reg = ADIS16475_REG_GLOB_CMD;
+	data->diag_stat_reg = ADIS16475_REG_DIAG_STAT;
+	data->cs_change_delay = 16;
+	data->read_delay = 5;
+	data->write_delay = 5;
+	data->status_error_msgs = adis16475_status_error_msgs;
+	data->status_error_mask = BIT(ADIS16475_DIAG_STAT_DATA_PATH) |
+				BIT(ADIS16475_DIAG_STAT_FLASH_MEM) |
+				BIT(ADIS16475_DIAG_STAT_SPI) |
+				BIT(ADIS16475_DIAG_STAT_STANDBY) |
+				BIT(ADIS16475_DIAG_STAT_SENSOR) |
+				BIT(ADIS16475_DIAG_STAT_MEMORY) |
+				BIT(ADIS16475_DIAG_STAT_CLK);
+	data->enable_irq = adis16475_enable_irq;
+	data->timeouts = st->info->timeouts;
+
+	return data;
+}
+
 static int adis16475_probe(struct spi_device *spi)
 {
 	struct iio_dev *indio_dev;
 	struct adis16475 *st;
 	struct gpio_desc *desc;
 	const struct spi_device_id *id = spi_get_device_id(spi);
+	const struct adis_data *adis16475_data;
 	int ret;
 
 	indio_dev = devm_iio_device_alloc(&spi->dev, sizeof(*st));
@@ -1159,7 +1168,11 @@ static int adis16475_probe(struct spi_device *spi)
 	st->info = &adis16475_chip_info[id->driver_data];
 	spi_set_drvdata(spi, indio_dev);
 
-	ret = adis_init(&st->adis, indio_dev, spi, &adis16475_data);
+	adis16475_data = adis16475_adis_data_alloc(st);
+	if (IS_ERR(adis16475_data))
+		return PTR_ERR(adis16475_data);
+
+	ret = adis_init(&st->adis, indio_dev, spi, adis16475_data);
 	if (ret)
 		return ret;
 

--- a/drivers/iio/imu/adis16480.c
+++ b/drivers/iio/imu/adis16480.c
@@ -152,9 +152,7 @@ struct adis16480_chip_info {
 	const unsigned int *filter_freqs;
 	bool has_pps_clk_mode;
 	struct adis_burst *burst;
-	u16 reset_ms;
-	u16 sw_reset_ms;
-	u16 self_test_ms;
+	const struct adis_timeout *timeouts;
 };
 
 enum adis16480_int_pin {
@@ -900,6 +898,30 @@ enum adis16480_variant {
 	ADIS16497_3,
 };
 
+static const struct adis_timeout adis16485_timeouts = {
+	.reset_ms = 560,
+	.sw_reset_ms = 120,
+	.self_test_ms = 12,
+};
+
+static const struct adis_timeout adis16480_timeouts = {
+	.reset_ms = 560,
+	.sw_reset_ms = 560,
+	.self_test_ms = 12,
+};
+
+static const struct adis_timeout adis16495_timeouts = {
+	.reset_ms = 170,
+	.sw_reset_ms = 130,
+	.self_test_ms = 40,
+};
+
+static const struct adis_timeout adis16495_1_timeouts = {
+	.reset_ms = 250,
+	.sw_reset_ms = 210,
+	.self_test_ms = 20,
+};
+
 static const struct adis16480_chip_info adis16480_chip_info[] = {
 	[ADIS16375] = {
 		.channels = adis16485_channels,
@@ -918,9 +940,7 @@ static const struct adis16480_chip_info adis16480_chip_info[] = {
 		.int_clk = 2460000,
 		.max_dec_rate = 2048,
 		.filter_freqs = adis16480_def_filter_freqs,
-		.reset_ms = 500,
-		.sw_reset_ms = 74,
-		.self_test_ms = 10,
+		.timeouts = &adis16485_timeouts,
 	},
 	[ADIS16480] = {
 		.channels = adis16480_channels,
@@ -933,9 +953,7 @@ static const struct adis16480_chip_info adis16480_chip_info[] = {
 		.int_clk = 2460000,
 		.max_dec_rate = 2048,
 		.filter_freqs = adis16480_def_filter_freqs,
-		.reset_ms = 560,
-		.sw_reset_ms = 560,
-		.self_test_ms = 12,
+		.timeouts = &adis16480_timeouts,
 
 	},
 	[ADIS16485] = {
@@ -949,9 +967,7 @@ static const struct adis16480_chip_info adis16480_chip_info[] = {
 		.int_clk = 2460000,
 		.max_dec_rate = 2048,
 		.filter_freqs = adis16480_def_filter_freqs,
-		.reset_ms = 560,
-		.sw_reset_ms = 120,
-		.self_test_ms = 12,
+		.timeouts = &adis16485_timeouts,
 	},
 	[ADIS16488] = {
 		.channels = adis16480_channels,
@@ -964,9 +980,7 @@ static const struct adis16480_chip_info adis16480_chip_info[] = {
 		.int_clk = 2460000,
 		.max_dec_rate = 2048,
 		.filter_freqs = adis16480_def_filter_freqs,
-		.reset_ms = 500,
-		.sw_reset_ms = 120,
-		.self_test_ms = 12,
+		.timeouts = &adis16485_timeouts,
 	},
 	[ADIS16490] = {
 		.channels = adis16485_channels,
@@ -980,9 +994,7 @@ static const struct adis16480_chip_info adis16480_chip_info[] = {
 		.max_dec_rate = 4250,
 		.filter_freqs = adis16495_def_filter_freqs,
 		.has_pps_clk_mode = true,
-		.reset_ms = 170,
-		.sw_reset_ms = 130,
-		.self_test_ms = 40,
+		.timeouts = &adis16495_timeouts,
 	},
 	[ADIS16495_1] = {
 		.channels = adis16495_channels,
@@ -997,9 +1009,7 @@ static const struct adis16480_chip_info adis16480_chip_info[] = {
 		.filter_freqs = adis16495_def_filter_freqs,
 		.has_pps_clk_mode = true,
 		.burst = &adis16495_burst,
-		.reset_ms = 250,
-		.sw_reset_ms = 210,
-		.self_test_ms = 20,
+		.timeouts = &adis16495_1_timeouts,
 	},
 	[ADIS16495_2] = {
 		.channels = adis16495_channels,
@@ -1014,9 +1024,7 @@ static const struct adis16480_chip_info adis16480_chip_info[] = {
 		.filter_freqs = adis16495_def_filter_freqs,
 		.has_pps_clk_mode = true,
 		.burst = &adis16495_burst,
-		.reset_ms = 250,
-		.sw_reset_ms = 210,
-		.self_test_ms = 20,
+		.timeouts = &adis16495_1_timeouts,
 	},
 	[ADIS16495_3] = {
 		.channels = adis16495_channels,
@@ -1031,9 +1039,7 @@ static const struct adis16480_chip_info adis16480_chip_info[] = {
 		.filter_freqs = adis16495_def_filter_freqs,
 		.has_pps_clk_mode = true,
 		.burst = &adis16495_burst,
-		.reset_ms = 250,
-		.sw_reset_ms = 210,
-		.self_test_ms = 20,
+		.timeouts = &adis16495_1_timeouts,
 	},
 	[ADIS16497_1] = {
 		.channels = adis16495_channels,
@@ -1048,9 +1054,7 @@ static const struct adis16480_chip_info adis16480_chip_info[] = {
 		.filter_freqs = adis16495_def_filter_freqs,
 		.has_pps_clk_mode = true,
 		.burst = &adis16495_burst,
-		.reset_ms = 250,
-		.sw_reset_ms = 210,
-		.self_test_ms = 20,
+		.timeouts = &adis16495_1_timeouts,
 	},
 	[ADIS16497_2] = {
 		.channels = adis16495_channels,
@@ -1065,9 +1069,7 @@ static const struct adis16480_chip_info adis16480_chip_info[] = {
 		.filter_freqs = adis16495_def_filter_freqs,
 		.has_pps_clk_mode = true,
 		.burst = &adis16495_burst,
-		.reset_ms = 250,
-		.sw_reset_ms = 210,
-		.self_test_ms = 20,
+		.timeouts = &adis16495_1_timeouts,
 	},
 	[ADIS16497_3] = {
 		.channels = adis16495_channels,
@@ -1082,9 +1084,7 @@ static const struct adis16480_chip_info adis16480_chip_info[] = {
 		.filter_freqs = adis16495_def_filter_freqs,
 		.has_pps_clk_mode = true,
 		.burst = &adis16495_burst,
-		.reset_ms = 250,
-		.sw_reset_ms = 210,
-		.self_test_ms = 20,
+		.timeouts = &adis16495_1_timeouts,
 	},
 };
 
@@ -1246,14 +1246,15 @@ static int adis16480_initial_setup(struct iio_dev *indio_dev)
 	uint16_t prod_id;
 	unsigned int device_id;
 	int ret;
+	const struct adis_timeout *timeouts = st->chip_info->timeouts;
 
 	adis_reset(&st->adis);
-	msleep(st->chip_info->sw_reset_ms);
+	msleep(timeouts->sw_reset_ms);
 
 	ret = adis_write_reg_16(&st->adis, ADIS16480_REG_GLOB_CMD, BIT(1));
 	if (ret)
 		return ret;
-	msleep(st->chip_info->self_test_ms);
+	msleep(timeouts->self_test_ms);
 
 	ret = adis_check_status(&st->adis);
 	if (ret)
@@ -1296,29 +1297,6 @@ static const char * const adis16480_status_error_msgs[] = {
 	[ADIS16480_DIAG_STAT_YMAGN_FAIL] = "Y-axis magnetometer self-test failure",
 	[ADIS16480_DIAG_STAT_ZMAGN_FAIL] = "Z-axis magnetometer self-test failure",
 	[ADIS16480_DIAG_STAT_BARO_FAIL] = "Barometer self-test failure",
-};
-
-static const struct adis_data adis16480_data = {
-	.diag_stat_reg = ADIS16480_REG_DIAG_STS,
-	.glob_cmd_reg = ADIS16480_REG_GLOB_CMD,
-	.has_paging = true,
-
-	.read_delay = 5,
-	.write_delay = 5,
-
-	.status_error_msgs = adis16480_status_error_msgs,
-	.status_error_mask = BIT(ADIS16480_DIAG_STAT_XGYRO_FAIL) |
-		BIT(ADIS16480_DIAG_STAT_YGYRO_FAIL) |
-		BIT(ADIS16480_DIAG_STAT_ZGYRO_FAIL) |
-		BIT(ADIS16480_DIAG_STAT_XACCL_FAIL) |
-		BIT(ADIS16480_DIAG_STAT_YACCL_FAIL) |
-		BIT(ADIS16480_DIAG_STAT_ZACCL_FAIL) |
-		BIT(ADIS16480_DIAG_STAT_XMAGN_FAIL) |
-		BIT(ADIS16480_DIAG_STAT_YMAGN_FAIL) |
-		BIT(ADIS16480_DIAG_STAT_ZMAGN_FAIL) |
-		BIT(ADIS16480_DIAG_STAT_BARO_FAIL),
-
-	.enable_irq = adis16480_enable_irq,
 };
 
 static int adis16480_config_irq_pin(struct device_node *of_node,
@@ -1471,9 +1449,41 @@ static int adis16480_get_ext_clocks(struct adis16480 *st)
 	return 0;
 }
 
+static struct adis_data *adis16480_adis_data_alloc(struct adis16480 *st)
+{
+	struct adis_data *data;
+	struct device *dev = &st->adis.spi->dev;
+
+	data = devm_kzalloc(dev, sizeof(struct adis_data), GFP_KERNEL);
+	if (!data)
+		return ERR_PTR(-ENOMEM);
+
+	data->glob_cmd_reg = ADIS16480_REG_GLOB_CMD;
+	data->diag_stat_reg = ADIS16480_REG_DIAG_STS;
+	data->has_paging = true;
+	data->read_delay = 5;
+	data->write_delay = 5;
+	data->status_error_msgs = adis16480_status_error_msgs;
+	data->status_error_mask = BIT(ADIS16480_DIAG_STAT_XGYRO_FAIL) |
+				BIT(ADIS16480_DIAG_STAT_YGYRO_FAIL) |
+				BIT(ADIS16480_DIAG_STAT_ZGYRO_FAIL) |
+				BIT(ADIS16480_DIAG_STAT_XACCL_FAIL) |
+				BIT(ADIS16480_DIAG_STAT_YACCL_FAIL) |
+				BIT(ADIS16480_DIAG_STAT_ZACCL_FAIL) |
+				BIT(ADIS16480_DIAG_STAT_XMAGN_FAIL) |
+				BIT(ADIS16480_DIAG_STAT_YMAGN_FAIL) |
+				BIT(ADIS16480_DIAG_STAT_ZMAGN_FAIL) |
+				BIT(ADIS16480_DIAG_STAT_BARO_FAIL);
+	data->enable_irq = adis16480_enable_irq;
+	data->timeouts = st->chip_info->timeouts;
+
+	return data;
+}
+
 static int adis16480_probe(struct spi_device *spi)
 {
 	const struct spi_device_id *id = spi_get_device_id(spi);
+	const struct adis_data *adis16480_data;
 	struct iio_dev *indio_dev;
 	struct adis16480 *st;
 	int ret;
@@ -1499,9 +1509,13 @@ static int adis16480_probe(struct spi_device *spi)
 	if (IS_ERR(gpio))
 		return PTR_ERR(gpio);
 	else if (gpio)
-		msleep(st->chip_info->reset_ms);
+		msleep(st->chip_info->timeouts->reset_ms);
 
-	ret = adis_init(&st->adis, indio_dev, spi, &adis16480_data);
+	adis16480_data = adis16480_adis_data_alloc(st);
+	if (IS_ERR(adis16480_data))
+		return PTR_ERR(adis16480_data);
+
+	ret = adis_init(&st->adis, indio_dev, spi, adis16480_data);
 	if (ret)
 		return ret;
 

--- a/drivers/iio/imu/adis16480.c
+++ b/drivers/iio/imu/adis16480.c
@@ -23,7 +23,6 @@
 #include <linux/slab.h>
 #include <linux/sysfs.h>
 #include <linux/module.h>
-#include <linux/gpio/consumer.h>
 
 #include <linux/iio/iio.h>
 #include <linux/iio/sysfs.h>
@@ -1240,41 +1239,6 @@ static int adis16480_enable_irq(struct adis *adis, bool enable)
 	return __adis_write_reg_16(adis, ADIS16480_REG_FNCTIO_CTRL, val);
 }
 
-static int adis16480_initial_setup(struct iio_dev *indio_dev)
-{
-	struct adis16480 *st = iio_priv(indio_dev);
-	uint16_t prod_id;
-	unsigned int device_id;
-	int ret;
-	const struct adis_timeout *timeouts = st->chip_info->timeouts;
-
-	adis_reset(&st->adis);
-	msleep(timeouts->sw_reset_ms);
-
-	ret = adis_write_reg_16(&st->adis, ADIS16480_REG_GLOB_CMD, BIT(1));
-	if (ret)
-		return ret;
-	msleep(timeouts->self_test_ms);
-
-	ret = adis_check_status(&st->adis);
-	if (ret)
-		return ret;
-
-	ret = adis_read_reg_16(&st->adis, ADIS16480_REG_PROD_ID, &prod_id);
-	if (ret)
-		return ret;
-
-	ret = sscanf(indio_dev->name, "adis%u\n", &device_id);
-	if (ret != 1)
-		return -EINVAL;
-
-	if (prod_id != device_id)
-		dev_warn(&indio_dev->dev, "Device ID(%u) and product ID(%u) do not match.",
-				device_id, prod_id);
-
-	return 0;
-}
-
 #define ADIS16480_DIAG_STAT_XGYRO_FAIL 0
 #define ADIS16480_DIAG_STAT_YGYRO_FAIL 1
 #define ADIS16480_DIAG_STAT_ZGYRO_FAIL 2
@@ -1460,7 +1424,10 @@ static struct adis_data *adis16480_adis_data_alloc(struct adis16480 *st)
 
 	data->glob_cmd_reg = ADIS16480_REG_GLOB_CMD;
 	data->diag_stat_reg = ADIS16480_REG_DIAG_STS;
+	data->prod_id_reg = ADIS16480_REG_PROD_ID;
 	data->has_paging = true;
+	data->self_test_mask = BIT(1);
+	data->self_test_reg = ADIS16480_REG_GLOB_CMD;
 	data->read_delay = 5;
 	data->write_delay = 5;
 	data->status_error_msgs = adis16480_status_error_msgs;
@@ -1487,7 +1454,6 @@ static int adis16480_probe(struct spi_device *spi)
 	struct iio_dev *indio_dev;
 	struct adis16480 *st;
 	int ret;
-	struct gpio_desc *gpio;
 
 	indio_dev = devm_iio_device_alloc(&spi->dev, sizeof(*st));
 	if (indio_dev == NULL)
@@ -1505,12 +1471,6 @@ static int adis16480_probe(struct spi_device *spi)
 	indio_dev->info = &adis16480_info;
 	indio_dev->modes = INDIO_DIRECT_MODE;
 
-	gpio = devm_gpiod_get_optional(&spi->dev, "reset", GPIOD_OUT_LOW);
-	if (IS_ERR(gpio))
-		return PTR_ERR(gpio);
-	else if (gpio)
-		msleep(st->chip_info->timeouts->reset_ms);
-
 	adis16480_data = adis16480_adis_data_alloc(st);
 	if (IS_ERR(adis16480_data))
 		return PTR_ERR(adis16480_data);
@@ -1519,18 +1479,22 @@ static int adis16480_probe(struct spi_device *spi)
 	if (ret)
 		return ret;
 
-	ret = adis16480_config_irq_pin(spi->dev.of_node, st);
+	ret = __adis_initial_startup(&st->adis);
 	if (ret)
 		return ret;
 
+	ret = adis16480_config_irq_pin(spi->dev.of_node, st);
+	if (ret)
+		goto error_stop_device;
+
 	ret = adis16480_get_ext_clocks(st);
 	if (ret)
-		return ret;
+		goto error_stop_device;
 
 	if (!IS_ERR_OR_NULL(st->ext_clk)) {
 		ret = adis16480_ext_clk_config(st, spi->dev.of_node, true);
 		if (ret)
-			return ret;
+			goto error_stop_device;
 
 		st->clk_freq = clk_get_rate(st->ext_clk);
 		st->clk_freq *= 1000; /* micro */
@@ -1550,24 +1514,20 @@ static int adis16480_probe(struct spi_device *spi)
 	if (ret)
 		goto error_clk_disable_unprepare;
 
-	ret = adis16480_initial_setup(indio_dev);
-	if (ret)
-		goto error_cleanup_buffer;
-
 	ret = iio_device_register(indio_dev);
 	if (ret)
-		goto error_stop_device;
+		goto error_cleanup_buffer;
 
 	adis16480_debugfs_init(indio_dev);
 
 	return 0;
 
-error_stop_device:
-	adis16480_stop_device(indio_dev);
 error_cleanup_buffer:
 	adis_cleanup_buffer_and_trigger(&st->adis, indio_dev);
 error_clk_disable_unprepare:
 	clk_disable_unprepare(st->ext_clk);
+error_stop_device:
+	adis16480_stop_device(indio_dev);
 	return ret;
 }
 

--- a/drivers/staging/iio/accel/adis16201.c
+++ b/drivers/staging/iio/accel/adis16201.c
@@ -294,6 +294,12 @@ static const char * const adis16201_status_error_msgs[] = {
 	[ADIS16201_DIAG_STAT_POWER_LOW_BIT] = "Power supply below 3.15V",
 };
 
+static const struct adis_timeout adis16201_timeouts = {
+	.reset_ms = ADIS16201_STARTUP_DELAY,
+	.sw_reset_ms = ADIS16201_STARTUP_DELAY,
+	.self_test_ms = ADIS16201_STARTUP_DELAY,
+};
+
 static const struct adis_data adis16201_data = {
 	.read_delay = 20,
 	.msc_ctrl_reg = ADIS16201_MSC_CTRL,
@@ -303,6 +309,7 @@ static const struct adis_data adis16201_data = {
 	.self_test_mask = ADIS16201_MSC_CTRL_SELF_TEST_EN,
 	.self_test_no_autoclear = true,
 	.startup_delay = ADIS16201_STARTUP_DELAY,
+	.timeouts = &adis16201_timeouts,
 
 	.status_error_msgs = adis16201_status_error_msgs,
 	.status_error_mask = BIT(ADIS16201_DIAG_STAT_SPI_FAIL_BIT) |

--- a/drivers/staging/iio/accel/adis16201.c
+++ b/drivers/staging/iio/accel/adis16201.c
@@ -308,7 +308,6 @@ static const struct adis_data adis16201_data = {
 
 	.self_test_mask = ADIS16201_MSC_CTRL_SELF_TEST_EN,
 	.self_test_no_autoclear = true,
-	.startup_delay = ADIS16201_STARTUP_DELAY,
 	.timeouts = &adis16201_timeouts,
 
 	.status_error_msgs = adis16201_status_error_msgs,

--- a/drivers/staging/iio/accel/adis16201.c
+++ b/drivers/staging/iio/accel/adis16201.c
@@ -307,6 +307,7 @@ static const struct adis_data adis16201_data = {
 	.diag_stat_reg = ADIS16201_DIAG_STAT,
 
 	.self_test_mask = ADIS16201_MSC_CTRL_SELF_TEST_EN,
+	.self_test_reg = ADIS16201_MSC_CTRL,
 	.self_test_no_autoclear = true,
 	.timeouts = &adis16201_timeouts,
 

--- a/drivers/staging/iio/accel/adis16203.c
+++ b/drivers/staging/iio/accel/adis16203.c
@@ -243,6 +243,12 @@ static const char * const adis16203_status_error_msgs[] = {
 	[ADIS16203_DIAG_STAT_POWER_LOW_BIT] = "Power supply below 3.15V",
 };
 
+static const struct adis_timeout adis16203_timeouts = {
+	.reset_ms = ADIS16203_STARTUP_DELAY,
+	.sw_reset_ms = ADIS16203_STARTUP_DELAY,
+	.self_test_ms = ADIS16203_STARTUP_DELAY
+};
+
 static const struct adis_data adis16203_data = {
 	.read_delay = 20,
 	.msc_ctrl_reg = ADIS16203_MSC_CTRL,
@@ -252,6 +258,7 @@ static const struct adis_data adis16203_data = {
 	.self_test_mask = ADIS16203_MSC_CTRL_SELF_TEST_EN,
 	.self_test_no_autoclear = true,
 	.startup_delay = ADIS16203_STARTUP_DELAY,
+	.timeouts = &adis16203_timeouts,
 
 	.status_error_msgs = adis16203_status_error_msgs,
 	.status_error_mask = BIT(ADIS16203_DIAG_STAT_SELFTEST_FAIL_BIT) |

--- a/drivers/staging/iio/accel/adis16203.c
+++ b/drivers/staging/iio/accel/adis16203.c
@@ -256,6 +256,7 @@ static const struct adis_data adis16203_data = {
 	.diag_stat_reg = ADIS16203_DIAG_STAT,
 
 	.self_test_mask = ADIS16203_MSC_CTRL_SELF_TEST_EN,
+	.self_test_reg = ADIS16203_MSC_CTRL,
 	.self_test_no_autoclear = true,
 	.timeouts = &adis16203_timeouts,
 

--- a/drivers/staging/iio/accel/adis16203.c
+++ b/drivers/staging/iio/accel/adis16203.c
@@ -257,7 +257,6 @@ static const struct adis_data adis16203_data = {
 
 	.self_test_mask = ADIS16203_MSC_CTRL_SELF_TEST_EN,
 	.self_test_no_autoclear = true,
-	.startup_delay = ADIS16203_STARTUP_DELAY,
 	.timeouts = &adis16203_timeouts,
 
 	.status_error_msgs = adis16203_status_error_msgs,

--- a/drivers/staging/iio/accel/adis16209.c
+++ b/drivers/staging/iio/accel/adis16209.c
@@ -310,7 +310,6 @@ static const struct adis_data adis16209_data = {
 
 	.self_test_mask = ADIS16209_MSC_CTRL_SELF_TEST_EN,
 	.self_test_no_autoclear = true,
-	.startup_delay = ADIS16209_STARTUP_DELAY,
 	.timeouts = &adis16209_timeouts,
 
 	.status_error_msgs = adis16209_status_error_msgs,

--- a/drivers/staging/iio/accel/adis16209.c
+++ b/drivers/staging/iio/accel/adis16209.c
@@ -296,6 +296,12 @@ static const char * const adis16209_status_error_msgs[] = {
 	[ADIS16209_DIAG_STAT_POWER_LOW_BIT] = "Power supply below 3.15V",
 };
 
+static const struct adis_timeout adis16209_timeouts = {
+	.reset_ms = ADIS16209_STARTUP_DELAY,
+	.self_test_ms = ADIS16209_STARTUP_DELAY,
+	.sw_reset_ms = ADIS16209_STARTUP_DELAY,
+};
+
 static const struct adis_data adis16209_data = {
 	.read_delay = 30,
 	.msc_ctrl_reg = ADIS16209_MSC_CTRL,
@@ -305,6 +311,7 @@ static const struct adis_data adis16209_data = {
 	.self_test_mask = ADIS16209_MSC_CTRL_SELF_TEST_EN,
 	.self_test_no_autoclear = true,
 	.startup_delay = ADIS16209_STARTUP_DELAY,
+	.timeouts = &adis16209_timeouts,
 
 	.status_error_msgs = adis16209_status_error_msgs,
 	.status_error_mask = BIT(ADIS16209_DIAG_STAT_SELFTEST_FAIL_BIT) |

--- a/drivers/staging/iio/accel/adis16209.c
+++ b/drivers/staging/iio/accel/adis16209.c
@@ -309,6 +309,7 @@ static const struct adis_data adis16209_data = {
 	.diag_stat_reg = ADIS16209_DIAG_STAT,
 
 	.self_test_mask = ADIS16209_MSC_CTRL_SELF_TEST_EN,
+	.self_test_reg = ADIS16209_MSC_CTRL,
 	.self_test_no_autoclear = true,
 	.timeouts = &adis16209_timeouts,
 

--- a/drivers/staging/iio/accel/adis16240.c
+++ b/drivers/staging/iio/accel/adis16240.c
@@ -372,6 +372,12 @@ static const char * const adis16240_status_error_msgs[] = {
 	[ADIS16240_DIAG_STAT_POWER_LOW_BIT] = "Power supply below 2.225V",
 };
 
+static const struct adis_timeout adis16240_timeouts = {
+	.reset_ms = ADIS16240_STARTUP_DELAY,
+	.sw_reset_ms = ADIS16240_STARTUP_DELAY,
+	.self_test_ms = ADIS16240_STARTUP_DELAY,
+};
+
 static const struct adis_data adis16240_data = {
 	.write_delay = 35,
 	.read_delay = 35,
@@ -382,6 +388,7 @@ static const struct adis_data adis16240_data = {
 	.self_test_mask = ADIS16240_MSC_CTRL_SELF_TEST_EN,
 	.self_test_no_autoclear = true,
 	.startup_delay = ADIS16240_STARTUP_DELAY,
+	.timeouts = &adis16240_timeouts,
 
 	.status_error_msgs = adis16240_status_error_msgs,
 	.status_error_mask = BIT(ADIS16240_DIAG_STAT_PWRON_FAIL_BIT) |

--- a/drivers/staging/iio/accel/adis16240.c
+++ b/drivers/staging/iio/accel/adis16240.c
@@ -386,6 +386,7 @@ static const struct adis_data adis16240_data = {
 	.diag_stat_reg = ADIS16240_DIAG_STAT,
 
 	.self_test_mask = ADIS16240_MSC_CTRL_SELF_TEST_EN,
+	.self_test_reg = ADIS16240_MSC_CTRL,
 	.self_test_no_autoclear = true,
 	.timeouts = &adis16240_timeouts,
 

--- a/drivers/staging/iio/accel/adis16240.c
+++ b/drivers/staging/iio/accel/adis16240.c
@@ -387,7 +387,6 @@ static const struct adis_data adis16240_data = {
 
 	.self_test_mask = ADIS16240_MSC_CTRL_SELF_TEST_EN,
 	.self_test_no_autoclear = true,
-	.startup_delay = ADIS16240_STARTUP_DELAY,
 	.timeouts = &adis16240_timeouts,
 
 	.status_error_msgs = adis16240_status_error_msgs,

--- a/include/linux/iio/imu/adis.h
+++ b/include/linux/iio/imu/adis.h
@@ -42,6 +42,7 @@ struct adis_timeout {
  * @glob_cmd_reg: Register address of the GLOB_CMD register
  * @msc_ctrl_reg: Register address of the MSC_CTRL register
  * @diag_stat_reg: Register address of the DIAG_STAT register
+ * @self_test_reg: Register address to request self test command
  * @status_error_msgs: Array of error messgaes
  * @status_error_mask:
  * @timeouts: Chip specific delays
@@ -56,6 +57,7 @@ struct adis_data {
 	unsigned int diag_stat_reg;
 
 	unsigned int self_test_mask;
+	unsigned int self_test_reg;
 	bool self_test_no_autoclear;
 	const struct adis_timeout *timeouts;
 

--- a/include/linux/iio/imu/adis.h
+++ b/include/linux/iio/imu/adis.h
@@ -24,6 +24,17 @@ struct adis;
 struct adis_burst;
 
 /**
+ * struct adis_timeouts - ADIS chip variant timeouts
+ * @reset_ms - Wait time after rst pin goes inactive
+ * @sw_reset_ms - Wait time after sw reset command
+ * @self_test_ms - Wait time after self test command
+ */
+struct adis_timeout {
+	u16 reset_ms;
+	u16 sw_reset_ms;
+	u16 self_test_ms;
+};
+/**
  * struct adis_data - ADIS chip variant specific data
  * @read_delay: SPI delay for read operations in us
  * @write_delay: SPI delay for write operations in us
@@ -33,6 +44,7 @@ struct adis_burst;
  * @diag_stat_reg: Register address of the DIAG_STAT register
  * @status_error_msgs: Array of error messgaes
  * @status_error_mask:
+ * @timeouts: Chip specific delays
  */
 struct adis_data {
 	unsigned int read_delay;
@@ -46,6 +58,7 @@ struct adis_data {
 	unsigned int self_test_mask;
 	bool self_test_no_autoclear;
 	unsigned int startup_delay;
+	const struct adis_timeout *timeouts;
 
 	const char * const *status_error_msgs;
 	unsigned int status_error_mask;

--- a/include/linux/iio/imu/adis.h
+++ b/include/linux/iio/imu/adis.h
@@ -57,7 +57,6 @@ struct adis_data {
 
 	unsigned int self_test_mask;
 	bool self_test_no_autoclear;
-	unsigned int startup_delay;
 	const struct adis_timeout *timeouts;
 
 	const char * const *status_error_msgs;


### PR DESCRIPTION
This series adds some refactoring to the adis library. There was 2 main motivations for this:

1. The definitions of the timeouts for the various devices supported on the drivers was just a big confusion. The timings defined in the datasheets were just not being respected. Sometimes we were not sleeping enough time while some other times we were sleeping way to much. Furthermore, a unique timeout was being defined for all the devices and for both reset and self_test command. In first place, in some devices this timings are different and this is also true between different devices (even when supported by the same driver);

2. Apparently new devices use the GLOB_CMD register while older devices used the MSG_CTRL for the self_test command. This (I think) made that new drivers stopped calling `adis_initial_startup()`. This is starting to lead to some code duplication, (eg: [adis16480_initial_setup](https://github.com/analogdevicesinc/linux/blob/50c0b4a0b69a7a94af69a1e777d0f23e657a5797/drivers/iio/imu/adis16480.c#L1243), [adis16460_initial_setup](https://github.com/analogdevicesinc/linux/blob/50c0b4a0b69a7a94af69a1e777d0f23e657a5797/drivers/iio/imu/adis16460.c#L337)). All the actions done can be passed to the adis library with some refactoring.

Original discussion in #625 