### PR TITLE
gpio: gpio-xilinx: Fix set_multiple() issues

### DIFF
--- a/drivers/gpio/gpio-xilinx.c
+++ b/drivers/gpio/gpio-xilinx.c
@@ -154,18 +154,16 @@ static void xgpio_set_multiple(struct gpio_chip *gc, unsigned long *mask,
 
 	/* Write to GPIO signals */
 	for (i = 0; i < gc->ngpio; i++) {
-		if (*mask == 0)
-			break;
-		if (index !=  xgpio_index(chip, i)) {
+		if (index != xgpio_index(chip, i)) {
 			xgpio_writereg(mm_gc->regs + XGPIO_DATA_OFFSET +
-				       xgpio_regoffset(chip, i),
+				       xgpio_regoffset(chip, i - 1),
 				       chip->gpio_state[index]);
 			spin_unlock_irqrestore(&chip->gpio_lock[index], flags);
-			index =  xgpio_index(chip, i);
+			index = xgpio_index(chip, i);
 			spin_lock_irqsave(&chip->gpio_lock[index], flags);
 		}
 		if (__test_and_clear_bit(i, mask)) {
-			offset =  xgpio_offset(chip, i);
+			offset = xgpio_offset(chip, i);
 			if (test_bit(i, bits))
 				chip->gpio_state[index] |= BIT(offset);
 			else


### PR DESCRIPTION
This fixes two issues with the set_multiple() implementation.
 * mask is a bitmask, which on 32-bit systems BITS_PER_LONG = 32 may
   evaluate to 0, while bits > 32 still can be set. Remove this check
   completely.
 * This gpio controller handles up to 64 GPIOs, split across two
   registers. When crossing the register banks, the first one is updated.
   However a bug in the code writes the value for the first bank to
   the second bank register offset. This results in undesired behavior.

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>