### PR TITLE
drivers: iio: adc: ad9361: Add continuous digital tune mode on intel

### DIFF
--- a/arch/arm/boot/dts/socfpga_arria10_socdk_fmcomms2.dts
+++ b/arch/arm/boot/dts/socfpga_arria10_socdk_fmcomms2.dts
@@ -1,0 +1,131 @@
+/dts-v1/;
+#include "socfpga_arria10_socdk.dtsi"
+
+&mmc {
+	status = "okay";
+	num-slots = <1>;
+	cap-sd-highspeed;
+	broken-cd;
+	bus-width = <4>;
+	altr,dw-mshc-ciu-div = <3>;
+	altr,dw-mshc-sdr-timing = <0 3>;
+};
+
+/ {
+	clocks {
+		dmac_clkin: clock@2 {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <250000000>;
+			clock-output-names = "dma_clock";
+		};
+	};
+
+	soc {
+		sys_hps_bridges: bridge@ff200000 {
+			compatible = "simple-bus";
+			reg = <0xff200000 0x00200000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges = <0x00000000 0xff200000 0x00200000>;
+
+			gpio: gpio@20 {
+				compatible = "altr,pio-1.0";
+				reg = <0x00000020 0x00000010>;
+				altr,gpio-bank-width = <32>;
+				resetvalue = <0>;
+				#gpio-cells = <2>;
+				gpio-controller;
+			};
+
+			sys_spi: spi@40 {
+				compatible = "altr,spi-1.0";
+				reg = <0x00000040 0x00000020>;
+				interrupt-parent = <&intc>;
+				interrupts = <0 26 4>;
+				#address-cells = <0x1>;
+				#size-cells = <0x0>;
+			};
+
+			cf_ad9361_adc_core_0: cf-ad9361-lpc@20000 {
+				compatible = "adi,axi-ad9361-6.00.a";
+				reg = <0x00020000 0x00010000>;
+				dmas = <&adc_dma 0>;
+				dma-names = "rx";
+				spibus-connected = <&adc0_ad9361>;
+			};
+
+			cf_ad9361_dac_core_0: cf-ad9361-dds-core-lpc@24000 {
+				compatible = "adi,axi-ad9361-dds-6.00.a";
+				reg = <0x00024000 0x00001000>;
+				dmas = <&dac_dma 0>;
+				dma-names = "tx";
+				clocks = <&adc0_ad9361 13>;
+				clock-names = "sampl_clk";
+			};
+
+			adc_dma: adc_dma@40000 {
+				compatible = "adi,axi-dmac-1.00.a";
+				reg = <0x00040000 0x00001000>;
+				interrupt-parent = <&intc>;
+				interrupts = <0 21 4>;
+				#dma-cells = <1>;
+				clocks = <&dmac_clkin>;
+
+				adi,channels {
+				#size-cells = <0>;
+				#address-cells = <1>;
+
+					dma-channel@0 {
+						reg = <0>;
+						adi,source-bus-width = <64>;
+						adi,source-bus-type = <2>;
+						adi,destination-bus-width = <128>;
+						adi,destination-bus-type = <0>;
+					};
+				};
+			};
+
+			dac_dma: dac_dma@44000 {
+				compatible = "adi,axi-dmac-1.00.a";
+				reg = <0x00044000 0x00001000>;
+				interrupt-parent = <&intc>;
+				interrupts = <0 22 4>;
+				#dma-cells = <1>;
+				clocks = <&dmac_clkin>;
+
+				adi,channels {
+					#size-cells = <0>;
+					#address-cells = <1>;
+
+					dma-channel@0 {
+						reg = <0>;
+						adi,source-bus-width = <64>;
+						adi,source-bus-type = <0>;
+						adi,destination-bus-width = <64>;
+						adi,destination-bus-type = <1>;
+					};
+				};
+			};
+		};
+	};
+};
+
+
+#define fmc_spi sys_spi
+#define fmc_i2c i2c0
+
+#include "adi-fmcomms2.dtsi"
+
+&adc0_ad9361 {
+	/delete-property/ spi-cpha;
+
+	/* GPIO */
+	reset-gpios = <&gpio 14 0>;
+	sync-gpios = <&gpio 13 0>;
+	en_agc-gpios = <&gpio 12 0>;
+
+	/* AXI Converter */
+	adi,axi-half-dac-rate-enable;
+	adi,bb-clk-change-dig-tune-enable;
+};

--- a/drivers/iio/adc/ad9361.c
+++ b/drivers/iio/adc/ad9361.c
@@ -4143,6 +4143,13 @@ static int ad9361_set_trx_clock_chain(struct ad9361_rf_phy *phy,
 	if (!phy->pdata->dig_interface_tune_fir_disable &&
 		!(st->bypass_tx_fir && st->bypass_rx_fir))
 		ret = ad9361_dig_tune(phy, 0, SKIP_STORE_RESULT);
+	if (ret < 0)
+		return ret;
+
+	if (phy->pdata->bb_clk_change_dig_tune_en)
+		ret = ad9361_dig_tune(phy, 0, 0);
+	if (ret < 0)
+		return ret;
 
 	return ad9361_bb_clk_change_handler(phy);
 }
