### PR TITLE
ci: travis: github-actions: move checkpatch to Github actions

### DIFF
--- a/.github/workflows/checkpatch.yml
+++ b/.github/workflows/checkpatch.yml
@@ -1,0 +1,16 @@
+name: Run Linux's checkpatch.pl script
+
+on: [pull_request]
+
+jobs:
+  checkpatch:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Fetch 'github.head_ref'
+      run: git clone --depth=50 --single-branch --branch ${{ github.head_ref }} https://github.com/${{ github.repository }} .
+    - name: Fetch 'github.base_ref'
+      run: git fetch --depth=50 origin +refs/heads/${{ github.base_ref }}:${{ github.base_ref }}
+    - name: checkpatch.pl
+      run: ./scripts/checkpatch.pl --git ${{ github.base_ref }}..${{ github.head_ref }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ notifications:
 env:
   matrix:
   - BUILD_TYPE=sync_branches_with_master_travis DO_NOT_DOCKERIZE=1
-  - BUILD_TYPE=checkpatch DO_NOT_DOCKERIZE=1
   - BUILD_TYPE=dtb_build_test ARCH=arm DTS_FILES=arch/arm/boot/dts/zynq-*.dts DO_NOT_DOCKERIZE=1
   - BUILD_TYPE=dtb_build_test ARCH=arm64 DTS_FILES=arch/arm64/boot/dts/xilinx/zynqmp-*.dts DO_NOT_DOCKERIZE=1
   - DEFCONFIG=zynq_xcomm_adv7511_defconfig ARCH=arm IMAGE=uImage


### PR DESCRIPTION
With this, we can have it separately, and better view it, if it fails.
checkpatch fails quite often and is one of those checks that is not
 **a must** to merge the code, and so far the Travis-CI check would show up
as failing because of it.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>