### PR TITLE
iio: imu: adis16475: check non-zero when checking for error

### DIFF
--- a/drivers/iio/imu/adis16475.c
+++ b/drivers/iio/imu/adis16475.c
@@ -121,7 +121,7 @@ static ssize_t adis16475_show_firmware_revision(struct file *file,
 	int ret;
 
 	ret = adis_read_reg_16(&st->adis, ADIS16475_REG_FIRM_REV, &rev);
-	if (ret < 0)
+	if (ret)
 		return ret;
 
 	len = scnprintf(buf, sizeof(buf), "%x.%x\n", rev >> 8, rev & 0xff);
@@ -147,11 +147,11 @@ static ssize_t adis16475_show_firmware_date(struct file *file,
 	int ret;
 
 	ret = adis_read_reg_16(&st->adis, ADIS16475_REG_FIRM_Y, &year);
-	if (ret < 0)
+	if (ret)
 		return ret;
 
 	ret = adis_read_reg_16(&st->adis, ADIS16475_REG_FIRM_DM, &md);
-	if (ret < 0)
+	if (ret)
 		return ret;
 
 	len = snprintf(buf, sizeof(buf), "%.2x-%.2x-%.4x\n", md >> 8, md & 0xff,
@@ -174,7 +174,7 @@ static int adis16475_show_serial_number(void *arg, u64 *val)
 	int ret;
 
 	ret = adis_read_reg_16(&st->adis, ADIS16475_REG_SERIAL_NUM, &serial);
-	if (ret < 0)
+	if (ret)
 		return ret;
 
 	*val = serial;
@@ -191,7 +191,7 @@ static int adis16475_show_product_id(void *arg, u64 *val)
 	int ret;
 
 	ret = adis_read_reg_16(&st->adis, ADIS16475_REG_PROD_ID, &prod_id);
-	if (ret < 0)
+	if (ret)
 		return ret;
 
 	*val = prod_id;
@@ -209,7 +209,7 @@ static int adis16475_show_flash_count(void *arg, u64 *val)
 
 	ret = adis_read_reg_32(&st->adis, ADIS16475_REG_FLASH_CNT,
 			       &flash_count);
-	if (ret < 0)
+	if (ret)
 		return ret;
 
 	*val = flash_count;


### PR DESCRIPTION
This driver hasn't been upstreamed yet, so it did not get updated to check
`if (ret)` vs `if (ret < 0)`.

Though, from the driver's standpoint, both are correct (adis_read_reg()
returns 0 for success and negative for error), the compiler complains that
this could lead to potentially uninitialized assignments of the variables
pass to adis_read_reg() for reading.

So, to please the compiler, we check for `ret` being non-zero vs `< 0`.
This seems to show up under certain builds, in this case, in our rpi-4.19.y
branch. But this could happen also upstream.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>