### PR TITLE
arch: arm: update ADI zynq device-trees with proper interrupt definitions/flags (part 2)

### DIFF
--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad6676-fmc.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad6676-fmc.dts
@@ -129,7 +129,7 @@
 		compatible = "adi,axi-jesd204-rx-1.0";
 		reg = <0x44aa0000 0x1000>;
 
-		interrupts = <0 56 0>;
+		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
 
 		clocks = <&clkc 16>, <&axi_adxcvr 1>, <&axi_adxcvr 0>;
 		clock-names = "s_axi_aclk", "device_clk", "lane_clk";

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad9172-fmc-ebz.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad9172-fmc-ebz.dts
@@ -39,7 +39,7 @@
 		compatible = "adi,axi-jesd204-tx-1.0";
 		reg = <0x44A90000 0x4000>;
 
-		interrupts = <0 54 0>;
+		interrupts = <0 54 IRQ_TYPE_LEVEL_HIGH>;
 
 		clocks = <&clkc 16>, <&axi_ad9172_adxcvr 1>, <&axi_ad9172_adxcvr 0>;
 		clock-names = "s_axi_aclk", "device_clk", "lane_clk";

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad9625-fmcadc2.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad9625-fmcadc2.dts
@@ -104,7 +104,7 @@
 		compatible = "adi,axi-jesd204-rx-1.0";
 		reg = <0x44aa0000 0x1000>;
 
-		interrupts = <0 56 0>;
+		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
 
 		clocks = <&clkc 16>, <&axi_adxcvr 1>, <&axi_adxcvr 0>;
 		clock-names = "s_axi_aclk", "device_clk", "lane_clk";

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9008-1.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9008-1.dts
@@ -68,7 +68,7 @@
 		compatible = "adi,axi-jesd204-rx-1.0";
 		reg = <0x44aa0000 0x1000>;
 
-		interrupts = <0 54 0>;
+		interrupts = <0 54 IRQ_TYPE_LEVEL_HIGH>;
 
 		clocks = <&clkc 16>, <&axi_rx_clkgen>, <&axi_adrv9009_adxcvr_rx 0>;
 		clock-names = "s_axi_aclk", "device_clk", "lane_clk";

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9008-2.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9008-2.dts
@@ -121,7 +121,7 @@
 		compatible = "adi,axi-jesd204-rx-1.0";
 		reg = <0x44ab0000 0x1000>;
 
-		interrupts = <0 52 0>;
+		interrupts = <0 52 IRQ_TYPE_LEVEL_HIGH>;
 
 		clocks = <&clkc 16>, <&axi_rx_os_clkgen>, <&axi_adrv9009_adxcvr_rx_os 0>;
 		clock-names = "s_axi_aclk", "device_clk", "lane_clk";

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9008-2.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9008-2.dts
@@ -101,7 +101,7 @@
 		compatible = "adi,axi-jesd204-tx-1.0";
 		reg = <0x44a90000 0x1000>;
 
-		interrupts = <0 53 0>;
+		interrupts = <0 53 IRQ_TYPE_LEVEL_HIGH>;
 
 		clocks = <&clkc 16>, <&axi_tx_clkgen>, <&axi_adrv9009_adxcvr_tx 0>;
 		clock-names = "s_axi_aclk", "device_clk", "lane_clk";

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9009.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9009.dts
@@ -129,7 +129,7 @@
 		compatible = "adi,axi-jesd204-rx-1.0";
 		reg = <0x44aa0000 0x1000>;
 
-		interrupts = <0 54 0>;
+		interrupts = <0 54 IRQ_TYPE_LEVEL_HIGH>;
 
 		clocks = <&clkc 16>, <&axi_rx_clkgen>, <&axi_adrv9009_adxcvr_rx 0>;
 		clock-names = "s_axi_aclk", "device_clk", "lane_clk";
@@ -165,7 +165,7 @@
 		compatible = "adi,axi-jesd204-rx-1.0";
 		reg = <0x44ab0000 0x1000>;
 
-		interrupts = <0 52 0>;
+		interrupts = <0 52 IRQ_TYPE_LEVEL_HIGH>;
 
 		clocks = <&clkc 16>, <&axi_rx_os_clkgen>, <&axi_adrv9009_adxcvr_rx_os 0>;
 		clock-names = "s_axi_aclk", "device_clk", "lane_clk";

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9009.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9009.dts
@@ -145,7 +145,7 @@
 		compatible = "adi,axi-jesd204-tx-1.0";
 		reg = <0x44a90000 0x1000>;
 
