### PR TITLE
drivers: iio: adc: ad9361: Added continuous digital tune 

### DIFF
--- a/drivers/iio/adc/ad9361.c
+++ b/drivers/iio/adc/ad9361.c
@@ -4140,9 +4140,17 @@ static int ad9361_set_trx_clock_chain(struct ad9361_rf_phy *phy,
 	 * If it is disabled we restore the values from the initial calibration.
 	 */
 
-	if (!phy->pdata->dig_interface_tune_fir_disable &&
-		!(st->bypass_tx_fir && st->bypass_rx_fir))
+	if ((!phy->pdata->dig_interface_tune_fir_disable &&
+		!(st->bypass_tx_fir && st->bypass_rx_fir)) &&
+		!phy->pdata->bb_clk_change_dig_tune_en)
 		ret = ad9361_dig_tune(phy, 0, SKIP_STORE_RESULT);
+	if (ret < 0)
+		return ret;
+
+	if (phy->pdata->bb_clk_change_dig_tune_en)
+		ret = ad9361_dig_tune(phy, 0, 0);
+	if (ret < 0)
+		return ret;
 
 	return ad9361_bb_clk_change_handler(phy);
 }
@@ -4160,6 +4168,31 @@ bool ad9361_uses_rx2tx2(struct ad9361_rf_phy *phy)
 	return phy && phy->pdata && phy->pdata->rx2tx2;
 }
 EXPORT_SYMBOL(ad9361_uses_rx2tx2);
+
+bool ad9361_axi_half_dac_rate(struct ad9361_rf_phy *phy)
+{
+	return phy && phy->pdata && phy->pdata->axi_half_dac_rate_en;
+}
+EXPORT_SYMBOL(ad9361_axi_half_dac_rate);
+
+bool ad9361_bb_clk_change_dig_tune_en(struct ad9361_rf_phy *phy)
+{
+	return phy && phy->pdata && phy->pdata->bb_clk_change_dig_tune_en;
+}
+EXPORT_SYMBOL(ad9361_bb_clk_change_dig_tune_en);
+
+u32 ad9361_get_dig_interface_tune_skipmode(struct ad9361_rf_phy *phy)
+{
+	return phy && phy->pdata && phy->pdata->dig_interface_tune_skipmode;
+}
+EXPORT_SYMBOL(ad9361_get_dig_interface_tune_skipmode);
+
+void ad9361_set_dig_interface_tune_skipmode(struct ad9361_rf_phy *phy, u32 skip)
+{
+	if (phy && phy->pdata)
+		phy->pdata->dig_interface_tune_skipmode = skip;
+}
+EXPORT_SYMBOL(ad9361_set_dig_interface_tune_skipmode);
 
 int ad9361_get_dig_tune_data(struct ad9361_rf_phy *phy,
 			     struct ad9361_dig_tune_data *data)
@@ -9010,6 +9043,13 @@ static struct ad9361_phy_platform_data
 	ad9361_of_get_u32(iodev, np, "adi,txmon-2-lo-cm", 48,
 			&pdata->txmon_ctrl.tx2_mon_lo_cm);
 
+	/* AXI Converter */
+	ad9361_of_get_bool(iodev, np, "adi,axi-half-dac-rate-enable",
+			&pdata->axi_half_dac_rate_en);
+
+	/* Digital tune after modifying the sampling rate */
+	ad9361_of_get_bool(iodev, np, "adi,bb-clk-change-dig-tune-enable",
+			&pdata->bb_clk_change_dig_tune_en);
 
 	return pdata;
 }

--- a/drivers/iio/adc/ad9361.h
+++ b/drivers/iio/adc/ad9361.h
@@ -184,6 +184,10 @@ int ad9361_write_clock_data_delays(struct ad9361_rf_phy *phy);
 bool ad9361_uses_lvds_mode(struct ad9361_rf_phy *phy);
 int ad9361_set_rx_port(struct ad9361_rf_phy *phy, enum rx_port_sel sel);
 int ad9361_set_tx_port(struct ad9361_rf_phy *phy, enum tx_port_sel sel);
+bool ad9361_bb_clk_change_dig_tune_en(struct ad9361_rf_phy *phy);
+u32 ad9361_get_dig_interface_tune_skipmode(struct ad9361_rf_phy *phy);
+void ad9361_set_dig_interface_tune_skipmode(struct ad9361_rf_phy *phy,
+					    u32 skip);
 
 #ifdef CONFIG_AD9361_EXT_BAND_CONTROL
 int ad9361_register_ext_band_control(struct ad9361_rf_phy *phy);

--- a/drivers/iio/adc/ad9361.h
+++ b/drivers/iio/adc/ad9361.h
@@ -177,6 +177,7 @@ int ad9361_dig_tune(struct ad9361_rf_phy *phy, unsigned long max_freq,
 int ad9361_tx_mute(struct ad9361_rf_phy *phy, u32 state);
 int ad9361_write_bist_reg(struct ad9361_rf_phy *phy, u32 val);
 bool ad9361_uses_rx2tx2(struct ad9361_rf_phy *phy);
+bool ad9361_axi_half_dac_rate(struct ad9361_rf_phy *phy);
 int ad9361_get_dig_tune_data(struct ad9361_rf_phy *phy,
 			     struct ad9361_dig_tune_data *data);
 int ad9361_read_clock_data_delays(struct ad9361_rf_phy *phy);

--- a/drivers/iio/adc/ad9361_conv.c
+++ b/drivers/iio/adc/ad9361_conv.c
@@ -680,7 +680,12 @@ static int ad9361_post_setup(struct iio_dev *indio_dev)
 	struct ad9361_rf_phy *phy = conv->phy;
 	bool rx2tx2 = ad9361_uses_rx2tx2(phy);
 	unsigned tmp, num_chan, flags;
+	unsigned int skipmode;
 	int i, ret;
+
+	skipmode = ad9361_get_dig_interface_tune_skipmode(phy);
+	if (ad9361_bb_clk_change_dig_tune_en(phy))
+		ad9361_set_dig_interface_tune_skipmode(phy, SKIP_ALL);
 
 	num_chan = ad9361_num_phy_chan(conv);
 
@@ -722,6 +727,9 @@ static int ad9361_post_setup(struct iio_dev *indio_dev)
 		if (ret < 0)
 			goto error;
 	}
+
+	if (ad9361_bb_clk_change_dig_tune_en(phy))
+		ad9361_set_dig_interface_tune_skipmode(phy, skipmode);
 
 	ret = ad9361_set_trx_clock_chain_default(phy);
 

--- a/drivers/iio/adc/ad9361_private.h
+++ b/drivers/iio/adc/ad9361_private.h
@@ -376,6 +376,7 @@ struct ad9361_phy_platform_data {
 	struct gpio_desc			*cal_sw1_gpio;
 	struct gpio_desc			*cal_sw2_gpio;
 
+	bool		axi_half_dac_rate_en;
 };
 
 struct rf_rx_gain {

--- a/drivers/iio/adc/ad9361_private.h
+++ b/drivers/iio/adc/ad9361_private.h
@@ -352,6 +352,7 @@ struct ad9361_phy_platform_data {
 	u32			rx_fastlock_delay_ns;
 	u32			tx_fastlock_delay_ns;
 	bool			trx_fastlock_pinctrl_en[2];
+	bool			bb_clk_change_dig_tune_en;
 
 	enum ad9361_clkout	ad9361_clkout_mode;
 


### PR DESCRIPTION
Changing the sampling frequency may cause the digital interface timing to
modify on intel carriers. This change adds a feature that forces the calibration of the
digital interface every time the sampling rate changes.