### PR TITLE
drm: adi_axi_hdmi: remove driver's fbdev reference

### DIFF
--- a/drivers/gpu/drm/adi_axi_hdmi/axi_hdmi_drv.h
+++ b/drivers/gpu/drm/adi_axi_hdmi/axi_hdmi_drv.h
@@ -24,7 +24,6 @@ struct axi_hdmi_encoder;
 
 struct axi_hdmi_private {
 	struct drm_device *drm_dev;
-	struct drm_fbdev_cma *fbdev;
 	struct drm_crtc *crtc;
 	struct axi_hdmi_encoder *encoder;
 	struct i2c_client *encoder_slave;


### PR DESCRIPTION
The newer kernel helpers hold a reference for the fbdev instance, and
offer some helpers/hooks to manage it.

This change removes the driver's reference, and hooks the DRM helpers.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>