### PR TITLE
Fix adis fix null ptr

### DIFF
--- a/drivers/iio/gyro/adis16136.c
+++ b/drivers/iio/gyro/adis16136.c
@@ -507,10 +507,10 @@ static const struct adis16136_chip_info adis16136_chip_info[] = {
 	},
 };
 
-static struct adis_data *adis16136_adis_data_alloc(struct adis16136 *st)
+static struct adis_data *adis16136_adis_data_alloc(struct adis16136 *st,
+						   struct device *dev)
 {
 	struct adis_data *data;
-	struct device *dev = &st->adis.spi->dev;
 
 	data = devm_kzalloc(dev, sizeof(struct adis_data), GFP_KERNEL);
 	if (!data)
@@ -557,7 +557,7 @@ static int adis16136_probe(struct spi_device *spi)
 	indio_dev->info = &adis16136_info;
 	indio_dev->modes = INDIO_DIRECT_MODE;
 
-	adis16136_data = adis16136_adis_data_alloc(adis16136);
+	adis16136_data = adis16136_adis_data_alloc(adis16136, &spi->dev);
 	if (IS_ERR(adis16136_data))
 		return PTR_ERR(adis16136_data);
 

--- a/drivers/iio/imu/adis16400.c
+++ b/drivers/iio/imu/adis16400.c
@@ -1136,10 +1136,10 @@ static void adis16400_setup_chan_mask(struct adis16400_state *st)
 	}
 }
 
-static struct adis_data *adis16400_adis_data_alloc(struct adis16400_state *st)
+static struct adis_data *adis16400_adis_data_alloc(struct adis16400_state *st,
+						   struct device *dev)
 {
 	struct adis_data *data;
-	struct device *dev = &st->adis.spi->dev;
 
 	data = devm_kzalloc(dev, sizeof(struct adis_data), GFP_KERNEL);
 	if (!data)
@@ -1205,7 +1205,7 @@ static int adis16400_probe(struct spi_device *spi)
 			st->adis.burst->extra_len = sizeof(u16);
 	}
 
-	adis16400_data = adis16400_adis_data_alloc(st);
+	adis16400_data = adis16400_adis_data_alloc(st, &spi->dev);
 	if (IS_ERR(adis16400_data))
 		return PTR_ERR(adis16400_data);
 

--- a/drivers/iio/imu/adis16475.c
+++ b/drivers/iio/imu/adis16475.c
@@ -1082,10 +1082,10 @@ burst16:
 	return 0;
 }
 
-static struct adis_data *adis16475_adis_data_alloc(struct adis16475 *st)
+static struct adis_data *adis16475_adis_data_alloc(struct adis16475 *st,
+						   struct device *dev)
 {
 	struct adis_data *data;
-	struct device *dev = &st->adis.spi->dev;
 
 	data = devm_kzalloc(dev, sizeof(struct adis_data), GFP_KERNEL);
 	if (!data)
@@ -1130,7 +1130,7 @@ static int adis16475_probe(struct spi_device *spi)
 	st->info = &adis16475_chip_info[id->driver_data];
 	spi_set_drvdata(spi, indio_dev);
 
-	adis16475_data = adis16475_adis_data_alloc(st);
+	adis16475_data = adis16475_adis_data_alloc(st, &spi->dev);
 	if (IS_ERR(adis16475_data))
 		return PTR_ERR(adis16475_data);
 

--- a/drivers/iio/imu/adis16480.c
+++ b/drivers/iio/imu/adis16480.c
@@ -1413,10 +1413,10 @@ static int adis16480_get_ext_clocks(struct adis16480 *st)
 	return 0;
 }
 
-static struct adis_data *adis16480_adis_data_alloc(struct adis16480 *st)
+static struct adis_data *adis16480_adis_data_alloc(struct adis16480 *st,
+						   struct device *dev)
 {
 	struct adis_data *data;
-	struct device *dev = &st->adis.spi->dev;
 
 	data = devm_kzalloc(dev, sizeof(struct adis_data), GFP_KERNEL);
 	if (!data)
@@ -1471,7 +1471,7 @@ static int adis16480_probe(struct spi_device *spi)
 	indio_dev->info = &adis16480_info;
 	indio_dev->modes = INDIO_DIRECT_MODE;
 
-	adis16480_data = adis16480_adis_data_alloc(st);
+	adis16480_data = adis16480_adis_data_alloc(st, &spi->dev);
 	if (IS_ERR(adis16480_data))
 		return PTR_ERR(adis16480_data);
 


### PR DESCRIPTION
This series fixes a NULL ptr dereference introduced by  9020f82.