### PR TITLE
arch: arm64: rename clk -> zynqmp_clk

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-reva.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-reva.dts
@@ -1196,7 +1196,7 @@
 
 			interrupts = <0 109 0>;
 
-			clocks = <&clk 71>, <&hmc7044 7>, <&axi_adrv9009_adxcvr_rx 0>;
+			clocks = <&zynqmp_clk 71>, <&hmc7044 7>, <&axi_adrv9009_adxcvr_rx 0>;
 			clock-names = "s_axi_aclk", "device_clk", "lane_clk";
 
 			#clock-cells = <0>;
@@ -1230,7 +1230,7 @@
 
 			interrupts = <0 107 0>;
 
-			clocks = <&clk 71>, <&hmc7044 6>, <&axi_adrv9009_adxcvr_rx_os 0>;
+			clocks = <&zynqmp_clk 71>, <&hmc7044 6>, <&axi_adrv9009_adxcvr_rx_os 0>;
 			clock-names = "s_axi_aclk", "device_clk", "lane_clk";
 
 			#clock-cells = <0>;
@@ -1262,7 +1262,7 @@
 
 			interrupts = <0 108 0>;
 
-			clocks = <&clk 71>, <&hmc7044 6>, <&axi_adrv9009_adxcvr_tx 0>;
+			clocks = <&zynqmp_clk 71>, <&hmc7044 6>, <&axi_adrv9009_adxcvr_tx 0>;
 			clock-names = "s_axi_aclk", "device_clk", "lane_clk";
 
 			#clock-cells = <0>;
