### PR TITLE
[2018_R2] arm64: zynqmp: Prevent mmcblk0 error -110

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp.dtsi
+++ b/arch/arm64/boot/dts/xilinx/zynqmp.dtsi
@@ -897,6 +897,7 @@
 			power-domains = <&pd_sd0>;
 			nvmem-cells = <&soc_revision>;
 			nvmem-cell-names = "soc_revision";
+			broken-mmc-highspeed;
 		};
 
 		sdhci1: sdhci@ff170000 {
@@ -913,6 +914,7 @@
 			power-domains = <&pd_sd1>;
 			nvmem-cells = <&soc_revision>;
 			nvmem-cell-names = "soc_revision";
+			broken-mmc-highspeed;
 		};
 
 		smmu: smmu@fd800000 {


### PR DESCRIPTION
https://www.xilinx.com/support/answers/69995.html

The issue is still present and affects other SD card models
too (e.g. SanDisk Ultra microSDHC 16GB).

Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>
(cherry picked from commit b1b92c9423f7e120003f23bc5b675b09080b8f2f)