### PR TITLE
iio: adc: ad9081: fix implicit fall-throughs

### DIFF
--- a/drivers/iio/adc/ad9081.c
+++ b/drivers/iio/adc/ad9081.c
@@ -212,9 +212,11 @@ unsigned long ad9081_calc_lanerate(struct ad9081_jesd_link *link,
 	case 2:
 		encoding_n = 66; /* JESD 204C */
 		encoding_d = 64;
+		break;
 	default:
 		encoding_n = 10; /* JESD 204AB */
 		encoding_d = 8;
+		break;
 	}
 
 	rate = link->jesd_param.jesd_m * link->jesd_param.jesd_np * encoding_n *


### PR DESCRIPTION
It looks like that switch statement is missing some break statements.
The newer kernel branch caught this via build:
```
 CC      drivers/iio/adc/ad9081.o
drivers/iio/adc/ad9081.c: In function 'ad9081_calc_lanerate':
drivers/iio/adc/ad9081.c:214:14: error: this statement may fall through [-Werror=implicit-fallthrough=]
  214 |   encoding_d = 64;
      |   ~~~~~~~~~~~^~~~
drivers/iio/adc/ad9081.c:215:2: note: here
  215 |  default:
      |  ^~~~~~~
  CC      net/ipv4/metrics.o
```

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>