### PR TITLE
arm64: zynqmp: Prevent mmcblk0 error -110

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp.dtsi
+++ b/arch/arm64/boot/dts/xilinx/zynqmp.dtsi
@@ -965,6 +965,7 @@
 			power-domains = <&pd_sd0>;
 			nvmem-cells = <&soc_revision>;
 			nvmem-cell-names = "soc_revision";
+			broken-mmc-highspeed;
 		};
 
 		sdhci1: mmc@ff170000 {
@@ -981,6 +982,7 @@
 			power-domains = <&pd_sd1>;
 			nvmem-cells = <&soc_revision>;
 			nvmem-cell-names = "soc_revision";
+			broken-mmc-highspeed;
 		};
 
 		spi0: spi@ff040000 {


### PR DESCRIPTION
https://www.xilinx.com/support/answers/69995.html

The issue is still present and affects other SD card models too (e.g. SanDisk Ultra microSDHC 16GB).

Until the issue is not confirmed on other branches, I would keep the fix only for 2019_R1.