### PR TITLE
iio: frequency: adf4350: remove of.h functions  use

### DIFF
--- a/include/linux/iio/frequency/adf4350.h
+++ b/include/linux/iio/frequency/adf4350.h
@@ -122,7 +122,7 @@ struct adf4350_platform_data {
 	unsigned		r2_user_settings;
 	unsigned		r3_user_settings;
 	unsigned		r4_user_settings;
-	int			gpio_lock_detect;
+	struct gpio_desc	*gpio_lock_detect;
 };
 
 #endif /* IIO_PLL_ADF4350_H_ */


### PR DESCRIPTION
This patch removes the use of of.h and of_gpio.h functions
and relaces them with the property.h and gpio/consumer.h ones.

Signed-off-by: Alexandru Tachici <alexandru.tachici@analog.com>