### PR TITLE
ASoc: adi: Kconfig: Remove depends on for ADI reference designs

### DIFF
--- a/sound/soc/adi/Kconfig
+++ b/sound/soc/adi/Kconfig
@@ -1,6 +1,5 @@
 config SND_SOC_ADI
 	tristate "Audio support for Analog Devices reference designs"
-	depends on MICROBLAZE || ARCH_ZYNQ || COMPILE_TEST
 	help
 	  Audio support for various reference designs by Analog Devices.
 


### PR DESCRIPTION
Audio ADI reference designs are used on some non ZYNQ or Microblaze
platforms like ADRV2CRR-FMC Carrier Board so remove this dependency.

Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>