### PR TITLE
arch: arm: pluto,m2k & derivatives: add project tags

### DIFF
--- a/arch/arm/boot/dts/zynq-e310.dts
+++ b/arch/arm/boot/dts/zynq-e310.dts
@@ -1,9 +1,12 @@
+// SPDX-License-Identifier: GPL-2.0
 /*
  * Ettus Research E310
+ * Link: https://www.ettus.com/all-products/e310/
  *
- * Copyright (C) 2018 Analog Devices Inc.
+ * hdl_project: <usrpe31x>
+ * board_revision: <>
  *
- * Licensed under the GPL-2.
+ * Copyright (C) 2018-2019 Analog Devices Inc.
  */
 /dts-v1/;
 #include "zynq.dtsi"

--- a/arch/arm/boot/dts/zynq-m2k-reva.dts
+++ b/arch/arm/boot/dts/zynq-m2k-reva.dts
@@ -1,3 +1,16 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices ADALM2000
+ * https://wiki.analog.com/university/tools/m2k
+ * https://wiki.analog.com/university/courses/electronics/labs
+ * https://wiki.analog.com/university/tools/adalm2000/devs/intro
+ * https://wiki.analog.com/university/tools/m2k/users/quick_start
+ *
+ * hdl_project: <m2k/standalone>
+ * board_revision: <A>
+ *
+ * Copyright (C) 2018-2019 Analog Devices Inc.
+ */
 /dts-v1/;
 
 #include "zynq-m2k.dtsi"

--- a/arch/arm/boot/dts/zynq-m2k-revb.dts
+++ b/arch/arm/boot/dts/zynq-m2k-revb.dts
@@ -1,3 +1,16 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices ADALM2000
+ * https://wiki.analog.com/university/tools/m2k
+ * https://wiki.analog.com/university/courses/electronics/labs
+ * https://wiki.analog.com/university/tools/adalm2000/devs/intro
+ * https://wiki.analog.com/university/tools/m2k/users/quick_start
+ *
+ * hdl_project: <m2k/standalone>
+ * board_revision: <B>
+ *
+ * Copyright (C) 2018-2019 Analog Devices Inc.
+ */
 /*
  * 	Summary of RevA -> RevB hardware changes which require firmware changes:
  *

--- a/arch/arm/boot/dts/zynq-m2k-revc.dts
+++ b/arch/arm/boot/dts/zynq-m2k-revc.dts
@@ -1,3 +1,16 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices ADALM2000
+ * https://wiki.analog.com/university/tools/m2k
+ * https://wiki.analog.com/university/courses/electronics/labs
+ * https://wiki.analog.com/university/tools/adalm2000/devs/intro
+ * https://wiki.analog.com/university/tools/m2k/users/quick_start
+ *
+ * hdl_project: <m2k/standalone>
+ * board_revision: <C>
+ *
+ * Copyright (C) 2018-2019 Analog Devices Inc.
+ */
 /*
  * 	Summary of RevB -> RevC hardware changes which require firmware changes:
  *

--- a/arch/arm/boot/dts/zynq-m2k-revd.dts
+++ b/arch/arm/boot/dts/zynq-m2k-revd.dts
@@ -1,3 +1,16 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices ADALM2000
+ * https://wiki.analog.com/university/tools/m2k
+ * https://wiki.analog.com/university/courses/electronics/labs
+ * https://wiki.analog.com/university/tools/adalm2000/devs/intro
+ * https://wiki.analog.com/university/tools/m2k/users/quick_start
+ *
+ * hdl_project: <m2k/standalone>
+ * board_revision: <D>
+ *
+ * Copyright (C) 2018-2019 Analog Devices Inc.
+ */
 /*
  * 	Summary of RevC -> RevD hardware changes which require firmware changes:
  *	Nothing: Update model string to be in sync with the PCB silkscreen

--- a/arch/arm/boot/dts/zynq-m2k-reve.dts
+++ b/arch/arm/boot/dts/zynq-m2k-reve.dts
@@ -1,3 +1,16 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices ADALM2000
+ * https://wiki.analog.com/university/tools/m2k
+ * https://wiki.analog.com/university/courses/electronics/labs
+ * https://wiki.analog.com/university/tools/adalm2000/devs/intro
+ * https://wiki.analog.com/university/tools/m2k/users/quick_start
+ *
+ * hdl_project: <m2k/standalone>
+ * board_revision: <E>
+ *
+ * Copyright (C) 2018-2019 Analog Devices Inc.
+ */
 /*
  * 	Summary of RevD -> RevE hardware changes which require firmware changes:
  *	Placeholder only for potential future revision

--- a/arch/arm/boot/dts/zynq-m2k-revf.dts
+++ b/arch/arm/boot/dts/zynq-m2k-revf.dts
@@ -1,3 +1,16 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices ADALM2000
+ * https://wiki.analog.com/university/tools/m2k
+ * https://wiki.analog.com/university/courses/electronics/labs
+ * https://wiki.analog.com/university/tools/adalm2000/devs/intro
+ * https://wiki.analog.com/university/tools/m2k/users/quick_start
+ *
+ * hdl_project: <m2k/standalone>
+ * board_revision: <F>
+ *
+ * Copyright (C) 2018-2019 Analog Devices Inc.
+ */
 /*
  * 	Summary of RevE -> RevF hardware changes which require firmware changes:
  *	Placeholder only for potential future revision

--- a/arch/arm/boot/dts/zynq-pluto-sdr-revb.dts
+++ b/arch/arm/boot/dts/zynq-pluto-sdr-revb.dts
@@ -1,3 +1,16 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices ADALM Pluto
+ * https://wiki.analog.com/university/tools/pluto
+ * https://wiki.analog.com/university/tools/pluto/users
+ * https://wiki.analog.com/university/tools/pluto/users/firmware
+ * https://wiki.analog.com/university/tools/pluto/other
+ *
+ * hdl_project: <pluto>
+ * board_revision: <B>
+ *
+ * Copyright (C) 2016-2019 Analog Devices Inc.
+ */
 /dts-v1/;
 #include "zynq-pluto-sdr.dtsi"
 #include <dt-bindings/input/input.h>

