### PR TITLE
iio: adc: axi_pulse_capture: Use of_node name as indio_dev name

### DIFF
--- a/drivers/iio/adc/axi_pulse_capture.c
+++ b/drivers/iio/adc/axi_pulse_capture.c
@@ -615,7 +615,7 @@ static int axi_pulse_capture_probe(struct platform_device *pdev)
 	axi_pulse_capture_config(pulse);
 
 	indio_dev->dev.parent = &pdev->dev;
-	indio_dev->name = dev_name(&pdev->dev);
+	indio_dev->name = pdev->dev.of_node->name;
 	indio_dev->modes = INDIO_DIRECT_MODE;
 	indio_dev->channels = axi_pulse_capture_channels;
 	indio_dev->num_channels = ARRAY_SIZE(axi_pulse_capture_channels);


### PR DESCRIPTION
indio_dev->name was address dependent. That led to:
   root@analog:~# cat /sys/bus/iio/devices/iio:device0/name
   7c700000.axi-pulse-capture // on ZC706
   9c700000.axi-pulse-capture // on ZCU102
Since most of the user space applications are not carrier dependent,
this needs to be fixed somehow.
Having indio_dev->name set to of_node->name, solves the address
dependency:
   root@analog:~# cat /sys/bus/iio/devices/iio:device0/name
   axi-pulse-capture

Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>