### PR TITLE
arch: arm: rfsom: add project tags

### DIFF
--- a/arch/arm/boot/dts/zynq-adrv9361-z7035-bob-cmos.dts
+++ b/arch/arm/boot/dts/zynq-adrv9361-z7035-bob-cmos.dts
@@ -1,3 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * AD9361-Z7035 System on Module (SOM) SDR - Breakout Carrier (CMOS)
+ * Link: https://www.analog.com/ADRV9361-Z7035
+ * Link: https://wiki.analog.com/resources/eval/user-guides/adrv936x_rfsom
+ *
+ * hdl_project: <adrv9361z7035/ccbob_cmos>
+ * board_revision: <>
+ *
+ * Copyright 2016-2019 Analog Devices Inc.
+ */
 #include  "zynq-adrv9361-z7035-bob.dts"
 
 &adc0_ad9361 {

--- a/arch/arm/boot/dts/zynq-adrv9361-z7035-bob.dts
+++ b/arch/arm/boot/dts/zynq-adrv9361-z7035-bob.dts
@@ -1,3 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * AD9361-Z7035 System on Module (SOM) SDR - Breakout Carrier
+ * Link: https://www.analog.com/ADRV9361-Z7035
+ * Link: https://wiki.analog.com/resources/eval/user-guides/adrv936x_rfsom
+ *
+ * hdl_project: <adrv9361z7035/ccbob_lvds>
+ * board_revision: <>
+ *
+ * Copyright 2015-2019 Analog Devices Inc.
+ */
 /dts-v1/;
 #include "zynq-adrv9361-z7035.dtsi"
 

--- a/arch/arm/boot/dts/zynq-adrv9361-z7035-fmc-rfcard-tdd.dts
+++ b/arch/arm/boot/dts/zynq-adrv9361-z7035-fmc-rfcard-tdd.dts
@@ -1,3 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * AD9361-Z7035 System on Module (SOM) SDR - FMC Carrier - TDD mode
+ * Link: https://www.analog.com/ADRV9361-Z7035
+ * Link: https://wiki.analog.com/resources/eval/user-guides/adrv936x_rfsom
+ *
+ * hdl_project: <adrv9361z7035/ccfmc_lvds>
+ * board_revision: <>
+ *
+ * Copyright 2015-2019 Analog Devices Inc.
+ */
 #include "zynq-adrv9361-z7035-fmc.dts"
 
 &adc0_ad9361 {

--- a/arch/arm/boot/dts/zynq-adrv9361-z7035-fmc.dts
+++ b/arch/arm/boot/dts/zynq-adrv9361-z7035-fmc.dts
@@ -1,3 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * AD9361-Z0735 System on Module (SOM) SDR - FMC Carrier
+ * Link: https://www.analog.com/ADRV9361-Z7035
+ * Link: https://wiki.analog.com/resources/eval/user-guides/adrv936x_rfsom
+ *
+ * hdl_project: <adrv9361z7035/ccfmc_lvds>
+ * board_revision: <>
+ *
+ * Copyright 2015-2019 Analog Devices Inc.
+ */
 /dts-v1/;
 #include "zynq-adrv9361-z7035.dtsi"
 

--- a/arch/arm/boot/dts/zynq-adrv9361-z7035-packrf.dts
+++ b/arch/arm/boot/dts/zynq-adrv9361-z7035-packrf.dts
@@ -1,3 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * AD9361-Z7035 System on Module (SOM) SDR - PackRF Carrier
+ * Link: https://www.analog.com/ADRV9361-Z7035
+ * Link: https://wiki.analog.com/resources/eval/user-guides/adrv936x_rfsom
+ *
+ * hdl_project: <adrv9361z7035/ccpackrf_lvds>
+ * board_revision: <>
+ *
+ * Copyright 2016-2019 Analog Devices Inc.
+ */
 /dts-v1/;
 #include "zynq-adrv9361-z7035.dtsi"
 #include <dt-bindings/input/input.h>

--- a/arch/arm/boot/dts/zynq-adrv9361-z7035-userspace.dts
+++ b/arch/arm/boot/dts/zynq-adrv9361-z7035-userspace.dts
@@ -1,8 +1,20 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * AD9361-Z7035 System on Module (SOM) SDR - Userspace Portable Radio Reference Design
+ * Link: https://www.analog.com/ADRV9361-Z7035
+ * Link: https://wiki.analog.com/resources/eval/user-guides/adrv936x_rfsom
+ * Link: https://wiki.analog.com/resources/eval/user-guides/pzsdr/carriers/portable-radio-reference-design/features
+ *
+ * hdl_project: <adrv9361z7035/ccfmc_lvds>
+ * board_revision: <>
+ *
+ * Copyright 2015-2019 Analog Devices Inc.
+ */
 /dts-v1/;
 #include "zynq.dtsi"
 
 / {
-	model = "Analog Devices ADRV9364-Z7020";
+	model = "Analog Devices ADRV9361-Z7035";
 	memory {
 		device_type = "memory";
 		reg = <0x00000000 0x40000000>;

--- a/arch/arm/boot/dts/zynq-adrv9364-z7020-bob-cmos.dts
+++ b/arch/arm/boot/dts/zynq-adrv9364-z7020-bob-cmos.dts
@@ -1,3 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * AD9364-Z7020 System on Module (SOM) SDR - Breakout Carrier (CMOS)
+ * Link: https://www.analog.com/ADRV9361-Z7020
+ * Link: https://wiki.analog.com/resources/eval/user-guides/adrv936x_rfsom
+ *
+ * hdl_project: <adrv9364z7020/ccbob_cmos>
+ * board_revision: <>
+ *
+ * Copyright 2016-2019 Analog Devices Inc.
+ */
 #include  "zynq-adrv9364-z7020-bob.dts"
 
 &adc0_ad9364 {

--- a/arch/arm/boot/dts/zynq-adrv9364-z7020-bob.dts
+++ b/arch/arm/boot/dts/zynq-adrv9364-z7020-bob.dts
@@ -1,3 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * AD9364-Z7020 System on Module (SOM) SDR - Breakout Carrier
+ * Link: https://www.analog.com/ADRV9361-Z7020
+ * Link: https://wiki.analog.com/resources/eval/user-guides/adrv936x_rfsom
+ *
+ * hdl_project: <adrv9364z7020/ccbob_lvds>
+ * board_revision: <>
+ *
+ * Copyright 2015-2019 Analog Devices Inc.
+ */
 /dts-v1/;
 #include "zynq-adrv9364-z7020.dtsi"
 

--- a/arch/arm/boot/dts/zynq-adrv9364-z7020-packrf.dts
+++ b/arch/arm/boot/dts/zynq-adrv9364-z7020-packrf.dts
@@ -1,3 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * AD9364-Z7020 System on Module (SOM) SDR - PackRF Carrier
+ * Link: https://www.analog.com/ADRV9361-Z7020
+ * Link: https://wiki.analog.com/resources/eval/user-guides/adrv936x_rfsom
+ *
+ * hdl_project: <adrv9364z7020/ccpackrf_lvds>
+ * board_revision: <>
+ *
+ * Copyright 2016-2019 Analog Devices Inc.
+ */
 /dts-v1/;
 #include "zynq-adrv9364-z7020.dtsi"
 #include <dt-bindings/input/input.h>


### PR DESCRIPTION
This change adds project tags to the RFSOM device-trees.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>