### PR TITLE
iio: jesd204: axi_adxcvr,xilinx_transceivers: print warning & move cpll/qpll ranges in functions

### DIFF
--- a/drivers/iio/jesd204/axi_adxcvr.c
+++ b/drivers/iio/jesd204/axi_adxcvr.c
@@ -515,6 +515,7 @@ MODULE_DEVICE_TABLE(of, adxcvr_of_match);
 static void adxcvr_enforce_settings(struct adxcvr_state *st)
 {
 	unsigned long lane_rate, parent_rate;
+	int ret;
 
 	/*
 	 * Make sure filter settings, etc. are correct for the supplied reference
@@ -526,7 +527,11 @@ static void adxcvr_enforce_settings(struct adxcvr_state *st)
 
 	lane_rate = adxcvr_clk_recalc_rate(&st->lane_clk_hw, parent_rate);
 
-	adxcvr_clk_set_rate(&st->lane_clk_hw, lane_rate, parent_rate);
+	ret = adxcvr_clk_set_rate(&st->lane_clk_hw, lane_rate, parent_rate);
+	if (ret)
+		dev_err(st->dev,
+			"%s: Rate %lu Hz Parent Rate %lu Hz, error: %d",
+			__func__, lane_rate, parent_rate, ret);
 }
 
 static void adxcvr_get_info(struct adxcvr_state *st)


### PR DESCRIPTION
Related to #672 

These 2 changes have been split from that PR and should be safe to implement now.
The only behavior change should be the warning-print.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>