### PR TITLE
arch: arm, microblaze: dts: ad9467: add license + project tags

### DIFF
--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad9467-fmc-250ebz.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad9467-fmc-250ebz.dts
@@ -1,3 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD9467
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-adc/axi-adc-hdl
+ * https://wiki.analog.com/resources/eval/ad9467-fmc-250ebz
+ * https://wiki.analog.com/resources/fpga/xilinx/fmc/ad9467
+ *
+ * hdl_project: <ad9467_fmc/zed>
+ * board_revision: <>
+ *
+ * Copyright (C) 2016-2019 Analog Devices Inc.
+ */
 /dts-v1/;
 
 #include "zynq-zed.dtsi"

--- a/arch/microblaze/boot/dts/kc705_ad9467_fmc.dts
+++ b/arch/microblaze/boot/dts/kc705_ad9467_fmc.dts
@@ -1,4 +1,15 @@
-
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD9467
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-adc/axi-adc-hdl
+ * https://wiki.analog.com/resources/eval/ad9467-fmc-250ebz
+ * https://wiki.analog.com/resources/fpga/xilinx/fmc/ad9467
+ *
+ * hdl_project: <ad9467_fmc/kc705>
+ * board_revision: <>
+ *
+ * Copyright (C) 2016-2019 Analog Devices Inc.
+ */
 /dts-v1/;
 /include/ "kc705.dtsi"
 


### PR DESCRIPTION
This change adds license and project tags to the AD9467 device-trees on
ZED and KC705 platforms.

Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>