### PR TITLE
iio: jesd204: axi_jesd204_rx: add explicit fall-through comment

### DIFF
--- a/drivers/iio/jesd204/axi_jesd204_rx.c
+++ b/drivers/iio/jesd204/axi_jesd204_rx.c
@@ -685,6 +685,7 @@ static int axi_jesd204_rx_probe(struct platform_device *pdev)
 		device_create_file(&pdev->dev, &dev_attr_lane10_info);
 		device_create_file(&pdev->dev, &dev_attr_lane9_info);
 		device_create_file(&pdev->dev, &dev_attr_lane8_info);
+		/* fall-through */
 	case 8:
 		device_create_file(&pdev->dev, &dev_attr_lane4_info);
 		device_create_file(&pdev->dev, &dev_attr_lane5_info);


### PR DESCRIPTION
This only fails on newer kernels which have this check enabled.
Fix this is in master so that it propagates.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>