### PR TITLE
Fix interpolation decim

### DIFF
--- a/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9009.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9009.dts
@@ -100,7 +100,7 @@
 		dma-names = "rx";
 		spibus-connected = <&trx0_adrv9009>;
 		adi,axi-decimation-core-available;
-		decimation-gpios = <&gpio0 115 GPIO_ACTIVE_LOW>;
+		decimation-gpios = <&gpio0 115 GPIO_ACTIVE_HIGH>;
 	};
 
 	axi_adrv9009_core_rx_obs: axi-adrv9009-rx-obs-hpc@44a08000 {
@@ -122,7 +122,7 @@
 		spibus-connected = <&trx0_adrv9009>;
 		adi,axi-pl-fifo-enable;
 		adi,axi-interpolation-core-available;
-		interpolation-gpios = <&gpio0 116 GPIO_ACTIVE_LOW>;
+		interpolation-gpios = <&gpio0 116 GPIO_ACTIVE_HIGH>;
 	};
 
 	axi_adrv9009_rx_jesd: axi-jesd204-rx@44aa0000 {

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9371.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9371.dts
@@ -98,7 +98,7 @@
 		dma-names = "rx";
 		spibus-connected = <&trx0_ad9371>;
 		adi,axi-decimation-core-available;
-		decimation-gpios = <&gpio0 115 GPIO_ACTIVE_LOW>;
+		decimation-gpios = <&gpio0 115 GPIO_ACTIVE_HIGH>;
 	};
 
 	axi_ad9371_core_rx_obs: axi-ad9371-rx-obs-hpc@44a08000 {
@@ -120,7 +120,7 @@
 		spibus-connected = <&trx0_ad9371>;
 		adi,axi-pl-fifo-enable;
 		adi,axi-interpolation-core-available;
-		interpolation-gpios = <&gpio0 116 GPIO_ACTIVE_LOW>;
+		interpolation-gpios = <&gpio0 116 GPIO_ACTIVE_HIGH>;
 	};
 
 	axi_ad9371_rx_jesd: axi-jesd204-rx@44aa0000 {

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9008-1.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9008-1.dts
@@ -64,7 +64,7 @@
 			dma-names = "rx";
 			spibus-connected = <&trx0_adrv9009>;
 			adi,axi-decimation-core-available;
-			decimation-gpios = <&gpio 133 GPIO_ACTIVE_LOW>;
+			decimation-gpios = <&gpio 139 GPIO_ACTIVE_HIGH>;
 		};
 
 		axi_adrv9009_rx_jesd: axi-jesd204-rx@84aa0000 {

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9008-2.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9008-2.dts
@@ -98,7 +98,7 @@
 			spibus-connected = <&trx0_adrv9009>;
 			//adi,axi-pl-fifo-enable;
 			adi,axi-interpolation-core-available;
-			interpolation-gpios = <&gpio 134 GPIO_ACTIVE_LOW>;
+			interpolation-gpios = <&gpio 140 GPIO_ACTIVE_HIGH>;
 
 		};
 

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9009.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9009.dts
@@ -119,7 +119,7 @@
 			dma-names = "rx";
 			spibus-connected = <&trx0_adrv9009>;
 			adi,axi-decimation-core-available;
-			decimation-gpios = <&gpio 133 GPIO_ACTIVE_LOW>;
+			decimation-gpios = <&gpio 139 GPIO_ACTIVE_HIGH>;
 		};
 
 		axi_adrv9009_core_rx_obs: axi-adrv9009-rx-obs-hpc@84a08000 {
@@ -141,7 +141,7 @@
 			spibus-connected = <&trx0_adrv9009>;
 			//adi,axi-pl-fifo-enable;
 			adi,axi-interpolation-core-available;
-			interpolation-gpios = <&gpio 134 GPIO_ACTIVE_LOW>;
+			interpolation-gpios = <&gpio 140 GPIO_ACTIVE_HIGH>;
 		};
 
 		axi_adrv9009_rx_jesd: axi-jesd204-rx@84aa0000 {

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9371.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9371.dts
@@ -102,7 +102,7 @@
 			dma-names = "rx";
 			spibus-connected = <&trx0_ad9371>;
 			adi,axi-decimation-core-available;
-			decimation-gpios = <&gpio 133 GPIO_ACTIVE_LOW>;
+			decimation-gpios = <&gpio 139 GPIO_ACTIVE_HIGH>;
 		};
 
 		axi_ad9371_core_rx_obs: axi-ad9371-rx-obs-hpc@84a08000 {
@@ -124,7 +124,7 @@
 			spibus-connected = <&trx0_ad9371>;
 			adi,axi-pl-fifo-enable;
 			adi,axi-interpolation-core-available;
-			interpolation-gpios = <&gpio 134 GPIO_ACTIVE_LOW>;
+			interpolation-gpios = <&gpio 140 GPIO_ACTIVE_HIGH>;
 		};
 
 		axi_ad9371_rx_jesd: axi-jesd204-rx@84aa0000 {

--- a/arch/microblaze/boot/dts/kcu105_adrv9371x.dts
+++ b/arch/microblaze/boot/dts/kcu105_adrv9371x.dts
@@ -13,7 +13,7 @@
 		dma-names = "rx";
 		spibus-connected = <&trx0_ad9371>;
 		adi,axi-decimation-core-available;
-		decimation-gpios = <&axi_gpio 61 GPIO_ACTIVE_LOW>;
+		decimation-gpios = <&axi_gpio 61 GPIO_ACTIVE_HIGH>;
 	};
 	axi_ad9371_core_rx_obs: axi-ad9371-rx-obs-hpc@44a08000 {
 		compatible = "adi,axi-ad9371-obs-1.0";
@@ -33,7 +33,7 @@
 		spibus-connected = <&trx0_ad9371>;
 		adi,axi-pl-fifo-enable;
 		adi,axi-interpolation-core-available;
-		interpolation-gpios = <&axi_gpio 62 GPIO_ACTIVE_LOW>;
+		interpolation-gpios = <&axi_gpio 62 GPIO_ACTIVE_HIGH>;
 	};
 	rx_dma: rx-dmac@7c400000 {
 		compatible = "adi,axi-dmac-1.00.a";


### PR DESCRIPTION
This issue was reported on Jira. The active state for the FIR filter gpios was set to active low and was set by default. Also for zcu102 the gpio address was incorrect. 

This set of patches must be ported to 2019_R1 branch also.