### PR TITLE
arch: arm, microblaze: dts: ad6676: add license + project tags

### DIFF
--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad6676-fmc.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad6676-fmc.dts
@@ -1,3 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD6676
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-adc/ad6676
+ * https://wiki.analog.com/resources/eval/ad6676-wideband_rx_subsystem_ad6676ebz
+ *
+ * hdl_project: <ad6676evb/zc706>
+ * board_revision: <>
+ *
+ * Copyright (C) 2016-2019 Analog Devices Inc.
+ */
 /dts-v1/;
 
 #include "zynq-zc706.dtsi"

--- a/arch/microblaze/boot/dts/vc707_ad6676evb.dts
+++ b/arch/microblaze/boot/dts/vc707_ad6676evb.dts
@@ -1,4 +1,14 @@
-
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD6676
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-adc/ad6676
+ * https://wiki.analog.com/resources/eval/ad6676-wideband_rx_subsystem_ad6676ebz
+ *
+ * hdl_project: <ad6676evb/vc707>
+ * board_revision: <>
+ *
+ * Copyright (C) 2016-2019 Analog Devices Inc.
+ */
 /dts-v1/;
 /include/ "vc707.dtsi"
 


### PR DESCRIPTION
This change adds license + project tags for the ad6676 device-trees for
ZC706 and VC707.

Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>