### PR TITLE
iio: hmc425a: limit GPIOs to 6 (max)

### DIFF
--- a/drivers/iio/amplifiers/hmc425a.c
+++ b/drivers/iio/amplifiers/hmc425a.c
@@ -19,6 +19,8 @@
 #include <linux/of_device.h>
 #include <linux/of_platform.h>
 
+#define HMC425A_NR_GPIOS	6
+
 enum hmc425_type {
 	ID_HMC425 ,
 };
@@ -47,7 +49,7 @@ static struct hmc425_info hmc425_infos[] = {
 static int hmc425_write(struct iio_dev *indio_dev, u32 value)
 {
 	struct hmc425_state *st = iio_priv(indio_dev);
-	int i, values[st->gpios->ndescs];
+	int i, values[HMC425A_NR_GPIOS];
 
 	for (i = 0; i < st->gpios->ndescs; i++)
 		values[i] = (value >> i) & 1;
@@ -173,6 +175,11 @@ static int hmc425_probe(struct platform_device *pdev)
 		if (ret != -EPROBE_DEFER)
 			dev_err(&pdev->dev, "failed to get gpios\n");
 		return ret;
+	}
+
+	if (st->gpios->ndescs != HMC425A_NR_GPIOS) {
+		dev_err(&pdev->dev, "%d GPIOs needed to operate\n");
+		return -ENODEV;
 	}
 
 	st->reg = devm_regulator_get(&pdev->dev, "vcc");


### PR DESCRIPTION
There build warnings/errors in the newer kernel is:
```
drivers/iio/amplifiers/hmc425a.c:50:2: error: ISO C90 forbids variable length array 'values' [-Werror=vla]
   50 |  int i, values[st->gpios->ndescs];
      |  ^~~
```

Seems that it does not allow C99 variable-length-arrays.
This change also enforces a max of 6 GPIOs via DT [which is what the device
supports], and limits only the use of the first 6 [if more are specified]
while printing a warning.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>