### PR TITLE
iio: hmc425a: fix typo

### DIFF
--- a/drivers/iio/amplifiers/hmc425a.c
+++ b/drivers/iio/amplifiers/hmc425a.c
@@ -137,7 +137,7 @@ static const struct iio_info hmc425a_info = {
 	.write_raw = &hmc425a_write_raw,
 };
 
-#define HMC245A_CHAN(_channel)                                          \
+#define HMC425A_CHAN(_channel)                                          \
 {                                                                      \
 	.type = IIO_VOLTAGE, .output = 1, .indexed = 1,                \
 	.channel = _channel,                                           \


### PR DESCRIPTION
This patch fixes a typo for the HMC425A_CHAN macro.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>