### PR TITLE
[backports] iio: imu: adis:  assign values only on success paths (part 3)

### DIFF
--- a/drivers/iio/imu/adis.c
+++ b/drivers/iio/imu/adis.c
@@ -254,7 +254,8 @@ int adis_debugfs_reg_access(struct iio_dev *indio_dev,
 		int ret;
 
 		ret = adis_read_reg_16(adis, reg, &val16);
-		*readval = val16;
+		if (ret == 0)
+			*readval = val16;
 
 		return ret;
 	} else {

--- a/drivers/iio/imu/adis16480.c
+++ b/drivers/iio/imu/adis16480.c
@@ -522,12 +522,14 @@ static int adis16480_get_calibbias(struct iio_dev *indio_dev,
 	case IIO_MAGN:
 	case IIO_PRESSURE:
 		ret = adis_read_reg_16(&st->adis, reg, &val16);
-		*bias = sign_extend32(val16, 15);
+		if (ret == 0)
+			*bias = sign_extend32(val16, 15);
 		break;
 	case IIO_ANGL_VEL:
 	case IIO_ACCEL:
 		ret = adis_read_reg_32(&st->adis, reg, &val32);
-		*bias = sign_extend32(val32, 31);
+		if (ret == 0)
+			*bias = sign_extend32(val32, 31);
 		break;
 	default:
 			ret = -EINVAL;

--- a/include/linux/iio/imu/adis.h
+++ b/include/linux/iio/imu/adis.h
@@ -116,7 +116,7 @@ int __adis_read_reg(struct adis *adis, unsigned int reg,
 	unsigned int *val, unsigned int size);
 
 /**
- * __adis_write_reg_8() - Write single byte to a register (unlocked version)
+ * __adis_write_reg_8() - Write single byte to a register (unlocked)
  * @adis: The adis device
  * @reg: The address of the register to be written
  * @value: The value to write
@@ -128,7 +128,7 @@ static inline int __adis_write_reg_8(struct adis *adis, unsigned int reg,
 }
 
 /**
- * __adis_write_reg_16() - Write 2 bytes to a pair of registers (unlocked version)
+ * __adis_write_reg_16() - Write 2 bytes to a pair of registers (unlocked)
  * @adis: The adis device
  * @reg: The address of the lower of the two registers
  * @value: Value to be written
@@ -140,7 +140,7 @@ static inline int __adis_write_reg_16(struct adis *adis, unsigned int reg,
 }
 
 /**
- * __adis_write_reg_32() - write 4 bytes to four registers (unlocked version)
+ * __adis_write_reg_32() - write 4 bytes to four registers (unlocked)
  * @adis: The adis device
  * @reg: The address of the lower of the four register
  * @value: Value to be written
@@ -152,7 +152,7 @@ static inline int __adis_write_reg_32(struct adis *adis, unsigned int reg,
 }
 
 /**
- * __adis_read_reg_16() - read 2 bytes from a 16-bit register (unlocked version)
+ * __adis_read_reg_16() - read 2 bytes from a 16-bit register (unlocked)
  * @adis: The adis device
  * @reg: The address of the lower of the two registers
  * @val: The value read back from the device
@@ -171,7 +171,7 @@ static inline int __adis_read_reg_16(struct adis *adis, unsigned int reg,
 }
 
 /**
- * __adis_read_reg_32() - read 4 bytes from a 32-bit register (unlocked version)
+ * __adis_read_reg_32() - read 4 bytes from a 32-bit register (unlocked)
  * @adis: The adis device
  * @reg: The address of the lower of the two registers
  * @val: The value read back from the device

--- a/include/linux/iio/imu/adis.h
+++ b/include/linux/iio/imu/adis.h
@@ -164,7 +164,8 @@ static inline int __adis_read_reg_16(struct adis *adis, unsigned int reg,
 	int ret;
 
 	ret = __adis_read_reg(adis, reg, &tmp, 2);
-	*val = tmp;
+	if (ret == 0)
+		*val = tmp;
 
 	return ret;
 }
@@ -182,7 +183,8 @@ static inline int __adis_read_reg_32(struct adis *adis, unsigned int reg,
 	int ret;
 
 	ret = __adis_read_reg(adis, reg, &tmp, 4);
-	*val = tmp;
+	if (ret == 0)
+		*val = tmp;
 
 	return ret;
 }

--- a/include/linux/iio/imu/adis.h
+++ b/include/linux/iio/imu/adis.h
@@ -274,7 +274,8 @@ static inline int adis_read_reg_16(struct adis *adis, unsigned int reg,
 	int ret;
 
 	ret = adis_read_reg(adis, reg, &tmp, 2);
-	*val = tmp;
+	if (ret == 0)
+		*val = tmp;
 
 	return ret;
 }
@@ -292,7 +293,8 @@ static inline int adis_read_reg_32(struct adis *adis, unsigned int reg,
 	int ret;
 
 	ret = adis_read_reg(adis, reg, &tmp, 4);
-	*val = tmp;
+	if (ret == 0)
+		*val = tmp;
 
 	return ret;
 }


### PR DESCRIPTION
This changeset is the final set of ADIS backports that were upstreamed.
Predominantly cases of checking return code when assigning values.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>