### PR TITLE
net: macb: ptp: initialize tsu_rate

### DIFF
--- a/drivers/net/ethernet/cadence/macb_ptp.c
+++ b/drivers/net/ethernet/cadence/macb_ptp.c
@@ -370,6 +370,7 @@ void gem_ptp_init(struct net_device *dev)
 	bp->ptp_clock_info = gem_ptp_caps_template;
 
 	/* nominal frequency and maximum adjustment in ppb */
+	bp->tsu_rate = bp->ptp_info->get_tsu_rate(bp);
 	bp->ptp_clock_info.max_adj = bp->ptp_info->get_ptp_max_adj();
 	gem_ptp_init_timer(bp);
 	bp->ptp_clock = ptp_clock_register(&bp->ptp_clock_info, &dev->dev);


### PR DESCRIPTION
This seems to cause some division-by-zero warnings in the kernel. It looks
like the upstream version of this code has this initialization, while the
Xilinx one doesn't. It may have been lost during some merge, since the
commit ab91f0a9b5f4b ("net: macb: Add hardware PTP support") is present in
the Xilinx tree.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>