@@ -4166,6 +4173,25 @@ bool ad9361_axi_half_dac_rate(struct ad9361_rf_phy *phy)
 	return phy && phy->pdata && phy->pdata->axi_half_dac_rate_en;
 }
 EXPORT_SYMBOL(ad9361_axi_half_dac_rate);
+
+bool ad9361_bb_clk_change_dig_tune_en(struct ad9361_rf_phy *phy)
+{
+	return phy && phy->pdata && phy->pdata->bb_clk_change_dig_tune_en;
+}
+EXPORT_SYMBOL(ad9361_bb_clk_change_dig_tune_en);
+
+u32 ad9361_get_dig_interface_tune_skipmode(struct ad9361_rf_phy *phy)
+{
+	return phy && phy->pdata && phy->pdata->dig_interface_tune_skipmode;
+}
+EXPORT_SYMBOL(ad9361_get_dig_interface_tune_skipmode);
+
+void ad9361_set_dig_interface_tune_skipmode(struct ad9361_rf_phy *phy, u32 skip)
+{
+	if (phy && phy->pdata)
+		phy->pdata->dig_interface_tune_skipmode = skip;
+}
+EXPORT_SYMBOL(ad9361_set_dig_interface_tune_skipmode);
 
 int ad9361_get_dig_tune_data(struct ad9361_rf_phy *phy,
 			     struct ad9361_dig_tune_data *data)
@@ -9020,6 +9046,11 @@ static struct ad9361_phy_platform_data
 
 	ad9361_of_get_bool(iodev, np, "adi,axi-half-dac-rate-enable",
 			&pdata->axi_half_dac_rate_en);
+
+	/* Digital tune after modifying the sampling rate */
+
+	ad9361_of_get_bool(iodev, np, "adi,bb-clk-change-dig-tune-enable",
+			&pdata->bb_clk_change_dig_tune_en);
 
 	return pdata;
 }

--- a/drivers/iio/adc/ad9361.h
+++ b/drivers/iio/adc/ad9361.h
@@ -185,6 +185,9 @@ int ad9361_write_clock_data_delays(struct ad9361_rf_phy *phy);
 bool ad9361_uses_lvds_mode(struct ad9361_rf_phy *phy);
 int ad9361_set_rx_port(struct ad9361_rf_phy *phy, enum rx_port_sel sel);
 int ad9361_set_tx_port(struct ad9361_rf_phy *phy, enum tx_port_sel sel);
+bool ad9361_bb_clk_change_dig_tune_en(struct ad9361_rf_phy *phy);
+u32 ad9361_get_dig_interface_tune_skipmode(struct ad9361_rf_phy *phy);
+void ad9361_set_dig_interface_tune_skipmode(struct ad9361_rf_phy *phy, u32 skip);
 
 #ifdef CONFIG_AD9361_EXT_BAND_CONTROL
 int ad9361_register_ext_band_control(struct ad9361_rf_phy *phy);

--- a/drivers/iio/adc/ad9361_conv.c
+++ b/drivers/iio/adc/ad9361_conv.c
@@ -680,8 +680,12 @@ static int ad9361_post_setup(struct iio_dev *indio_dev)
 	struct ad9361_rf_phy *phy = conv->phy;
 	bool rx2tx2 = ad9361_uses_rx2tx2(phy);
 	bool half_rate = ad9361_axi_half_dac_rate(phy);
-	unsigned tmp, num_chan, flags;
+	unsigned tmp, num_chan, flags, skipmode;
 	int i, ret;
+
+	skipmode = ad9361_get_dig_interface_tune_skipmode(phy);
+	if (ad9361_bb_clk_change_dig_tune_en(phy))
+		ad9361_set_dig_interface_tune_skipmode(phy, 2);
 
 	num_chan = ad9361_num_phy_chan(conv);
 
@@ -729,6 +733,9 @@ static int ad9361_post_setup(struct iio_dev *indio_dev)
 		if (ret < 0)
 			goto error;
 	}
+
+	if (ad9361_bb_clk_change_dig_tune_en(phy))
+		ad9361_set_dig_interface_tune_skipmode(phy, skipmode);
 
 	ret = ad9361_set_trx_clock_chain_default(phy);
 

--- a/drivers/iio/adc/ad9361_private.h
+++ b/drivers/iio/adc/ad9361_private.h
@@ -352,6 +352,7 @@ struct ad9361_phy_platform_data {
 	u32			rx_fastlock_delay_ns;
 	u32			tx_fastlock_delay_ns;
 	bool			trx_fastlock_pinctrl_en[2];
+	bool			bb_clk_change_dig_tune_en;
 
 	enum ad9361_clkout	ad9361_clkout_mode;
 


### PR DESCRIPTION
Changing the sampling frequency may cause the digital interface timing to
modify. This change adds a feature that forces the calibration of the
digital interface every time the sampling rate changes.
Added fmcomms2 support on arria10soc.