--- a/arch/arm/boot/dts/zynq-pluto-sdr-revc.dts
+++ b/arch/arm/boot/dts/zynq-pluto-sdr-revc.dts
@@ -1,3 +1,16 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices ADALM Pluto
+ * https://wiki.analog.com/university/tools/pluto
+ * https://wiki.analog.com/university/tools/pluto/users
+ * https://wiki.analog.com/university/tools/pluto/users/firmware
+ * https://wiki.analog.com/university/tools/pluto/other
+ *
+ * hdl_project: <pluto>
+ * board_revision: <C>
+ *
+ * Copyright (C) 2016-2019 Analog Devices Inc.
+ */
 /dts-v1/;
 #include "zynq-pluto-sdr.dtsi"
 #include <dt-bindings/input/input.h>

--- a/arch/arm/boot/dts/zynq-pluto-sdr.dts
+++ b/arch/arm/boot/dts/zynq-pluto-sdr.dts
@@ -1,3 +1,16 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices ADALM Pluto
+ * https://wiki.analog.com/university/tools/pluto
+ * https://wiki.analog.com/university/tools/pluto/users
+ * https://wiki.analog.com/university/tools/pluto/users/firmware
+ * https://wiki.analog.com/university/tools/pluto/other
+ *
+ * hdl_project: <pluto>
+ * board_revision: <A>
+ *
+ * Copyright (C) 2016-2019 Analog Devices Inc.
+ */
 /dts-v1/;
 #include "zynq-pluto-sdr.dtsi"
 

--- a/arch/arm/boot/dts/zynq-sidekiqz2-revb.dts
+++ b/arch/arm/boot/dts/zynq-sidekiqz2-revb.dts
@@ -1,3 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * EPIQ Solutions Sidekiq Z2
+ * https://epiqsolutions.com/rf-transceiver/sidekiq-z2/
+ *
+ * hdl_project: <sidekiqz2>
+ * board_revision: <>
+ *
+ * Copyright (C) 2018-2019 Analog Devices Inc.
+ */
 /dts-v1/;
 #include "zynq-pluto-sdr.dtsi"
 #include <dt-bindings/input/input.h>


### PR DESCRIPTION
This change adds project tags to the M2k device-trees, and Pluto dts & derivatives [e310 & sidekiqz2].

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>