### PR TITLE
arch: arm: adrv9371/5, adrv9008/9: add license + project tags

### DIFF
--- a/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9008-1.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9008-1.dts
@@ -1,10 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0
 /*
- * dts file for ADRV9008-1 on Xilinx Zynq ZC706
+ * Analog Devices ADRV9008-1
+ * https://wiki.analog.com/resources/eval/user-guides/adrv9009
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9009
+ * https://wiki.analog.com/resources/tools-software/linux-software/adrv9009_advanced_plugin
+ *
+ * hdl_project: <adrv9009/zc706>
+ * board_revision: <>
  *
  * Copyright (C) 2019 Analog Devices Inc.
- *
- * Licensed under the GPL-2.
-*/
+ */
 /dts-v1/;
 
 #include "zynq-zc706.dtsi"

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9008-2.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9008-2.dts
@@ -1,10 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0
 /*
- * dts file for ADRV9008-2 on Xilinx Zynq ZC706
+ * Analog Devices ADRV9008-2
+ * https://wiki.analog.com/resources/eval/user-guides/adrv9009
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9009
+ * https://wiki.analog.com/resources/tools-software/linux-software/adrv9009_advanced_plugin
+ *
+ * hdl_project: <adrv9009/zc706>
+ * board_revision: <>
  *
  * Copyright (C) 2019 Analog Devices Inc.
- *
- * Licensed under the GPL-2.
-*/
+ */
 /dts-v1/;
 
 #include "zynq-zc706.dtsi"

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9009.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9009.dts
@@ -1,10 +1,20 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices ADRV9008-1
+ * https://wiki.analog.com/resources/eval/user-guides/adrv9009
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9009
+ * https://wiki.analog.com/resources/tools-software/linux-software/adrv9009_advanced_plugin
+ *
+ * hdl_project: <adrv9009/zc706>
+ * board_revision: <>
+ *
+ * Copyright (C) 2019 Analog Devices Inc.
+ */
 /dts-v1/;
 
 #include "zynq-zc706.dtsi"
 #include "zynq-zc706-adv7511.dtsi"
 #include <dt-bindings/gpio/gpio.h>
-
-
 
 &i2c_mux {
 	i2c@5 { /* HPC IIC */

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9371.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9371.dts
@@ -1,3 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices ADRV9371
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/ad9371
+ * https://wiki.analog.com/resources/eval/user-guides/mykonos
+ *
+ * hdl_project: <adrv9371x/zc706>
+ * board_revision: <>
+ *
+ * Copyright (C) 2016-2019 Analog Devices Inc.
+ */
 /dts-v1/;
 
 #include "zynq-zc706.dtsi"

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9375.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9375.dts
@@ -1,3 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices ADRV9375
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/ad9371
+ * https://wiki.analog.com/resources/eval/user-guides/mykonos
+ *
+ * hdl_project: <adrv9371x/zc706>
+ * board_revision: <>
+ *
+ * Copyright (C) 2016-2019 Analog Devices Inc.
+ */
 #include "zynq-zc706-adv7511-adrv9371.dts"
 
 &trx0_ad9371 {


### PR DESCRIPTION
This change adds license + project tags for the ADRV9371 & ADRV9375, ADRV9008-1,ADRV9008-2,
ADRV9009 device-trees for ZC706.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>