### PR TITLE
arch: arm64: define interrupt-types for AXI IP cores

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-reva.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-reva.dts
@@ -1281,7 +1281,7 @@
 			compatible = "adi,axi-fan-control-1.00.a";
 			reg = <0x0 0x80000000 0x10000>;
 			clocks = <&zynqmp_clk 71>;
-			interrupts = <0 110 0>;
+			interrupts = <0 110 IRQ_TYPE_LEVEL_HIGH>;
 
 			adi,pulses-per-revolution = <2>;
 		};

--- a/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-reva.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-reva.dts
@@ -1195,7 +1195,7 @@
 			compatible = "adi,axi-jesd204-rx-1.0";
 			reg = <0x0 0x84a50000 0x1000>;
 
-			interrupts = <0 109 0>;
+			interrupts = <0 109 IRQ_TYPE_LEVEL_HIGH>;
 
 			clocks = <&zynqmp_clk 71>, <&hmc7044 7>, <&axi_adrv9009_adxcvr_rx 0>;
 			clock-names = "s_axi_aclk", "device_clk", "lane_clk";
@@ -1229,7 +1229,7 @@
 			compatible = "adi,axi-jesd204-rx-1.0";
 			reg = <0x0 0x84a70000 0x1000>;
 
-			interrupts = <0 107 0>;
+			interrupts = <0 107 IRQ_TYPE_LEVEL_HIGH>;
 
 			clocks = <&zynqmp_clk 71>, <&hmc7044 6>, <&axi_adrv9009_adxcvr_rx_os 0>;
 			clock-names = "s_axi_aclk", "device_clk", "lane_clk";
@@ -1261,7 +1261,7 @@
 			compatible = "adi,axi-jesd204-tx-1.0";
 			reg = <0x0 0x84a30000 0x1000>;
 
-			interrupts = <0 108 0>;
+			interrupts = <0 108 IRQ_TYPE_LEVEL_HIGH>;
 
 			clocks = <&zynqmp_clk 71>, <&hmc7044 6>, <&axi_adrv9009_adxcvr_tx 0>;
 			clock-names = "s_axi_aclk", "device_clk", "lane_clk";

--- a/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-reva.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-reva.dts
@@ -14,6 +14,7 @@
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/pinctrl/pinctrl-zynqmp.h>
 #include <dt-bindings/phy/phy.h>
