### PR TITLE
Adf4350 remove of use

### DIFF
--- a/drivers/iio/frequency/adf4350.c
+++ b/drivers/iio/frequency/adf4350.c
@@ -363,7 +363,7 @@ static struct adf4350_platform_data *adf4350_parse_dt(struct device *dev)
 
 	pdata = devm_kzalloc(dev, sizeof(*pdata), GFP_KERNEL);
 	if (!pdata)
-		return NULL;
+		return ERR_PTR(-ENOMEM);
 
 	strncpy(&pdata->name[0], np->name, SPI_NAME_SIZE - 1);
 
@@ -382,7 +382,7 @@ static struct adf4350_platform_data *adf4350_parse_dt(struct device *dev)
 	pdata->gpio_lock_detect = devm_gpiod_get_optional(dev, "lock_detect",
 							  GPIOD_IN);
 	if (IS_ERR(pdata->gpio_lock_detect))
-		return NULL;
+		return ERR_CAST(pdata->gpio_lock_detect);
 
 	pdata->ref_doubler_en = of_property_read_bool(np,
 			"adi,reference-doubler-enable");
@@ -476,8 +476,8 @@ static int adf4350_probe(struct spi_device *spi)
 
 	if (spi->dev.of_node) {
 		pdata = adf4350_parse_dt(&spi->dev);
-		if (pdata == NULL)
-			return -EINVAL;
+		if (IS_ERR(pdata))
+			return PTR_ERR(pdata);
 	} else {
 		pdata = spi->dev.platform_data;
 	}

--- a/drivers/iio/frequency/adf4350.c
+++ b/drivers/iio/frequency/adf4350.c
@@ -15,11 +15,10 @@
 #include <linux/err.h>
 #include <linux/module.h>
 #include <linux/gcd.h>
-#include <linux/gpio.h>
 #include <asm/div64.h>
 #include <linux/clk.h>
 #include <linux/of.h>
-#include <linux/of_gpio.h>
+#include <linux/gpio/consumer.h>
 
 #include <linux/iio/iio.h>
 #include <linux/iio/sysfs.h>
@@ -62,7 +61,6 @@ static struct adf4350_platform_data default_pdata = {
 	.r3_user_settings = ADF4350_REG3_12BIT_CLKDIV_MODE(0),
 	.r4_user_settings = ADF4350_REG4_OUTPUT_PWR(3) |
 			    ADF4350_REG4_MUTE_TILL_LOCK_EN,
-	.gpio_lock_detect = -1,
 };
 
 static int adf4350_sync_config(struct adf4350_state *st, bool sync_all)
