### PR TITLE
[2019_R1] iio: jesd204: backport patches from master

### DIFF
--- a/drivers/iio/jesd204/axi_adxcvr.c
+++ b/drivers/iio/jesd204/axi_adxcvr.c
@@ -24,7 +24,7 @@ static struct adxcvr_state *xcvr_to_adxcvr(struct xilinx_xcvr *xcvr)
 }
 
 static inline unsigned int adxcvr_read(struct adxcvr_state *st,
-									   unsigned int reg)
+				       unsigned int reg)
 {
 	dev_vdbg(st->dev, "%s: reg 0x%X val 0x%X\n", __func__,
 			 reg, ioread32(st->regs + reg));
@@ -33,8 +33,8 @@ static inline unsigned int adxcvr_read(struct adxcvr_state *st,
 }
 
 static inline void adxcvr_write(struct adxcvr_state *st,
-								unsigned int reg,
-								unsigned int val)
+				unsigned int reg,
+				unsigned int val)
 {
 	dev_vdbg(st->dev, "%s: reg 0x%X val 0x%X\n", __func__,
 			 reg, val);
@@ -60,8 +60,9 @@ static int adxcvr_drp_wait_idle(struct adxcvr_state *st, unsigned int drp_addr)
 	return -ETIMEDOUT;
 }
 
