### PR TITLE
iio: adc: ad9081: adi_ad9081_jesd: Fix warning [-Wmaybe-uninitialized]

### DIFF
--- a/drivers/iio/adc/ad9081/adi_ad9081_jesd.c
+++ b/drivers/iio/adc/ad9081/adi_ad9081_jesd.c
@@ -921,6 +921,7 @@ int32_t adi_ad9081_jesd_rx_bring_up(adi_ad9081_device_t *device,
 		  (jesd204b_en > 0 ? 5 : 11);
 	if (bit_rate <= 2000000000ULL) {
 		AD9081_LOG_ERR("jrx bit rate is lower than 2Gbps.");
+		return API_CMS_ERROR_INVALID_PARAM;
 	} else if (bit_rate > 2000000000ULL && bit_rate <= 4000000000ULL) {
 		b_lcpll = b_lcpll * 4;
 		rx_div_rate = 1;


### PR DESCRIPTION
drivers/iio/adc/ad9081/adi_ad9081_jesd.c: In function ‘adi_ad9081_jesd_rx_bring_up’:
drivers/iio/adc/ad9081/adi_ad9081_jesd.c:950:8: warning: ‘rx_div_rate’ may be used uninitialized in this function [-Wmaybe-uninitialized]
  err = adi_ad9081_hal_bf_set(device, REG_PLL_RXDIVRATE_ADDR,
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         BF_RXDIVRATE_LCPLL_RC_INFO,
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~
         rx_div_rate); /* not paged */


Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>