@@ -297,8 +295,8 @@ static ssize_t adf4350_read(struct iio_dev *indio_dev,
 			(u64)st->fpfd;
 		do_div(val, st->r1_mod * (1 << st->r4_rf_div_sel));
 		/* PLL unlocked? return error */
-		if (gpio_is_valid(st->pdata->gpio_lock_detect))
-			if (!gpio_get_value(st->pdata->gpio_lock_detect)) {
+		if (st->pdata->gpio_lock_detect)
+			if (!gpiod_get_value(st->pdata->gpio_lock_detect)) {
 				dev_dbg(&st->spi->dev, "PLL un-locked\n");
 				ret = -EBUSY;
 			}
@@ -362,7 +360,6 @@ static struct adf4350_platform_data *adf4350_parse_dt(struct device *dev)
 	struct device_node *np = dev->of_node;
 	struct adf4350_platform_data *pdata;
 	unsigned int tmp;
-	int ret;
 
 	pdata = devm_kzalloc(dev, sizeof(*pdata), GFP_KERNEL);
 	if (!pdata)
@@ -382,11 +379,10 @@ static struct adf4350_platform_data *adf4350_parse_dt(struct device *dev)
 	of_property_read_u32(np, "adi,reference-div-factor", &tmp);
 	pdata->ref_div_factor = tmp;
 
-	ret = of_get_gpio(np, 0);
-	if (ret < 0)
-		pdata->gpio_lock_detect = -1;
-	else
-		pdata->gpio_lock_detect = ret;
+	pdata->gpio_lock_detect = devm_gpiod_get_optional(dev, "lock_detect",
+							  GPIOD_IN);
+	if (IS_ERR(pdata->gpio_lock_detect))
+		return NULL;
 
 	pdata->ref_doubler_en = of_property_read_bool(np,
 			"adi,reference-doubler-enable");
@@ -542,23 +538,15 @@ static int adf4350_probe(struct spi_device *spi)
 
 	memset(st->regs_hw, 0xFF, sizeof(st->regs_hw));
 
-	if (gpio_is_valid(pdata->gpio_lock_detect)) {
+	if (pdata->gpio_lock_detect) {
 		int i;
-		ret = devm_gpio_request(&spi->dev, pdata->gpio_lock_detect,
-					indio_dev->name);
-		if (ret) {
-			dev_err(&spi->dev, "fail to request lock detect GPIO-%d",
-				pdata->gpio_lock_detect);
-			goto error_disable_reg;
-		}
-		gpio_direction_input(pdata->gpio_lock_detect);
 
 		/* ADF4350/1 are write only devices, try to probe it this way */
 		for (i = 0; i < 4; i++) {
 			st->regs[ADF4350_REG2] = ADF4350_REG2_MUXOUT((i & 1) ?
 				ADF4350_MUXOUT_DVDD : ADF4350_MUXOUT_GND);
 			adf4350_sync_config(st, false);
-			ret = gpio_get_value(st->pdata->gpio_lock_detect);
+			ret = gpiod_get_value(st->pdata->gpio_lock_detect);
 			if (ret != ((i & 1) ? 1 : 0)) {
 				ret = -ENODEV;
 				dev_err(&spi->dev, "Probe failed (muxout)");

--- a/drivers/iio/frequency/adf4350.c
+++ b/drivers/iio/frequency/adf4350.c
@@ -17,7 +17,6 @@
 #include <linux/gcd.h>
 #include <asm/div64.h>
 #include <linux/clk.h>
-#include <linux/of.h>
 #include <linux/gpio/consumer.h>
 
 #include <linux/iio/iio.h>
@@ -354,10 +353,8 @@ static const struct iio_info adf4350_info = {
 	.driver_module = THIS_MODULE,
 };
 
-#ifdef CONFIG_OF
 static struct adf4350_platform_data *adf4350_parse_dt(struct device *dev)
 {
-	struct device_node *np = dev->of_node;
 	struct adf4350_platform_data *pdata;
 	unsigned int tmp;
 
@@ -365,18 +362,18 @@ static struct adf4350_platform_data *adf4350_parse_dt(struct device *dev)
 	if (!pdata)
 		return ERR_PTR(-ENOMEM);
 
-	strncpy(&pdata->name[0], np->name, SPI_NAME_SIZE - 1);
+	strncpy(&pdata->name[0], dev_name(dev), SPI_NAME_SIZE - 1);
 
-	tmp = 10000;
-	of_property_read_u32(np, "adi,channel-spacing", &tmp);
+	if (device_property_read_u32(dev, "adi,channel-spacing", &tmp))
+		tmp = 10000;
 	pdata->channel_spacing = tmp;
 
-	tmp = 0;
-	of_property_read_u32(np, "adi,power-up-frequency", &tmp);
+	if (device_property_read_u32(dev, "adi,power-up-frequency", &tmp))
+		tmp = 0;
 	pdata->power_up_frequency = tmp;
 
-	tmp = 0;
-	of_property_read_u32(np, "adi,reference-div-factor", &tmp);
+	if (device_property_read_u32(dev, "adi,reference-div-factor", &tmp))
+		tmp = 0;
 	pdata->ref_div_factor = tmp;
 
 	pdata->gpio_lock_detect = devm_gpiod_get_optional(dev, "lock_detect",
@@ -384,87 +381,81 @@ static struct adf4350_platform_data *adf4350_parse_dt(struct device *dev)
 	if (IS_ERR(pdata->gpio_lock_detect))
 		return ERR_CAST(pdata->gpio_lock_detect);
 
-	pdata->ref_doubler_en = of_property_read_bool(np,
+	pdata->ref_doubler_en = device_property_read_bool(dev,
 			"adi,reference-doubler-enable");
-	pdata->ref_div2_en = of_property_read_bool(np,
+	pdata->ref_div2_en = device_property_read_bool(dev,
 			"adi,reference-div2-enable");
 
 	/* r2_user_settings */
-	pdata->r2_user_settings = of_property_read_bool(np,
+	pdata->r2_user_settings = device_property_read_bool(dev,
 			"adi,phase-detector-polarity-positive-enable") ?
 			ADF4350_REG2_PD_POLARITY_POS : 0;
-	pdata->r2_user_settings |= of_property_read_bool(np,
+	pdata->r2_user_settings |= device_property_read_bool(dev,
 			"adi,lock-detect-precision-6ns-enable") ?
 			ADF4350_REG2_LDP_6ns : 0;
-	pdata->r2_user_settings |= of_property_read_bool(np,
+	pdata->r2_user_settings |= device_property_read_bool(dev,
 			"adi,lock-detect-function-integer-n-enable") ?
 			ADF4350_REG2_LDF_INT_N : 0;
 
-	tmp = 2500;
-	of_property_read_u32(np, "adi,charge-pump-current", &tmp);
+	if (device_property_read_u32(dev, "adi,charge-pump-current", &tmp))
+		tmp = 2500;
 	pdata->r2_user_settings |= ADF4350_REG2_CHARGE_PUMP_CURR_uA(tmp);
 
-	tmp = 0;
-	of_property_read_u32(np, "adi,muxout-select", &tmp);
+	if (device_property_read_u32(dev, "adi,muxout-select", &tmp))
+		tmp = 0;
 	pdata->r2_user_settings |= ADF4350_REG2_MUXOUT(tmp);
 
-	pdata->r2_user_settings |= of_property_read_bool(np,
+	pdata->r2_user_settings |= device_property_read_bool(dev,
 			"adi,low-spur-mode-enable") ?
 			ADF4350_REG2_NOISE_MODE(0x3) : 0;
 
 	/* r3_user_settings */
 
-	pdata->r3_user_settings = of_property_read_bool(np,
+	pdata->r3_user_settings = device_property_read_bool(dev,
 			"adi,cycle-slip-reduction-enable") ?
 			ADF4350_REG3_12BIT_CSR_EN : 0;
-	pdata->r3_user_settings |= of_property_read_bool(np,
+	pdata->r3_user_settings |= device_property_read_bool(dev,
 			"adi,charge-cancellation-enable") ?
 			ADF4351_REG3_CHARGE_CANCELLATION_EN : 0;
 
-	pdata->r3_user_settings |= of_property_read_bool(np,
+	pdata->r3_user_settings |= device_property_read_bool(dev,
 			"adi,anti-backlash-3ns-enable") ?
 			ADF4351_REG3_ANTI_BACKLASH_3ns_EN : 0;
-	pdata->r3_user_settings |= of_property_read_bool(np,
+	pdata->r3_user_settings |= device_property_read_bool(dev,
 			"adi,band-select-clock-mode-high-enable") ?
 			ADF4351_REG3_BAND_SEL_CLOCK_MODE_HIGH : 0;
 
-	tmp = 0;
-	of_property_read_u32(np, "adi,12bit-clk-divider", &tmp);
+	if (device_property_read_u32(dev, "adi,12bit-clk-divider", &tmp))
+		tmp = 0;
 	pdata->r3_user_settings |= ADF4350_REG3_12BIT_CLKDIV(tmp);
 
-	tmp = 0;
-	of_property_read_u32(np, "adi,clk-divider-mode", &tmp);
+
+	if (device_property_read_u32(dev, "adi,clk-divider-mode", &tmp))
+		tmp = 0;
 	pdata->r3_user_settings |= ADF4350_REG3_12BIT_CLKDIV_MODE(tmp);
 
 	/* r4_user_settings */
 
-	pdata->r4_user_settings = of_property_read_bool(np,
+	pdata->r4_user_settings = device_property_read_bool(dev,
 			"adi,aux-output-enable") ?
 			ADF4350_REG4_AUX_OUTPUT_EN : 0;
-	pdata->r4_user_settings |= of_property_read_bool(np,
+	pdata->r4_user_settings |= device_property_read_bool(dev,
 			"adi,aux-output-fundamental-enable") ?
 			ADF4350_REG4_AUX_OUTPUT_FUND : 0;
-	pdata->r4_user_settings |= of_property_read_bool(np,
+	pdata->r4_user_settings |= device_property_read_bool(dev,
 			"adi,mute-till-lock-enable") ?
 			ADF4350_REG4_MUTE_TILL_LOCK_EN : 0;
 
-	tmp = 0;
-	of_property_read_u32(np, "adi,output-power", &tmp);
+	if (device_property_read_u32(dev, "adi,output-power", &tmp))
+		tmp = 0;
 	pdata->r4_user_settings |= ADF4350_REG4_OUTPUT_PWR(tmp);
 
-	tmp = 0;
-	of_property_read_u32(np, "adi,aux-output-power", &tmp);
+	if (device_property_read_u32(dev, "adi,aux-output-power", &tmp))
+		tmp = 0;
 	pdata->r4_user_settings |= ADF4350_REG4_AUX_OUTPUT_PWR(tmp);
 
 	return pdata;
 }
-#else
-static
-struct adf4350_platform_data *adf4350_parse_dt(struct device *dev)
-{
-	return NULL;
-}
-#endif
 
 static int adf4350_probe(struct spi_device *spi)
 {
@@ -474,7 +465,7 @@ static int adf4350_probe(struct spi_device *spi)
 	struct clk *clk = NULL;
 	int ret;
 
-	if (spi->dev.of_node) {
+	if (dev_fwnode(&spi->dev)) {
 		pdata = adf4350_parse_dt(&spi->dev);
 		if (IS_ERR(pdata))
 			return PTR_ERR(pdata);

--- a/include/linux/iio/frequency/adf4350.h
+++ b/include/linux/iio/frequency/adf4350.h
@@ -122,7 +122,7 @@ struct adf4350_platform_data {
 	unsigned		r2_user_settings;
 	unsigned		r3_user_settings;
 	unsigned		r4_user_settings;
-	int			gpio_lock_detect;
+	struct gpio_desc	*gpio_lock_detect;
 };
 
 #endif /* IIO_PLL_ADF4350_H_ */


### PR DESCRIPTION
This patch replaces functions from of.h and of_gpio.h with their counterparts 
from property.h and gpio/consumer.h.