### PR TITLE
 dts: arch: arm: adrv9371-arria10: Updated dma channels description

### DIFF
--- a/arch/arm/boot/dts/socfpga_arria10_socdk_adrv9371.dts
+++ b/arch/arm/boot/dts/socfpga_arria10_socdk_adrv9371.dts
@@ -1,3 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Complete Radio Card platform containing AD9371
+ * Link: https://wiki.analog.com/resources/eval/user-guides/mykonos/quickstart
+ *
+ * hdl_project: <adrv9371x/a10soc>
+ * board_revision: <A>
+ *
+ * Copyright 2016-2019 Analog Devices Inc.
+ */
 /dts-v1/;
 #include "socfpga_arria10_socdk.dtsi"
 #include <dt-bindings/iio/frequency/ad9528.h>

--- a/arch/arm/boot/dts/socfpga_arria10_socdk_adrv9371.dts
+++ b/arch/arm/boot/dts/socfpga_arria10_socdk_adrv9371.dts
@@ -11,6 +11,7 @@
 /dts-v1/;
 #include "socfpga_arria10_socdk.dtsi"
 #include <dt-bindings/iio/frequency/ad9528.h>
+#include <dt-bindings/interrupt-controller/irq.h>
 
 &mmc {
 	status = "okay";
@@ -60,7 +61,7 @@
 				compatible = "altr,spi-1.0";
 				reg = <0x00000040 0x00000020>;
 				interrupt-parent = <&intc>;
-				interrupts = <0 26 4>;
+				interrupts = <0 26 IRQ_TYPE_LEVEL_HIGH>;
 				#address-cells = <0x1>;
 				#size-cells = <0x0>;
 			};
@@ -70,7 +71,7 @@
 				reg = <0x00020000 0x4000>;
 
 				interrupt-parent = <&intc>;
-				interrupts = <0 28 0>;
+				interrupts = <0 28 IRQ_TYPE_LEVEL_HIGH>;
 
 				clocks = <&sys_clk>, <&tx_device_clk_pll>, <&axi_ad9371_tx_xcvr>;
 				clock-names = "s_axi_aclk", "device_clk", "lane_clk";
@@ -91,7 +92,7 @@
 				reg = <0x00030000 0x4000>;
 
 				interrupt-parent = <&intc>;
-				interrupts = <0 27 0>;
+				interrupts = <0 27 IRQ_TYPE_LEVEL_HIGH>;
 
 				clocks = <&sys_clk>, <&rx_device_clk_pll>, <&axi_ad9371_rx_xcvr>;
 				clock-names = "s_axi_aclk", "device_clk", "lane_clk";
@@ -111,7 +112,7 @@
 				reg = <0x00040000 0x4000>;
 
 				interrupt-parent = <&intc>;
-				interrupts = <0 29 0>;
+				interrupts = <0 29 IRQ_TYPE_LEVEL_HIGH>;
 
 				clocks = <&sys_clk>, <&rx_os_device_clk_pll>, <&axi_ad9371_rx_os_xcvr>;
 				clock-names = "s_axi_aclk", "device_clk", "lane_clk";
@@ -175,7 +176,7 @@
 				compatible = "adi,axi-dmac-1.00.a";
 				reg = <0x0002c000 0x00004000>;
 				interrupt-parent = <&intc>;
-				interrupts = <0 30 4>;
+				interrupts = <0 30 IRQ_TYPE_LEVEL_HIGH>;
 				#dma-cells = <1>;
 				clocks = <&dma_clk>;
 
@@ -190,7 +191,7 @@
 				compatible = "adi,axi-dmac-1.00.a";
 				reg = <0x0003c000 0x00004000>;
 				interrupt-parent = <&intc>;
-				interrupts = <0 31 4>;
+				interrupts = <0 31 IRQ_TYPE_LEVEL_HIGH>;
 				#dma-cells = <1>;
 				clocks = <&dma_clk>;
 
@@ -205,7 +206,7 @@
 				compatible = "adi,axi-dmac-1.00.a";
 				reg = <0x0004c000 0x00004000>;
 				interrupt-parent = <&intc>;
-				interrupts = <0 32 4>;
+				interrupts = <0 32 IRQ_TYPE_LEVEL_HIGH>;
 				#dma-cells = <1>;
 				clocks = <&dma_clk>;
 

--- a/arch/arm/boot/dts/socfpga_arria10_socdk_adrv9371.dts
+++ b/arch/arm/boot/dts/socfpga_arria10_socdk_adrv9371.dts
@@ -180,10 +180,16 @@
 				#dma-cells = <1>;
 				clocks = <&dma_clk>;
 
-				dma-channel {
-					adi,source-bus-width = <128>;
-					adi,destination-bus-width = <128>;
-					adi,type = <1>;
+				adi,channels {
+					#size-cells = <0>;
+					#address-cells = <1>;
+					dma-channel@0 {
+						reg = <0>;
+						adi,source-bus-width = <128>;
+						adi,source-bus-type = <0>;
+						adi,destination-bus-width = <128>;
+						adi,destination-bus-type = <1>;
+					};
 				};
 			};
 
@@ -195,10 +201,16 @@
 				#dma-cells = <1>;
 				clocks = <&dma_clk>;
 
-				dma-channel {
-					adi,source-bus-width = <64>;
-					adi,destination-bus-width = <128>;
-					adi,type = <0>;
+				adi,channels {
+					#size-cells = <0>;
+					#address-cells = <1>;
+					dma-channel@0 {
+						reg = <0>;
+						adi,source-bus-width = <64>;
+						adi,source-bus-type = <2>;
+						adi,destination-bus-width = <128>;
+						adi,destination-bus-type = <0>;
+					};
 				};
 			};
 
@@ -210,10 +222,16 @@
 				#dma-cells = <1>;
 				clocks = <&dma_clk>;
 
-				dma-channel {
-					adi,source-bus-width = <64>;
-					adi,destination-bus-width = <128>;
-					adi,type = <0>;
+				adi,channels {
+					#size-cells = <0>;
+					#address-cells = <1>;
+					dma-channel@0 {
+						reg = <0>;
+						adi,source-bus-width = <64>;
+						adi,source-bus-type = <2>;
+						adi,destination-bus-width = <128>;
+						adi,destination-bus-type = <0>;
+					};
 				};
 			};
 


### PR DESCRIPTION
Using the old DMA's device tree attributes, the iio devices won't get registered.
This PR updates the description for the tx,rx and rx_obs channels and specifies the interrupt types in order to remove the irqchip warnings in the boot phase.

Signed-off-by: Sergiu Cuciurean <sergiu.cuciurean@analog.com>