-		interrupts = <0 53 0>;
+		interrupts = <0 53 IRQ_TYPE_LEVEL_HIGH>;
 
 		clocks = <&clkc 16>, <&axi_tx_clkgen>, <&axi_adrv9009_adxcvr_tx 0>;
 		clock-names = "s_axi_aclk", "device_clk", "lane_clk";

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9371.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9371.dts
@@ -143,7 +143,7 @@
 		compatible = "adi,axi-jesd204-tx-1.0";
 		reg = <0x44a90000 0x1000>;
 
-		interrupts = <0 53 0>;
+		interrupts = <0 53 IRQ_TYPE_LEVEL_HIGH>;
 
 		clocks = <&clkc 16>, <&axi_tx_clkgen>, <&axi_ad9371_adxcvr_tx 0>;
 		clock-names = "s_axi_aclk", "device_clk", "lane_clk";

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9371.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9371.dts
@@ -127,7 +127,7 @@
 		compatible = "adi,axi-jesd204-rx-1.0";
 		reg = <0x44aa0000 0x1000>;
 
-		interrupts = <0 54 0>;
+		interrupts = <0 54 IRQ_TYPE_LEVEL_HIGH>;
 
 		clocks = <&clkc 16>, <&axi_rx_clkgen>, <&axi_ad9371_adxcvr_rx 0>;
 		clock-names = "s_axi_aclk", "device_clk", "lane_clk";
@@ -163,7 +163,7 @@
 		compatible = "adi,axi-jesd204-rx-1.0";
 		reg = <0x44ab0000 0x1000>;
 
-		interrupts = <0 52 0>;
+		interrupts = <0 52 IRQ_TYPE_LEVEL_HIGH>;
 
 		clocks = <&clkc 16>, <&axi_rx_os_clkgen>, <&axi_ad9371_adxcvr_rx_os 0>;
 		clock-names = "s_axi_aclk", "device_clk", "lane_clk";

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcadc4.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcadc4.dts
@@ -46,7 +46,7 @@
 		compatible = "adi,axi-jesd204-rx-1.0";
 		reg = <0x44aa0000 0x1000>;
 
-		interrupts = <0 56 0>;
+		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
 
 		clocks = <&clkc 16>, <&axi_adxcvr 1>, <&axi_adxcvr 0>;
 		clock-names = "s_axi_aclk", "device_clk", "lane_clk";

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcdaq2.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcdaq2.dts
@@ -83,7 +83,7 @@
 		compatible = "adi,axi-jesd204-tx-1.0";
 		reg = <0x44a90000 0x1000>;
 
-		interrupts = <0 54 0>;
+		interrupts = <0 54 IRQ_TYPE_LEVEL_HIGH>;
 
 		clocks = <&clkc 16>, <&axi_ad9144_adxcvr 1>, <&axi_ad9144_adxcvr 0>;
 		clock-names = "s_axi_aclk", "device_clk", "lane_clk";

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcdaq2.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcdaq2.dts
@@ -110,7 +110,7 @@
 		compatible = "adi,axi-jesd204-rx-1.0";
 		reg = <0x44aa0000 0x1000>;
 
-		interrupts = <0 55 0>;
+		interrupts = <0 55 IRQ_TYPE_LEVEL_HIGH>;
 
 		clocks = <&clkc 16>, <&axi_ad9680_adxcvr 1>, <&axi_ad9680_adxcvr 0>;
 		clock-names = "s_axi_aclk", "device_clk", "lane_clk";

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcdaq3.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcdaq3.dts
@@ -84,7 +84,7 @@
 		compatible = "adi,axi-jesd204-tx-1.0";
 		reg = <0x44a90000 0x1000>;
 
-		interrupts = <0 54 0>;
+		interrupts = <0 54 IRQ_TYPE_LEVEL_HIGH>;
 
 		clocks = <&clkc 16>, <&axi_ad9152_adxcvr 1>, <&axi_ad9152_adxcvr 0>;
 		clock-names = "s_axi_aclk", "device_clk", "lane_clk";

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcdaq3.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcdaq3.dts
@@ -112,7 +112,7 @@
 		compatible = "adi,axi-jesd204-rx-1.0";
 		reg = <0x44aa0000 0x1000>;
 
