### PR TITLE
Ad7124 fix unipolar channels

### DIFF
--- a/drivers/iio/adc/ad7124.c
+++ b/drivers/iio/adc/ad7124.c
@@ -495,13 +495,11 @@ static int ad7124_of_parse_channel_config(struct iio_dev *indio_dev,
 		st->channel_config[channel].buf_negative =
 			of_property_read_bool(child, "adi,buffered-negative");
 
-		*chan = ad7124_channel_template;
-		chan->address = channel;
-		chan->scan_index = channel;
-		chan->channel = ain[0];
-		chan->channel2 = ain[1];
-
-		chan++;
+		chan[channel] = ad7124_channel_template;
+		chan[channel].address = channel;
+		chan[channel].scan_index = channel;
+		chan[channel].channel = ain[0];
+		chan[channel].channel2 = ain[1];
 	}
 
 	return 0;

--- a/drivers/iio/adc/ad7124.c
+++ b/drivers/iio/adc/ad7124.c
@@ -22,6 +22,8 @@
 #include <linux/iio/sysfs.h>
 #include <linux/iio/adc/ad_sigma_delta.h>
 
+#define AD7124_SEQUENCER_SLOTS		16
+
 /* AD7124 registers */
 #define AD7124_COMMS			0x00
 #define AD7124_STATUS			0x00
@@ -640,6 +642,7 @@ static int ad7124_probe(struct spi_device *spi)
 	st->chip_info = &ad7124_chip_info_tbl[id->driver_data];
 
 	ad_sd_init(&st->sd, indio_dev, spi, &ad7124_sigma_delta_info);
+	st->sd.num_slots = AD7124_SEQUENCER_SLOTS;
 	spi_set_drvdata(spi, indio_dev);
 
 	indio_dev->dev.parent = &spi->dev;

--- a/drivers/iio/adc/ad7124.c
+++ b/drivers/iio/adc/ad7124.c
@@ -692,6 +692,11 @@ static int ad7124_probe(struct spi_device *spi)
 	if (ret < 0)
 		goto error_clk_disable_unprepare;
 	indio_dev->pollfunc->thread = ad_sd_trigger_handler;
+	ret = irq_set_irq_type(st->sd.spi->irq, IRQ_TYPE_EDGE_FALLING);
+	if (ret < 0) {
+		dev_err(&spi->dev, "Failed to set irq to EDGE_FALLING\n");
+		goto error_clk_disable_unprepare;
+	}
 
 	ret = iio_device_register(indio_dev);
 	if (ret < 0) {

--- a/drivers/iio/adc/ad7124.c
+++ b/drivers/iio/adc/ad7124.c
@@ -359,6 +359,26 @@ static int ad7124_write_raw(struct iio_dev *indio_dev,
 	}
 }
 
+static int ad7124_update_scan_mode(struct iio_dev *indio_dev,
+				   const unsigned long *scan_mask)
+{
+	struct ad7124_state *st = iio_priv(indio_dev);
+	bool bit_set;
+	int ret;
+	int i;
+
+	for (i = 0; i < indio_dev->masklength; i++) {
+		bit_set = test_bit(i, indio_dev->active_scan_mask);
+		ret = ad7124_spi_write_mask(st, AD7124_CHANNEL(i),
+					    AD7124_CHANNEL_EN_MSK,
+					    AD7124_CHANNEL_EN(bit_set),
+					    2);
+		if (ret < 0)
+			return ret;
+	}
+	return 0;
+}
+
 static IIO_CONST_ATTR(in_voltage_scale_available,
 	"0.000001164 0.000002328 0.000004656 0.000009313 0.000018626 0.000037252 0.000074505 0.000149011 0.000298023");
 
@@ -375,6 +395,7 @@ static const struct iio_info ad7124_info = {
 	.read_raw = ad7124_read_raw,
 	.write_raw = ad7124_write_raw,
 	.validate_trigger = ad_sd_validate_trigger,
+	.update_scan_mode = ad7124_update_scan_mode,
 	.attrs = &ad7124_attrs_group,
 };
 


### PR DESCRIPTION
Changes summary:
- added an update_scan_mode function to update chip channels as specified in the sysfs files
- overridden the sigma_delta trigger handler with one that aligns data in buffer for iio-osciloscope
- changed iio_chan_spec  for each channel in order to make sigma_delta ask for only 3 bytes of data from the chip (not 4 bytes as before)
- set IRQ on falling edge instead of low (irq on low made iio osciloscope to mix signals, did not color them correctly)