### PR TITLE
arch: ar: boot: dts: Add adxl345 overlay

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -130,6 +130,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	rpi-ad7768-1.dtbo \
 	rpi-ad9834.dtbo \
 	rpi-adgs1408.dtbo \
+	rpi-adxl345.dtbo \
 	rpi-adxl372.dtbo \
 	rpi-adxl375.dtbo \
 	rpi-ad5770r.dtbo \

--- a/arch/arm/boot/dts/overlays/rpi-adxl345-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-adxl345-overlay.dts
@@ -1,0 +1,35 @@
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/interrupt-controller/irq.h>
+
+/ {
+	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709";
+
+	fragment@0 {
+		target = <&spi0>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			adxl345@0 {
+				compatible = "adi,adxl345";
+				reg = <0>;
+				spi-max-frequency = <1000000>;
+				spi-cpha;
+				spi-cpol;
+				interrupts = <19 IRQ_TYPE_LEVEL_HIGH>;
+				interrupt-parent = <&gpio>;
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&spidev0>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+};
+


### PR DESCRIPTION
This patch adds a device tree example for adxl345.

Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>