### PR TITLE
iio: ad_sigma_delta: Add custom irq flags

### DIFF
--- a/drivers/iio/adc/ad_sigma_delta.c
+++ b/drivers/iio/adc/ad_sigma_delta.c
@@ -566,7 +566,7 @@ static int ad_sd_probe_trigger(struct iio_dev *indio_dev)
 
 	ret = request_irq(sigma_delta->spi->irq,
 			  ad_sd_data_rdy_trig_poll,
-			  IRQF_TRIGGER_LOW,
+			  sigma_delta->irq_flags,
 			  indio_dev->name,
 			  sigma_delta);
 	if (ret)
@@ -659,10 +659,17 @@ EXPORT_SYMBOL_GPL(ad_sd_cleanup_buffer_and_trigger);
 int ad_sd_init(struct ad_sigma_delta *sigma_delta, struct iio_dev *indio_dev,
 	struct spi_device *spi, const struct ad_sigma_delta_info *info)
 {
+	unsigned long set_trigger_flags;
+
 	sigma_delta->spi = spi;
 	sigma_delta->info = info;
 	sigma_delta->num_slots = 1;
 	sigma_delta->active_slots = 1;
+
+	set_trigger_flags = sigma_delta->irq_flags & IRQF_TRIGGER_MASK;
+	if (set_trigger_flags == IRQF_TRIGGER_NONE)
+		sigma_delta->irq_flags |= IRQF_TRIGGER_LOW;
+
 	iio_device_set_drvdata(indio_dev, sigma_delta);
 
 	return 0;

--- a/include/linux/iio/adc/ad_sigma_delta.h
+++ b/include/linux/iio/adc/ad_sigma_delta.h
@@ -64,6 +64,7 @@ struct ad_sigma_delta_info {
  * @spi: The spi device associated with the Sigma Delta device.
  * @trig: The IIO trigger associated with the Sigma Delta device.
  * @num_slots: Number of sequencer slots
+ * @irq_flags: flags for the interrupt used by the triggered buffer
  *
  * Most of the fields are private to the sigma delta library code and should not
  * be accessed by individual drivers.
@@ -73,6 +74,7 @@ struct ad_sigma_delta {
 	struct iio_trigger	*trig;
 
 	unsigned int		num_slots;
+	unsigned long		irq_flags;
 
 /* private: */
 	struct completion	completion;


### PR DESCRIPTION
The current implementation of the ad_sigma_delta driver assumes that all
it's users have the same interrupt type (IRQF_TRIGGER_LOW).

This isn't true for the AD7124 driver, which needs IRQF_TRIGGER_FALLING.

To accommodate support for such variations, the ad_sigma_delta driver
needs a field to store these interrupt type (as flags), and fallback
to IRQF_TRIGGER_LOW if it isn't set.

Signed-off-by: Alexandru Tachici <alexandru.tachici@analog.com>