### PR TITLE
iio: adc: ad9680: cleanup clock {un}init paths

### DIFF
--- a/drivers/iio/adc/cf_axi_adc.h
+++ b/drivers/iio/adc/cf_axi_adc.h
@@ -230,6 +230,7 @@ struct axiadc_converter {
 
 	struct delayed_work	watchdog_work;
 	bool			sample_rate_read_only;
+	bool			running;
 
 	int (*reg_access)(struct iio_dev *indio_dev, unsigned int reg,
 		unsigned int writeval, unsigned int *readval);


### PR DESCRIPTION
When trying to set an invalid rate to the driver, the clk_set_rate() may
fail, exiting without re-initializing the clocks.
This is fine.

However when trying to write a new (maybe valid rate) syslog would get
spammed with plenty of stack-trace warnings like:

```
[<c010ee74>] (unwind_backtrace) from [<c010b5b0>] (show_stack+0x10/0x14)
[<c010b5b0>] (show_stack) from [<c06d4374>] (dump_stack+0x8c/0xa0)
[<c06d4374>] (dump_stack) from [<c011cb6c>] (__warn+0xe4/0x100)
[<c011cb6c>] (__warn) from [<c011c838>] (warn_slowpath_null+0x20/0x28)
[<c011c838>] (warn_slowpath_null) from [<c03354a8>] (clk_unprepare+0x24/0x2c)
[<c03354a8>] (clk_unprepare) from [<c05b0d80>] (ad9680_write_raw+0x23c/0x408)
[<c05b0d80>] (ad9680_write_raw) from [<c05404e0>] (iio_write_channel_info+0x9c/0xc0)
[<c05404e0>] (iio_write_channel_info) from [<c0250118>] (kernfs_fop_write+0xec/0x1f0)
[<c0250118>] (kernfs_fop_write) from [<c01ed160>] (__vfs_write+0x1c/0x128)
[<c01ed160>] (__vfs_write) from [<c01ed3e0>] (vfs_write+0xa4/0x168)
[<c01ed3e0>] (vfs_write) from [<c01ed5a4>] (SyS_write+0x3c/0x90)
[<c01ed5a4>] (SyS_write) from [<c0107a20>] (ret_fast_syscall+0x0/0x48)
```

This is because, clk_disable_unprepare() is being called on a
disabled/unprepared clock, and the clock framework is noisy about it.

This change tries to avoid this, by cleaning up the exit/error paths for
enabling the link.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>