### PR TITLE
iio: buffer: cleanup & backport

### DIFF
--- a/drivers/iio/buffer/industrialio-buffer-dmaengine.c
+++ b/drivers/iio/buffer/industrialio-buffer-dmaengine.c
@@ -202,7 +202,7 @@ struct iio_buffer *iio_dmaengine_buffer_alloc(struct device *dev,
 	if (!dmaengine_buffer)
 		return ERR_PTR(-ENOMEM);
 
-	chan = dma_request_slave_channel_reason(dev, channel);
+	chan = dma_request_chan(dev, channel);
 	if (IS_ERR(chan)) {
 		ret = PTR_ERR(chan);
 		goto err_free;

--- a/drivers/iio/industrialio-buffer.c
+++ b/drivers/iio/industrialio-buffer.c
@@ -120,9 +120,6 @@ ssize_t iio_buffer_read_first_n_outer(struct file *filp, char __user *buf,
 	if (!indio_dev->info)
 		return -ENODEV;
 
-	if (!indio_dev->info)
-		return -ENODEV;
-
 	if (!rb || !rb->access->read)
 		return -EINVAL;
 


### PR DESCRIPTION
While checking the IIO DMA buffer, these 2 came out of the diffs.
The backport is straightforward and we can add it now. The only benefit is that it reduces the diff with upstream.

The NULL check seems to have slipped through merges.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>