### PR TITLE
iio: iio-regmap: Fix uninitialized variable

### DIFF
--- a/drivers/iio/regmap/iio-regmap.c
+++ b/drivers/iio/regmap/iio-regmap.c
@@ -513,7 +513,7 @@ int iio_regmap_probe(struct device *dev, struct regmap *regmap,
 	const struct iio_regmap_op *register_ops;
 	struct iio_dev *indio_dev;
 	struct iio_regmap *st;
-	int nr_ops;
+	int nr_ops = 0;
 	int ret;
 
 	indio_dev = devm_iio_device_alloc(dev, sizeof(*st));


### PR DESCRIPTION
Before this patch, in iio_regmap_probe, nr_ops was not
initialized when parse_firmware failed, the compiler giving
a warning.

Now nr_ops is initialized in iio_regmap_probe.

Signed-off-by: Alexandru Tachici <alexandru.tachici@analog.com>