### PR TITLE
drm: adv7511: add includes for struct types

### DIFF
--- a/drivers/gpu/drm/bridge/adv7511/adv7511_debugfs.c
+++ b/drivers/gpu/drm/bridge/adv7511/adv7511_debugfs.c
@@ -8,6 +8,8 @@
 #include <linux/types.h>
 #include <linux/debugfs.h>
 #include <drm/drm_print.h>
+#include <drm/drm_device.h>
+#include <drm/drm_file.h>
 
 #include "adv7511.h"
 


### PR DESCRIPTION
In upstream Linux, the DRM subsystem has organized their includes. In
order for this file to build, these includes are required so that the
compiler can evaluate these structs.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>