### PR TITLE
ci,build: configure default CROSS_COMPILE based on ARCH

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,17 +16,15 @@ env:
   matrix:
   - BUILD_TYPE=sync_branches_with_master_travis DO_NOT_DOCKERIZE=1
   - BUILD_TYPE=checkpatch DO_NOT_DOCKERIZE=1
-  - BUILD_TYPE=dtb_build_test ARCH=arm DTS_FILES=arch/arm/boot/dts/zynq-*.dts
-    CROSS_COMPILE=arm-linux-gnueabihf- DO_NOT_DOCKERIZE=1
-  - BUILD_TYPE=dtb_build_test ARCH=arm64 DTS_FILES=arch/arm64/boot/dts/xilinx/zynqmp-*.dts
-    CROSS_COMPILE=aarch64-linux-gnu- DO_NOT_DOCKERIZE=1
-  - DEFCONFIG=zynq_xcomm_adv7511_defconfig ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- IMAGE=uImage
-  - DEFCONFIG=zynq_pluto_defconfig ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- IMAGE=uImage
-  - DEFCONFIG=zynq_sidekiqz2_defconfig ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- IMAGE=uImage
-  - DEFCONFIG=adi_zynqmp_defconfig ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- IMAGE=Image
-  - DEFCONFIG=zynq_m2k_defconfig ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- IMAGE=uImage
-  - BUILD_TYPE=compile_test DEFCONFIG=zynq_xcomm_adv7511_defconfig ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf-
-  - BUILD_TYPE=compile_test DEFCONFIG=adi_zynqmp_defconfig ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu-
+  - BUILD_TYPE=dtb_build_test ARCH=arm DTS_FILES=arch/arm/boot/dts/zynq-*.dts DO_NOT_DOCKERIZE=1
+  - BUILD_TYPE=dtb_build_test ARCH=arm64 DTS_FILES=arch/arm64/boot/dts/xilinx/zynqmp-*.dts DO_NOT_DOCKERIZE=1
+  - DEFCONFIG=zynq_xcomm_adv7511_defconfig ARCH=arm IMAGE=uImage
+  - DEFCONFIG=zynq_pluto_defconfig ARCH=arm IMAGE=uImage
+  - DEFCONFIG=zynq_sidekiqz2_defconfig ARCH=arm IMAGE=uImage
+  - DEFCONFIG=adi_zynqmp_defconfig ARCH=arm64 IMAGE=Image
+  - DEFCONFIG=zynq_m2k_defconfig ARCH=arm IMAGE=uImage
+  - BUILD_TYPE=compile_test DEFCONFIG=zynq_xcomm_adv7511_defconfig ARCH=arm
+  - BUILD_TYPE=compile_test DEFCONFIG=adi_zynqmp_defconfig ARCH=arm64
 
 script:
   - ./ci/travis/run-build-docker.sh

--- a/ci/travis/run-build.sh
+++ b/ci/travis/run-build.sh
@@ -41,8 +41,20 @@ adjust_kcflags_against_gcc() {
 APT_LIST="build-essential bc u-boot-tools flex bison libssl-dev"
 
 if [ "$ARCH" == "arm64" ] ; then
+	if [ -z "$CROSS_COMPILE" ] ; then
+		CROSS_COMPILE=aarch64-linux-gnu-
+		export CROSS_COMPILE
+	fi
+
 	APT_LIST="$APT_LIST gcc-aarch64-linux-gnu"
-else
+fi
+
+if [ "$ARCH" == "arm" ] ; then
+	if [ -z "$CROSS_COMPILE" ] ; then
+		CROSS_COMPILE=arm-linux-gnueabihf-
+		export CROSS_COMPILE
+	fi
+
 	APT_LIST="$APT_LIST gcc-arm-linux-gnueabihf"
 fi
 


### PR DESCRIPTION
We typically don't configure other compiler types for the ARCHs that we
build, so just select the default CROSS_COMPILE prefixes in the script.

Users are still allowed to override them from outside the script.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>