### PR TITLE
backport: clk-gpio: remove `clk-set-rate-parent-enable` prop 

### DIFF
--- a/arch/arm/boot/dts/zynq-adrv9361-z7035.dtsi
+++ b/arch/arm/boot/dts/zynq-adrv9361-z7035.dtsi
@@ -42,7 +42,6 @@
 		compatible = "gpio-gate-clock";
 		clocks = <&xo_40mhz_fixed_clk>;
 		enable-gpios = <&gpio0 105 0>; /* Set to 1 for extern AD9361_CLK (J1 on PZSDRCC-FMC) */
-		clk-set-rate-parent-enable;
 		clock-output-names = "ad9361_ext_refclk";
 	};
 

--- a/drivers/clk/clk-gpio.c
+++ b/drivers/clk/clk-gpio.c
@@ -209,7 +209,6 @@ static int gpio_clk_driver_probe(struct platform_device *pdev)
 	struct device_node *node = pdev->dev.of_node;
 	const char **parent_names, *gpio_name;
 	unsigned int num_parents;
-	unsigned long clk_flags;
 	struct gpio_desc *gpiod;
 	struct clk *clk;
 	bool is_mux;
@@ -243,16 +242,13 @@ static int gpio_clk_driver_probe(struct platform_device *pdev)
 		return ret;
 	}
 
-	clk_flags = of_property_read_bool(node, "clk-set-rate-parent-enable") ?
-			CLK_SET_RATE_PARENT : 0;
-
 	if (is_mux)
 		clk = clk_register_gpio_mux(&pdev->dev, node->name,
-				parent_names, num_parents, gpiod, clk_flags);
+				parent_names, num_parents, gpiod, 0);
 	else
 		clk = clk_register_gpio_gate(&pdev->dev, node->name,
 				parent_names ?  parent_names[0] : NULL, gpiod,
-				clk_flags);
+				CLK_SET_RATE_PARENT);
 	if (IS_ERR(clk))
 		return PTR_ERR(clk);
 


### PR DESCRIPTION
The clk-gpio driver always sets the parent rate now.
The change for the driver is also upstreamed.
This property can now be removed from the DT.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>