### PR TITLE
iio: hmc425a: fix printf format

### DIFF
--- a/drivers/iio/amplifiers/hmc425a.c
+++ b/drivers/iio/amplifiers/hmc425a.c
@@ -178,7 +178,8 @@ static int hmc425_probe(struct platform_device *pdev)
 	}
 
 	if (st->gpios->ndescs != HMC425A_NR_GPIOS) {
-		dev_err(&pdev->dev, "%d GPIOs needed to operate\n");
+		dev_err(&pdev->dev, "%d GPIOs needed to operate\n",
+			HMC425A_NR_GPIOS);
 		return -ENODEV;
 	}
 


### PR DESCRIPTION
Seems I was a bit too soon when I merged the HMC425a updated code.
This fixes error:
```
drivers/iio/amplifiers/hmc425a.c:181:23: error: format '%d' expects a matching 'int' argument [-Werror=format=]
  181 |   dev_err(&pdev->dev, "%d GPIOs needed to operate\n");
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./include/linux/device.h:1335:22: note: in definition of macro 'dev_fmt'
 1335 | #define dev_fmt(fmt) fmt
      |                      ^~~
drivers/iio/amplifiers/hmc425a.c:181:3: note: in expansion of macro 'dev_err'
  181 |   dev_err(&pdev->dev, "%d GPIOs needed to operate\n");
      |   ^~~~~~~
drivers/iio/amplifiers/hmc425a.c:181:25: note: format string is defined here
  181 |   dev_err(&pdev->dev, "%d GPIOs needed to operate\n");
      |                        ~^
      |                         |
      |                         int
cc1: all warnings being treated as errors
```

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>