### PR TITLE
arch: arm: dts: ad7768: add license + project tags

### DIFF
--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad7768.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad7768.dts
@@ -1,3 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD7768
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-adc/ad7768
+ *
+ * hdl_project: <ad7768evb/zed>
+ * board_revision: <>
+ *
+ * Copyright (C) 2016-2019 Analog Devices Inc.
+ */
 /dts-v1/;
 
 #include "zynq-zed.dtsi"


### PR DESCRIPTION
This change adds license and project tags to the AD7768 device-tree.

Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>