### PR TITLE
arch: arm: adv7511,fmcomms2/3, daq2/3: add license + project tags

### DIFF
--- a/arch/arm/boot/dts/zynq-zc702-adv7511-ad9361-4-fmcomms2-3-4-userspace.dts
+++ b/arch/arm/boot/dts/zynq-zc702-adv7511-ad9361-4-fmcomms2-3-4-userspace.dts
@@ -1,3 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD-FMCOMMS2-EBZ/AD-FMCOMMS3-EBZ
+ * https://wiki.analog.com/resources/eval/user-guides/ad-fmcomms2-ebz
+ * https://wiki.analog.com/resources/eval/user-guides/ad-fmcomms3-ebz
+ *
+ * hdl_project: <fmcomms2/zc702>
+ * board_revision: <>
+ *
+ * Copyright (C) 2014-2019 Analog Devices Inc.
+ */
 /dts-v1/;
 
 #include "zynq-zc702.dtsi"

--- a/arch/arm/boot/dts/zynq-zc702-adv7511-ad9361-fmcomms2-3.dts
+++ b/arch/arm/boot/dts/zynq-zc702-adv7511-ad9361-fmcomms2-3.dts
@@ -1,3 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD-FMCOMMS2-EBZ/AD-FMCOMMS3-EBZ
+ * https://wiki.analog.com/resources/eval/user-guides/ad-fmcomms2-ebz
+ * https://wiki.analog.com/resources/eval/user-guides/ad-fmcomms3-ebz
+ *
+ * hdl_project: <fmcomms2/zc702>
+ * board_revision: <>
+ *
+ * Copyright (C) 2014-2019 Analog Devices Inc.
+ */
 /dts-v1/;
 
 #include "zynq-zc702.dtsi"

--- a/arch/arm/boot/dts/zynq-zc702-adv7511.dts
+++ b/arch/arm/boot/dts/zynq-zc702-adv7511.dts
@@ -1,3 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices ADV7511
+ * https://www.analog.com/en/products/adv7511.html
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/platforms/zynq
+ * https://wiki.analog.com/resources/fpga/xilinx/kc705/adv7511
+ *
+ * hdl_project: <adv7511/zc702>
+ * board_revision: <>
+ *
+ * Copyright (C) 2012-2019 Analog Devices Inc.
+ */
 /dts-v1/;
 
 #include "zynq-zc702.dtsi"

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad9361-4-fmcomms2-3-4-userspace.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad9361-4-fmcomms2-3-4-userspace.dts
@@ -1,3 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD-FMCOMMS2-EBZ/AD-FMCOMMS3-EBZ
+ * https://wiki.analog.com/resources/eval/user-guides/ad-fmcomms2-ebz
+ * https://wiki.analog.com/resources/eval/user-guides/ad-fmcomms3-ebz
+ *
+ * hdl_project: <fmcomms2/zc706>
+ * board_revision: <>
+ *
+ * Copyright (C) 2014-2019 Analog Devices Inc.
+ */
 /dts-v1/;
 
 #include "zynq-zc706.dtsi"

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad9361-fmcomms2-3.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad9361-fmcomms2-3.dts
@@ -1,3 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD-FMCOMMS2-EBZ/AD-FMCOMMS3-EBZ
+ * https://wiki.analog.com/resources/eval/user-guides/ad-fmcomms2-ebz
+ * https://wiki.analog.com/resources/eval/user-guides/ad-fmcomms3-ebz
+ *
+ * hdl_project: <fmcomms2/zc706>
+ * board_revision: <>
+ *
+ * Copyright (C) 2014-2019 Analog Devices Inc.
+ */
 /dts-v1/;
 
 #include "zynq-zc706.dtsi"

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcdaq2.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcdaq2.dts
@@ -1,3 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD-FMCDAQ2-EBZ
+ * https://wiki.analog.com/resources/eval/user-guides/ad-fmcdaq2-ebz
+ *
+ * hdl_project: <daq2/zc706>
+ * board_revision: <>
+ *
+ * Copyright (C) 2014-2019 Analog Devices Inc.
+ */
 /dts-v1/;
 
 #include "zynq-zc706.dtsi"

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcdaq3-revC.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcdaq3-revC.dts
@@ -1,3 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD-FMCDAQ3-EBZ
+ * https://wiki.analog.com/resources/eval/user-guides/ad-fmcdaq3-ebz
+ *
+ * hdl_project: <daq3/zc706>
+ * board_revision: <C>
+ *
+ * Copyright (C) 2015-2019 Analog Devices Inc.
+ */
 #include "zynq-zc706-adv7511-fmcdaq3.dts"
 
 /delete-node/ &ad9528_0_c13;

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcdaq3.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcdaq3.dts
@@ -1,3 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD-FMCDAQ3-EBZ
+ * https://wiki.analog.com/resources/eval/user-guides/ad-fmcdaq3-ebz
+ *
+ * hdl_project: <daq3/zc706>
+ * board_revision: <>
+ *
+ * Copyright (C) 2015-2019 Analog Devices Inc.
+ */
 /dts-v1/;
 
 #include "zynq-zc706.dtsi"

--- a/arch/arm/boot/dts/zynq-zc706-adv7511.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511.dts
@@ -1,3 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices ADV7511
+ * https://www.analog.com/en/products/adv7511.html
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/platforms/zynq
+ * https://wiki.analog.com/resources/fpga/xilinx/kc705/adv7511
+ *
+ * hdl_project: <adv7511/zc706>
+ * board_revision: <>
+ *
+ * Copyright (C) 2012-2019 Analog Devices Inc.
+ */
 /dts-v1/;
 
 #include "zynq-zc706.dtsi"

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad9361-4-fmcomms2-3-4-userspace.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad9361-4-fmcomms2-3-4-userspace.dts
@@ -1,3 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD-FMCOMMS2-EBZ/AD-FMCOMMS3-EBZ
+ * https://wiki.analog.com/resources/eval/user-guides/ad-fmcomms2-ebz
+ * https://wiki.analog.com/resources/eval/user-guides/ad-fmcomms3-ebz
+ *
+ * hdl_project: <fmcomms2/zed>
+ * board_revision: <>
+ *
+ * Copyright (C) 2014-2019 Analog Devices Inc.
+ */
 /dts-v1/;
 
 #include "zynq-zed.dtsi"

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad9361-fmcomms2-3.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad9361-fmcomms2-3.dts
@@ -1,3 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD-FMCOMMS2-EBZ/AD-FMCOMMS3-EBZ
+ * https://wiki.analog.com/resources/eval/user-guides/ad-fmcomms2-ebz
+ * https://wiki.analog.com/resources/eval/user-guides/ad-fmcomms3-ebz
+ *
+ * hdl_project: <fmcomms2/zed>
+ * board_revision: <>
+ *
+ * Copyright (C) 2014-2019 Analog Devices Inc.
+ */
 /dts-v1/;
 
 #include "zynq-zed.dtsi"

--- a/arch/arm/boot/dts/zynq-zed-adv7511.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511.dts
@@ -1,3 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices ADV7511
+ * https://www.analog.com/en/products/adv7511.html
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/platforms/zynq
+ * https://wiki.analog.com/resources/fpga/xilinx/kc705/adv7511
+ *
+ * hdl_project: <adv7511/zed>
+ * board_revision: <>
+ *
+ * Copyright (C) 2012-2019 Analog Devices Inc.
+ */
 /dts-v1/;
 
 #include "zynq-zed.dtsi"


### PR DESCRIPTION
This changeset adds add license + project tags to the ADV7511, DAQ2/3 & FMCOMMS2/3 projects.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>