-static int adxcvr_drp_read(struct xilinx_xcvr *xcvr, unsigned int drp_port,
-	unsigned int reg)
+static int adxcvr_drp_read(struct xilinx_xcvr *xcvr,
+			   unsigned int drp_port,
+			   unsigned int reg)
 {
 	struct adxcvr_state *st = xcvr_to_adxcvr(xcvr);
 	unsigned int drp_addr, drp_sel;
@@ -75,7 +76,8 @@ static int adxcvr_drp_read(struct xilinx_xcvr *xcvr, unsigned int drp_port,
 	drp_sel = drp_port & 0xFF;
 
 	adxcvr_write(st, ADXCVR_REG_DRP_SEL(drp_addr), drp_sel);
-	adxcvr_write(st, ADXCVR_REG_DRP_CTRL(drp_addr), ADXCVR_DRP_CTRL_ADDR(reg));
+	adxcvr_write(st, ADXCVR_REG_DRP_CTRL(drp_addr),
+		     ADXCVR_DRP_CTRL_ADDR(reg));
 
 	ret = adxcvr_drp_wait_idle(st, drp_addr);
 	if (ret < 0)
@@ -84,8 +86,10 @@ static int adxcvr_drp_read(struct xilinx_xcvr *xcvr, unsigned int drp_port,
 	return ret & 0xffff;
 }
 
-static int adxcvr_drp_write(struct xilinx_xcvr *xcvr, unsigned int drp_port,
-	unsigned int reg, unsigned int val)
+static int adxcvr_drp_write(struct xilinx_xcvr *xcvr,
+			    unsigned int drp_port,
+			    unsigned int reg,
+			    unsigned int val)
 {
 	struct adxcvr_state *st = xcvr_to_adxcvr(xcvr);
 	unsigned int drp_addr, drp_sel;
@@ -99,8 +103,10 @@ static int adxcvr_drp_write(struct xilinx_xcvr *xcvr, unsigned int drp_port,
 	drp_sel = drp_port & 0xFF;
 
 	adxcvr_write(st, ADXCVR_REG_DRP_SEL(drp_addr), drp_sel);
-	adxcvr_write(st, ADXCVR_REG_DRP_CTRL(drp_addr), (ADXCVR_DRP_CTRL_WR |
-		ADXCVR_DRP_CTRL_ADDR(reg) | ADXCVR_DRP_CTRL_WDATA(val)));
+	adxcvr_write(st, ADXCVR_REG_DRP_CTRL(drp_addr),
+		(ADXCVR_DRP_CTRL_WR |
+		 ADXCVR_DRP_CTRL_ADDR(reg) |
+		 ADXCVR_DRP_CTRL_WDATA(val)));
 
 	ret = adxcvr_drp_wait_idle(st, drp_addr);
 	if (ret < 0)
@@ -115,8 +121,8 @@ static const struct xilinx_xcvr_drp_ops adxcvr_drp_ops = {
 };
 
 static ssize_t adxcvr_debug_reg_write(struct device *dev,
-				struct device_attribute *attr,
-				const char *buf, size_t count)
+				      struct device_attribute *attr,
+				      const char *buf, size_t count)
 {
 	struct adxcvr_state *st = dev_get_drvdata(dev);
 	int ret, val, val2, val3;
@@ -250,7 +256,7 @@ static void adxcvr_clk_disable(struct clk_hw *hw)
 }
 
 static unsigned long adxcvr_clk_recalc_rate(struct clk_hw *hw,
-	unsigned long parent_rate)
+					    unsigned long parent_rate)
 {
 	struct adxcvr_state *st =
 		container_of(hw, struct adxcvr_state, lane_clk_hw);
@@ -298,8 +304,9 @@ static unsigned long adxcvr_clk_recalc_rate(struct clk_hw *hw,
 	}
 }
 
-static long adxcvr_clk_round_rate(struct clk_hw *hw, unsigned long rate,
-	unsigned long *prate)
+static long adxcvr_clk_round_rate(struct clk_hw *hw,
+				  unsigned long rate,
+				  unsigned long *prate)
 {
 	struct adxcvr_state *st =
 		container_of(hw, struct adxcvr_state, lane_clk_hw);
@@ -322,8 +329,9 @@ static long adxcvr_clk_round_rate(struct clk_hw *hw, unsigned long rate,
 	return ret < 0 ? ret : rate;
 }
 
-static int adxcvr_clk_set_rate(struct clk_hw *hw, unsigned long rate,
-							   unsigned long parent_rate)
+static int adxcvr_clk_set_rate(struct clk_hw *hw,
+			       unsigned long rate,
+			       unsigned long parent_rate)
 {
 	struct adxcvr_state *st =
 		container_of(hw, struct adxcvr_state, lane_clk_hw);
@@ -408,8 +416,9 @@ static const struct clk_ops clkout_ops = {
 	.set_rate = adxcvr_clk_set_rate,
 };
 
-static int adxcvr_clk_register(struct device *dev, struct device_node *node,
-	const char *parent_name)
+static int adxcvr_clk_register(struct device *dev,
+			       struct device_node *node,
+			       const char *parent_name)
 {
 	struct adxcvr_state *st = dev_get_drvdata(dev);
 	unsigned int out_clk_divider, out_clk_multiplier;
@@ -484,18 +493,13 @@ static int adxcvr_clk_register(struct device *dev, struct device_node *node,
 	return ret;
 }
 
-static int adxcvr_parse_dt(struct adxcvr_state *st,
-						   struct device_node *np)
+static int adxcvr_parse_dt(struct adxcvr_state *st, struct device_node *np)
 {
-	of_property_read_u32(np, "adi,sys-clk-select",
-				&st->sys_clk_sel);
-	of_property_read_u32(np, "adi,out-clk-select",
-				&st->out_clk_sel);
+	of_property_read_u32(np, "adi,sys-clk-select", &st->sys_clk_sel);
+	of_property_read_u32(np, "adi,out-clk-select", &st->out_clk_sel);
 
-	st->cpll_enable = of_property_read_bool(np,
-				"adi,use-cpll-enable");
-	st->lpm_enable = of_property_read_bool(np,
-				"adi,use-lpm-enable");
+	st->cpll_enable = of_property_read_bool(np, "adi,use-cpll-enable");
+	st->lpm_enable = of_property_read_bool(np, "adi,use-lpm-enable");
 
 	INIT_WORK(&st->work, adxcvr_work_func);
 
@@ -719,8 +723,8 @@ static struct platform_driver adxcvr_of_driver = {
 		.owner = THIS_MODULE,
 		.of_match_table = adxcvr_of_match,
 	},
-	.probe		= adxcvr_probe,
-	.remove		= adxcvr_remove,
+	.probe  = adxcvr_probe,
+	.remove = adxcvr_remove,
 };
 
 module_platform_driver(adxcvr_of_driver);

--- a/drivers/iio/jesd204/axi_adxcvr.c
+++ b/drivers/iio/jesd204/axi_adxcvr.c
@@ -493,6 +493,46 @@ static int adxcvr_clk_register(struct device *dev,
 	return ret;
 }
 
+static void adxcvr_parse_dt_vco_ranges(struct adxcvr_state *st,
+				       struct device_node *np)
+{
+	u32 tmp;
+
+	if (st->cpll_enable) {
+		if (of_property_read_u32(np, "adi,vco-min-khz", &tmp) == 0)
+			st->xcvr.vco0_min = tmp;
+		else
+			st->xcvr.vco0_min = 0;
+
+		if (of_property_read_u32(np, "adi,vco-max-khz", &tmp) == 0)
+			st->xcvr.vco0_max = tmp;
+		else
+			st->xcvr.vco0_max = 0;
+
+		return;
+	}
+
+	if (of_property_read_u32(np, "adi,vco0-min-khz", &tmp) == 0)
+		st->xcvr.vco0_min = tmp;
+	else
+		st->xcvr.vco0_min = 0;
+
+	if (of_property_read_u32(np, "adi,vco0-max-khz", &tmp) == 0)
+		st->xcvr.vco0_max = tmp;
+	else
+		st->xcvr.vco0_max = 0;
+
+	if (of_property_read_u32(np, "adi,vco1-min-khz", &tmp) == 0)
+		st->xcvr.vco1_min = tmp;
+	else
+		st->xcvr.vco1_min = 0;
+
+	if (of_property_read_u32(np, "adi,vco1-max-khz", &tmp) == 0)
+		st->xcvr.vco1_max = tmp;
+	else
+		st->xcvr.vco1_max = 0;
+}
+
 static int adxcvr_parse_dt(struct adxcvr_state *st, struct device_node *np)
 {
 	of_property_read_u32(np, "adi,sys-clk-select", &st->sys_clk_sel);
@@ -500,6 +540,8 @@ static int adxcvr_parse_dt(struct adxcvr_state *st, struct device_node *np)
 
 	st->cpll_enable = of_property_read_bool(np, "adi,use-cpll-enable");
 	st->lpm_enable = of_property_read_bool(np, "adi,use-lpm-enable");
+
+	adxcvr_parse_dt_vco_ranges(st, np);
 
 	INIT_WORK(&st->work, adxcvr_work_func);
 

--- a/drivers/iio/jesd204/axi_adxcvr.h
+++ b/drivers/iio/jesd204/axi_adxcvr.h
@@ -48,10 +48,6 @@
 #define ADXCVR_DRP_PORT_COMMON(x)	(x)
 #define ADXCVR_DRP_PORT_CHANNEL(x)	(0x100 + (x))
 
-#define ADXCVR_GTH_SYSCLK_CPLL		0
-#define ADXCVR_GTH_SYSCLK_QPLL1		2
-#define ADXCVR_GTH_SYSCLK_QPLL0		3
-
 struct adxcvr_state {
 	struct device		*dev;
 	void __iomem		*regs;

--- a/drivers/iio/jesd204/axi_jesd204b_gt.c
+++ b/drivers/iio/jesd204/axi_jesd204b_gt.c
@@ -652,12 +652,13 @@ static unsigned long jesd204b_gt_clk_recalc_rate(struct clk_hw *hw,
 		struct xilinx_xcvr_qpll_config qpll_conf;
 
 		ret = xilinx_xcvr_qpll_read_config(&st->xcvr,
+			gt_link->sys_clk_sel,
 			JESD204B_GT_DRP_PORT_COMMON, &qpll_conf);
 		if (ret < 0)
 			return ret;
 
 		lane_rate = xilinx_xcvr_qpll_calc_lane_rate(&st->xcvr, parent_rate,
-			&qpll_conf, out_div); 
+			gt_link->sys_clk_sel, &qpll_conf, out_div);
 
 		dev_dbg(st->dev, "%s QPLL  %lu %lu\n", __func__,
 			gt_link->lane_rate, lane_rate);
@@ -684,7 +685,8 @@ static long jesd204b_gt_clk_round_rate(struct clk_hw *hw, unsigned long rate,
 		ret = xilinx_xcvr_calc_cpll_config(&st->xcvr, *prate / 1000, rate,
 				NULL, NULL);
 	else
-		ret = xilinx_xcvr_calc_qpll_config(&st->xcvr, *prate / 1000, rate,
+		ret = xilinx_xcvr_calc_qpll_config(&st->xcvr,
+				gt_link->sys_clk_sel, *prate / 1000, rate,
 				NULL, NULL);
 
 	if (ret < 0)
@@ -713,7 +715,8 @@ static int jesd204b_gt_clk_set_rate(struct clk_hw *hw, unsigned long rate,
 		ret = xilinx_xcvr_calc_cpll_config(&st->xcvr, parent_rate, rate,
 				&cpll_conf, &out_div);
 	else
-		ret = xilinx_xcvr_calc_qpll_config(&st->xcvr, parent_rate, rate,
+		ret = xilinx_xcvr_calc_qpll_config(&st->xcvr,
+				gt_link->sys_clk_sel, parent_rate, rate,
 				&qpll_conf, &out_div);
 
 
@@ -734,6 +737,7 @@ static int jesd204b_gt_clk_set_rate(struct clk_hw *hw, unsigned long rate,
 		} else {
 			if (!pll_done) {
 				xilinx_xcvr_qpll_write_config(&st->xcvr,
+				    gt_link->sys_clk_sel,
 				    JESD204B_GT_DRP_PORT_COMMON, &qpll_conf);
 				pll_done = 1;
 			}

--- a/drivers/iio/jesd204/axi_jesd204b_v51.c
+++ b/drivers/iio/jesd204/axi_jesd204b_v51.c
@@ -319,6 +319,7 @@ static int jesd204b_probe(struct platform_device *pdev)
 			device_create_file(&pdev->dev, &dev_attr_lane6_syncstat);
 			device_create_file(&pdev->dev, &dev_attr_lane7_syncstat);
 		}
+		/* fall-through */
 	case 4:
 		device_create_file(&pdev->dev, &dev_attr_lane2_info);
 		device_create_file(&pdev->dev, &dev_attr_lane3_info);
@@ -326,10 +327,12 @@ static int jesd204b_probe(struct platform_device *pdev)
 			device_create_file(&pdev->dev, &dev_attr_lane2_syncstat);
 			device_create_file(&pdev->dev, &dev_attr_lane3_syncstat);
 		}
+		/* fall-through */
 	case 2:
 		device_create_file(&pdev->dev, &dev_attr_lane1_info);
 		if (!st->transmit)
 			device_create_file(&pdev->dev, &dev_attr_lane1_syncstat);
+		/* fall-through */
 	case 1:
 		device_create_file(&pdev->dev, &dev_attr_lane0_info);
 		if (!st->transmit)

--- a/drivers/iio/jesd204/xilinx_transceiver.c
+++ b/drivers/iio/jesd204/xilinx_transceiver.c
@@ -662,6 +662,7 @@ static int xilinx_xcvr_gtx2_cpll_write_config(struct xilinx_xcvr *xcvr,
 	switch (conf->fb_div_N2) {
 	case 1:
 		val |= 0x10;
+		/* fall-through */
 	case 2:
 		val |= 0x00;
 		break;

--- a/drivers/iio/jesd204/xilinx_transceiver.c
+++ b/drivers/iio/jesd204/xilinx_transceiver.c
@@ -68,6 +68,14 @@
 #define TX_CLK25_DIV			0x6a
 #define TX_CLK25_DIV_MASK		0x1f
 
+#define GTH34_QPLL0_FBDIV_DIV		0x14
+#define GTH34_QPLL0_REFCLK_DIV		0x18
+#define GTH34_QPLL1_FBDIV		0x94
+#define GTH34_QPLL1_REFCLK_DIV		0x98
+
+#define GTH34_QPLL_FBDIV(x)		(0x14 + (x) * 0x80)
+#define GTH34_QPLL_REFCLK_DIV(x)	(0x18 + (x) * 0x80)
+
 static int xilinx_xcvr_drp_read(struct xilinx_xcvr *xcvr,
 	unsigned int drp_port, unsigned int reg)
 {
@@ -765,15 +773,8 @@ static int xilinx_xcvr_gth34_qpll_read_config(struct xilinx_xcvr *xcvr,
 {
 	int val;
 
-	#define QPLL0_FBDIV_DIV 0x14
-	#define QPLL0_REFCLK_DIV 0x18
-	#define QPLL1_FBDIV 0x94
-	#define QPLL1_REFCLK_DIV 0x98
-
-	#define QPLL_FBDIV(x) (0x14 + (x) * 0x80)
-	#define QPLL_REFCLK_DIV(x) (0x18 + (x) * 0x80)
-
-	val = xilinx_xcvr_drp_read(xcvr, drp_port, QPLL_REFCLK_DIV(conf->qpll));
+	val = xilinx_xcvr_drp_read(xcvr, drp_port,
+			GTH34_QPLL_REFCLK_DIV(conf->qpll));
 	if (val < 0)
 		return val;
 
@@ -795,7 +796,8 @@ static int xilinx_xcvr_gth34_qpll_read_config(struct xilinx_xcvr *xcvr,
 		break;
 	}
 
-	val = xilinx_xcvr_drp_read(xcvr, drp_port, QPLL_FBDIV(conf->qpll));
+	val = xilinx_xcvr_drp_read(xcvr, drp_port,
+			GTH34_QPLL_FBDIV(conf->qpll));
 	if (val < 0)
 		return val;
 
@@ -920,13 +922,13 @@ static int xilinx_xcvr_gth34_qpll_write_config(struct xilinx_xcvr *xcvr,
 		return -EINVAL;
 	}
 
-	ret = xilinx_xcvr_drp_update(xcvr, drp_port, QPLL_FBDIV(conf->qpll),
-		0xff, fbdiv);
+	ret = xilinx_xcvr_drp_update(xcvr, drp_port,
+			GTH34_QPLL_FBDIV(conf->qpll), 0xff, fbdiv);
 	if (ret < 0)
 		return ret;
 
-	return xilinx_xcvr_drp_update(xcvr, drp_port, QPLL_REFCLK_DIV(conf->qpll),
-		0xf80, refclk << 7);
+	return xilinx_xcvr_drp_update(xcvr, drp_port,
+			GTH34_QPLL_REFCLK_DIV(conf->qpll), 0xf80, refclk << 7);
 }
 
 static int xilinx_xcvr_gtx2_qpll_write_config(struct xilinx_xcvr *xcvr,

--- a/drivers/iio/jesd204/xilinx_transceiver.c
+++ b/drivers/iio/jesd204/xilinx_transceiver.c
@@ -351,6 +351,12 @@ static int xilinx_xcvr_get_cpll_vco_ranges(struct xilinx_xcvr *xcvr,
 	if (ADI_AXI_PCORE_VER_MAJOR(xcvr->version) > 0x10)
 		xilinx_xcvr_setup_cpll_vco_range(xcvr, vco_max);
 
+	if (xcvr->vco0_min)
+		*vco_min = xcvr->vco0_min;
+
+	if (xcvr->vco0_max)
+		*vco_max = xcvr->vco0_max;
+
 	return 0;
 }
 
@@ -442,6 +448,18 @@ static int xilinx_xcvr_get_qpll_vco_ranges(struct xilinx_xcvr *xcvr,
 		xilinx_xcvr_setup_qpll_vco_range(xcvr,
 						 vco0_min, vco0_max,
 						 vco1_min, vco1_max);
+
+	if (xcvr->vco0_min)
+		*vco0_min = xcvr->vco0_min;
+
+	if (xcvr->vco0_max)
+		*vco0_max = xcvr->vco0_max;
+
+	if (xcvr->vco1_min)
+		*vco0_min = xcvr->vco1_min;
+
+	if (xcvr->vco1_max)
+		*vco1_max = xcvr->vco1_max;
 
 	return 0;
 }

--- a/drivers/iio/jesd204/xilinx_transceiver.h
+++ b/drivers/iio/jesd204/xilinx_transceiver.h
@@ -75,7 +75,6 @@ struct xilinx_xcvr_qpll_config {
 	unsigned int refclk_div;
 	unsigned int fb_div;
 	unsigned int band;
-	unsigned int qpll;
 };
 
 int xilinx_xcvr_configure_cdr(struct xilinx_xcvr *xcvr, unsigned int drp_port,
@@ -96,15 +95,18 @@ int xilinx_xcvr_cpll_calc_lane_rate(struct xilinx_xcvr *xcvr,
 	unsigned int out_div);
 
 int xilinx_xcvr_calc_qpll_config(struct xilinx_xcvr *xcvr,
-	unsigned int refclk_hz, unsigned int lanerate_khz,
-	struct xilinx_xcvr_qpll_config *conf,
+	unsigned int sys_clk_sel, unsigned int refclk_hz,
+	unsigned int lanerate_khz, struct xilinx_xcvr_qpll_config *conf,
 	unsigned int *out_div);
 int xilinx_xcvr_qpll_read_config(struct xilinx_xcvr *xcvr,
-	unsigned int drp_port, struct xilinx_xcvr_qpll_config *conf);
+	unsigned int drp_port, unsigned int sys_clk_sel,
+	struct xilinx_xcvr_qpll_config *conf);
 int xilinx_xcvr_qpll_write_config(struct xilinx_xcvr *xcvr,
-	unsigned int drp_port, const struct xilinx_xcvr_qpll_config *conf);
+	unsigned int sys_clk_sell, unsigned int drp_port,
+	const struct xilinx_xcvr_qpll_config *conf);
 int xilinx_xcvr_qpll_calc_lane_rate(struct xilinx_xcvr *xcvr,
-	unsigned int ref_clk_hz, const struct xilinx_xcvr_qpll_config *conf,
+	unsigned int sys_clk_sel, unsigned int ref_clk_hz,
+	const struct xilinx_xcvr_qpll_config *conf,
 	unsigned int out_div);
 
 int xilinx_xcvr_read_out_div(struct xilinx_xcvr *xcvr, unsigned int drp_port,

--- a/drivers/iio/jesd204/xilinx_transceiver.h
+++ b/drivers/iio/jesd204/xilinx_transceiver.h
@@ -56,6 +56,11 @@ struct xilinx_xcvr {
 	enum adi_axi_fpga_speed_grade speed_grade;
 	enum adi_axi_fpga_dev_pack dev_package;
 	unsigned int voltage;
+
+	unsigned int vco0_min;
+	unsigned int vco0_max;
+	unsigned int vco1_min;
+	unsigned int vco1_max;
 };
 
 #define ENC_8B10B					810


### PR DESCRIPTION
These patches sync the XCVR code in 2019_R1 with master.
Not all patches have been backported.
These 2 were skipped:
* 46464976eaf18909fce5dbccf1081c2f57cbab27  - `iio: jesd204: axi_jesd204_rx: Add support for up to 16 lanes`
* 0c7173a1f0530a80483aebb365a8926f0f24b813 - `iio: axi_adxcvr: print warning on set_rate in adxcvr_enforce_settings()`

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>
