### PR TITLE
ci,travis: remove 4.14 rebased branches from auto-sync

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: c
 branches:
   except:
   - xcomm_zynq
-  - adi-4.14.0 # current rebased versions of master; change this when updating kernel ver
+  - adi-4.19.0 # current rebased versions of master; change this when updating kernel ver
 
 os: linux
 

--- a/ci/travis/run-build.sh
+++ b/ci/travis/run-build.sh
@@ -189,10 +189,8 @@ __handle_sync_with_master() {
 build_sync_branches_with_master() {
 	GIT_FETCH_DEPTH=50
 	BRANCH1="xcomm_zynq:fast-forward"
-	BRANCH2="adi-4.14.0:cherry-pick"
 	BRANCH3="adi-4.19.0:cherry-pick"
 	BRANCH4="rpi-4.19.y:cherry-pick"
-	BRANCH5="rpi-4.14.y:cherry-pick"
 	BRANCH6="altera_4.14:cherry-pick"
 	BRANCH7="adi-iio:cherry-pick"
 


### PR DESCRIPTION
We will update to 4.19 in the near-future.
We can stop auto-syncing these rebased branches now, to prevent
un-necessary builds that may fail.

We also would want to stop supporting them.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>