### PR TITLE
iio: adc: ad7124: allow multiple-channels enabled

### DIFF
--- a/drivers/iio/adc/ad7124.c
+++ b/drivers/iio/adc/ad7124.c
@@ -18,6 +18,8 @@
 #include <linux/iio/adc/ad_sigma_delta.h>
 #include <linux/iio/sysfs.h>
 
+#define AD7124_SEQUENCER_SLOTS		16
+
 /* AD7124 registers */
 #define AD7124_COMMS			0x00
 #define AD7124_STATUS			0x00
@@ -582,7 +584,7 @@ static int ad7124_probe(struct spi_device *spi)
 	st->chip_info = &ad7124_chip_info_tbl[id->driver_data];
 
 	ad_sd_init(&st->sd, indio_dev, spi, &ad7124_sigma_delta_info);
-
+	st->sd.num_slots = AD7124_SEQUENCER_SLOTS;
 	spi_set_drvdata(spi, indio_dev);
 
 	indio_dev->dev.parent = &spi->dev;


### PR DESCRIPTION
This patch allows the user to enable multiple channels.
ad_sigma_delta will not allow the user to enable multiple
channels unless there are multiple sequencer slots available.
The number of slots available is specified in the num_slots
of the ad_sigma_delta struct.

The ad7124 chip supports up to 16 channels enabled. When all
channels are enabled, an internal sequencer will perform
a conversion on each channel sequentially.

Signed-off-by: Alexandru Tachici <alexandru.tachici@analog.com>