### PR TITLE
drm: adv7511: Add debugfs interface

### DIFF
--- a/drivers/gpu/drm/bridge/adv7511/Makefile
+++ b/drivers/gpu/drm/bridge/adv7511/Makefile
@@ -2,4 +2,5 @@ adv7511-y := adv7511_drv.o
 adv7511-$(CONFIG_DRM_I2C_ADV7511_AUDIO) += adv7511_audio.o
 adv7511-$(CONFIG_DRM_I2C_ADV7511_CEC) += adv7511_cec.o
 adv7511-$(CONFIG_DRM_I2C_ADV7533) += adv7533.o
+adv7511-$(CONFIG_DEBUG_FS) += adv7511_debugfs.o
 obj-$(CONFIG_DRM_I2C_ADV7511) += adv7511.o

--- a/drivers/gpu/drm/bridge/adv7511/adv7511.h
+++ b/drivers/gpu/drm/bridge/adv7511/adv7511.h
@@ -220,6 +220,11 @@
 
 #define ADV7533_REG_CEC_OFFSET		0x70
 
+#define ADV7533_REG_TPG			0x55
+#define ADV7533_TPG_ENABLE		0x80
+#define ADV7533_TPG_RAMP		0x20
+#define ADV7533_TPG_COLORBAR		0x00
+
 enum adv7511_input_clock {
 	ADV7511_INPUT_CLOCK_1X,
 	ADV7511_INPUT_CLOCK_2X,
@@ -351,6 +356,7 @@ struct adv7511 {
 
 	struct drm_bridge bridge;
 	struct drm_connector connector;
+	struct dentry *debugfs;
 
 	bool embedded_sync;
 	enum adv7511_sync_polarity vsync_polarity;
@@ -454,5 +460,19 @@ static inline void adv7511_audio_exit(struct adv7511 *adv7511)
 {
 }
 #endif /* CONFIG_DRM_I2C_ADV7511_AUDIO */
+
+#ifdef CONFIG_DEBUG_FS
+int adv7511_debugfs_init(struct adv7511 *adv7511);
+void adv7511_debugfs_remove(struct adv7511 *adv7511);
+#else
+static inline int adv7511_debugfs_init(struct adv7511 *adv7511)
+{
+	return 0;
+}
+static inline void adv7511_debugfs_remove(struct adv7511 *adv7511)
+{
+	return 0;
+}
+#endif
 
 #endif /* __DRM_I2C_ADV7511_H__ */

--- a/drivers/gpu/drm/bridge/adv7511/adv7511_debugfs.c
+++ b/drivers/gpu/drm/bridge/adv7511/adv7511_debugfs.c
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices ADV7511/33/35 HDMI transmitter driver
+ *
+ * Copyright (C) 2018-2019 Analog Devices, All Rights Reserved.
+ */
+
+#include <linux/types.h>
+#include <linux/debugfs.h>
+#include <drm/drm_print.h>
+
+#include "adv7511.h"
+
+static int tpg_show(struct seq_file *m, void *data)
+{
+	struct adv7511 *adv = m->private;
+	unsigned int val;
+	int ret;
+
+	ret = regmap_read(adv->regmap_cec, ADV7533_REG_TPG, &val);
+	if (ret)
+		return ret;
+
+	if (!(val & ADV7533_TPG_ENABLE))
+		seq_puts(m, "off\n");
+	else if (val & ADV7533_TPG_RAMP)
+		seq_puts(m, "ramp\n");
+	else if (val & ADV7533_TPG_ENABLE)
+		seq_puts(m, "colorbar\n");
+
+	return 0;
+}
+
+static int tpg_open(struct inode *inode, struct file *file)
+{
+	struct drm_connector *dev = inode->i_private;
+
+	return single_open(file, tpg_show, dev);
+}
+
+static ssize_t tpg_write(struct file *file, const char __user *ubuf,
+			 size_t len, loff_t *offp)
+{
+	struct seq_file *m = file->private_data;
+	struct adv7511 *adv = m->private;
+	char buf[9];
+	int ret;
+
+	if (len > sizeof(buf))
+		return -EINVAL;
+
+	if (copy_from_user(buf, ubuf, len))
+		return -EFAULT;
+
+	buf[len] = '\0';
+
+	if (sysfs_streq(buf, "colorbar"))
+		ret = regmap_update_bits(adv->regmap_cec, ADV7533_REG_TPG, 0xE0,
+				   ADV7533_TPG_ENABLE | ADV7533_TPG_COLORBAR);
+	else if (sysfs_streq(buf, "ramp"))
+		ret = regmap_update_bits(adv->regmap_cec, ADV7533_REG_TPG, 0xE0,
+				   ADV7533_TPG_ENABLE | ADV7533_TPG_RAMP);
+	else if (sysfs_streq(buf, "off"))
+		ret = regmap_update_bits(adv->regmap_cec, ADV7533_REG_TPG,
+				   ADV7533_TPG_ENABLE, ~ADV7533_TPG_ENABLE);
+	else
+		return -EINVAL;
+
+	if (ret)
+		return ret;
+
+	return len;
+}
+
+static const struct file_operations adv7511_tpg_fops = {
+	.owner = THIS_MODULE,
+	.open = tpg_open,
+	.read = seq_read,
+	.llseek = seq_lseek,
+	.release = single_release,
+	.write = tpg_write
+};
+
+int adv7511_debugfs_init(struct adv7511 *adv7511)
+{
+	struct drm_bridge *bridge = &adv7511->bridge;
+	struct drm_minor *minor = bridge->dev->primary;
+	struct dentry *debugfs_file;
+
+	adv7511->debugfs = debugfs_create_dir("adv7511", minor->debugfs_root);
+	if (IS_ERR_OR_NULL(adv7511->debugfs))
+		return -ENOMEM;
+
+	/* tpg only on ADV7533/35*/
+	if (adv7511->type == ADV7533 || adv7511->type == ADV7535) {
+		debugfs_file = debugfs_create_file("tpg", 0644,
+				adv7511->debugfs, adv7511, &adv7511_tpg_fops);
+
+		if (IS_ERR_OR_NULL(debugfs_file))
+			DRM_ERROR("Failed to create TPG debugfs file\n");
+	}
+
+	return 0;
+}
+
+void adv7511_debugfs_remove(struct adv7511 *adv7511)
+{
+	debugfs_remove_recursive(adv7511->debugfs);
+}

--- a/drivers/gpu/drm/bridge/adv7511/adv7511_drv.c
+++ b/drivers/gpu/drm/bridge/adv7511/adv7511_drv.c
@@ -22,6 +22,12 @@
 
 #include "adv7511.h"
 
+#if defined(DEBUG)
+#define adv_trace	trace_printk
+#else
+#define adv_trace(...)
+#endif /* adv_trace */
+
 /* ADI recommended values for proper operation. */
 static const struct reg_sequence adv7511_fixed_registers[] = {
 	{ 0x98, 0x03 },
@@ -462,6 +468,9 @@ static int adv7511_irq_process(struct adv7511 *adv7511, bool process_hpd)
 	if (ret < 0)
 		return ret;
 
+	adv_trace(": IRQ reg 0x96 = 0x%02x, IRQ reg 0x97 = 0x%02x\n", irq0,
+		  irq1);
+
 	regmap_write(adv7511->regmap, ADV7511_REG_INT(0), irq0);
 	regmap_write(adv7511->regmap, ADV7511_REG_INT(1), irq1);
 
@@ -886,7 +895,16 @@ static int adv7511_bridge_attach(struct drm_bridge *bridge)
 		regmap_write(adv->regmap, ADV7511_REG_INT_ENABLE(0),
 			     ADV7511_INT0_HPD);
 
+	adv7511_debugfs_init(adv);
+
 	return ret;
+}
+
+static void adv7511_bridge_detach(struct drm_bridge *bridge)
+{
+	struct adv7511 *adv = bridge_to_adv7511(bridge);
+
+	adv7511_debugfs_remove(adv);
 }
 
 static const struct drm_bridge_funcs adv7511_bridge_funcs = {
@@ -894,6 +912,7 @@ static const struct drm_bridge_funcs adv7511_bridge_funcs = {
 	.disable = adv7511_bridge_disable,
 	.mode_set = adv7511_bridge_mode_set,
 	.attach = adv7511_bridge_attach,
+	.detach = adv7511_bridge_detach,
 };
 
 /* -----------------------------------------------------------------------------


### PR DESCRIPTION
Add debugfs interface to control Test Pattern Generator on ADV7535.

Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>