### PR TITLE
hwmon: Add convience macro to define simple static sensors

### DIFF
--- a/include/linux/hwmon.h
+++ b/include/linux/hwmon.h
@@ -363,6 +363,14 @@ struct hwmon_channel_info {
 	const u32 *config;
 };
 
+#define HWMON_CHANNEL_INFO(stype, ...)	\
+	(&(struct hwmon_channel_info) {	\
+		.type = hwmon_##stype,	\
+		.config = (u32 []) {	\
+			__VA_ARGS__, 0	\
+		}			\
+	})
+
 /**
  * Chip configuration
  * @ops:	Pointer to hwmon operations.


### PR DESCRIPTION
It takes a fair amount of boiler plate code to add new sensors, add a
macro that can be used to specify simple static sensors.

Signed-off-by: Charles Keepax <ckeepax@opensource.cirrus.com>
Signed-off-by: Guenter Roeck <linux@roeck-us.net>