### PR TITLE
arch: arm: update ADI zynq device-trees with proper interrupt definitions/flags (part 1).

### DIFF
--- a/arch/arm/boot/dts/adi-zynq-cn0363.dtsi
+++ b/arch/arm/boot/dts/adi-zynq-cn0363.dtsi
@@ -50,7 +50,7 @@
 		compatible = "adi,axi-spi-engine-1.00.a";
 		reg = <0x44a00000 0x1000>;
 		interrupt-parent = <&intc>;
-		interrupts = <0 56 4>;
+		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 15 &clkc 15>;
 		clock-names = "s_axi_aclk", "spi_clk";
 		num-cs = <2>;

--- a/arch/arm/boot/dts/adi-zynq-cn0363.dtsi
+++ b/arch/arm/boot/dts/adi-zynq-cn0363.dtsi
@@ -1,3 +1,5 @@
+#include <dt-bindings/interrupt-controller/irq.h>
+
 / {
 	clocks {
 		adc_clkin: clock@0 {
@@ -15,7 +17,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x44a30000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 57 0>;
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 15>;
 
 		adi,channels {

--- a/arch/arm/boot/dts/socfpga_cyclone5_sockit_arradio.dts
+++ b/arch/arm/boot/dts/socfpga_cyclone5_sockit_arradio.dts
@@ -231,7 +231,7 @@
 					compatible = "altr,spi-14.0", "altr,spi-1.0";
 					reg = <0x00008000 0x00000020>;
 					interrupt-parent = <&intc>;
-					interrupts = <0 41 4>;
+					interrupts = <0 41 IRQ_TYPE_LEVEL_HIGH>;
 					#address-cells = <0x1>;
 					#size-cells = <0x0>;
 					adc0_ad9361: ad9361-phy@0 {

--- a/arch/arm/boot/dts/socfpga_cyclone5_sockit_arradio.dts
+++ b/arch/arm/boot/dts/socfpga_cyclone5_sockit_arradio.dts
@@ -1,3 +1,4 @@
+#include <dt-bindings/interrupt-controller/irq.h>
 
 #include "socfpga_cyclone5.dtsi"
 
@@ -175,7 +176,7 @@
 					compatible = "adi,axi-dmac-1.00.a";
 					reg = <0x00004000 0x00004000>;
 					interrupt-parent = <&intc>;
-					interrupts = <0 42 4>;
+					interrupts = <0 42 IRQ_TYPE_LEVEL_HIGH>;
 					#dma-cells = <1>;
 					clocks = <&axi_dmac0_clk>;
 					clock-names = "axi_dmac0_clkin";
@@ -198,7 +199,7 @@
 					compatible = "adi,axi-dmac-1.00.a";
 					reg = <0x00000000 0x00004000>;
 					interrupt-parent = <&intc>;
-					interrupts = <0 43 4>;
+					interrupts = <0 43 IRQ_TYPE_LEVEL_HIGH>;
 					#dma-cells = <1>;
 					clocks = <&axi_dmac0_clk>;
 					clock-names = "axi_dmac0_clkin";

--- a/arch/arm/boot/dts/zynq-adrv9361-z7035-bob.dts
+++ b/arch/arm/boot/dts/zynq-adrv9361-z7035-bob.dts
@@ -1,5 +1,5 @@
 /dts-v1/;
-/include/ "zynq-adrv9361-z7035.dtsi"
+#include "zynq-adrv9361-z7035.dtsi"
 
 
 &axi_i2c0 {

--- a/arch/arm/boot/dts/zynq-adrv9361-z7035-box.dts
+++ b/arch/arm/boot/dts/zynq-adrv9361-z7035-box.dts
@@ -1,5 +1,5 @@
 /dts-v1/;
-/include/ "zynq-adrv9361-z7035.dtsi"
+#include "zynq-adrv9361-z7035.dtsi"
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/interrupt-controller/irq.h>

--- a/arch/arm/boot/dts/zynq-adrv9361-z7035-fmc.dts
+++ b/arch/arm/boot/dts/zynq-adrv9361-z7035-fmc.dts
@@ -163,7 +163,7 @@
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x43000000 0x10000>;
 			#dma-cells = <1>;
-			interrupts = <0 59 0>;
+			interrupts = <0 59 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&clkc 16>;
 
 			adi,channels {

--- a/arch/arm/boot/dts/zynq-adrv9361-z7035-fmc.dts
+++ b/arch/arm/boot/dts/zynq-adrv9361-z7035-fmc.dts
@@ -1,5 +1,5 @@
 /dts-v1/;
-/include/ "zynq-adrv9361-z7035.dtsi"
+#include "zynq-adrv9361-z7035.dtsi"
 
 #include <dt-bindings/input/input.h>
 

--- a/arch/arm/boot/dts/zynq-adrv9361-z7035-userspace.dts
+++ b/arch/arm/boot/dts/zynq-adrv9361-z7035-userspace.dts
@@ -1,5 +1,5 @@
 /dts-v1/;
-/include/ "zynq.dtsi"
+#include "zynq.dtsi"
 
 / {
 	model = "Analog Devices ADRV9364-Z7020";

--- a/arch/arm/boot/dts/zynq-adrv9361-z7035.dtsi
+++ b/arch/arm/boot/dts/zynq-adrv9361-z7035.dtsi
@@ -142,7 +142,7 @@
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x7c400000 0x10000>;
 			#dma-cells = <1>;
-			interrupts = <0 57 0>;
+			interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&clkc 16>;
 
 			adi,channels {
@@ -163,7 +163,7 @@
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x7c420000 0x10000>;
 			#dma-cells = <1>;
-			interrupts = <0 56 0>;
+			interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&clkc 16>;
 
 			adi,channels {

--- a/arch/arm/boot/dts/zynq-adrv9361-z7035.dtsi
+++ b/arch/arm/boot/dts/zynq-adrv9361-z7035.dtsi
@@ -5,7 +5,7 @@
  *
  * Licensed under the GPL-2.
  */
-/include/ "zynq.dtsi"
+#include "zynq.dtsi"
 
 #include <dt-bindings/interrupt-controller/irq.h>
 

--- a/arch/arm/boot/dts/zynq-adrv9361-z7035.dtsi
+++ b/arch/arm/boot/dts/zynq-adrv9361-z7035.dtsi
@@ -7,6 +7,8 @@
  */
 /include/ "zynq.dtsi"
 
+#include <dt-bindings/interrupt-controller/irq.h>
+
 / {
 	model = "Analog Devices ADRV9361-Z7035 (Z7035/AD9361)";
 	memory {

--- a/arch/arm/boot/dts/zynq-adrv9364-z7020-bob.dts
+++ b/arch/arm/boot/dts/zynq-adrv9364-z7020-bob.dts
@@ -1,5 +1,5 @@
 /dts-v1/;
-/include/ "zynq-adrv9364-z7020.dtsi"
+#include "zynq-adrv9364-z7020.dtsi"
 
 
 &axi_i2c0 {

--- a/arch/arm/boot/dts/zynq-adrv9364-z7020-box.dts
+++ b/arch/arm/boot/dts/zynq-adrv9364-z7020-box.dts
@@ -1,5 +1,5 @@
 /dts-v1/;
-/include/ "zynq-adrv9364-z7020.dtsi"
+#include "zynq-adrv9364-z7020.dtsi"
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/interrupt-controller/irq.h>

--- a/arch/arm/boot/dts/zynq-adrv9364-z7020.dtsi
+++ b/arch/arm/boot/dts/zynq-adrv9364-z7020.dtsi
@@ -7,6 +7,8 @@
  */
 /include/ "zynq.dtsi"
 
+#include <dt-bindings/interrupt-controller/irq.h>
+
 / {
 	model = "Analog Devices ADRV9364-Z7020 (Z7020/AD9364)";
 	memory {

--- a/arch/arm/boot/dts/zynq-adrv9364-z7020.dtsi
+++ b/arch/arm/boot/dts/zynq-adrv9364-z7020.dtsi
@@ -5,7 +5,7 @@
  *
  * Licensed under the GPL-2.
  */
-/include/ "zynq.dtsi"
+#include "zynq.dtsi"
 
 #include <dt-bindings/interrupt-controller/irq.h>
 

--- a/arch/arm/boot/dts/zynq-adrv9364-z7020.dtsi
+++ b/arch/arm/boot/dts/zynq-adrv9364-z7020.dtsi
@@ -133,7 +133,7 @@
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x7c400000 0x10000>;
 			#dma-cells = <1>;
-			interrupts = <0 57 0>;
+			interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&clkc 16>;
 
 			adi,channels {
@@ -154,7 +154,7 @@
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x7c420000 0x10000>;
 			#dma-cells = <1>;
-			interrupts = <0 56 0>;
+			interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&clkc 16>;
 
 			adi,channels {

--- a/arch/arm/boot/dts/zynq-e310.dts
+++ b/arch/arm/boot/dts/zynq-e310.dts
@@ -6,7 +6,7 @@
  * Licensed under the GPL-2.
  */
 /dts-v1/;
-/include/ "zynq.dtsi"
+#include "zynq.dtsi"
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/interrupt-controller/irq.h>

--- a/arch/arm/boot/dts/zynq-e310.dts
+++ b/arch/arm/boot/dts/zynq-e310.dts
@@ -134,7 +134,7 @@
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x7c400000 0x10000>;
 			#dma-cells = <1>;
-			interrupts = <0 57 0>;
+			interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&clkc 16>;
 
 			adi,channels {
@@ -155,7 +155,7 @@
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x7c420000 0x10000>;
 			#dma-cells = <1>;
-			interrupts = <0 56 0>;
+			interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&clkc 16>;
 
 			adi,channels {

--- a/arch/arm/boot/dts/zynq-m2k-reva.dts
+++ b/arch/arm/boot/dts/zynq-m2k-reva.dts
@@ -157,7 +157,7 @@
 		fmc_i2c: i2c@41600000 {
 			compatible = "xlnx,axi-iic-1.01.b", "xlnx,xps-iic-2.00.a";
 			interrupt-parent = <&intc>;
-			interrupts = <0 58 0x4>;
+			interrupts = <0 58 IRQ_TYPE_LEVEL_HIGH>;
 			reg = <0x41600000 0x10000>;
 			clocks = <&clkc 15>;
 			clock-names = "pclk";

--- a/arch/arm/boot/dts/zynq-m2k-reva.dts
+++ b/arch/arm/boot/dts/zynq-m2k-reva.dts
@@ -1,6 +1,6 @@
 /dts-v1/;
 
-/include/ "zynq-m2k.dtsi"
+#include "zynq-m2k.dtsi"
 
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/gpio/gpio.h>

--- a/arch/arm/boot/dts/zynq-m2k-reva.dts
+++ b/arch/arm/boot/dts/zynq-m2k-reva.dts
@@ -205,7 +205,7 @@
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x7c440000 0x10000>;
 			#dma-cells = <1>;
-			interrupts = <0 54 0>;
+			interrupts = <0 54 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&clkc 15>;
 
 			adi,channels {
@@ -226,7 +226,7 @@
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x7c460000 0x10000>;
 			#dma-cells = <1>;
-			interrupts = <0 36 0>;
+			interrupts = <0 36 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&clkc 15>;
 
 			dma-channel {
@@ -239,7 +239,7 @@
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x7c480000 0x10000>;
 			#dma-cells = <1>;
-			interrupts = <0 53 0>;
+			interrupts = <0 53 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&clkc 15>;
 
 			adi,channels {
@@ -260,7 +260,7 @@
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x7c460000 0x10000>;
 			#dma-cells = <1>;
-			interrupts = <0 52 0>;
+			interrupts = <0 52 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&clkc 15>;
 
 			adi,channels {
@@ -311,7 +311,7 @@
 			reg = <0x7c400000 0x10000>;
 
 			#dma-cells = <1>;
-			interrupts = <0 57 0>;
+			interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&clkc 15>;
 
 			adi,channels {
@@ -333,7 +333,7 @@
 			reg = <0x7c420000 0x10000>;
 
 			#dma-cells = <1>;
-			interrupts = <0 56 0>;
+			interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&clkc 15>;
 
 			adi,channels {

--- a/arch/arm/boot/dts/zynq-m2k.dtsi
+++ b/arch/arm/boot/dts/zynq-m2k.dtsi
@@ -7,6 +7,8 @@
  */
 /include/ "zynq.dtsi"
 
+#include <dt-bindings/interrupt-controller/irq.h>
+
 / {
 	model = "Analog Devices M2k Rev.A (Z7010)";
 	memory {

--- a/arch/arm/boot/dts/zynq-m2k.dtsi
+++ b/arch/arm/boot/dts/zynq-m2k.dtsi
@@ -5,7 +5,7 @@
  *
  * Licensed under the GPL-2.
  */
-/include/ "zynq.dtsi"
+#include "zynq.dtsi"
 
 #include <dt-bindings/interrupt-controller/irq.h>
 

--- a/arch/arm/boot/dts/zynq-microzed-cn0363.dts
+++ b/arch/arm/boot/dts/zynq-microzed-cn0363.dts
@@ -1,4 +1,4 @@
 /dts-v1/;
 
-/include/ "zynq-microzed.dtsi"
-/include/ "adi-zynq-cn0363.dtsi"
+#include "zynq-microzed.dtsi"
+#include "adi-zynq-cn0363.dtsi"

--- a/arch/arm/boot/dts/zynq-microzed.dts
+++ b/arch/arm/boot/dts/zynq-microzed.dts
@@ -4,7 +4,7 @@
  * Copyright (C) 2016 Jagan Teki <jteki@openedev.com>
  */
 /dts-v1/;
-/include/ "zynq-7000.dtsi"
+#include "zynq-7000.dtsi"
 
 / {
 	model = "Avnet MicroZed board";

--- a/arch/arm/boot/dts/zynq-microzed.dtsi
+++ b/arch/arm/boot/dts/zynq-microzed.dtsi
@@ -1,4 +1,4 @@
-/include/ "zynq.dtsi"
+#include "zynq.dtsi"
 
 / {
 	model = "Avnet MicroZed";

--- a/arch/arm/boot/dts/zynq-parallella.dts
+++ b/arch/arm/boot/dts/zynq-parallella.dts
@@ -9,7 +9,7 @@
  *  Copyright (C) 2013 Xilinx
  */
 /dts-v1/;
-/include/ "zynq-7000.dtsi"
+#include "zynq-7000.dtsi"
 
 / {
 	model = "Adapteva Parallella board";

--- a/arch/arm/boot/dts/zynq-pluto-sdr-revb.dts
+++ b/arch/arm/boot/dts/zynq-pluto-sdr-revb.dts
@@ -1,5 +1,5 @@
 /dts-v1/;
-/include/ "zynq-pluto-sdr.dtsi"
+#include "zynq-pluto-sdr.dtsi"
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/interrupt-controller/irq.h>

--- a/arch/arm/boot/dts/zynq-pluto-sdr-revc.dts
+++ b/arch/arm/boot/dts/zynq-pluto-sdr-revc.dts
@@ -1,5 +1,5 @@
 /dts-v1/;
-/include/ "zynq-pluto-sdr.dtsi"
+#include "zynq-pluto-sdr.dtsi"
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/interrupt-controller/irq.h>

--- a/arch/arm/boot/dts/zynq-pluto-sdr.dts
+++ b/arch/arm/boot/dts/zynq-pluto-sdr.dts
@@ -1,5 +1,5 @@
 /dts-v1/;
-/include/ "zynq-pluto-sdr.dtsi"
+#include "zynq-pluto-sdr.dtsi"
 
 
 &axi_i2c0 {

--- a/arch/arm/boot/dts/zynq-pluto-sdr.dtsi
+++ b/arch/arm/boot/dts/zynq-pluto-sdr.dtsi
@@ -121,7 +121,7 @@
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x7c400000 0x10000>;
 			#dma-cells = <1>;
-			interrupts = <0 57 0>;
+			interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&clkc 16>;
 
 			adi,channels {
@@ -142,7 +142,7 @@
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x7c420000 0x10000>;
 			#dma-cells = <1>;
-			interrupts = <0 56 0>;
+			interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&clkc 16>;
 
 			adi,channels {

--- a/arch/arm/boot/dts/zynq-pluto-sdr.dtsi
+++ b/arch/arm/boot/dts/zynq-pluto-sdr.dtsi
@@ -5,7 +5,7 @@
  *
  * Licensed under the GPL-2.
  */
-/include/ "zynq.dtsi"
+#include "zynq.dtsi"
 
 #include <dt-bindings/interrupt-controller/irq.h>
 

--- a/arch/arm/boot/dts/zynq-pluto-sdr.dtsi
+++ b/arch/arm/boot/dts/zynq-pluto-sdr.dtsi
@@ -7,6 +7,8 @@
  */
 /include/ "zynq.dtsi"
 
+#include <dt-bindings/interrupt-controller/irq.h>
+
 / {
 	model = "Analog Devices PlutoSDR Rev.A (Z7010/AD9363)";
 	memory {

--- a/arch/arm/boot/dts/zynq-pluto-sdr.dtsi
+++ b/arch/arm/boot/dts/zynq-pluto-sdr.dtsi
@@ -108,7 +108,7 @@
 			compatible = "xlnx,axi-iic-1.02.a", "xlnx,xps-iic-2.00.a";
 			reg = <0x41600000 0x10000>;
 			interrupt-parent = <&intc>;
-			interrupts = <0 59 4>;
+			interrupts = <0 59 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&clkc 15>;
 			clock-names = "pclk";
 

--- a/arch/arm/boot/dts/zynq-sidekiqz2-revb.dts
+++ b/arch/arm/boot/dts/zynq-sidekiqz2-revb.dts
@@ -1,5 +1,5 @@
 /dts-v1/;
-/include/ "zynq-pluto-sdr.dtsi"
+#include "zynq-pluto-sdr.dtsi"
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/interrupt-controller/irq.h>

--- a/arch/arm/boot/dts/zynq-zc702-adv7511-ad9361-4-fmcomms2-3-4-userspace.dts
+++ b/arch/arm/boot/dts/zynq-zc702-adv7511-ad9361-4-fmcomms2-3-4-userspace.dts
@@ -1,7 +1,7 @@
 /dts-v1/;
 
-/include/ "zynq-zc702.dtsi"
-/include/ "zynq-zc702-adv7511.dtsi"
+#include "zynq-zc702.dtsi"
+#include "zynq-zc702-adv7511.dtsi"
 
 &fmc_i2c {
 	eeprom@50 {

--- a/arch/arm/boot/dts/zynq-zc702-adv7511-ad9361-fmcomms2-3.dts
+++ b/arch/arm/boot/dts/zynq-zc702-adv7511-ad9361-fmcomms2-3.dts
@@ -19,7 +19,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 57 0>;
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 
 		adi,channels {
@@ -40,7 +40,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 56 0>;
+		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 
 		adi,channels {

--- a/arch/arm/boot/dts/zynq-zc702-adv7511-ad9361-fmcomms2-3.dts
+++ b/arch/arm/boot/dts/zynq-zc702-adv7511-ad9361-fmcomms2-3.dts
@@ -1,7 +1,7 @@
 /dts-v1/;
 
-/include/ "zynq-zc702.dtsi"
-/include/ "zynq-zc702-adv7511.dtsi"
+#include "zynq-zc702.dtsi"
+#include "zynq-zc702-adv7511.dtsi"
 
 &spi0 {
 	status = "okay";

--- a/arch/arm/boot/dts/zynq-zc702-adv7511-ad9361-fmcomms5-userspace.dts
+++ b/arch/arm/boot/dts/zynq-zc702-adv7511-ad9361-fmcomms5-userspace.dts
@@ -1,7 +1,7 @@
 /dts-v1/;
 
-/include/ "zynq-zc702.dtsi"
-/include/ "zynq-zc702-adv7511.dtsi"
+#include "zynq-zc702.dtsi"
+#include "zynq-zc702-adv7511.dtsi"
 
 &fmc_i2c {
 	eeprom@50 {

--- a/arch/arm/boot/dts/zynq-zc702-adv7511-ad9361-fmcomms5.dts
+++ b/arch/arm/boot/dts/zynq-zc702-adv7511-ad9361-fmcomms5.dts
@@ -14,7 +14,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 57 0>;
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 
 		adi,channels {
@@ -35,7 +35,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 56 0>;
+		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 
 		adi,channels {

--- a/arch/arm/boot/dts/zynq-zc702-adv7511-ad9361-fmcomms5.dts
+++ b/arch/arm/boot/dts/zynq-zc702-adv7511-ad9361-fmcomms5.dts
@@ -1,7 +1,7 @@
 /dts-v1/;
 
-/include/ "zynq-zc702.dtsi"
-/include/ "zynq-zc702-adv7511.dtsi"
+#include "zynq-zc702.dtsi"
+#include "zynq-zc702-adv7511.dtsi"
 
 &spi0 {
 	status = "okay";

--- a/arch/arm/boot/dts/zynq-zc702-adv7511-ad9364-fmcomms4.dts
+++ b/arch/arm/boot/dts/zynq-zc702-adv7511-ad9364-fmcomms4.dts
@@ -8,7 +8,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 57 0>;
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 
 		adi,channels {
@@ -29,7 +29,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 56 0>;
+		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 
 		adi,channels {

--- a/arch/arm/boot/dts/zynq-zc702-adv7511-ad9364-fmcomms4.dts
+++ b/arch/arm/boot/dts/zynq-zc702-adv7511-ad9364-fmcomms4.dts
@@ -1,7 +1,7 @@
 /dts-v1/;
 
-/include/ "zynq-zc702.dtsi"
-/include/ "zynq-zc702-adv7511.dtsi"
+#include "zynq-zc702.dtsi"
+#include "zynq-zc702-adv7511.dtsi"
 
 &fpga_axi {
 	rx_dma: dma@7c400000 {

--- a/arch/arm/boot/dts/zynq-zc702-adv7511-fmcomms1.dts
+++ b/arch/arm/boot/dts/zynq-zc702-adv7511-fmcomms1.dts
@@ -8,7 +8,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 57 0>;
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 
 		adi,channels {
@@ -29,7 +29,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 56 0>;
+		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 
 		adi,channels {

--- a/arch/arm/boot/dts/zynq-zc702-adv7511-fmcomms1.dts
+++ b/arch/arm/boot/dts/zynq-zc702-adv7511-fmcomms1.dts
@@ -1,7 +1,7 @@
 /dts-v1/;
 
-/include/ "zynq-zc702.dtsi"
-/include/ "zynq-zc702-adv7511.dtsi"
+#include "zynq-zc702.dtsi"
+#include "zynq-zc702-adv7511.dtsi"
 
 &fpga_axi {
 	rx_dma: dma@7c400000 {
@@ -65,4 +65,4 @@
 	};
 };
 
-/include/ "adi-fmcomms1.dtsi"
+#include "adi-fmcomms1.dtsi"

--- a/arch/arm/boot/dts/zynq-zc702-adv7511.dts
+++ b/arch/arm/boot/dts/zynq-zc702-adv7511.dts
@@ -1,4 +1,4 @@
 /dts-v1/;
 
-/include/ "zynq-zc702.dtsi"
-/include/ "zynq-zc702-adv7511.dtsi"
+#include "zynq-zc702.dtsi"
+#include "zynq-zc702-adv7511.dtsi"

--- a/arch/arm/boot/dts/zynq-zc702-adv7511.dtsi
+++ b/arch/arm/boot/dts/zynq-zc702-adv7511.dtsi
@@ -82,7 +82,7 @@
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x43000000 0x10000>;
 			#dma-cells = <1>;
-			interrupts = <0 59 0>;
+			interrupts = <0 59 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&clkc 16>;
 
 			adi,channels {

--- a/arch/arm/boot/dts/zynq-zc702-adv7511.dtsi
+++ b/arch/arm/boot/dts/zynq-zc702-adv7511.dtsi
@@ -9,7 +9,7 @@
 			compatible = "xlnx,axi-iic-1.02.a", "xlnx,xps-iic-2.00.a";
 			reg = <0x41600000 0x10000>;
 			interrupt-parent = <&intc>;
-			interrupts = <0 58 4>;
+			interrupts = <0 58 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&clkc 15>;
 			clock-names = "pclk";
 

--- a/arch/arm/boot/dts/zynq-zc702.dtsi
+++ b/arch/arm/boot/dts/zynq-zc702.dtsi
@@ -1,5 +1,7 @@
 /include/ "zynq.dtsi"
 
+#include <dt-bindings/interrupt-controller/irq.h>
+
 / {
 	model = "Xilinx Zynq ZC702";
 

--- a/arch/arm/boot/dts/zynq-zc702.dtsi
+++ b/arch/arm/boot/dts/zynq-zc702.dtsi
@@ -1,4 +1,4 @@
-/include/ "zynq.dtsi"
+#include "zynq.dtsi"
 
 #include <dt-bindings/interrupt-controller/irq.h>
 

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad6676-fmc.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad6676-fmc.dts
@@ -100,7 +100,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 57 0>;
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 
 		adi,channels {

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad6676-fmc.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad6676-fmc.dts
@@ -1,7 +1,7 @@
 /dts-v1/;
 
-/include/ "zynq-zc706.dtsi"
-/include/ "zynq-zc706-adv7511.dtsi"
+#include "zynq-zc706.dtsi"
+#include "zynq-zc706-adv7511.dtsi"
 
 / {
 	clocks {

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad9136-fmc-ebz.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad9136-fmc-ebz.dts
@@ -1,7 +1,7 @@
 /dts-v1/;
 
-/include/ "zynq-zc706.dtsi"
-/include/ "zynq-zc706-adv7511.dtsi"
+#include "zynq-zc706.dtsi"
+#include "zynq-zc706-adv7511.dtsi"
 
 &i2c_mux {
 	i2c@5 { /* HPC IIC */

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad9172-fmc-ebz.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad9172-fmc-ebz.dts
@@ -1,7 +1,7 @@
 /dts-v1/;
 
-/include/ "zynq-zc706.dtsi"
-/include/ "zynq-zc706-adv7511.dtsi"
+#include "zynq-zc706.dtsi"
+#include "zynq-zc706-adv7511.dtsi"
 
 &fpga_axi {
 	tx_dma: tx-dmac@7c420000 {

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad9172-fmc-ebz.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad9172-fmc-ebz.dts
@@ -8,7 +8,7 @@
 		#dma-cells = <1>;
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x10000>;
-		interrupts = <0 56 0>;
+		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 
 		adi,channels {

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad9265-fmc-125ebz.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad9265-fmc-125ebz.dts
@@ -1,7 +1,7 @@
 /dts-v1/;
 
-/include/ "zynq-zc706.dtsi"
-/include/ "zynq-zc706-adv7511.dtsi"
+#include "zynq-zc706.dtsi"
+#include "zynq-zc706-adv7511.dtsi"
 
 &fpga_axi {
 	rx_dma: rx-dmac@44a30000 {

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad9265-fmc-125ebz.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad9265-fmc-125ebz.dts
@@ -8,7 +8,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x44a30000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 57 0>;
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 
 		adi,channels {

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad9361-4-fmcomms2-3-4-userspace.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad9361-4-fmcomms2-3-4-userspace.dts
@@ -1,7 +1,7 @@
 /dts-v1/;
 
-/include/ "zynq-zc706.dtsi"
-/include/ "zynq-zc706-adv7511.dtsi"
+#include "zynq-zc706.dtsi"
+#include "zynq-zc706-adv7511.dtsi"
 
 &i2c_mux {
 	fmc_i2c: i2c@6 {

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad9361-fmcomms2-3.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad9361-fmcomms2-3.dts
@@ -1,7 +1,7 @@
 /dts-v1/;
 
-/include/ "zynq-zc706.dtsi"
-/include/ "zynq-zc706-adv7511.dtsi"
+#include "zynq-zc706.dtsi"
+#include "zynq-zc706-adv7511.dtsi"
 
 &i2c_mux {
 	fmc_i2c: i2c@6 {

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad9361-fmcomms2-3.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad9361-fmcomms2-3.dts
@@ -16,7 +16,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 57 0>;
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 
 		adi,channels {
@@ -37,7 +37,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 56 0>;
+		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 
 		adi,channels {

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad9361-fmcomms5-userspace.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad9361-fmcomms5-userspace.dts
@@ -1,7 +1,7 @@
 /dts-v1/;
 
-/include/ "zynq-zc706.dtsi"
-/include/ "zynq-zc706-adv7511.dtsi"
+#include "zynq-zc706.dtsi"
+#include "zynq-zc706-adv7511.dtsi"
 
 &i2c_mux {
 	fmc_i2c: i2c@6 {

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad9361-fmcomms5.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad9361-fmcomms5.dts
@@ -1,7 +1,7 @@
 /dts-v1/;
 
-/include/ "zynq-zc706.dtsi"
-/include/ "zynq-zc706-adv7511.dtsi"
+#include "zynq-zc706.dtsi"
+#include "zynq-zc706-adv7511.dtsi"
 
 &i2c_mux {
 	fmc_i2c: i2c@5 { /* HPC */

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad9361-fmcomms5.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad9361-fmcomms5.dts
@@ -16,7 +16,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 57 0>;
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 
 		adi,channels {
@@ -37,7 +37,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 56 0>;
+		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 
 		adi,channels {

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad9364-fmcomms4.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad9364-fmcomms4.dts
@@ -1,7 +1,7 @@
 /dts-v1/;
 
-/include/ "zynq-zc706.dtsi"
-/include/ "zynq-zc706-adv7511.dtsi"
+#include "zynq-zc706.dtsi"
+#include "zynq-zc706-adv7511.dtsi"
 
 &i2c_mux {
 	fmc_i2c: i2c@6 {

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad9364-fmcomms4.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad9364-fmcomms4.dts
@@ -16,7 +16,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 57 0>;
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 
 		adi,channels {
@@ -37,7 +37,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 56 0>;
+		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 
 		adi,channels {

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad9434-fmc-500ebz.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad9434-fmc-500ebz.dts
@@ -1,7 +1,7 @@
 /dts-v1/;
 
-/include/ "zynq-zc706.dtsi"
-/include/ "zynq-zc706-adv7511.dtsi"
+#include "zynq-zc706.dtsi"
+#include "zynq-zc706-adv7511.dtsi"
 
 &fpga_axi {
 	rx_dma: rx-dmac@44a30000 {

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad9434-fmc-500ebz.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad9434-fmc-500ebz.dts
@@ -8,7 +8,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x44a30000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 57 0>; /* 57 */
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>; /* 57 */
 		clocks = <&clkc 16>;
 
 		adi,channels {

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad9625-fmcadc2.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad9625-fmcadc2.dts
@@ -75,7 +75,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 57 0>;
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 
 		adi,channels {

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad9625-fmcadc2.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad9625-fmcadc2.dts
@@ -1,7 +1,7 @@
 /dts-v1/;
 
-/include/ "zynq-zc706.dtsi"
-/include/ "zynq-zc706-adv7511.dtsi"
+#include "zynq-zc706.dtsi"
+#include "zynq-zc706-adv7511.dtsi"
 
 / {
 	clocks {

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad9625-fmcadc3.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad9625-fmcadc3.dts
@@ -1,4 +1,4 @@
-/include/ "zynq-zc706-adv7511-ad9625-fmcadc2.dts"
+#include "zynq-zc706-adv7511-ad9625-fmcadc2.dts"
 
 &spi0 {
 	/* FMCADC3 only:

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad9625-fmcadc7.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad9625-fmcadc7.dts
@@ -1,7 +1,7 @@
 /dts-v1/;
 
-/include/ "zynq-zc706.dtsi"
-/include/ "zynq-zc706-adv7511.dtsi"
+#include "zynq-zc706.dtsi"
+#include "zynq-zc706-adv7511.dtsi"
 
 / {
 

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad9625-fmcadc7.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad9625-fmcadc7.dts
@@ -107,7 +107,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 57 0>;
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 
 		dma-channel {

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad9739a-fmc.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad9739a-fmc.dts
@@ -41,7 +41,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 56 0>;
+		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 
 		adi,channels {

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad9739a-fmc.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad9739a-fmc.dts
@@ -1,7 +1,7 @@
 /dts-v1/;
 
-/include/ "zynq-zc706.dtsi"
-/include/ "zynq-zc706-adv7511.dtsi"
+#include "zynq-zc706.dtsi"
+#include "zynq-zc706-adv7511.dtsi"
 
 &i2c_mux {
 	fmc_i2c: i2c@6 {

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9008-1.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9008-1.dts
@@ -7,8 +7,8 @@
 */
 /dts-v1/;
 
-/include/ "zynq-zc706.dtsi"
-/include/ "zynq-zc706-adv7511.dtsi"
+#include "zynq-zc706.dtsi"
+#include "zynq-zc706-adv7511.dtsi"
 
 &i2c_mux {
 	i2c@5 { /* HPC IIC */

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9008-1.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9008-1.dts
@@ -39,7 +39,7 @@
 		reg = <0x7c400000 0x10000>;
 		#dma-cells = <1>;
 		#clock-cells = <0>;
-		interrupts = <0 57 0>;
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 
 		adi,channels {

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9008-2.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9008-2.dts
@@ -39,7 +39,7 @@
 		reg = <0x7c440000 0x10000>;
 		#dma-cells = <1>;
 		#clock-cells = <0>;
-		interrupts = <0 55 0>;
+		interrupts = <0 55 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 
 		adi,channels {
@@ -60,7 +60,7 @@
 		reg = <0x7c420000 0x10000>;
 		#dma-cells = <1>;
 		#clock-cells = <0>;
-		interrupts = <0 56 0>;
+		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 
 		adi,channels {

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9008-2.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9008-2.dts
@@ -7,8 +7,8 @@
 */
 /dts-v1/;
 
-/include/ "zynq-zc706.dtsi"
-/include/ "zynq-zc706-adv7511.dtsi"
+#include "zynq-zc706.dtsi"
+#include "zynq-zc706-adv7511.dtsi"
 
 &i2c_mux {
 	i2c@5 { /* HPC IIC */

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9009.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9009.dts
@@ -34,7 +34,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 57 0>;
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 
 		adi,channels {
@@ -55,7 +55,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c440000  0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 55 0>;
+		interrupts = <0 55 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 
 		adi,channels {
@@ -76,7 +76,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 56 0>;
+		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 
 		adi,channels {

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9009.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9009.dts
@@ -1,7 +1,7 @@
 /dts-v1/;
 
-/include/ "zynq-zc706.dtsi"
-/include/ "zynq-zc706-adv7511.dtsi"
+#include "zynq-zc706.dtsi"
+#include "zynq-zc706-adv7511.dtsi"
 #include <dt-bindings/gpio/gpio.h>
 
 

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9371.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9371.dts
@@ -1,7 +1,7 @@
 /dts-v1/;
 
-/include/ "zynq-zc706.dtsi"
-/include/ "zynq-zc706-adv7511.dtsi"
+#include "zynq-zc706.dtsi"
+#include "zynq-zc706-adv7511.dtsi"
 #include <dt-bindings/gpio/gpio.h>
 
 &i2c_mux {

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9371.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9371.dts
@@ -32,7 +32,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 57 0>;
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 
 		adi,channels {
@@ -53,7 +53,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c440000  0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 55 0>;
+		interrupts = <0 55 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 
 		adi,channels {
@@ -74,7 +74,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 56 0>;
+		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 
 		adi,channels {

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-cn0506-mii.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-cn0506-mii.dts
@@ -1,5 +1,5 @@
 /dts-v1/;
 
-/include/ "zynq-zc706.dtsi"
-/include/ "zynq-zc706-adv7511.dtsi"
-/include/ "adi-cn0506-mii.dtsi"
+#include "zynq-zc706.dtsi"
+#include "zynq-zc706-adv7511.dtsi"
+#include "adi-cn0506-mii.dtsi"

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-cn0506-rgmii.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-cn0506-rgmii.dts
@@ -1,5 +1,5 @@
 /dts-v1/;
 
-/include/ "zynq-zc706.dtsi"
-/include/ "zynq-zc706-adv7511.dtsi"
-/include/ "adi-cn0506-rgmii.dtsi"
+#include "zynq-zc706.dtsi"
+#include "zynq-zc706-adv7511.dtsi"
+#include "adi-cn0506-rgmii.dtsi"

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcadc4.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcadc4.dts
@@ -8,7 +8,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 57 0>;
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 
 		adi,channels {

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcadc4.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcadc4.dts
@@ -1,7 +1,7 @@
 /dts-v1/;
 
-/include/ "zynq-zc706.dtsi"
-/include/ "zynq-zc706-adv7511.dtsi"
+#include "zynq-zc706.dtsi"
+#include "zynq-zc706-adv7511.dtsi"
 
 &fpga_axi {
 	rx_dma0: rx-dmac@7c400000 {

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcdaq1.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcdaq1.dts
@@ -8,7 +8,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x44a60000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 57 0>;
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 
 		adi,channels {

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcdaq1.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcdaq1.dts
@@ -1,7 +1,7 @@
 /dts-v1/;
 
-/include/ "zynq-zc706.dtsi"
-/include/ "zynq-zc706-adv7511.dtsi"
+#include "zynq-zc706.dtsi"
+#include "zynq-zc706-adv7511.dtsi"
 
 &fpga_axi {
 	rx_dma: dma@44a60000 {

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcdaq2.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcdaq2.dts
@@ -32,7 +32,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 57 0>;
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 
 		adi,channels {
@@ -53,7 +53,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 56 0>;
+		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 
 		adi,channels {

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcdaq2.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcdaq2.dts
@@ -1,7 +1,7 @@
 /dts-v1/;
 
-/include/ "zynq-zc706.dtsi"
-/include/ "zynq-zc706-adv7511.dtsi"
+#include "zynq-zc706.dtsi"
+#include "zynq-zc706-adv7511.dtsi"
 
 &i2c_mux {
 	i2c@5 { /* HPC IIC */

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcdaq3.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcdaq3.dts
@@ -31,7 +31,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 57 0>;
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 
 		adi,channels {
@@ -52,7 +52,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 56 0>;
+		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 
 		adi,channels {

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcdaq3.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcdaq3.dts
@@ -1,7 +1,7 @@
 /dts-v1/;
 
-/include/ "zynq-zc706.dtsi"
-/include/ "zynq-zc706-adv7511.dtsi"
+#include "zynq-zc706.dtsi"
+#include "zynq-zc706-adv7511.dtsi"
 
 &i2c_mux {
 	i2c@5 { /* HPC IIC */

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcjesdadc1.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcjesdadc1.dts
@@ -1,7 +1,7 @@
 /dts-v1/;
 
-/include/ "zynq-zc706.dtsi"
-/include/ "zynq-zc706-adv7511.dtsi"
+#include "zynq-zc706.dtsi"
+#include "zynq-zc706-adv7511.dtsi"
 
 &i2c_mux {
 	i2c@5 { /* HPC IIC */

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcjesdadc1.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcjesdadc1.dts
@@ -31,7 +31,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 57 0>;
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 
 		adi,channels {
@@ -52,7 +52,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c430000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 56 0>;
+		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 
 		adi,channels {

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmclidar1.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmclidar1.dts
@@ -67,7 +67,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 57 0>;
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 
 		adi,channels {

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmclidar1.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmclidar1.dts
@@ -31,7 +31,7 @@
 		fifo-size = <16>;
 		interrupt-names = "ip2intc_irpt";
 		interrupt-parent = <&intc>;
-		interrupts = <0 54 1>;
+		interrupts = <0 54 IRQ_TYPE_EDGE_RISING>;
 		num-cs = <0x1>;
 		xlnx,num-ss-bits = <0x1>;
 		xlnx,spi-mode = <0>;
@@ -48,7 +48,7 @@
 		fifo-size = <16>;
 		interrupt-names = "ip2intc_irpt";
 		interrupt-parent = <&intc>;
-		interrupts = <0 53 1>;
+		interrupts = <0 53 IRQ_TYPE_EDGE_RISING>;
 		num-cs = <0x1>;
 		xlnx,num-ss-bits = <0x1>;
 		xlnx,spi-mode = <0>;

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmclidar1.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmclidar1.dts
@@ -1,7 +1,7 @@
 /dts-v1/;
 
-/include/ "zynq-zc706.dtsi"
-/include/ "zynq-zc706-adv7511.dtsi"
+#include "zynq-zc706.dtsi"
+#include "zynq-zc706-adv7511.dtsi"
 
 &i2c_mux {
 	i2c@5 { /* HPC IIC */

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcomms1.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcomms1.dts
@@ -1,7 +1,7 @@
 /dts-v1/;
 
-/include/ "zynq-zc706.dtsi"
-/include/ "zynq-zc706-adv7511.dtsi"
+#include "zynq-zc706.dtsi"
+#include "zynq-zc706-adv7511.dtsi"
 
 &i2c_mux {
 	fmc_i2c: i2c@6 {
@@ -73,4 +73,4 @@
 	};
 };
 
-/include/ "adi-fmcomms1.dtsi"
+#include "adi-fmcomms1.dtsi"

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcomms1.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcomms1.dts
@@ -16,7 +16,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 57 0>;
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 
 		adi,channels {
@@ -37,7 +37,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 56 0>;
+		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 
 		adi,channels {

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcomms11-RevA.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcomms11-RevA.dts
@@ -1,7 +1,7 @@
 /dts-v1/;
 
-/include/ "zynq-zc706.dtsi"
-/include/ "zynq-zc706-adv7511.dtsi"
+#include "zynq-zc706.dtsi"
+#include "zynq-zc706-adv7511.dtsi"
 
 &i2c_mux {
 	i2c@5 { /* HPC IIC */

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcomms11-RevA.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcomms11-RevA.dts
@@ -31,7 +31,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 57 0>;
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 
 		adi,channels {
@@ -53,7 +53,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 56 0>;
+		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 
 		adi,channels {

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcomms11.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcomms11.dts
@@ -31,7 +31,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 57 0>;
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 
 		adi,channels {
@@ -52,7 +52,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 56 0>;
+		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 
 		adi,channels {

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcomms11.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcomms11.dts
@@ -1,7 +1,7 @@
 /dts-v1/;
 
-/include/ "zynq-zc706.dtsi"
-/include/ "zynq-zc706-adv7511.dtsi"
+#include "zynq-zc706.dtsi"
+#include "zynq-zc706-adv7511.dtsi"
 
 &i2c_mux {
 	i2c@5 { /* HPC IIC */

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcomms6.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcomms6.dts
@@ -16,7 +16,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 57 0>;
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 
 		adi,channels {

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcomms6.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcomms6.dts
@@ -1,7 +1,7 @@
 /dts-v1/;
 
-/include/ "zynq-zc706.dtsi"
-/include/ "zynq-zc706-adv7511.dtsi"
+#include "zynq-zc706.dtsi"
+#include "zynq-zc706-adv7511.dtsi"
 
 &i2c_mux {
 	fmc_i2c: i2c@6 { /* LPC */

--- a/arch/arm/boot/dts/zynq-zc706-adv7511.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511.dts
@@ -1,4 +1,4 @@
 /dts-v1/;
 
-/include/ "zynq-zc706.dtsi"
-/include/ "zynq-zc706-adv7511.dtsi"
+#include "zynq-zc706.dtsi"
+#include "zynq-zc706-adv7511.dtsi"

--- a/arch/arm/boot/dts/zynq-zc706-adv7511.dtsi
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511.dtsi
@@ -11,7 +11,7 @@
 			compatible = "xlnx,axi-iic-1.02.a", "xlnx,xps-iic-2.00.a";
 			reg = <0x41600000 0x10000>;
 			interrupt-parent = <&intc>;
-			interrupts = <0 58 4>;
+			interrupts = <0 58 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&clkc 15>;
 			clock-names = "pclk";
 

--- a/arch/arm/boot/dts/zynq-zc706-adv7511.dtsi
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511.dtsi
@@ -1,3 +1,5 @@
+#include <dt-bindings/interrupt-controller/irq.h>
+
 / {
 	fpga_axi: fpga-axi@0 {
 		compatible = "simple-bus";
@@ -108,7 +110,7 @@
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x43000000 0x10000>;
 			#dma-cells = <1>;
-			interrupts = <0 59 0>;
+			interrupts = <0 59 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&clkc 16>;
 
 			adi,channels {

--- a/arch/arm/boot/dts/zynq-zc706.dtsi
+++ b/arch/arm/boot/dts/zynq-zc706.dtsi
@@ -1,4 +1,4 @@
-/include/ "zynq.dtsi"
+#include "zynq.dtsi"
 
 #include <dt-bindings/interrupt-controller/irq.h>
 

--- a/arch/arm/boot/dts/zynq-zc706.dtsi
+++ b/arch/arm/boot/dts/zynq-zc706.dtsi
@@ -1,5 +1,7 @@
 /include/ "zynq.dtsi"
 
+#include <dt-bindings/interrupt-controller/irq.h>
+
 / {
 	model = "Xilinx Zynq ZC706";
 	memory {

--- a/arch/arm/boot/dts/zynq-zed-adf7242.dts
+++ b/arch/arm/boot/dts/zynq-zed-adf7242.dts
@@ -1,7 +1,7 @@
 /dts-v1/;
 
-/include/ "zynq-zed.dtsi"
-/include/ "zynq-zed-adv7511.dtsi"
+#include "zynq-zed.dtsi"
+#include "zynq-zed-adv7511.dtsi"
 
 /*
  * SPI:

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad4020.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad4020.dts
@@ -18,7 +18,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x44a30000 0x1000>;
 		#dma-cells = <1>;
-		interrupts = <0 57 0>;
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 
 		adi,channels {

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad4020.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad4020.dts
@@ -1,7 +1,7 @@
 /dts-v1/;
 
-/include/ "zynq-zed.dtsi"
-/include/ "zynq-zed-adv7511.dtsi"
+#include "zynq-zed.dtsi"
+#include "zynq-zed-adv7511.dtsi"
 
 / {
 	vref: regulator-vref {

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad4020.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad4020.dts
@@ -39,7 +39,7 @@
 		compatible = "adi,axi-spi-engine-1.00.a";
 		reg = <0x44a00000 0x1000>;
 		interrupt-parent = <&intc>;
-		interrupts = <0 56 4>;
+		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 15 &clkc 15>;
 		clock-names = "s_axi_aclk", "spi_clk";
 		num-cs = <1>;

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad5593r.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad5593r.dts
@@ -1,7 +1,7 @@
 /dts-v1/;
 
-/include/ "zynq-zed.dtsi"
-/include/ "zynq-zed-adv7511.dtsi"
+#include "zynq-zed.dtsi"
+#include "zynq-zed-adv7511.dtsi"
 
 /*
  * USING:

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad7768.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad7768.dts
@@ -1,7 +1,7 @@
 /dts-v1/;
 
-/include/ "zynq-zed.dtsi"
-/include/ "zynq-zed-adv7511.dtsi"
+#include "zynq-zed.dtsi"
+#include "zynq-zed-adv7511.dtsi"
 
 
 / {

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad7768.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad7768.dts
@@ -27,7 +27,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 57 0>;
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 
 		adi,channels {

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad9361-4-fmcomms2-3-4-userspace.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad9361-4-fmcomms2-3-4-userspace.dts
@@ -1,7 +1,7 @@
 /dts-v1/;
 
-/include/ "zynq-zed.dtsi"
-/include/ "zynq-zed-adv7511.dtsi"
+#include "zynq-zed.dtsi"
+#include "zynq-zed-adv7511.dtsi"
 
 &spi0 {
 	status = "okay";

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad9361-fmcomms2-3.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad9361-fmcomms2-3.dts
@@ -1,7 +1,7 @@
 /dts-v1/;
 
-/include/ "zynq-zed.dtsi"
-/include/ "zynq-zed-adv7511.dtsi"
+#include "zynq-zed.dtsi"
+#include "zynq-zed-adv7511.dtsi"
 
 &fpga_axi {
 	fmc_i2c: i2c@41620000 {

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad9361-fmcomms2-3.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad9361-fmcomms2-3.dts
@@ -8,7 +8,7 @@
 		compatible = "xlnx,axi-iic-1.01.b", "xlnx,xps-iic-2.00.a";
 		reg = <0x41620000 0x10000>;
 		interrupt-parent = <&intc>;
-		interrupts = <0 55 0x4>;
+		interrupts = <0 55 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 15>;
 		clock-names = "pclk";
 

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad9361-fmcomms2-3.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad9361-fmcomms2-3.dts
@@ -20,7 +20,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 57 0>;
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 
 		adi,channels {
@@ -41,7 +41,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 56 0>;
+		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 
 		adi,channels {

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad9364-fmcomms4.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad9364-fmcomms4.dts
@@ -1,7 +1,7 @@
 /dts-v1/;
 
-/include/ "zynq-zed.dtsi"
-/include/ "zynq-zed-adv7511.dtsi"
+#include "zynq-zed.dtsi"
+#include "zynq-zed-adv7511.dtsi"
 
 &fpga_axi {
 	fmc_i2c: i2c@41620000 {

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad9364-fmcomms4.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad9364-fmcomms4.dts
@@ -8,7 +8,7 @@
 		compatible = "xlnx,axi-iic-1.01.b", "xlnx,xps-iic-2.00.a";
 		reg = <0x41620000 0x10000>;
 		interrupt-parent = <&intc>;
-		interrupts = <0 55 0x4>;
+		interrupts = <0 55 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 15>;
 		clock-names = "pclk";
 

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad9364-fmcomms4.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad9364-fmcomms4.dts
@@ -20,7 +20,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 57 0>;
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 
 		adi,channels {
@@ -41,7 +41,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 56 0>;
+		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 
 		adi,channels {

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad9467-fmc-250ebz.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad9467-fmc-250ebz.dts
@@ -1,7 +1,7 @@
 /dts-v1/;
 
-/include/ "zynq-zed.dtsi"
-/include/ "zynq-zed-adv7511.dtsi"
+#include "zynq-zed.dtsi"
+#include "zynq-zed-adv7511.dtsi"
 
 &fpga_axi {
 	rx_dma: rx-dmac@44a30000 {

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad9467-fmc-250ebz.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad9467-fmc-250ebz.dts
@@ -8,7 +8,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x44A30000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 57 0>;
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 
 		adi,channels {

--- a/arch/arm/boot/dts/zynq-zed-adv7511-cn0363.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-cn0363.dts
@@ -1,5 +1,5 @@
 /dts-v1/;
 
-/include/ "zynq-zed.dtsi"
-/include/ "zynq-zed-adv7511.dtsi"
-/include/ "adi-zynq-cn0363.dtsi"
+#include "zynq-zed.dtsi"
+#include "zynq-zed-adv7511.dtsi"
+#include "adi-zynq-cn0363.dtsi"

--- a/arch/arm/boot/dts/zynq-zed-adv7511-cn0506-mii.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-cn0506-mii.dts
@@ -1,5 +1,5 @@
 /dts-v1/;
 
-/include/ "zynq-zed.dtsi"
-/include/ "zynq-zed-adv7511.dtsi"
-/include/ "adi-cn0506-mii.dtsi"
+#include "zynq-zed.dtsi"
+#include "zynq-zed-adv7511.dtsi"
+#include "adi-cn0506-mii.dtsi"

--- a/arch/arm/boot/dts/zynq-zed-adv7511-cn0506-rgmii.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-cn0506-rgmii.dts
@@ -1,5 +1,5 @@
 /dts-v1/;
 
-/include/ "zynq-zed.dtsi"
-/include/ "zynq-zed-adv7511.dtsi"
-/include/ "adi-cn0506-rgmii.dtsi"
+#include "zynq-zed.dtsi"
+#include "zynq-zed-adv7511.dtsi"
+#include "adi-cn0506-rgmii.dtsi"

--- a/arch/arm/boot/dts/zynq-zed-adv7511-display-rotary-test.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-display-rotary-test.dts
@@ -1,7 +1,7 @@
 /dts-v1/;
 
-/include/ "zynq-zed.dtsi"
-/include/ "zynq-zed-adv7511.dtsi"
+#include "zynq-zed.dtsi"
+#include "zynq-zed-adv7511.dtsi"
 
 /*
  * USING:

--- a/arch/arm/boot/dts/zynq-zed-adv7511-fmcmotcon2.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-fmcmotcon2.dts
@@ -124,7 +124,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x40510000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 57 0>;
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 15>;
 
 		adi,channels {
@@ -151,7 +151,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x40520000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 54 0>;
+		interrupts = <0 54 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 15>;
 
 		adi,channels {
@@ -183,7 +183,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x40540000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 53 0>;
+		interrupts = <0 53 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 15>;
 
 		adi,channels {
@@ -210,7 +210,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x40550000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 52 0>;
+		interrupts = <0 52 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 15>;
 
 		adi,channels {

--- a/arch/arm/boot/dts/zynq-zed-adv7511-fmcmotcon2.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-fmcmotcon2.dts
@@ -1,7 +1,7 @@
 /dts-v1/;
 
-/include/ "zynq-zed.dtsi"
-/include/ "zynq-zed-adv7511.dtsi"
+#include "zynq-zed.dtsi"
+#include "zynq-zed-adv7511.dtsi"
 
 /delete-node/ &gem0;
 /delete-node/ &gem1;

--- a/arch/arm/boot/dts/zynq-zed-adv7511-fmcmotcon2.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-fmcmotcon2.dts
@@ -15,7 +15,7 @@
 	eth0: eth0@e000b000 {
 		compatible = "xlnx,ps7-ethernet-1.00.a";
 		reg = <0xe000b000 0x1000>;
-		interrupts = <0 22 4>;
+		interrupts = <0 22 IRQ_TYPE_LEVEL_HIGH>;
 		interrupt-parent = <&intc>;
 		#address-cells = <0x1>;
 		#size-cells = <0x0>;
@@ -54,7 +54,7 @@
 	eth1: eth1@e000c000 {
 		compatible = "xlnx,ps7-ethernet-1.00.a";
 		reg = <0xe000c000 0x1000>;
-		interrupts = <0 45 4>;
+		interrupts = <0 45 IRQ_TYPE_LEVEL_HIGH>;
 		interrupt-parent = <&intc>;
 		#address-cells = <0x1>;
 		#size-cells = <0x0>;
@@ -84,7 +84,7 @@
 		compatible = "xlnx,axi-iic-1.01.b", "xlnx,xps-iic-2.00.a";
 		reg = <0x41620000 0x10000>;
 		interrupt-parent = <&intc>;
-		interrupts = <0 55 0x4>;
+		interrupts = <0 55 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 15>;
 		clock-names = "pclk";
 
@@ -101,7 +101,7 @@
 		compatible = "xlnx,axi-iic-1.01.b", "xlnx,xps-iic-2.00.a";
 		reg = <0x41510000 0x10000>;
 		interrupt-parent = <&intc>;
-		interrupts = <0 56 0x4>;
+		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 15>;
 		clock-names = "pclk";
 

--- a/arch/arm/boot/dts/zynq-zed-adv7511-fmcomms1.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-fmcomms1.dts
@@ -1,7 +1,7 @@
 /dts-v1/;
 
-/include/ "zynq-zed.dtsi"
-/include/ "zynq-zed-adv7511.dtsi"
+#include "zynq-zed.dtsi"
+#include "zynq-zed-adv7511.dtsi"
 
 &fpga_axi {
 	fmc_i2c: i2c@41620000 {
@@ -77,4 +77,4 @@
 	};
 };
 
-/include/ "adi-fmcomms1.dtsi"
+#include "adi-fmcomms1.dtsi"

--- a/arch/arm/boot/dts/zynq-zed-adv7511-fmcomms1.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-fmcomms1.dts
@@ -8,7 +8,7 @@
 		compatible = "xlnx,axi-iic-1.01.b", "xlnx,xps-iic-2.00.a";
 		reg = <0x41620000 0x10000>;
 		interrupt-parent = <&intc>;
-		interrupts = <0 55 0x4>;
+		interrupts = <0 55 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 15>;
 		clock-names = "pclk";
 

--- a/arch/arm/boot/dts/zynq-zed-adv7511-fmcomms1.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-fmcomms1.dts
@@ -20,7 +20,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 57 0>;
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 
 		adi,channels {
@@ -41,7 +41,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 56 0>;
+		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 
 		adi,channels {

--- a/arch/arm/boot/dts/zynq-zed-adv7511-imageon-loopback.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-imageon-loopback.dts
@@ -1,7 +1,7 @@
 /dts-v1/;
 
-/include/ "zynq-zed.dtsi"
-/include/ "zynq-zed-adv7511.dtsi"
+#include "zynq-zed.dtsi"
+#include "zynq-zed-adv7511.dtsi"
 #include <dt-bindings/gpio/gpio.h>
 
 / {

--- a/arch/arm/boot/dts/zynq-zed-adv7511-m2k-revb.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-m2k-revb.dts
@@ -152,7 +152,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c440000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 54 0>;
+		interrupts = <0 54 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 15>;
 
 		dma-channel {
@@ -166,7 +166,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c460000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 36 0>;
+		interrupts = <0 36 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 15>;
 
 		dma-channel {
@@ -179,7 +179,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c480000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 52 0>;
+		interrupts = <0 52 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 15>;
 
 		dma-channel {
@@ -223,7 +223,7 @@
 		reg = <0x7c400000 0x10000>;
 
 		#dma-cells = <1>;
-		interrupts = <0 57 0>;
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 15>;
 
 		dma-channel {
@@ -238,7 +238,7 @@
 		reg = <0x7c420000 0x10000>;
 
 		#dma-cells = <1>;
-		interrupts = <0 56 0>;
+		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 15>;
 
 		dma-channel {

--- a/arch/arm/boot/dts/zynq-zed-adv7511-m2k-revb.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-m2k-revb.dts
@@ -1,7 +1,7 @@
 /dts-v1/;
 
-/include/ "zynq-zed.dtsi"
-/include/ "zynq-zed-adv7511.dtsi"
+#include "zynq-zed.dtsi"
+#include "zynq-zed-adv7511.dtsi"
 
 &usb0 {
 	dr_mode = "otg";

--- a/arch/arm/boot/dts/zynq-zed-adv7511-m2k-revb.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-m2k-revb.dts
@@ -106,7 +106,7 @@
 	fmc_i2c: i2c@41620000 {
 		compatible = "xlnx,axi-iic-1.01.b", "xlnx,xps-iic-2.00.a";
 		interrupt-parent = <&intc>;
-		interrupts = <0 55 0x4>;
+		interrupts = <0 55 IRQ_TYPE_LEVEL_HIGH>;
 		reg = <0x41620000 0x10000>;
 
 		#size-cells = <0>;

--- a/arch/arm/boot/dts/zynq-zed-adv7511-m2k-revc.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-m2k-revc.dts
@@ -170,7 +170,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c440000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 54 0>;
+		interrupts = <0 54 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 15>;
 
 		dma-channel {
@@ -184,7 +184,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c460000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 36 0>;
+		interrupts = <0 36 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 15>;
 
 		dma-channel {
@@ -197,7 +197,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c480000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 53 0>;
+		interrupts = <0 53 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 15>;
 
 		dma-channel {
@@ -212,7 +212,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c460000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 52 0>;
+		interrupts = <0 52 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 15>;
 
 		dma-channel {
@@ -257,7 +257,7 @@
 		reg = <0x7c400000 0x10000>;
 
 		#dma-cells = <1>;
-		interrupts = <0 57 0>;
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 15>;
 
 		dma-channel {
@@ -272,7 +272,7 @@
 		reg = <0x7c420000 0x10000>;
 
 		#dma-cells = <1>;
-		interrupts = <0 56 0>;
+		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 15>;
 
 		dma-channel {

--- a/arch/arm/boot/dts/zynq-zed-adv7511-m2k-revc.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-m2k-revc.dts
@@ -1,7 +1,7 @@
 /dts-v1/;
 
-/include/ "zynq-zed.dtsi"
-/include/ "zynq-zed-adv7511.dtsi"
+#include "zynq-zed.dtsi"
+#include "zynq-zed-adv7511.dtsi"
 
 &usb0 {
 	dr_mode = "otg";

--- a/arch/arm/boot/dts/zynq-zed-adv7511-m2k-revc.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-m2k-revc.dts
@@ -122,7 +122,7 @@
 	fmc_i2c: i2c@41620000 {
 		compatible = "xlnx,axi-iic-1.01.b", "xlnx,xps-iic-2.00.a";
 		interrupt-parent = <&intc>;
-		interrupts = <0 55 0x4>;
+		interrupts = <0 55 IRQ_TYPE_LEVEL_HIGH>;
 		reg = <0x41620000 0x10000>;
 		clocks = <&clkc 15>;
 		clock-names = "pclk";

--- a/arch/arm/boot/dts/zynq-zed-adv7511-pmod-ad1-da1.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-pmod-ad1-da1.dts
@@ -1,7 +1,7 @@
 /dts-v1/;
 
-/include/ "zynq-zed.dtsi"
-/include/ "zynq-zed-adv7511.dtsi"
+#include "zynq-zed.dtsi"
+#include "zynq-zed-adv7511.dtsi"
 
 / {
 	adc_vref: fixedregulator@0 {

--- a/arch/arm/boot/dts/zynq-zed-adv7511.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511.dts
@@ -1,4 +1,4 @@
 /dts-v1/;
 
-/include/ "zynq-zed.dtsi"
-/include/ "zynq-zed-adv7511.dtsi"
+#include "zynq-zed.dtsi"
+#include "zynq-zed-adv7511.dtsi"

--- a/arch/arm/boot/dts/zynq-zed-adv7511.dtsi
+++ b/arch/arm/boot/dts/zynq-zed-adv7511.dtsi
@@ -9,7 +9,7 @@
 			compatible = "xlnx,axi-iic-1.01.b", "xlnx,xps-iic-2.00.a";
 			reg = <0x41600000 0x10000>;
 			interrupt-parent = <&intc>;
-			interrupts = <0 58 0x4>;
+			interrupts = <0 58 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&clkc 15>;
 			clock-names = "pclk";
 

--- a/arch/arm/boot/dts/zynq-zed-adv7511.dtsi
+++ b/arch/arm/boot/dts/zynq-zed-adv7511.dtsi
@@ -62,7 +62,7 @@
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x43000000 0x10000>;
 			#dma-cells = <1>;
-			interrupts = <0 59 0>;
+			interrupts = <0 59 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&clkc 16>;
 
 			adi,channels {

--- a/arch/arm/boot/dts/zynq-zed-imageon.dts
+++ b/arch/arm/boot/dts/zynq-zed-imageon.dts
@@ -13,7 +13,7 @@
 			compatible = "xlnx,axi-iic-1.02.a", "xlnx,xps-iic-2.00.a";
 			reg = <0x43c40000 0x10000>;
 			interrupt-parent = <&intc>;
-			interrupts = <0 55 4>;
+			interrupts = <0 55 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&clkc 15>;
 			clock-names = "pclk";
 

--- a/arch/arm/boot/dts/zynq-zed-imageon.dts
+++ b/arch/arm/boot/dts/zynq-zed-imageon.dts
@@ -114,7 +114,7 @@
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x43000000 0x10000>;
 			#dma-cells = <1>;
-			interrupts = <0 59 0>;
+			interrupts = <0 59 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&clkc 16>;
 
 			adi,channels {
@@ -185,7 +185,7 @@
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x43c20000 0x10000>;
 			#dma-cells = <1>;
-			interrupts = <0 56 0>;
+			interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&clkc 16>;
 
 			adi,channels {

--- a/arch/arm/boot/dts/zynq-zed-imageon.dts
+++ b/arch/arm/boot/dts/zynq-zed-imageon.dts
@@ -1,6 +1,6 @@
 /dts-v1/;
 
-/include/ "zynq-zed.dtsi"
+#include "zynq-zed.dtsi"
 
 / {
 	fpga_axi: fpga-axi@0 {

--- a/arch/arm/boot/dts/zynq-zed-seps525.dts
+++ b/arch/arm/boot/dts/zynq-zed-seps525.dts
@@ -1,7 +1,7 @@
 /dts-v1/;
 
-/include/ "zynq-zed.dtsi"
-/include/ "zynq-zed-adv7511.dtsi"
+#include "zynq-zed.dtsi"
+#include "zynq-zed-adv7511.dtsi"
 
 /*
  * USING:

--- a/arch/arm/boot/dts/zynq-zed.dtsi
+++ b/arch/arm/boot/dts/zynq-zed.dtsi
@@ -1,5 +1,7 @@
 /include/ "zynq.dtsi"
 
+#include <dt-bindings/interrupt-controller/irq.h>
+
 / {
 	model = "Xilinx Zynq ZED";
 	memory {

--- a/arch/arm/boot/dts/zynq-zed.dtsi
+++ b/arch/arm/boot/dts/zynq-zed.dtsi
@@ -1,4 +1,4 @@
-/include/ "zynq.dtsi"
+#include "zynq.dtsi"
 
 #include <dt-bindings/interrupt-controller/irq.h>
 

--- a/arch/arm/boot/dts/zynq.dtsi
+++ b/arch/arm/boot/dts/zynq.dtsi
@@ -1,5 +1,5 @@
 
-/include/ "zynq-7000.dtsi"
+#include "zynq-7000.dtsi"
 
 / {
 	interrupt-parent = <&intc>;


### PR DESCRIPTION
The main driver for this change is a recent change in the kernel, where there is a WARN_ON(*type == IRQ_TYPE_NONE), which pollutes the syslog on many of our DTs.
This code is in `drivers/irqchip/irq-gic.c` introduced via change 83a86fbb5b56b ("irqchip/gic: Loudly complain about the use of IRQ_TYPE_NONE").

The simplest solution would have been to revert the patch, but a rework of our DTs was done in order to update our DTs more properly.
It could be that later in the future the INT flags become more important, so it's best not to delay these changes.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>