### PR TITLE
[rpi-4.19.y] clk: clk-gpio: remove unused variable in ``gpio_clk_driver_probe

### DIFF
--- a/drivers/clk/clk-gpio.c
+++ b/drivers/clk/clk-gpio.c
@@ -213,7 +213,6 @@ static int gpio_clk_driver_probe(struct platform_device *pdev)
 	struct clk *clk;
 	bool is_mux;
 	int ret;
-	unsigned long clk_flags;
 
 	num_parents = of_clk_get_parent_count(node);
 	if (num_parents) {


### PR DESCRIPTION
This was left-over from cherry-picking from master.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>