### PR TITLE
spi: spi-axi: prefix with 'static inline' functions in header

### DIFF
--- a/include/linux/spi/spi-engine.h
+++ b/include/linux/spi/spi-engine.h
@@ -18,16 +18,16 @@ int spi_engine_offload_load_msg(struct spi_device *spi,
 
 #else
 
-bool spi_engine_offload_supported(struct spi_device *spi)
+static inline bool spi_engine_offload_supported(struct spi_device *spi)
 {
 	return false;
 }
 
-void spi_engine_offload_enable(struct spi_device *spi, bool enable)
+static inline void spi_engine_offload_enable(struct spi_device *spi, bool enable)
 {
 }
 
-int spi_engine_offload_load_msg(struct spi_device *spi,
+static inline int spi_engine_offload_load_msg(struct spi_device *spi,
 	struct spi_message *msg)
 {
 	return -ENODEV;


### PR DESCRIPTION
If SPI AXI engine is not enabled, then a linker error can occur with
multiple re-definitions of these functions.

Adding 'static inline' makes sure this doesn't happen.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>