### PR TITLE
 arm64: dts: talise: fix ethernet interfaces after migration to 4.19

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-reva-adrv2crr-fmc.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-reva-adrv2crr-fmc.dts
@@ -145,7 +145,7 @@
 	phy1: phy@1 {
 		device_type = "ethernet-phy";
 		reg = <1>;
-		reset-gpios = <&gpio 31 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&gpio 31 GPIO_ACTIVE_LOW>;
 	};
 };
 /*

--- a/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-reva.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-reva.dts
@@ -58,7 +58,7 @@
 		device_type = "ethernet-phy";
 		reg = <0x0>;
 		marvell,reg-init = <3 16 0xff00 0x1e 3 17 0xfff0 0x00>;
-		reset-gpios = <&gpio 25 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&gpio 25 GPIO_ACTIVE_LOW>;
 	};
 };
 

--- a/drivers/net/ethernet/cadence/macb.h
+++ b/drivers/net/ethernet/cadence/macb.h
@@ -1249,6 +1249,12 @@ struct macb {
 	int	tx_bd_rd_prefetch;
 
 	u32	rx_intr_mask;
+
+	/* special flag for when the connection between
+	 * the phy and the MAC fails, but, there are more
+	 * phys on the mdio bus...
+	 */
+	bool keep_mac_around;
 };
 
 #ifdef CONFIG_MACB_USE_HWSTAMP


### PR DESCRIPTION
The merge to 4.19, dropped a few patches that were done for 4.14 in the ADI tree.
This changeset brings back what's needed from the old patchset, and also fixes the GPIO polarity for the PHY reset pins on the Talise. In 4.19 phylib handles the reset GPIOs [if specified in the PHY's DT].

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>