+#include <dt-bindings/interrupt-controller/irq.h>
 #include <dt-bindings/iio/frequency/hmc7044.h>
 
 / {

--- a/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-reva.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-reva.dts
@@ -1291,7 +1291,7 @@
 			reg = <0x0 0x9c420000 0x10000>;
 			#dma-cells = <1>;
 			#clock-cells = <0>;
-			interrupts = <0 106 0>;
+			interrupts = <0 106 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&zynqmp_clk 73>;
 
 			adi,channels {
@@ -1313,7 +1313,7 @@
 			reg = <0x0 0x9c440000 0x10000>;
 			#dma-cells = <1>;
 			#clock-cells = <0>;
-			interrupts = <0 104 0>;
+			interrupts = <0 104 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&zynqmp_clk 73>;
 
 			adi,channels {
@@ -1335,7 +1335,7 @@
 			reg = <0x0 0x9c400000 0x10000>;
 			#dma-cells = <1>;
 			#clock-cells = <0>;
-			interrupts = <0 105 0>;
+			interrupts = <0 105 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&zynqmp_clk 73>;
 
 			adi,channels {

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9172-fmc-ebz.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9172-fmc-ebz.dts
@@ -6,6 +6,7 @@
  */
 
 #include "zynqmp-zcu102-rev1.0.dts"
+#include <dt-bindings/interrupt-controller/irq.h>
 
 &i2c1 {
 	i2c-mux@75 {

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9172-fmc-ebz.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9172-fmc-ebz.dts
@@ -72,7 +72,7 @@
 			compatible = "adi,axi-jesd204-tx-1.0";
 			reg = <0x84a90000 0x4000>;
 
-			interrupts = <0 106 0>;
+			interrupts = <0 106 IRQ_TYPE_LEVEL_HIGH>;
 
 			clocks = <&zynqmp_clk 71>, <&axi_ad9172_adxcvr 1>, <&axi_ad9172_adxcvr 0>;
 			clock-names = "s_axi_aclk", "device_clk", "lane_clk";

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9172-fmc-ebz.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9172-fmc-ebz.dts
@@ -41,7 +41,7 @@
 			#dma-cells = <1>;
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c420000 0x10000>;
-			interrupts = <0 108 0>;
+			interrupts = <0 108 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&zynqmp_clk 71>;
 
 			adi,channels {

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9208-hmc7044.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9208-hmc7044.dts
@@ -46,7 +46,7 @@
 			#dma-cells = <1>;
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c420000 0x10000>;
-			interrupts = <0 109 0>;
+			interrupts = <0 109 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&zynqmp_clk 71>;
 
 			adi,channels {

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9208-hmc7044.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9208-hmc7044.dts
@@ -74,7 +74,7 @@
 		axi_ad9208_jesd: axi-jesd204-rx@84aa0000 {
 			compatible = "adi,axi-jesd204-rx-1.0";
 			reg = <0x84aa0000 0x4000>;
-			interrupts = <0 108 0>;
+			interrupts = <0 108 IRQ_TYPE_LEVEL_HIGH>;
 
 			clocks = <&zynqmp_clk 71>, <&axi_ad9208_adxcvr 1>, <&axi_ad9208_adxcvr 0>;
 			clock-names = "s_axi_aclk", "device_clk", "lane_clk";

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9208-hmc7044.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9208-hmc7044.dts
@@ -7,6 +7,7 @@
  */
 
 #include "zynqmp-zcu102-rev1.0.dts"
+#include <dt-bindings/interrupt-controller/irq.h>
 #include <dt-bindings/iio/adc/adi,ad9208.h>
 #include <dt-bindings/iio/frequency/hmc7044.h>
 

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9208.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9208.dts
@@ -51,7 +51,7 @@
 			#dma-cells = <1>;
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c420000 0x10000>;
-			interrupts = <0 109 0>;
+			interrupts = <0 109 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&zynqmp_clk 71>;
 
 			adi,channels {

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9208.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9208.dts
@@ -79,7 +79,7 @@
 		axi_ad9208_jesd: axi-jesd204-rx@84aa0000 {
 			compatible = "adi,axi-jesd204-rx-1.0";
 			reg = <0x84aa0000 0x4000>;
-			interrupts = <0 108 0>;
+			interrupts = <0 108 IRQ_TYPE_LEVEL_HIGH>;
 
 			clocks = <&zynqmp_clk 71>, <&axi_ad9208_adxcvr 1>, <&axi_ad9208_adxcvr 0>;
 			clock-names = "s_axi_aclk", "device_clk", "lane_clk";

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9208.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9208.dts
@@ -7,6 +7,7 @@
  */
 
 #include "zynqmp-zcu102-rev1.0.dts"
+#include <dt-bindings/interrupt-controller/irq.h>
 #include <dt-bindings/iio/adc/adi,ad9208.h>
 
 &i2c1 {

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9361-fmcomms2-3.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9361-fmcomms2-3.dts
@@ -43,7 +43,7 @@
 			reg = <0x9c400000 0x10000>;
 			#dma-cells = <1>;
 			#clock-cells = <0>;
-			interrupts = <0 109 0>;
+			interrupts = <0 109 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&zynqmp_clk 71>;
 
 			adi,channels {
@@ -65,7 +65,7 @@
 			reg = <0x9c420000 0x10000>;
 			#dma-cells = <1>;
 			#clock-cells = <0>;
-			interrupts = <0 108 0>;
+			interrupts = <0 108 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&zynqmp_clk 71>;
 
 			adi,channels {

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9361-fmcomms2-3.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9361-fmcomms2-3.dts
@@ -7,6 +7,7 @@
  */
 
 #include "zynqmp-zcu102-rev1.0.dts"
+#include <dt-bindings/interrupt-controller/irq.h>
 
 &i2c1 {
 	i2c-mux@75 {

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9361-fmcomms5.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9361-fmcomms5.dts
@@ -7,6 +7,7 @@
  */
 
 #include "zynqmp-zcu102-rev1.0.dts"
+#include <dt-bindings/interrupt-controller/irq.h>
 
 &i2c1 {
 	i2c-mux@75 {

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9361-fmcomms5.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9361-fmcomms5.dts
@@ -40,7 +40,7 @@
 			reg = <0x9c400000 0x10000>;
 			#dma-cells = <1>;
 			#clock-cells = <0>;
-			interrupts = <0 109 0>;
+			interrupts = <0 109 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&zynqmp_clk 73>;
 
 			adi,channels {
@@ -62,7 +62,7 @@
 			reg = <0x9c420000 0x10000>;
 			#dma-cells = <1>;
 			#clock-cells = <0>;
-			interrupts = <0 108 0>;
+			interrupts = <0 108 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&zynqmp_clk 73>;
 
 			adi,channels {

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9364-fmcomms4.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9364-fmcomms4.dts
@@ -43,7 +43,7 @@
 			reg = <0x9c400000 0x10000>;
 			#dma-cells = <1>;
 			#clock-cells = <0>;
-			interrupts = <0 109 0>;
+			interrupts = <0 109 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&zynqmp_clk 71>;
 
 			adi,channels {
@@ -65,7 +65,7 @@
 			reg = <0x9c420000 0x10000>;
 			#dma-cells = <1>;
 			#clock-cells = <0>;
-			interrupts = <0 108 0>;
+			interrupts = <0 108 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&zynqmp_clk 71>;
 
 			adi,channels {

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9364-fmcomms4.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9364-fmcomms4.dts
@@ -7,6 +7,7 @@
  */
 
 #include "zynqmp-zcu102-rev1.0.dts"
+#include <dt-bindings/interrupt-controller/irq.h>
 
 &i2c1 {
 	i2c-mux@75 {

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9008-1.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9008-1.dts
@@ -72,7 +72,7 @@
 			compatible = "adi,axi-jesd204-rx-1.0";
 			reg = <0x84aa0000 0x1000>;
 
-			interrupts = <0 106 0>;
+			interrupts = <0 106 IRQ_TYPE_LEVEL_HIGH>;
 
 			clocks = <&zynqmp_clk 71>, <&axi_rx_clkgen>, <&axi_adrv9009_adxcvr_rx 0>;
 			clock-names = "s_axi_aclk", "device_clk", "lane_clk";

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9008-1.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9008-1.dts
@@ -6,6 +6,7 @@
  * Licensed under the GPL-2.
  */
 #include "zynqmp-zcu102-rev1.0.dts"
+#include <dt-bindings/interrupt-controller/irq.h>
 
 &i2c1 {
 	i2c-mux@75 {

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9008-1.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9008-1.dts
@@ -41,7 +41,7 @@
 			reg = <0x9c400000 0x10000>;
 			#dma-cells = <1>;
 			#clock-cells = <0>;
-			interrupts = <0 109 0>;
+			interrupts = <0 109 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&zynqmp_clk 73>;
 
 			adi,channels {

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9008-2.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9008-2.dts
@@ -107,7 +107,7 @@
 			compatible = "adi,axi-jesd204-tx-1.0";
 			reg = <0x84a90000 0x1000>;
 
-			interrupts = <0 105 0>;
+			interrupts = <0 105 IRQ_TYPE_LEVEL_HIGH>;
 
 			clocks = <&zynqmp_clk 71>, <&axi_tx_clkgen>, <&axi_adrv9009_adxcvr_tx 0>;
 			clock-names = "s_axi_aclk", "device_clk", "lane_clk";
@@ -127,7 +127,7 @@
 			compatible = "adi,axi-jesd204-rx-1.0";
 			reg = <0x84ab0000 0x1000>;
 
-			interrupts = <0 104 0>;
+			interrupts = <0 104 IRQ_TYPE_LEVEL_HIGH>;
 
 			clocks = <&zynqmp_clk 71>, <&axi_rx_os_clkgen>, <&axi_adrv9009_adxcvr_rx_os 0>;
 			clock-names = "s_axi_aclk", "device_clk", "lane_clk";

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9008-2.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9008-2.dts
@@ -41,7 +41,7 @@
 			reg = <0x9c440000 0x10000>;
 			#dma-cells = <1>;
 			#clock-cells = <0>;
-			interrupts = <0 107 0>;
+			interrupts = <0 107 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&zynqmp_clk 73>;
 
 			adi,channels {
@@ -63,7 +63,7 @@
 			reg = <0x9c420000 0x10000>;
 			#dma-cells = <1>;
 			#clock-cells = <0>;
-			interrupts = <0 108 0>;
+			interrupts = <0 108 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&zynqmp_clk 73>;
 
 			adi,channels {

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9008-2.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9008-2.dts
@@ -6,6 +6,7 @@
  * Licensed under the GPL-2.
  */
 #include "zynqmp-zcu102-rev1.0.dts"
+#include <dt-bindings/interrupt-controller/irq.h>
 
 &i2c1 {
 	i2c-mux@75 {

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9009.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9009.dts
@@ -52,7 +52,7 @@
 			reg = <0x9c400000 0x10000>;
 			#dma-cells = <1>;
 			#clock-cells = <0>;
-			interrupts = <0 109 0>;
+			interrupts = <0 109 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&zynqmp_clk 73>;
 
 			adi,channels {
@@ -74,7 +74,7 @@
 			reg = <0x9c440000 0x10000>;
 			#dma-cells = <1>;
 			#clock-cells = <0>;
-			interrupts = <0 107 0>;
+			interrupts = <0 107 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&zynqmp_clk 73>;
 
 			adi,channels {
@@ -96,7 +96,7 @@
 			reg = <0x9c420000 0x10000>;
 			#dma-cells = <1>;
 			#clock-cells = <0>;
-			interrupts = <0 108 0>;
+			interrupts = <0 108 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&zynqmp_clk 73>;
 
 			adi,channels {

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9009.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9009.dts
@@ -149,7 +149,7 @@
 			compatible = "adi,axi-jesd204-rx-1.0";
 			reg = <0x84aa0000 0x1000>;
 
-			interrupts = <0 106 0>;
+			interrupts = <0 106 IRQ_TYPE_LEVEL_HIGH>;
 
 			clocks = <&zynqmp_clk 71>, <&axi_rx_clkgen>, <&axi_adrv9009_adxcvr_rx 0>;
 			clock-names = "s_axi_aclk", "device_clk", "lane_clk";
@@ -165,7 +165,7 @@
 			compatible = "adi,axi-jesd204-tx-1.0";
 			reg = <0x84a90000 0x1000>;
 
-			interrupts = <0 105 0>;
+			interrupts = <0 105 IRQ_TYPE_LEVEL_HIGH>;
 
 			clocks = <&zynqmp_clk 71>, <&axi_tx_clkgen>, <&axi_adrv9009_adxcvr_tx 0>;
 			clock-names = "s_axi_aclk", "device_clk", "lane_clk";
@@ -185,7 +185,7 @@
 			compatible = "adi,axi-jesd204-rx-1.0";
 			reg = <0x84ab0000 0x1000>;
 
-			interrupts = <0 104 0>;
+			interrupts = <0 104 IRQ_TYPE_LEVEL_HIGH>;
 
 			clocks = <&zynqmp_clk 71>, <&axi_rx_os_clkgen>, <&axi_adrv9009_adxcvr_rx_os 0>;
 			clock-names = "s_axi_aclk", "device_clk", "lane_clk";

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9009.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9009.dts
@@ -1,4 +1,5 @@
 #include "zynqmp-zcu102-rev1.0.dts"
+#include <dt-bindings/interrupt-controller/irq.h>
 
 &i2c1 {
 	i2c-mux@75 {

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9371.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9371.dts
@@ -132,7 +132,7 @@
 			compatible = "adi,axi-jesd204-rx-1.0";
 			reg = <0x84aa0000 0x1000>;
 
-			interrupts = <0 106 0>;
+			interrupts = <0 106 IRQ_TYPE_LEVEL_HIGH>;
 
 			clocks = <&zynqmp_clk 71>, <&axi_rx_clkgen>, <&axi_ad9371_adxcvr_rx 0>;
 			clock-names = "s_axi_aclk", "device_clk", "lane_clk";
@@ -148,7 +148,7 @@
 			compatible = "adi,axi-jesd204-tx-1.0";
 			reg = <0x84a90000 0x1000>;
 
-			interrupts = <0 105 0>;
+			interrupts = <0 105 IRQ_TYPE_LEVEL_HIGH>;
 
 			clocks = <&zynqmp_clk 71>, <&axi_tx_clkgen>, <&axi_ad9371_adxcvr_tx 0>;
 			clock-names = "s_axi_aclk", "device_clk", "lane_clk";
@@ -168,7 +168,7 @@
 			compatible = "adi,axi-jesd204-rx-1.0";
 			reg = <0x84ab0000 0x1000>;
 
-			interrupts = <0 104 0>;
+			interrupts = <0 104 IRQ_TYPE_LEVEL_HIGH>;
 
 			clocks = <&zynqmp_clk 71>, <&axi_rx_os_clkgen>, <&axi_ad9371_adxcvr_rx_os 0>;
 			clock-names = "s_axi_aclk", "device_clk", "lane_clk";

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9371.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9371.dts
@@ -35,7 +35,7 @@
 			reg = <0x9c400000 0x10000>;
 			#dma-cells = <1>;
 			#clock-cells = <0>;
-			interrupts = <0 109 0>;
+			interrupts = <0 109 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&zynqmp_clk 73>;
 
 			adi,channels {
@@ -57,7 +57,7 @@
 			reg = <0x9c440000 0x10000>;
 			#dma-cells = <1>;
 			#clock-cells = <0>;
-			interrupts = <0 107 0>;
+			interrupts = <0 107 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&zynqmp_clk 73>;
 
 			adi,channels {
@@ -79,7 +79,7 @@
 			reg = <0x9c420000 0x10000>;
 			#dma-cells = <1>;
 			#clock-cells = <0>;
-			interrupts = <0 108 0>;
+			interrupts = <0 108 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&zynqmp_clk 73>;
 
 			adi,channels {

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9371.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9371.dts
@@ -1,4 +1,5 @@
 #include "zynqmp-zcu102-rev1.0.dts"
+#include <dt-bindings/interrupt-controller/irq.h>
 
 &i2c1 {
 	i2c-mux@75 {

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-fmcdaq2.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-fmcdaq2.dts
@@ -43,7 +43,7 @@
 			reg = <0x9c400000 0x10000>;
 			#dma-cells = <1>;
 			#clock-cells = <0>;
-			interrupts = <0 109 0>;
+			interrupts = <0 109 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&zynqmp_clk 71>;
 
 			adi,channels {
@@ -65,7 +65,7 @@
 			reg = <0x9c420000 0x10000>;
 			#dma-cells = <1>;
 			#clock-cells = <0>;
-			interrupts = <0 108 0>;
+			interrupts = <0 108 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&zynqmp_clk 71>;
 
 			adi,channels {

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-fmcdaq2.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-fmcdaq2.dts
@@ -95,7 +95,7 @@
 			compatible = "adi,axi-jesd204-tx-1.0";
 			reg = <0x84a90000 0x4000>;
 
-			interrupts = <0 106 0>;
+			interrupts = <0 106 IRQ_TYPE_LEVEL_HIGH>;
 
 			clocks = <&zynqmp_clk 71>, <&axi_ad9144_adxcvr 1>, <&axi_ad9144_adxcvr 0>;
 			clock-names = "s_axi_aclk", "device_clk", "lane_clk";
@@ -122,7 +122,7 @@
 			compatible = "adi,axi-jesd204-rx-1.0";
 			reg = <0x84aa0000 0x4000>;
 
-			interrupts = <0 107 0>;
+			interrupts = <0 107 IRQ_TYPE_LEVEL_HIGH>;
 
 			clocks = <&zynqmp_clk 71>, <&axi_ad9680_adxcvr 1>, <&axi_ad9680_adxcvr 0>;
 			clock-names = "s_axi_aclk", "device_clk", "lane_clk";

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-fmcdaq2.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-fmcdaq2.dts
@@ -7,6 +7,7 @@
  */
 
 #include "zynqmp-zcu102-rev1.0.dts"
+#include <dt-bindings/interrupt-controller/irq.h>
 
 &i2c1 {
 	i2c-mux@75 {

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-fmcdaq3.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-fmcdaq3.dts
@@ -42,7 +42,7 @@
 			#dma-cells = <1>;
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c400000 0x10000>;
-			interrupts = <0 109 0>;
+			interrupts = <0 109 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&zynqmp_clk 71>;
 
 			adi,channels {
@@ -63,7 +63,7 @@
 			#dma-cells = <1>;
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c420000 0x10000>;
-			interrupts = <0 108 0>;
+			interrupts = <0 108 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&zynqmp_clk 71>;
 
 			adi,channels {

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-fmcdaq3.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-fmcdaq3.dts
@@ -100,7 +100,7 @@
 		axi_ad9680_jesd: axi-jesd204-rx@84aa0000 {
 			compatible = "adi,axi-jesd204-rx-1.0";
 			reg = <0x84aa0000 0x4000>;
-			interrupts = <0 107 0>;
+			interrupts = <0 107 IRQ_TYPE_LEVEL_HIGH>;
 
 			clocks = <&zynqmp_clk 71>, <&axi_ad9680_adxcvr 1>, <&axi_ad9680_adxcvr 0>;
 			clock-names = "s_axi_aclk", "device_clk", "lane_clk";
@@ -132,7 +132,7 @@
 			compatible = "adi,axi-jesd204-tx-1.0";
 			reg = <0x84a90000 0x4000>;
 
-			interrupts = <0 106 0>;
+			interrupts = <0 106 IRQ_TYPE_LEVEL_HIGH>;
 
 			clocks = <&zynqmp_clk 71>, <&axi_ad9152_adxcvr 1>, <&axi_ad9152_adxcvr 0>;
 			clock-names = "s_axi_aclk", "device_clk", "lane_clk";

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-fmcdaq3.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-fmcdaq3.dts
@@ -7,6 +7,7 @@
  */
 
 #include "zynqmp-zcu102-rev1.0.dts"
+#include <dt-bindings/interrupt-controller/irq.h>
 
 &i2c1 {
 	i2c-mux@75 {

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-revB-ad9361-fmcomms2-3.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-revB-ad9361-fmcomms2-3.dts
@@ -42,7 +42,7 @@
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c400000 0x10000>;
 			#dma-cells = <1>;
-			interrupts = <0 109 0>;
+			interrupts = <0 109 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&zynqmp_clk 71>;
 
 			adi,channels {
@@ -64,7 +64,7 @@
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c420000 0x10000>;
 			#dma-cells = <1>;
-			interrupts = <0 108 0>;
+			interrupts = <0 108 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&zynqmp_clk 71>;
 
 			adi,channels {

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-revB-ad9361-fmcomms2-3.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-revB-ad9361-fmcomms2-3.dts
@@ -7,6 +7,7 @@
  */
 
 #include "zynqmp-zcu102-revB.dts"
+#include <dt-bindings/interrupt-controller/irq.h>
 
 &i2c1 {
 	i2c-mux@75 {

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-revB-ad9364-fmcomms4.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-revB-ad9364-fmcomms4.dts
@@ -7,6 +7,7 @@
  */
 
 #include "zynqmp-zcu102-revB.dts"
+#include <dt-bindings/interrupt-controller/irq.h>
 
 &i2c1 {
 	i2c-mux@75{

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-revB-ad9364-fmcomms4.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-revB-ad9364-fmcomms4.dts
@@ -42,7 +42,7 @@
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x80010000 0x10000>;
 			#dma-cells = <1>;
-			interrupts = <0 109 0>;
+			interrupts = <0 109 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&zynqmp_clk 71>;
 
 			adi,channels {
@@ -63,7 +63,7 @@
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x80020000 0x10000>;
 			#dma-cells = <1>;
-			interrupts = <0 108 0>;
+			interrupts = <0 108 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&zynqmp_clk 71>;
 
 			adi,channels {


### PR DESCRIPTION
Continuation of #678 for ZynqMP

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>