### PR TITLE
arch: arm: dts: ad4020: add license + project tags

### DIFF
--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad4020.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad4020.dts
@@ -1,3 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD4020
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-adc/ad400x
+ * https://wiki.analog.com/resources/eval/user-guides/ad400x
+ *
+ * hdl_project: <ad40xx_fmc/zed>
+ * board_revision: <>
+ *
+ * Copyright (C) 2016-2019 Analog Devices Inc.
+ */
 /dts-v1/;
 
 #include "zynq-zed.dtsi"


### PR DESCRIPTION
This change adds license and project tags to the AD4020 device-tree.

Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>