@@ -1279,7 +1279,7 @@
 		axi_fan_control: axi-fan-control@80000000 {
 			compatible = "adi,axi-fan-control-1.00.a";
 			reg = <0x0 0x80000000 0x10000>;
-			clocks = <&clk 71>;
+			clocks = <&zynqmp_clk 71>;
 			interrupts = <0 110 0>;
 
 			adi,pulses-per-revolution = <2>;
@@ -1291,7 +1291,7 @@
 			#dma-cells = <1>;
 			#clock-cells = <0>;
 			interrupts = <0 106 0>;
-			clocks = <&clk 73>;
+			clocks = <&zynqmp_clk 73>;
 
 			adi,channels {
 				#size-cells = <0>;
@@ -1313,7 +1313,7 @@
 			#dma-cells = <1>;
 			#clock-cells = <0>;
 			interrupts = <0 104 0>;
-			clocks = <&clk 73>;
+			clocks = <&zynqmp_clk 73>;
 
 			adi,channels {
 				#size-cells = <0>;
@@ -1335,7 +1335,7 @@
 			#dma-cells = <1>;
 			#clock-cells = <0>;
 			interrupts = <0 105 0>;
-			clocks = <&clk 73>;
+			clocks = <&zynqmp_clk 73>;
 
 			adi,channels {
 				#size-cells = <0>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9172-fmc-ebz.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9172-fmc-ebz.dts
@@ -41,7 +41,7 @@
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c420000 0x10000>;
 			interrupts = <0 108 0>;
-			clocks = <&clk 71>;
+			clocks = <&zynqmp_clk 71>;
 
 			adi,channels {
 				#size-cells = <0>;
@@ -73,7 +73,7 @@
 
 			interrupts = <0 106 0>;
 
-			clocks = <&clk 71>, <&axi_ad9172_adxcvr 1>, <&axi_ad9172_adxcvr 0>;
+			clocks = <&zynqmp_clk 71>, <&axi_ad9172_adxcvr 1>, <&axi_ad9172_adxcvr 0>;
 			clock-names = "s_axi_aclk", "device_clk", "lane_clk";
 
 			adi,octets-per-frame = <1>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9208-hmc7044.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9208-hmc7044.dts
@@ -46,7 +46,7 @@
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c420000 0x10000>;
 			interrupts = <0 109 0>;
-			clocks = <&clk 71>;
+			clocks = <&zynqmp_clk 71>;
 
 			adi,channels {
 				#size-cells = <0>;
@@ -75,7 +75,7 @@
 			reg = <0x84aa0000 0x4000>;
 			interrupts = <0 108 0>;
 
-			clocks = <&clk 71>, <&axi_ad9208_adxcvr 1>, <&axi_ad9208_adxcvr 0>;
+			clocks = <&zynqmp_clk 71>, <&axi_ad9208_adxcvr 1>, <&axi_ad9208_adxcvr 0>;
 			clock-names = "s_axi_aclk", "device_clk", "lane_clk";
 
 			adi,octets-per-frame = <1>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9208.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9208.dts
@@ -51,7 +51,7 @@
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c420000 0x10000>;
 			interrupts = <0 109 0>;
-			clocks = <&clk 71>;
+			clocks = <&zynqmp_clk 71>;
 
 			adi,channels {
 				#size-cells = <0>;
@@ -80,7 +80,7 @@
 			reg = <0x84aa0000 0x4000>;
 			interrupts = <0 108 0>;
 
-			clocks = <&clk 71>, <&axi_ad9208_adxcvr 1>, <&axi_ad9208_adxcvr 0>;
+			clocks = <&zynqmp_clk 71>, <&axi_ad9208_adxcvr 1>, <&axi_ad9208_adxcvr 0>;
 			clock-names = "s_axi_aclk", "device_clk", "lane_clk";
 
 			adi,octets-per-frame = <1>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9361-fmcomms2-3.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9361-fmcomms2-3.dts
@@ -43,7 +43,7 @@
 			#dma-cells = <1>;
 			#clock-cells = <0>;
 			interrupts = <0 109 0>;
-			clocks = <&clk 71>;
+			clocks = <&zynqmp_clk 71>;
 
 			adi,channels {
 				#size-cells = <0>;
@@ -65,7 +65,7 @@
 			#dma-cells = <1>;
 			#clock-cells = <0>;
 			interrupts = <0 108 0>;
-			clocks = <&clk 71>;
+			clocks = <&zynqmp_clk 71>;
 
 			adi,channels {
 				#size-cells = <0>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9361-fmcomms5.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9361-fmcomms5.dts
@@ -40,7 +40,7 @@
 			#dma-cells = <1>;
 			#clock-cells = <0>;
 			interrupts = <0 109 0>;
-			clocks = <&clk 73>;
+			clocks = <&zynqmp_clk 73>;
 
 			adi,channels {
 				#size-cells = <0>;
@@ -62,7 +62,7 @@
 			#dma-cells = <1>;
 			#clock-cells = <0>;
 			interrupts = <0 108 0>;
-			clocks = <&clk 73>;
+			clocks = <&zynqmp_clk 73>;
 
 			adi,channels {
 				#size-cells = <0>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9364-fmcomms4.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9364-fmcomms4.dts
@@ -43,7 +43,7 @@
 			#dma-cells = <1>;
 			#clock-cells = <0>;
 			interrupts = <0 109 0>;
-			clocks = <&clk 71>;
+			clocks = <&zynqmp_clk 71>;
 
 			adi,channels {
 				#size-cells = <0>;
@@ -65,7 +65,7 @@
 			#dma-cells = <1>;
 			#clock-cells = <0>;
 			interrupts = <0 108 0>;
-			clocks = <&clk 71>;
+			clocks = <&zynqmp_clk 71>;
 
 			adi,channels {
 				#size-cells = <0>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9008-1.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9008-1.dts
@@ -41,7 +41,7 @@
 			#dma-cells = <1>;
 			#clock-cells = <0>;
 			interrupts = <0 109 0>;
-			clocks = <&clk 73>;
+			clocks = <&zynqmp_clk 73>;
 
 			adi,channels {
 				#size-cells = <0>;
@@ -73,7 +73,7 @@
 
 			interrupts = <0 106 0>;
 
-			clocks = <&clk 71>, <&axi_rx_clkgen>, <&axi_adrv9009_adxcvr_rx 0>;
+			clocks = <&zynqmp_clk 71>, <&axi_rx_clkgen>, <&axi_adrv9009_adxcvr_rx 0>;
 			clock-names = "s_axi_aclk", "device_clk", "lane_clk";
 
 			#clock-cells = <0>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9008-2.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9008-2.dts
@@ -41,7 +41,7 @@
 			#dma-cells = <1>;
 			#clock-cells = <0>;
 			interrupts = <0 107 0>;
-			clocks = <&clk 73>;
+			clocks = <&zynqmp_clk 73>;
 
 			adi,channels {
 				#size-cells = <0>;
@@ -63,7 +63,7 @@
 			#dma-cells = <1>;
 			#clock-cells = <0>;
 			interrupts = <0 108 0>;
-			clocks = <&clk 73>;
+			clocks = <&zynqmp_clk 73>;
 
 			adi,channels {
 				#size-cells = <0>;
@@ -108,7 +108,7 @@
 
 			interrupts = <0 105 0>;
 
-			clocks = <&clk 71>, <&axi_tx_clkgen>, <&axi_adrv9009_adxcvr_tx 0>;
+			clocks = <&zynqmp_clk 71>, <&axi_tx_clkgen>, <&axi_adrv9009_adxcvr_tx 0>;
 			clock-names = "s_axi_aclk", "device_clk", "lane_clk";
 
 			#clock-cells = <0>;
@@ -128,7 +128,7 @@
 
 			interrupts = <0 104 0>;
 
-			clocks = <&clk 71>, <&axi_rx_os_clkgen>, <&axi_adrv9009_adxcvr_rx_os 0>;
+			clocks = <&zynqmp_clk 71>, <&axi_rx_os_clkgen>, <&axi_adrv9009_adxcvr_rx_os 0>;
 			clock-names = "s_axi_aclk", "device_clk", "lane_clk";
 
 			#clock-cells = <0>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9009.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9009.dts
@@ -52,7 +52,7 @@
 			#dma-cells = <1>;
 			#clock-cells = <0>;
 			interrupts = <0 109 0>;
-			clocks = <&clk 73>;
+			clocks = <&zynqmp_clk 73>;
 
 			adi,channels {
 				#size-cells = <0>;
@@ -74,7 +74,7 @@
 			#dma-cells = <1>;
 			#clock-cells = <0>;
 			interrupts = <0 107 0>;
-			clocks = <&clk 73>;
+			clocks = <&zynqmp_clk 73>;
 
 			adi,channels {
 				#size-cells = <0>;
@@ -96,7 +96,7 @@
 			#dma-cells = <1>;
 			#clock-cells = <0>;
 			interrupts = <0 108 0>;
-			clocks = <&clk 73>;
+			clocks = <&zynqmp_clk 73>;
 
 			adi,channels {
 				#size-cells = <0>;
@@ -150,7 +150,7 @@
 
 			interrupts = <0 106 0>;
 
-			clocks = <&clk 71>, <&axi_rx_clkgen>, <&axi_adrv9009_adxcvr_rx 0>;
+			clocks = <&zynqmp_clk 71>, <&axi_rx_clkgen>, <&axi_adrv9009_adxcvr_rx 0>;
 			clock-names = "s_axi_aclk", "device_clk", "lane_clk";
 
 			#clock-cells = <0>;
@@ -166,7 +166,7 @@
 
 			interrupts = <0 105 0>;
 
-			clocks = <&clk 71>, <&axi_tx_clkgen>, <&axi_adrv9009_adxcvr_tx 0>;
+			clocks = <&zynqmp_clk 71>, <&axi_tx_clkgen>, <&axi_adrv9009_adxcvr_tx 0>;
 			clock-names = "s_axi_aclk", "device_clk", "lane_clk";
 
 			#clock-cells = <0>;
@@ -186,7 +186,7 @@
 
 			interrupts = <0 104 0>;
 
-			clocks = <&clk 71>, <&axi_rx_os_clkgen>, <&axi_adrv9009_adxcvr_rx_os 0>;
+			clocks = <&zynqmp_clk 71>, <&axi_rx_os_clkgen>, <&axi_adrv9009_adxcvr_rx_os 0>;
 			clock-names = "s_axi_aclk", "device_clk", "lane_clk";
 
 			#clock-cells = <0>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9371.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9371.dts
@@ -35,7 +35,7 @@
 			#dma-cells = <1>;
 			#clock-cells = <0>;
 			interrupts = <0 109 0>;
-			clocks = <&clk 73>;
+			clocks = <&zynqmp_clk 73>;
 
 			adi,channels {
 				#size-cells = <0>;
@@ -57,7 +57,7 @@
 			#dma-cells = <1>;
 			#clock-cells = <0>;
 			interrupts = <0 107 0>;
-			clocks = <&clk 73>;
+			clocks = <&zynqmp_clk 73>;
 
 			adi,channels {
 				#size-cells = <0>;
@@ -79,7 +79,7 @@
 			#dma-cells = <1>;
 			#clock-cells = <0>;
 			interrupts = <0 108 0>;
-			clocks = <&clk 73>;
+			clocks = <&zynqmp_clk 73>;
 
 			adi,channels {
 				#size-cells = <0>;
@@ -133,7 +133,7 @@
 
 			interrupts = <0 106 0>;
 
-			clocks = <&clk 71>, <&axi_rx_clkgen>, <&axi_ad9371_adxcvr_rx 0>;
+			clocks = <&zynqmp_clk 71>, <&axi_rx_clkgen>, <&axi_ad9371_adxcvr_rx 0>;
 			clock-names = "s_axi_aclk", "device_clk", "lane_clk";
 
 			#clock-cells = <0>;
@@ -149,7 +149,7 @@
 
 			interrupts = <0 105 0>;
 
-			clocks = <&clk 71>, <&axi_tx_clkgen>, <&axi_ad9371_adxcvr_tx 0>;
+			clocks = <&zynqmp_clk 71>, <&axi_tx_clkgen>, <&axi_ad9371_adxcvr_tx 0>;
 			clock-names = "s_axi_aclk", "device_clk", "lane_clk";
 
 			#clock-cells = <0>;
@@ -169,7 +169,7 @@
 
 			interrupts = <0 104 0>;
 
-			clocks = <&clk 71>, <&axi_rx_os_clkgen>, <&axi_ad9371_adxcvr_rx_os 0>;
+			clocks = <&zynqmp_clk 71>, <&axi_rx_os_clkgen>, <&axi_ad9371_adxcvr_rx_os 0>;
 			clock-names = "s_axi_aclk", "device_clk", "lane_clk";
 
 			#clock-cells = <0>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-fmcdaq2.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-fmcdaq2.dts
@@ -43,7 +43,7 @@
 			#dma-cells = <1>;
 			#clock-cells = <0>;
 			interrupts = <0 109 0>;
-			clocks = <&clk 71>;
+			clocks = <&zynqmp_clk 71>;
 
 			adi,channels {
 				#size-cells = <0>;
@@ -65,7 +65,7 @@
 			#dma-cells = <1>;
 			#clock-cells = <0>;
 			interrupts = <0 108 0>;
-			clocks = <&clk 71>;
+			clocks = <&zynqmp_clk 71>;
 
 			adi,channels {
 				#size-cells = <0>;
@@ -96,7 +96,7 @@
 
 			interrupts = <0 106 0>;
 
-			clocks = <&clk 71>, <&axi_ad9144_adxcvr 1>, <&axi_ad9144_adxcvr 0>;
+			clocks = <&zynqmp_clk 71>, <&axi_ad9144_adxcvr 1>, <&axi_ad9144_adxcvr 0>;
 			clock-names = "s_axi_aclk", "device_clk", "lane_clk";
 
 			adi,octets-per-frame = <1>;
@@ -123,7 +123,7 @@
 
 			interrupts = <0 107 0>;
 
-			clocks = <&clk 71>, <&axi_ad9680_adxcvr 1>, <&axi_ad9680_adxcvr 0>;
+			clocks = <&zynqmp_clk 71>, <&axi_ad9680_adxcvr 1>, <&axi_ad9680_adxcvr 0>;
 			clock-names = "s_axi_aclk", "device_clk", "lane_clk";
 
 			adi,octets-per-frame = <1>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-fmcdaq3.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-fmcdaq3.dts
@@ -42,7 +42,7 @@
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c400000 0x10000>;
 			interrupts = <0 109 0>;
-			clocks = <&clk 71>;
+			clocks = <&zynqmp_clk 71>;
 
 			adi,channels {
 				#size-cells = <0>;
@@ -63,7 +63,7 @@
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c420000 0x10000>;
 			interrupts = <0 108 0>;
-			clocks = <&clk 71>;
+			clocks = <&zynqmp_clk 71>;
 
 			adi,channels {
 				#size-cells = <0>;
@@ -101,7 +101,7 @@
 			reg = <0x84aa0000 0x4000>;
 			interrupts = <0 107 0>;
 
-			clocks = <&clk 71>, <&axi_ad9680_adxcvr 1>, <&axi_ad9680_adxcvr 0>;
+			clocks = <&zynqmp_clk 71>, <&axi_ad9680_adxcvr 1>, <&axi_ad9680_adxcvr 0>;
 			clock-names = "s_axi_aclk", "device_clk", "lane_clk";
 
 			adi,octets-per-frame = <1>;
@@ -133,7 +133,7 @@
 
 			interrupts = <0 106 0>;
 
-			clocks = <&clk 71>, <&axi_ad9152_adxcvr 1>, <&axi_ad9152_adxcvr 0>;
+			clocks = <&zynqmp_clk 71>, <&axi_ad9152_adxcvr 1>, <&axi_ad9152_adxcvr 0>;
 			clock-names = "s_axi_aclk", "device_clk", "lane_clk";
 
 			adi,octets-per-frame = <1>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-revB-ad9361-fmcomms2-3.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-revB-ad9361-fmcomms2-3.dts
@@ -42,7 +42,7 @@
 			reg = <0x9c400000 0x10000>;
 			#dma-cells = <1>;
 			interrupts = <0 109 0>;
-			clocks = <&clk 71>;
+			clocks = <&zynqmp_clk 71>;
 
 			adi,channels {
 				#size-cells = <0>;
@@ -64,7 +64,7 @@
 			reg = <0x9c420000 0x10000>;
 			#dma-cells = <1>;
 			interrupts = <0 108 0>;
-			clocks = <&clk 71>;
+			clocks = <&zynqmp_clk 71>;
 
 			adi,channels {
 				#size-cells = <0>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-revB-ad9364-fmcomms4.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-revB-ad9364-fmcomms4.dts
@@ -42,7 +42,7 @@
 			reg = <0x80010000 0x10000>;
 			#dma-cells = <1>;
 			interrupts = <0 109 0>;
-			clocks = <&clk 71>;
+			clocks = <&zynqmp_clk 71>;
 
 			adi,channels {
 				#size-cells = <0>;
@@ -63,7 +63,7 @@
 			reg = <0x80020000 0x10000>;
 			#dma-cells = <1>;
 			interrupts = <0 108 0>;
-			clocks = <&clk 71>;
+			clocks = <&zynqmp_clk 71>;
 
 			adi,channels {
 				#size-cells = <0>;


### PR DESCRIPTION
The reference got renamed in Xilinx's base device-trees.
This change renames it in ADI's device-trees for 4.19.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>