### PR TITLE
[backport] net: emaclite: fix compile warning in BUFFER_ALIGN

### DIFF
--- a/drivers/net/ethernet/xilinx/xilinx_emaclite.c
+++ b/drivers/net/ethernet/xilinx/xilinx_emaclite.c
@@ -98,7 +98,7 @@
 #define ALIGNMENT		4
 
 /* BUFFER_ALIGN(adr) calculates the number of bytes to the next alignment. */
-#define BUFFER_ALIGN(adr) ((ALIGNMENT - ((u32)adr)) % ALIGNMENT)
+#define BUFFER_ALIGN(adr) ((ALIGNMENT - ((ulong)adr)) % ALIGNMENT)
 
 #ifdef __BIG_ENDIAN
 #define xemaclite_readl		ioread32be


### PR DESCRIPTION
Use ulong instead of u32 to fix compile warning when building
kernel for arm64 (zynqmp):

drivers/net/ethernet/xilinx/xilinx_emaclite.c:98:42: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
   98 | #define BUFFER_ALIGN(adr) ((ALIGNMENT - ((u32)adr)) % ALIGNMENT)
      |                                          ^

Signed-off-by: Quanyang Wang <quanyang.wang@windriver.com>
Signed-off-by: Michal Simek <michal.simek@xilinx.com>
(cherry picked from commit bb248807fa923178ec6d4d76862e130fb8397bc5)