### PR TITLE
arch: arm64: talise: fix 4.19 device-tree definitions

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-reva-adrv2crr-fmc.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-reva-adrv2crr-fmc.dts
@@ -408,7 +408,7 @@
 		reg = <0x0 0x81001000 0x1000>;
 		#dma-cells = <1>;
 		#clock-cells = <0>;
-		interrupts = <0 95 0>;
+		interrupts = <0 95 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&zynqmp_clk 73>;
 
 		adi,channels {
@@ -430,7 +430,7 @@
 		reg = <0x0 0x81000000 0x1000>;
 		#dma-cells = <1>;
 		#clock-cells = <0>;
-		interrupts = <0 96 0>;
+		interrupts = <0 96 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&zynqmp_clk 73>;
 
 		adi,channels {

--- a/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-reva-adrv2crr-fmc.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-reva-adrv2crr-fmc.dts
@@ -409,7 +409,7 @@
 		#dma-cells = <1>;
 		#clock-cells = <0>;
 		interrupts = <0 95 0>;
-		clocks = <&clk 73>;
+		clocks = <&zynqmp_clk 73>;
 
 		adi,channels {
 			#size-cells = <0>;
@@ -431,7 +431,7 @@
 		#dma-cells = <1>;
 		#clock-cells = <0>;
 		interrupts = <0 96 0>;
-		clocks = <&clk 73>;
+		clocks = <&zynqmp_clk 73>;
 
 		adi,channels {
 			#size-cells = <0>;
@@ -452,7 +452,7 @@
 		reg = <0x0 0x82000000 0x10000>;
 		dmas = <&i2s_tx_dma 0 &i2s_rx_dma 0>;
 		dma-names = "tx", "rx";
-		clocks = <&clk 73>, <&audio_clock>;
+		clocks = <&zynqmp_clk 73>, <&audio_clock>;
 		clock-names = "axi", "ref";
 
 		#sound-dai-cells = <0>;


### PR DESCRIPTION
The device-tree was based on top of 4.14.
In 4.19, some things need to be changed.
This changeset does that. Tested on 4.19 with Talise SOM.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>