### PR TITLE
dts: arch: arm: daq2-arria10: Updated DMA channel description

### DIFF
--- a/arch/arm/boot/dts/socfpga_arria10_socdk_daq2.dts
+++ b/arch/arm/boot/dts/socfpga_arria10_socdk_daq2.dts
@@ -1,3 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Highspeed JESD-compatible data acquisition system
+ * Link: https://wiki.analog.com/resources/eval/user-guides/ad-fmcdaq2-ebz
+ *
+ * hdl_project: <daq2/a10soc>
+ * board_revision: <C>
+ *
+ * Copyright 2016-2019 Analog Devices Inc.
+ */
 /dts-v1/;
 #include "socfpga_arria10_socdk.dtsi"
 

--- a/arch/arm/boot/dts/socfpga_arria10_socdk_daq2.dts
+++ b/arch/arm/boot/dts/socfpga_arria10_socdk_daq2.dts
@@ -10,6 +10,7 @@
  */
 /dts-v1/;
 #include "socfpga_arria10_socdk.dtsi"
+#include <dt-bindings/interrupt-controller/irq.h>
 
 &mmc {
 	status = "okay";
@@ -64,7 +65,7 @@
 				compatible = "altr,spi-16.0", "altr,spi-1.0";
 				reg = <0x40 0x20>;
 				interrupt-parent = <&intc>;
-				interrupts = <0 26 4>;
+				interrupts = <0 26 IRQ_TYPE_LEVEL_HIGH>;
 				#address-cells = <0x1>;
 				#size-cells = <0x0>;
 			};
@@ -74,7 +75,7 @@
 				reg = <0x4c000 0x4000>;
 				#dma-cells = <1>;
 				interrupt-parent = <&intc>;
-				interrupts = <0 29 0>;
+				interrupts = <0 29 IRQ_TYPE_LEVEL_HIGH>;
 				clocks = <&dma_clk>;
 
 				dma-channel {
@@ -89,7 +90,7 @@
 				reg = <0x2c000 0x4000>;
 				#dma-cells = <1>;
 				interrupt-parent = <&intc>;
-				interrupts = <0 30 0>;
+				interrupts = <0 30 IRQ_TYPE_LEVEL_HIGH>;
 				clocks = <&dma_clk>;
 
 				dma-channel {
@@ -115,7 +116,7 @@
 				reg = <0x20000 0x4000>;
 
 				interrupt-parent = <&intc>;
-				interrupts = <0 28 0>;
+				interrupts = <0 28 IRQ_TYPE_LEVEL_HIGH>;
 
 				clocks = <&sys_clk>, <&tx_device_clk_pll>, <&axi_ad9144_xcvr>;
 				clock-names = "s_axi_aclk", "device_clk", "lane_clk";
@@ -143,7 +144,7 @@
 				reg = <0x40000 0x4000>;
 
 				interrupt-parent = <&intc>;
-				interrupts = <0 27 0>;
+				interrupts = <0 27 IRQ_TYPE_LEVEL_HIGH>;
 
 				clocks = <&sys_clk>, <&rx_device_clk_pll>, <&axi_ad9680_xcvr>;
 				clock-names = "s_axi_aclk", "device_clk", "lane_clk";

--- a/arch/arm/boot/dts/socfpga_arria10_socdk_daq2.dts
+++ b/arch/arm/boot/dts/socfpga_arria10_socdk_daq2.dts
@@ -78,10 +78,16 @@
 				interrupts = <0 29 IRQ_TYPE_LEVEL_HIGH>;
 				clocks = <&dma_clk>;
 
-				dma-channel {
-					adi,source-bus-width = <128>;
-					adi,destination-bus-width = <128>;
-					adi,type = <0>;
+				adi,channels {
+					#size-cells = <0>;
+					#address-cells = <1>;
+					dma-channel@0 {
+						reg = <0>;
+						adi,source-bus-width = <128>;
+						adi,source-bus-type = <1>;
+						adi,destination-bus-width = <128>;
+						adi,destination-bus-type = <0>;
+					};
 				};
 			};
 
@@ -93,11 +99,17 @@
 				interrupts = <0 30 IRQ_TYPE_LEVEL_HIGH>;
 				clocks = <&dma_clk>;
 
-				dma-channel {
-					adi,source-bus-width = <128>;
-					adi,destination-bus-width = <128>;
-					adi,type = <1>;
+				adi,channels {
+					#size-cells = <0>;
+					#address-cells = <1>;
+					dma-channel@0 {
+						reg = <0>;
+						adi,source-bus-width = <128>;
+						adi,source-bus-type = <0>;
+						adi,destination-bus-width = <128>;
+						adi,destination-bus-type = <1>;
 					adi,cyclic;
+					};
 				};
 			};
 


### PR DESCRIPTION
Using the old DMA's device tree attributes, the iio devices won't get registered.
This PR updates the description for the tx and rx channels and specifies the interrupt types in order to remove the irqchip warnings in the boot phase.

Signed-off-by: Sergiu Cuciurean <sergiu.cuciurean@analog.com>