### PR TITLE
ARM: dts: zynq-m2k-reva & zynq-pluto-sdr: remove axi_sysid_0 node

### DIFF
--- a/arch/arm/boot/dts/zynq-m2k-reva.dts
+++ b/arch/arm/boot/dts/zynq-m2k-reva.dts
@@ -365,11 +365,6 @@
 			reg = <0x7c4c0000 0x10000>;
 			clocks = <&converter_clock>;
 		};
-
-		axi_sysid_0: axi-sysid-0@45000000 {
-			compatible = "adi,axi-sysid-1.00.a";
-			reg = <0x45000000 0x10000>;
-		};
 	};
 };
 

--- a/arch/arm/boot/dts/zynq-pluto-sdr.dtsi
+++ b/arch/arm/boot/dts/zynq-pluto-sdr.dtsi
@@ -183,11 +183,6 @@
 			compatible = "mathworks,mwipcore-axi4lite-v1.00";
 			reg = <0x43c00000 0xffff>;
 		};
-
-		axi_sysid_0: axi-sysid-0@45000000 {
-			compatible = "adi,axi-sysid-1.00.a";
-			reg = <0x45000000 0x10000>;
-		};
 	};
 };
 


### PR DESCRIPTION
the axi_sysid_0 entry is removed from the devicetree because the AXI Sysid IP is missing from the HDL project