### PR TITLE
media: adi-axi-fb: cast var to uint32 for print message

### DIFF
--- a/drivers/media/platform/adi-axi-fb.c
+++ b/drivers/media/platform/adi-axi-fb.c
@@ -170,7 +170,7 @@ static int frame_buffer_probe(struct platform_device *pdev)
 		}
 	}
 	dev_info(&pdev->dev, "Allocated reserved memory, paddr: 0x%0X\n",
-		 frm_buff->video_ram_buf.start);
+		 (unsigned int)frm_buff->video_ram_buf.start);
 
 	/* Get physical address of DMAs*/
 	res = platform_get_resource_byname(pdev, IORESOURCE_MEM, "tx_dma");


### PR DESCRIPTION
On ARM64, the print throws a warning. Seems that the 'start' field is
dependent on the ARCH.
To make the print happy (and the compiler), we cast it to 'unsigned int'.
Using 'uintptr_t' is also possible, but it would not print anything, due to
some security-change in the kernel.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>