### PR TITLE
Ad sigma delta add irq flags field

### DIFF
--- a/drivers/iio/adc/ad7124.c
+++ b/drivers/iio/adc/ad7124.c
@@ -226,6 +226,7 @@ static const struct ad_sigma_delta_info ad7124_sigma_delta_info = {
 	.addr_shift = 0,
 	.read_mask = BIT(6),
 	.data_reg = AD7124_DATA,
+	.irq_flags = IRQF_TRIGGER_FALLING
 };
 
 static int ad7124_set_channel_odr(struct ad7124_state *st,

--- a/drivers/iio/adc/ad7173.c
+++ b/drivers/iio/adc/ad7173.c
@@ -462,6 +462,7 @@ static const struct ad_sigma_delta_info ad7173_sigma_delta_info = {
 	.data_reg = AD7173_REG_DATA,
 	.addr_shift = 0,
 	.read_mask = BIT(6),
+	.irq_flags = IRQF_TRIGGER_FALLING
 };
 
 static int ad7173_setup(struct iio_dev *indio_dev)

--- a/drivers/iio/adc/ad7791.c
+++ b/drivers/iio/adc/ad7791.c
@@ -214,6 +214,7 @@ static const struct ad_sigma_delta_info ad7791_sigma_delta_info = {
 	.has_registers = true,
 	.addr_shift = 4,
 	.read_mask = BIT(3),
+	.irq_flags = IRQF_TRIGGER_FALLING
 };
 
 static int ad7791_read_raw(struct iio_dev *indio_dev,

--- a/drivers/iio/adc/ad7793.c
+++ b/drivers/iio/adc/ad7793.c
@@ -221,6 +221,7 @@ static const struct ad_sigma_delta_info ad7793_sigma_delta_info = {
 	.has_registers = true,
 	.addr_shift = 3,
 	.read_mask = BIT(6),
+	.irq_flags = IRQF_TRIGGER_FALLING
 };
 
 static const struct ad_sd_calib_data ad7793_calib_arr[6] = {

--- a/drivers/iio/adc/ad_sigma_delta.c
+++ b/drivers/iio/adc/ad_sigma_delta.c
@@ -570,7 +570,7 @@ static int ad_sd_probe_trigger(struct iio_dev *indio_dev)
 
 	ret = request_irq(sigma_delta->spi->irq,
 			  ad_sd_data_rdy_trig_poll,
-			  sigma_delta->irq_flags,
+			  sigma_delta->info->irq_flags,
 			  indio_dev->name,
 			  sigma_delta);
 	if (ret)
@@ -663,16 +663,10 @@ EXPORT_SYMBOL_GPL(ad_sd_cleanup_buffer_and_trigger);
 int ad_sd_init(struct ad_sigma_delta *sigma_delta, struct iio_dev *indio_dev,
 	struct spi_device *spi, const struct ad_sigma_delta_info *info)
 {
-	unsigned long set_trigger_flags;
-
 	sigma_delta->spi = spi;
 	sigma_delta->info = info;
 	sigma_delta->num_slots = 1;
 	sigma_delta->active_slots = 1;
-
-	set_trigger_flags = sigma_delta->irq_flags & IRQF_TRIGGER_MASK;
-	if (set_trigger_flags == IRQF_TRIGGER_NONE)
-		sigma_delta->irq_flags |= IRQF_TRIGGER_LOW;
 
 	iio_device_set_drvdata(indio_dev, sigma_delta);
 

--- a/drivers/staging/iio/adc/ad7192.c
+++ b/drivers/staging/iio/adc/ad7192.c
@@ -281,6 +281,7 @@ static const struct ad_sigma_delta_info ad7192_sigma_delta_info = {
 	.has_registers = true,
 	.addr_shift = 3,
 	.read_mask = BIT(6),
+	.irq_flags = IRQF_TRIGGER_FALLING
 };
 
 static const struct ad_sd_calib_data ad7192_calib_arr[8] = {

--- a/drivers/staging/iio/adc/ad7780.c
+++ b/drivers/staging/iio/adc/ad7780.c
@@ -125,6 +125,7 @@ static const struct ad_sigma_delta_info ad7780_sigma_delta_info = {
 	.set_mode = ad7780_set_mode,
 	.postprocess_sample = ad7780_postprocess_sample,
 	.has_registers = false,
+	.irq_flags = IRQF_TRIGGER_FALLING
 };
 
 #define AD7780_CHANNEL(bits, wordsize) \

--- a/include/linux/iio/adc/ad_sigma_delta.h
+++ b/include/linux/iio/adc/ad_sigma_delta.h
@@ -44,6 +44,7 @@ struct iio_dev;
  * @addr_shift: Shift of the register address in the communications register.
  * @read_mask: Mask for the communications register having the read bit set.
  * @data_reg: Address of the data register, if 0 the default address of 0x3 will
+ * @irq_flags: flags for the interrupt used by the triggered buffer
  *   be used.
  */
 struct ad_sigma_delta_info {
@@ -57,6 +58,7 @@ struct ad_sigma_delta_info {
 	unsigned int addr_shift;
 	unsigned int read_mask;
 	unsigned int data_reg;
+	unsigned long irq_flags;
 };
 
 /**
@@ -64,7 +66,6 @@ struct ad_sigma_delta_info {
  * @spi: The spi device associated with the Sigma Delta device.
  * @trig: The IIO trigger associated with the Sigma Delta device.
  * @num_slots: Number of sequencer slots
- * @irq_flags: flags for the interrupt used by the triggered buffer
  *
  * Most of the fields are private to the sigma delta library code and should not
  * be accessed by individual drivers.
@@ -74,7 +75,6 @@ struct ad_sigma_delta {
 	struct iio_trigger	*trig;
 
 	unsigned int		num_slots;
-	unsigned long		irq_flags;
 
 /* private: */
 	struct completion	completion;


### PR DESCRIPTION
These patches move the irq_flag member from the ad_sigma_delta to ad_sigma_delta_info, as there should be no need to change the interrupt type at runtime. All drivers using the ad_sigma_delta layer have to set the irq_flag member of ad_sigma_delta_info before running ad_sd_init.