### PR TITLE
axi_adxcvr: Fix checking of selected QPLL

### DIFF
--- a/drivers/iio/jesd204/axi_adxcvr.c
+++ b/drivers/iio/jesd204/axi_adxcvr.c
@@ -344,6 +344,14 @@ static int adxcvr_clk_set_rate(struct clk_hw *hw,
 	dev_dbg(st->dev, "%s: Rate %lu Hz Parent Rate %lu Hz",
 		__func__, rate, parent_rate);
 
+	if ((st->xcvr.type == XILINX_XCVR_TYPE_US_GTH3) ||
+	    (st->xcvr.type == XILINX_XCVR_TYPE_US_GTH4)) {
+		if (st->sys_clk_sel == ADXCVR_GTH_SYSCLK_QPLL1)
+			qpll_conf.qpll = 1;
+		else
+			qpll_conf.qpll = 0;
+	}
+
 	clk25_div = DIV_ROUND_CLOSEST(parent_rate, 25000000);
 
 	if (st->cpll_enable)
@@ -355,13 +363,6 @@ static int adxcvr_clk_set_rate(struct clk_hw *hw,
 	if (ret < 0)
 		return ret;
 
-	if ((st->xcvr.type == XILINX_XCVR_TYPE_US_GTH3) ||
-	    (st->xcvr.type == XILINX_XCVR_TYPE_US_GTH4)) {
-		if (st->sys_clk_sel == ADXCVR_GTH_SYSCLK_QPLL1)
-			qpll_conf.qpll = 1;
-		else
-			qpll_conf.qpll = 0;
-	}
 
 	for (i = 0; i < st->num_lanes; i++) {
 


### PR DESCRIPTION
The QPLL 0/1 checking must go before the usage of the qpll_conf, in other case
the QPLL parameters will be calculated against the wrong VCO ranges
and the function might not find a solution.

Signed-off-by: Laszlo Nagy <laszlo.nagy@analog.com>

Tested on AD9172 ZCU102