### PR TITLE
dts: arm: overlays: Add ADAU1761 overlay

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -128,6 +128,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	pwm-ir-tx.dtbo \
 	qca7000.dtbo \
 	rotary-encoder.dtbo \
+	rpi-adau1761.dtbo \
 	rpi-addi9036.dtbo \
 	rpi-adf4371.dtbo \
 	rpi-ad5686.dtbo \

--- a/arch/arm/boot/dts/overlays/rpi-adau1761-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-adau1761-overlay.dts
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: GPL-2.0
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target = <&clocks>;
+		__overlay__ {
+			adau1761_mclk: oscillator {
+				compatible = "fixed-clock";
+				status = "okay";
+				#clock-cells=<0>;
+				clock-frequency = <12288000>;
+				clock-output-names = "adau1761_mclk";
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&i2s>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@2 {
+		target = <&i2c1>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			adau1761_codec: adau1761-codec@38 {
+				compatible = "adi,adau1761";
+				status = "okay";
+				reg = <0x38>;
+				#sound-dai-cells = <0>;
+				clock-names = "mclk";
+				clocks = <&adau1761_mclk>;
+			};
+		};
+	};
+
+	fragment@3 {
+		target = <&sound>;
+		sound_overlay: __overlay__ {
+			compatible = "simple-audio-card";
+			status = "okay";
+			simple-audio-card,format = "i2s";
+			simple-audio-card,name = "EVAL-ADAU1761Z";
+			simple-audio-card,bitclock-master = <&dailink0_master>;
+			simple-audio-card,frame-master = <&dailink0_master>;
+			simple-audio-card,widgets =
+				"Microphone", "Mic In",
+				"Headphone", "Headphone Out",
+				"Line", "Line In",
+				"Line", "Line Out";
+			simple-audio-card,routing =
+				"Line Out", "LOUT",
+				"Line Out", "ROUT",
+				"Headphone Out", "LHP",
+				"Headphone Out", "RHP",
+				"Mic In", "MICBIAS",
+				"LINN", "Mic In",
+				"RINN", "Mic In",
+				"LINP", "Mic In",
+				"RINP", "Mic In",
+				"LAUX", "Line In",
+				"RAUX", "Line In";
+			simple-audio-card,cpu {
+				/* so that bclk is 64x FS */
+				dai-tdm-slot-num = <2>;
+				dai-tdm-slot-width = <32>;
+				sound-dai = <&i2s>;
+			};
+			dailink0_master: simple-audio-card,codec {
+				sound-dai = <&adau1761_codec>;
+			};
+		};
+	};
+
+	__overrides__ {
+		card-name = <&sound_overlay>,"simple-audio-card,name";
+	};
+};


### PR DESCRIPTION
Add devicetree overlay for ADAU1761 SigmaDSP Stereo codec.

Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>