### PR TITLE
arch: arm: dts: ad9739a: add license + project tags

### DIFF
--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad9739a-fmc.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad9739a-fmc.dts
@@ -1,3 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD9739A
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-dds/axi-dac-dds-hdl
+ * https://wiki.analog.com/resources/fpga/xilinx/fmc/ad9739a
+ *
+ * hdl_project: <ad9739a_fmc/zc706>
+ * board_revision: <>
+ *
+ * Copyright (C) 2016-2019 Analog Devices Inc.
+ */
 /dts-v1/;
 
 #include "zynq-zc706.dtsi"


### PR DESCRIPTION
This change adds license and project tags to the AD9739A device-tree.

Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>