### PR TITLE
drm: xlnx: zynqmp_disp: Remove fb check in atomic update callback

### DIFF
--- a/drivers/gpu/drm/xlnx/zynqmp_disp.c
+++ b/drivers/gpu/drm/xlnx/zynqmp_disp.c
@@ -2676,9 +2676,6 @@ zynqmp_disp_plane_atomic_update(struct drm_plane *plane,
 	if (!plane->state->crtc || !plane->state->fb)
 		return;
 
-	if (plane->state->fb == old_state->fb)
-		return;
-
 	if (old_state->fb &&
 	    old_state->fb->format->format != plane->state->fb->format->format)
 		zynqmp_disp_plane_disable(plane);


### PR DESCRIPTION
The setup in which we are seeing is this, is on ZynqMP (also ZCU102) with a
monitor connected via DisplayPort and the following Xorg.conf:
```
cat /etc/X11/xorg.conf
Section "Device"
  Identifier "myfb"
  Driver "fbdev"
  Option "fbdev" "/dev/fb0"
EndSection
```
It seems that checking the `fb` pointer disallows the new mode to be set,
and the screen stays blank when the OS boots into a desktop session.
The symptoms seem to be that, on boot the console is displayed, but when
the desktop server initializes a desktop session, the screen goes blank.

It does look like an old state could point to the same DRM framebuffer
struct/info, so it probably doesn't make sense to do that check.

It's also unsure whether this brings back the old issue that the original
patch tried to fix.

Fixes: c4b7d6c966afe ("drm: xlnx: zynqmp_disp: Skip the modeset for same fb")
Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>