-		interrupts = <0 55 0>;
+		interrupts = <0 55 IRQ_TYPE_LEVEL_HIGH>;
 
 		clocks = <&clkc 16>, <&axi_ad9680_adxcvr 1>, <&axi_ad9680_adxcvr 0>;
 		clock-names = "s_axi_aclk", "device_clk", "lane_clk";

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcjesdadc1.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcjesdadc1.dts
@@ -91,7 +91,7 @@
 		compatible = "adi,axi-jesd204-rx-1.0";
 		reg = <0x44aa0000 0x1000>;
 
-		interrupts = <0 55 0>;
+		interrupts = <0 55 IRQ_TYPE_LEVEL_HIGH>;
 
 		clocks = <&clkc 16>, <&axi_adxcvr 1>, <&axi_adxcvr 0>;
 		clock-names = "s_axi_aclk", "device_clk", "lane_clk";

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmclidar1.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmclidar1.dts
@@ -97,7 +97,7 @@
 		compatible = "adi,axi-jesd204-rx-1.0";
 		reg = <0x44aa0000 0x1000>;
 
-		interrupts = <0 55 0>;
+		interrupts = <0 55 IRQ_TYPE_LEVEL_HIGH>;
 
 		clocks = <&clkc 16>, <&ad9528 4>, <&axi_ad9094_adxcvr 0>;
 		clock-names = "s_axi_aclk", "device_clk", "lane_clk";

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmclidar1.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmclidar1.dts
@@ -59,7 +59,7 @@
 	axi_pulse_capture: axi-pulse-capture@7c700000 {
 		compatible = "adi,axi-pulse-capture-1.00.a";
 		reg = <0x7c700000 0x10000>;
-		interrupts = <0 52 0>;
+		interrupts = <0 52 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&axi_ad9094_adxcvr 1>;
 	};
 

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcomms11-RevA.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcomms11-RevA.dts
@@ -109,7 +109,7 @@
 		compatible = "adi,axi-jesd204-rx-1.0";
 		reg = <0x44aa0000 0x1000>;
 
-		interrupts = <0 55 0>;
+		interrupts = <0 55 IRQ_TYPE_LEVEL_HIGH>;
 
 		clocks = <&clkc 16>, <&rx_adxcvr 1>, <&rx_adxcvr 0>;
 		clock-names = "s_axi_aclk", "device_clk", "lane_clk";

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcomms11-RevA.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcomms11-RevA.dts
@@ -82,7 +82,7 @@
 		compatible = "adi,axi-jesd204-tx-1.0";
 		reg = <0x44a90000 0x1000>;
 
-		interrupts = <0 54 0>;
+		interrupts = <0 54 IRQ_TYPE_LEVEL_HIGH>;
 
 		clocks = <&clkc 16>, <&tx_adxcvr 1>, <&tx_adxcvr 0>;
 		clock-names = "s_axi_aclk", "device_clk", "lane_clk";

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcomms11.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcomms11.dts
@@ -110,7 +110,7 @@
 		compatible = "adi,axi-jesd204-rx-1.0";
 		reg = <0x44aa0000 0x1000>;
 
-		interrupts = <0 55 0>;
+		interrupts = <0 55 IRQ_TYPE_LEVEL_HIGH>;
 
 		clocks = <&clkc 16>, <&rx_adxcvr 1>, <&rx_adxcvr 0>;
 		clock-names = "s_axi_aclk", "device_clk", "lane_clk";

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcomms11.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcomms11.dts
@@ -82,7 +82,7 @@
 		compatible = "adi,axi-jesd204-tx-1.0";
 		reg = <0x44a90000 0x1000>;
 
-		interrupts = <0 54 0>;
+		interrupts = <0 54 IRQ_TYPE_LEVEL_HIGH>;
 
 		clocks = <&clkc 16>, <&tx_adxcvr 1>, <&tx_adxcvr 0>;
 		clock-names = "s_axi_aclk", "device_clk", "lane_clk";


### PR DESCRIPTION
Part 2 for #677 
This fixes warnings/IRQ flags for AXI JESD204 RX/TX & Lidar IP cores.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>