### PR TITLE
iio: adc: ad9963: Fix external reference drift

### DIFF
--- a/drivers/iio/adc/ad9963.c
+++ b/drivers/iio/adc/ad9963.c
@@ -248,7 +248,7 @@ static int ad9963_m2k_setup(struct ad9963 *ad9963)
 	regmap_write(ad9963->regmap, AD9963_REG_ADC_ADDRESS, 0x03);
 	regmap_write(ad9963->regmap, AD9963_REG_RXCML, 0x02);
 	/* PD Internal Reference, enable DLL */
-	regmap_write(ad9963->regmap, AD9963_REG_POWER_DOWN0, 0xc0);
+	regmap_write(ad9963->regmap, AD9963_REG_POWER_DOWN0, 0x80);
 
 	/* Configure DLL, DAC source = DLL, DLL rate = 3/2 * 100 = 150 */
 	regmap_write(ad9963->regmap, AD9963_REG_DLL_CTRL0, 0x52);


### PR DESCRIPTION
For M2K turn on the bandgap DAC reference voltage.

Reported-by: Mihai Bancisor <mihai.bancisor@analog.com>
Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>