### PR TITLE
axi-adxcvr,daq2/3: override vco max frequencies for CPLL

### DIFF
--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcdaq2.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcdaq2.dts
@@ -136,6 +136,7 @@
 		adi,out-clk-select = <4>;
 		adi,use-lpm-enable;
 		adi,use-cpll-enable;
+		adi,vco-max-khz = <5000000>;
 	};
 
 	axi_ad9144_adxcvr: axi-adxcvr-tx@44a60000 {

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcdaq3.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcdaq3.dts
@@ -140,6 +140,7 @@
 		adi,out-clk-select = <4>;
 		adi,use-lpm-enable;
 		adi,use-cpll-enable;
+		adi,vco-max-khz = <6166670>;
 	};
 
 	axi_ad9152_adxcvr: axi-adxcvr-tx@44a60000 {

--- a/drivers/iio/jesd204/axi_adxcvr.c
+++ b/drivers/iio/jesd204/axi_adxcvr.c
@@ -492,6 +492,46 @@ static int adxcvr_clk_register(struct device *dev,
 	return ret;
 }
 
+static void adxcvr_parse_dt_vco_ranges(struct adxcvr_state *st,
+				       struct device_node *np)
+{
+	u32 tmp;
+
+	if (st->cpll_enable) {
+		if (of_property_read_u32(np, "adi,vco-min-khz", &tmp) == 0)
+			st->xcvr.vco0_min = tmp;
+		else
+			st->xcvr.vco0_min = 0;
+
+		if (of_property_read_u32(np, "adi,vco-max-khz", &tmp) == 0)
+			st->xcvr.vco0_max = tmp;
+		else
+			st->xcvr.vco0_max = 0;
+
+		return;
+	}
+
+	if (of_property_read_u32(np, "adi,vco0-min-khz", &tmp) == 0)
+		st->xcvr.vco0_min = tmp;
+	else
+		st->xcvr.vco0_min = 0;
+
+	if (of_property_read_u32(np, "adi,vco0-max-khz", &tmp) == 0)
+		st->xcvr.vco0_max = tmp;
+	else
+		st->xcvr.vco0_max = 0;
+
+	if (of_property_read_u32(np, "adi,vco1-min-khz", &tmp) == 0)
+		st->xcvr.vco1_min = tmp;
+	else
+		st->xcvr.vco1_min = 0;
+
+	if (of_property_read_u32(np, "adi,vco1-max-khz", &tmp) == 0)
+		st->xcvr.vco1_max = tmp;
+	else
+		st->xcvr.vco1_max = 0;
+}
+
 static int adxcvr_parse_dt(struct adxcvr_state *st, struct device_node *np)
 {
 	of_property_read_u32(np, "adi,sys-clk-select", &st->sys_clk_sel);
@@ -499,6 +539,8 @@ static int adxcvr_parse_dt(struct adxcvr_state *st, struct device_node *np)
 
 	st->cpll_enable = of_property_read_bool(np, "adi,use-cpll-enable");
 	st->lpm_enable = of_property_read_bool(np, "adi,use-lpm-enable");
+
+	adxcvr_parse_dt_vco_ranges(st, np);
 
 	INIT_WORK(&st->work, adxcvr_work_func);
 

--- a/drivers/iio/jesd204/xilinx_transceiver.c
+++ b/drivers/iio/jesd204/xilinx_transceiver.c
@@ -343,6 +343,12 @@ static int xilinx_xcvr_get_cpll_vco_ranges(struct xilinx_xcvr *xcvr,
 	if (ADI_AXI_PCORE_VER_MAJOR(xcvr->version) > 0x10)
 		xilinx_xcvr_setup_cpll_vco_range(xcvr, vco_max);
 
+	if (xcvr->vco0_min)
+		*vco_min = xcvr->vco0_min;
+
+	if (xcvr->vco0_max)
+		*vco_max = xcvr->vco0_max;
+
 	return 0;
 }
 
@@ -434,6 +440,18 @@ static int xilinx_xcvr_get_qpll_vco_ranges(struct xilinx_xcvr *xcvr,
 		xilinx_xcvr_setup_qpll_vco_range(xcvr,
 						 vco0_min, vco0_max,
 						 vco1_min, vco1_max);
+
+	if (xcvr->vco0_min)
+		*vco0_min = xcvr->vco0_min;
+
+	if (xcvr->vco0_max)
+		*vco0_max = xcvr->vco0_max;
+
+	if (xcvr->vco1_min)
+		*vco0_min = xcvr->vco1_min;
+
+	if (xcvr->vco1_max)
+		*vco1_max = xcvr->vco1_max;
 
 	return 0;
 }

--- a/drivers/iio/jesd204/xilinx_transceiver.h
+++ b/drivers/iio/jesd204/xilinx_transceiver.h
@@ -56,6 +56,11 @@ struct xilinx_xcvr {
 	enum adi_axi_fpga_speed_grade speed_grade;
 	enum adi_axi_fpga_dev_pack dev_package;
 	unsigned int voltage;
+
+	unsigned int vco0_min;
+	unsigned int vco0_max;
+	unsigned int vco1_min;
+	unsigned int vco1_max;
 };
 
 #define ENC_8B10B					810


### PR DESCRIPTION
The ZC706 runs the DAQ2 & DAQ3 boards at a VCO frequency that is out of
range/spec. Configure a setting in the DT, to not allow an even higher
frequency that the one that was tested.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>