### PR TITLE
arch: arm: dts: ad9434: add license + project tags

### DIFF
--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad9434-fmc-500ebz.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad9434-fmc-500ebz.dts
@@ -1,3 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD9434
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-adc/axi-adc-hdl
+ * https://wiki.analog.com/resources/fpga/xilinx/fmc/ad9434
+ *
+ * hdl_project: <ad9434_fmc/zc706>
+ * board_revision: <>
+ *
+ * Copyright (C) 2016-2019 Analog Devices Inc.
+ */
 /dts-v1/;
 
 #include "zynq-zc706.dtsi"


### PR DESCRIPTION
This change adds license and project tags to the AD9434 device-tree.

Signed-off-by: Bogdan Togorean bogdan.togorean@analog.com