### PR TITLE
iio: jesd204: axi_adxvcri,xilinx_transceiver: pass QPLL selection directly from the state struct

### DIFF
--- a/drivers/iio/jesd204/axi_adxcvr.h
+++ b/drivers/iio/jesd204/axi_adxcvr.h
@@ -48,10 +48,6 @@
 #define ADXCVR_DRP_PORT_COMMON(x)	(x)
 #define ADXCVR_DRP_PORT_CHANNEL(x)	(0x100 + (x))
 
-#define ADXCVR_GTH_SYSCLK_CPLL		0
-#define ADXCVR_GTH_SYSCLK_QPLL1		2
-#define ADXCVR_GTH_SYSCLK_QPLL0		3
-
 struct adxcvr_state {
 	struct device		*dev;
 	void __iomem		*regs;

--- a/drivers/iio/jesd204/axi_jesd204b_gt.c
+++ b/drivers/iio/jesd204/axi_jesd204b_gt.c
@@ -652,12 +652,13 @@ static unsigned long jesd204b_gt_clk_recalc_rate(struct clk_hw *hw,
 		struct xilinx_xcvr_qpll_config qpll_conf;
 
 		ret = xilinx_xcvr_qpll_read_config(&st->xcvr,
+			gt_link->sys_clk_sel,
 			JESD204B_GT_DRP_PORT_COMMON, &qpll_conf);
 		if (ret < 0)
 			return ret;
 
 		lane_rate = xilinx_xcvr_qpll_calc_lane_rate(&st->xcvr, parent_rate,
-			&qpll_conf, out_div); 
+			gt_link->sys_clk_sel, &qpll_conf, out_div);
 
 		dev_dbg(st->dev, "%s QPLL  %lu %lu\n", __func__,
 			gt_link->lane_rate, lane_rate);
@@ -684,7 +685,8 @@ static long jesd204b_gt_clk_round_rate(struct clk_hw *hw, unsigned long rate,
 		ret = xilinx_xcvr_calc_cpll_config(&st->xcvr, *prate / 1000, rate,
 				NULL, NULL);
 	else
-		ret = xilinx_xcvr_calc_qpll_config(&st->xcvr, *prate / 1000, rate,
+		ret = xilinx_xcvr_calc_qpll_config(&st->xcvr,
+				gt_link->sys_clk_sel, *prate / 1000, rate,
 				NULL, NULL);
 
 	if (ret < 0)
@@ -713,7 +715,8 @@ static int jesd204b_gt_clk_set_rate(struct clk_hw *hw, unsigned long rate,
 		ret = xilinx_xcvr_calc_cpll_config(&st->xcvr, parent_rate, rate,
 				&cpll_conf, &out_div);
 	else
-		ret = xilinx_xcvr_calc_qpll_config(&st->xcvr, parent_rate, rate,
+		ret = xilinx_xcvr_calc_qpll_config(&st->xcvr,
+				gt_link->sys_clk_sel, parent_rate, rate,
 				&qpll_conf, &out_div);
 
 
@@ -734,6 +737,7 @@ static int jesd204b_gt_clk_set_rate(struct clk_hw *hw, unsigned long rate,
 		} else {
 			if (!pll_done) {
 				xilinx_xcvr_qpll_write_config(&st->xcvr,
+				    gt_link->sys_clk_sel,
 				    JESD204B_GT_DRP_PORT_COMMON, &qpll_conf);
 				pll_done = 1;
 			}

--- a/drivers/iio/jesd204/xilinx_transceiver.c
+++ b/drivers/iio/jesd204/xilinx_transceiver.c
@@ -68,6 +68,14 @@
 #define TX_CLK25_DIV			0x6a
 #define TX_CLK25_DIV_MASK		0x1f
 
+#define GTH34_QPLL0_FBDIV_DIV		0x14
+#define GTH34_QPLL0_REFCLK_DIV		0x18
+#define GTH34_QPLL1_FBDIV		0x94
+#define GTH34_QPLL1_REFCLK_DIV		0x98
+
+#define GTH34_QPLL_FBDIV(x)		(0x14 + (x) * 0x80)
+#define GTH34_QPLL_REFCLK_DIV(x)	(0x18 + (x) * 0x80)
+
 static int xilinx_xcvr_drp_read(struct xilinx_xcvr *xcvr,
 	unsigned int drp_port, unsigned int reg)
 {
@@ -783,15 +791,8 @@ static int xilinx_xcvr_gth34_qpll_read_config(struct xilinx_xcvr *xcvr,
 {
 	int val;
 
-	#define QPLL0_FBDIV_DIV 0x14
-	#define QPLL0_REFCLK_DIV 0x18
-	#define QPLL1_FBDIV 0x94
-	#define QPLL1_REFCLK_DIV 0x98
-
-	#define QPLL_FBDIV(x) (0x14 + (x) * 0x80)
-	#define QPLL_REFCLK_DIV(x) (0x18 + (x) * 0x80)
-
-	val = xilinx_xcvr_drp_read(xcvr, drp_port, QPLL_REFCLK_DIV(conf->qpll));
+	val = xilinx_xcvr_drp_read(xcvr, drp_port,
+			GTH34_QPLL_REFCLK_DIV(conf->qpll));
 	if (val < 0)
 		return val;
 
@@ -813,7 +814,8 @@ static int xilinx_xcvr_gth34_qpll_read_config(struct xilinx_xcvr *xcvr,
 		break;
 	}
 
-	val = xilinx_xcvr_drp_read(xcvr, drp_port, QPLL_FBDIV(conf->qpll));
+	val = xilinx_xcvr_drp_read(xcvr, drp_port,
+			GTH34_QPLL_FBDIV(conf->qpll));
 	if (val < 0)
 		return val;
 
@@ -938,13 +940,13 @@ static int xilinx_xcvr_gth34_qpll_write_config(struct xilinx_xcvr *xcvr,
 		return -EINVAL;
 	}
 
-	ret = xilinx_xcvr_drp_update(xcvr, drp_port, QPLL_FBDIV(conf->qpll),
-		0xff, fbdiv);
+	ret = xilinx_xcvr_drp_update(xcvr, drp_port,
+			GTH34_QPLL_FBDIV(conf->qpll), 0xff, fbdiv);
 	if (ret < 0)
 		return ret;
 
-	return xilinx_xcvr_drp_update(xcvr, drp_port, QPLL_REFCLK_DIV(conf->qpll),
-		0xf80, refclk << 7);
+	return xilinx_xcvr_drp_update(xcvr, drp_port,
+			GTH34_QPLL_REFCLK_DIV(conf->qpll), 0xf80, refclk << 7);
 }
 
 static int xilinx_xcvr_gtx2_qpll_write_config(struct xilinx_xcvr *xcvr,

--- a/drivers/iio/jesd204/xilinx_transceiver.h
+++ b/drivers/iio/jesd204/xilinx_transceiver.h
@@ -75,7 +75,6 @@ struct xilinx_xcvr_qpll_config {
 	unsigned int refclk_div;
 	unsigned int fb_div;
 	unsigned int band;
-	unsigned int qpll;
 };
 
 int xilinx_xcvr_configure_cdr(struct xilinx_xcvr *xcvr, unsigned int drp_port,
@@ -96,15 +95,18 @@ int xilinx_xcvr_cpll_calc_lane_rate(struct xilinx_xcvr *xcvr,
 	unsigned int out_div);
 
 int xilinx_xcvr_calc_qpll_config(struct xilinx_xcvr *xcvr,
-	unsigned int refclk_hz, unsigned int lanerate_khz,
-	struct xilinx_xcvr_qpll_config *conf,
+	unsigned int sys_clk_sel, unsigned int refclk_hz,
+	unsigned int lanerate_khz, struct xilinx_xcvr_qpll_config *conf,
 	unsigned int *out_div);
 int xilinx_xcvr_qpll_read_config(struct xilinx_xcvr *xcvr,
-	unsigned int drp_port, struct xilinx_xcvr_qpll_config *conf);
+	unsigned int drp_port, unsigned int sys_clk_sel,
+	struct xilinx_xcvr_qpll_config *conf);
 int xilinx_xcvr_qpll_write_config(struct xilinx_xcvr *xcvr,
-	unsigned int drp_port, const struct xilinx_xcvr_qpll_config *conf);
+	unsigned int sys_clk_sell, unsigned int drp_port,
+	const struct xilinx_xcvr_qpll_config *conf);
 int xilinx_xcvr_qpll_calc_lane_rate(struct xilinx_xcvr *xcvr,
-	unsigned int ref_clk_hz, const struct xilinx_xcvr_qpll_config *conf,
+	unsigned int sys_clk_sel, unsigned int ref_clk_hz,
+	const struct xilinx_xcvr_qpll_config *conf,
 	unsigned int out_div);
 
 int xilinx_xcvr_read_out_div(struct xilinx_xcvr *xcvr, unsigned int drp_port,


### PR DESCRIPTION
This change moves the selection of the QPLL (0 or 1) to be an input of the
xilinx qpll functions. This API change is less error prone when configuring
the QPLL, as it is passed directly from the axi_adxcvr state struct (i.e.
st->sys_clk_sel).
    
This also means that the `conf` field from `struct xilinx_xcvr_qpll_config`
goes away, simplifying the use of this data-type. Using the `conf` field
was problematic as it would make the `struct xilinx_xcvr_qpll_config` have
a dual-role of both input & output when being used for QPLL functions.
    
Consideration has been taken for the fact that `st->sys_clk_sel` has value
different than 0 or 1. It looks like non-zero value selects QPLL1 and 0
selects QPLL0. Reworking this should probably be done in a different
rework, as this requires a lot of propagation in device-trees.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>