### PR TITLE
arch: arm, nios2: adrv9009: Add arria10gx/soc_adrv9009 DTBs

### DIFF
--- a/arch/arm/boot/dts/socfpga_arria10_socdk_adrv9009.dts
+++ b/arch/arm/boot/dts/socfpga_arria10_socdk_adrv9009.dts
@@ -1,0 +1,303 @@
+/dts-v1/;
+#include "socfpga_arria10_socdk.dtsi"
+#include <dt-bindings/iio/frequency/ad9528.h>
+
+&mmc {
+	status = "okay";
+	num-slots = <1>;
+	cap-sd-highspeed;
+	broken-cd;
+	bus-width = <4>;
+	altr,dw-mshc-ciu-div = <3>;
+	altr,dw-mshc-sdr-timing = <0 3>;
+};
+
+/ {
+	clocks {
+		sys_clk: sys_clk {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <100000000>;
+			clock-output-names = "system_clock";
+		};
+
+		dma_clk: dma_clk {
+			#clock-cells = <0x0>;
+			compatible = "fixed-clock";
+			clock-frequency = <250000000>;
+			clock-output-names = "dma_clk";
+		};
+	};
+
+	soc {
+		sys_hps_bridges: bridge@ff200000 {
+			compatible = "simple-bus";
+			reg = <0xff200000 0x00200000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges = <0x00000000 0xff200000 0x00200000>;
+
+			sys_gpio_out: gpio@20 {
+				compatible = "altr,pio-1.0";
+				reg = <0x00000020 0x00000010>;
+				altr,gpio-bank-width = <32>;
+				resetvalue = <0>;
+				#gpio-cells = <2>;
+				gpio-controller;
+			};
+
+			sys_spi: spi@40 {
+				compatible = "altr,spi-1.0";
+				reg = <0x00000040 0x00000020>;
+				interrupt-parent = <&intc>;
+				interrupts = <0 26 4>;
+				#address-cells = <0x1>;
+				#size-cells = <0x0>;
+			};
+
+			axi_adrv9009_tx_jesd: axi-jesd204-tx@20000 {
+				compatible = "adi,axi-jesd204-tx-1.0";
+				reg = <0x00020000 0x4000>;
+
+				interrupt-parent = <&intc>;
+				interrupts = <0 28 4>;
+
+				clocks = <&sys_clk>, <&tx_device_clk_pll>, <&axi_adrv9009_adxcvr_tx 0>;
+				clock-names = "s_axi_aclk", "device_clk", "lane_clk";
+
+				#clock-cells = <0>;
+				clock-output-names = "jesd_tx_lane_clk";
+
+				adi,octets-per-frame = <2>;
+				adi,frames-per-multiframe = <32>;
+				adi,converter-resolution = <16>;
+				adi,bits-per-sample = <16>;
+				adi,converters-per-device = <4>;
+				adi,control-bits-per-sample = <0>;
+			};
+
+			axi_adrv9009_adxcvr_tx: axi-adrv9009-tx-xcvr@24000 {
+				compatible = "adi,altera-adxcvr-1.00.a";
+				reg = <0x00024000 0x00001000>,
+					<0x00026000 0x00001000>,
+					<0x00028000 0x00001000>,
+					<0x00029000 0x00001000>,
+					<0x0002a000 0x00001000>,
+					<0x0002b000 0x00001000>;
+				reg-names = "adxcvr", "atx-pll", "adxcfg-0", "adxcfg-1", "adxcfg-2", "adxcfg-3";
+
+				clocks = <&clk0_ad9528 1>, <&tx_device_clk_pll>;
+				clock-names = "ref", "link";
+
+				#clock-cells = <0>;
+				clock-output-names = "jesd204_tx_lane_clock";
+			};
+
+			tx_device_clk_pll: altera-a10-fpll@25000 {
+				compatible = "altr,a10-fpll";
+				reg = <0x00025000 0x1000>;
+				clocks = <&clk0_ad9528 1>;
+
+				#clock-cells = <0>;
+				clock-output-names = "jesd204_tx_link_clock";
+			};
+
+			tx_dma: tx-dmac@2c000 {
+				compatible = "adi,axi-dmac-1.00.a";
+				reg = <0x0002c000 0x00004000>;
+				interrupt-parent = <&intc>;
+				interrupts = <0 30 4>;
+				#dma-cells = <1>;
+				clocks = <&dma_clk>;
+
+				adi,channels {
+					#size-cells = <0>;
+					#address-cells = <1>;
+
+					dma-channel@0 {
+						reg = <0>;
+						adi,source-bus-width = <128>;
+						adi,source-bus-type = <0>;
+						adi,destination-bus-width = <128>;
+						adi,destination-bus-type = <1>;
+					};
+				};
+			};
+
+			axi_adrv9009_rx_jesd: axi-jesd204-rx@30000 {
+				compatible = "adi,axi-jesd204-rx-1.0";
+				reg = <0x00030000 0x4000>;
+
+				interrupt-parent = <&intc>;
+				interrupts = <0 27 4>;
+
+				clocks = <&sys_clk>, <&rx_device_clk_pll>, <&axi_adrv9009_adxcvr_rx 0>;
+				clock-names = "s_axi_aclk", "device_clk", "lane_clk";
+
+				#clock-cells = <0>;
+				clock-output-names = "jesd_rx_lane_clk";
+
+				adi,octets-per-frame = <4>;
+				adi,frames-per-multiframe = <32>;
+			};
+
+			axi_adrv9009_adxcvr_rx: axi-adrv9009-rx-xcvr@34000 {
+				compatible = "adi,altera-adxcvr-1.00.a";
+				reg = <0x00034000 0x00001000>,
+					<0x00038000 0x00001000>,
+					<0x00039000 0x00001000>;
+				reg-names = "adxcvr", "adxcfg-0", "adxcfg-1";
+
+				clocks = <&clk0_ad9528 1>, <&rx_device_clk_pll>;
+				clock-names = "ref", "link";
+
+				#clock-cells = <0>;
+				clock-output-names = "jesd204_rx_lane_clock";
+			};
+
+			rx_device_clk_pll: altera-a10-fpll@35000 {
+				compatible = "altr,a10-fpll";
+				reg = <0x00035000 0x1000>;
+				clocks = <&clk0_ad9528 1>;
+
+				#clock-cells = <0>;
+				clock-output-names = "jesd204_rx_link_clock";
+			};
+
+			rx_dma: rx-dmac@3c000 {
+				compatible = "adi,axi-dmac-1.00.a";
+				reg = <0x0003c000 0x00004000>;
+				interrupt-parent = <&intc>;
+				interrupts = <0 31 4>;
+				#dma-cells = <1>;
+				clocks = <&dma_clk>;
+
+				adi,channels {
+					#size-cells = <0>;
+					#address-cells = <1>;
+
+					dma-channel@0 {
+						reg = <0>;
+						adi,source-bus-width = <64>;
+						adi,source-bus-type = <2>;
+						adi,destination-bus-width = <128>;
+						adi,destination-bus-type = <0>;
+					};
+				};
+			};
+
+			axi_adrv9009_rx_os_jesd: axi-jesd204-rx@40000 {
+				compatible = "adi,axi-jesd204-rx-1.0";
+				reg = <0x00040000 0x4000>;
+
+				interrupt-parent = <&intc>;
+				interrupts = <0 29 4>;
+
+				clocks = <&sys_clk>, <&rx_os_device_clk_pll>, <&axi_adrv9009_adxcvr_rx_os 0>;
+				clock-names = "s_axi_aclk", "device_clk", "lane_clk";
+
+				#clock-cells = <0>;
+				clock-output-names = "jesd_rx_os_lane_clk";
+
+				adi,octets-per-frame = <2>;
+				adi,frames-per-multiframe = <32>;
+			};
+
+			axi_adrv9009_adxcvr_rx_os: axi-adrv9009-rx-os-xcvr@44000 {
+				compatible = "adi,altera-adxcvr-1.00.a";
+				reg = <0x00044000 0x00001000>,
+					<0x00048000 0x00001000>,
+					<0x00049000 0x00001000>;
+				reg-names = "adxcvr", "adxcfg-0", "adxcfg-1";
+
+				clocks = <&clk0_ad9528 1>, <&rx_os_device_clk_pll>;
+				clock-names = "ref", "link";
+
+				#clock-cells = <0>;
+				clock-output-names = "jesd204_rx_os_lane_clock";
+			};
+
+			rx_os_device_clk_pll: altera-a10-fpll@45000 {
+				compatible = "altr,a10-fpll";
+				reg = <0x00045000 0x1000>;
+				clocks = <&clk0_ad9528 1>;
+
+				#clock-cells = <0>;
+				clock-output-names = "jesd204_rx_os_link_clock";
+			};
+
+			rx_obs_dma: rx-obs-dmac@4c000  {
+				compatible = "adi,axi-dmac-1.00.a";
+				reg = <0x0004c000 0x00004000>;
+				interrupt-parent = <&intc>;
+				interrupts = <0 32 4>;
+				#dma-cells = <1>;
+				clocks = <&dma_clk>;
+
+				adi,channels {
+					#size-cells = <0>;
+					#address-cells = <1>;
+
+					dma-channel@0 {
+						reg = <0>;
+						adi,source-bus-width = <128>;
+						adi,source-bus-type = <2>;
+						adi,destination-bus-width = <128>;
+						adi,destination-bus-type = <0>;
+					};
+				};
+			};
+
+			axi_adrv9009_core_rx: axi-adrv9009-rx-hpc@50000 {
+				compatible = "adi,axi-ad9371-rx-1.0";
+				reg = <0x00050000 0x00008000>;
+				dmas = <&rx_dma 0>;
+				dma-names = "rx";
+				spibus-connected = <&trx0_adrv9009>;
+			};
+
+			axi_adrv9009_core_tx: axi-adrv9009-tx-hpc@54000 {
+				compatible = "adi,axi-ad9371-tx-1.0";
+				reg = <0x00054000 0x00004000>;
+				dmas = <&tx_dma 0>;
+				dma-names = "tx";
+				clocks = <&trx0_adrv9009 2>;
+				clock-names = "sampl_clk";
+				spibus-connected = <&trx0_adrv9009>;
+				adi,axi-pl-fifo-enable;
+			};
+
+			axi_adrv9009_core_rx_obs: axi-adrv9009-rx-obs-hpc@58000 {
+				compatible = "adi,axi-ad9371-obs-1.0";
+				reg = <0x00058000 0x00001000>;
+				dmas = <&rx_obs_dma 0>;
+				dma-names = "rx";
+				clocks = <&trx0_adrv9009 1>;
+				clock-names = "sampl_clk";
+			};
+		};
+	};
+};
+
+#define fmc_spi sys_spi
+
+#include "adi-adrv9009.dtsi"
+
+&trx0_adrv9009 {
+	adi,jesd204-ser-pre-emphasis = <4>;
+	reset-gpios = <&sys_gpio_out 20 0>;
+	test-gpios = <&sys_gpio_out 21 0>;
+	sysref-req-gpios = <&sys_gpio_out 26 0>;
+	rx2-enable-gpios = <&sys_gpio_out 22 0>;
+	rx1-enable-gpios = <&sys_gpio_out 23 0>;
+	tx2-enable-gpios = <&sys_gpio_out 24 0>;
+	tx1-enable-gpios = <&sys_gpio_out 25 0>;
+};
+
+&clk0_ad9528 {
+	reset-gpios = <&sys_gpio_out 27 0>;
+};
+
+&axi_adrv9009_core_tx {
+	plddrbypass-gpios = <&sys_gpio_out 28 0>;
+};

--- a/arch/nios2/boot/dts/a10gx_adrv9009.dts
+++ b/arch/nios2/boot/dts/a10gx_adrv9009.dts
@@ -1,0 +1,877 @@
+/dts-v1/;
+
+#include <dt-bindings/iio/frequency/ad9528.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+
+/ {
+	model = "ALTR,system_bd";
+	compatible = "ALTR,system_bd";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		sys_cpu: cpu@0 {
+			device_type = "cpu";
+			compatible = "altr,nios2-1.1";
+			reg = <0x00000000>;
+			interrupt-controller;
+			#interrupt-cells = <1>;
+			altr,exception-addr = <3221225504>;
+			altr,fast-tlb-miss-addr = <3491762176>;
+			altr,has-initda = <1>;
+			altr,has-mmu = <1>;
+			altr,has-mul = <1>;
+			altr,implementation = "fast";
+			altr,pid-num-bits = <8>;
+			altr,reset-addr = <3221225472>;
+			altr,tlb-num-entries = <128>;
+			altr,tlb-num-ways = <16>;
+			altr,tlb-ptr-sz = <7>;
+			clock-frequency = <100000000>;
+			dcache-line-size = <32>;
+			dcache-size = <32768>;
+			icache-line-size = <32>;
+			icache-size = <32768>;
+		};
+	};
+
+	memory {
+		device_type = "memory";
+		reg = <0x00000000 0x10000000>,
+			<0x10140000 0x00028000>,
+			<0x10200000 0x00028000>;
+	};
+
+	clocks {
+		sys_clk: sys_clk {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <100000000>;
+			clock-output-names = "system_clock";
+		};
+
+		dma_clk: dma_clk {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <266520000>;
+			clock-output-names = "dma_clock";
+		};
+	};
+
+	sopc0: sopc {
+		device_type = "soc";
+		ranges;
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "ALTR,avalon", "simple-bus";
+		bus-frequency = <100000000>;
+
+		sys_uart: serial@101814f0 {
+			compatible = "altr,juart-1.0";
+			reg = <0x101814f0 0x00000008>;
+			interrupt-parent = <&sys_cpu>;
+			interrupts = <2>;
+		};
+
+		sys_ethernet: ethernet@10181000 {
+			compatible = "altr,tse-msgdma-1.0", "altr,tse-1.0";
+			reg = <0x10181000 0x00000400>,
+				<0x101814a0 0x00000020>,
+				<0x10181440 0x00000020>,
+				<0x101814e0 0x00000008>,
+				<0x10181480 0x00000020>,
+				<0x10181460 0x00000020>;
+			reg-names = "control_port", "rx_csr", "rx_desc", "rx_resp", "tx_csr", "tx_desc";
+			interrupt-parent = <&sys_cpu>;
+			interrupts = <0 1>;
+			interrupt-names = "rx_irq", "tx_irq";
+			ALTR,rx-fifo-depth = <4096>;
+			ALTR,tx-fifo-depth = <4096>;
+			rx-fifo-depth = <16384>;
+			tx-fifo-depth = <16384>;
+			address-bits = <48>;
+			max-frame-size = <1518>;
+			local-mac-address = [B2 94 3D 6E 11 8F];
+			altr,enable-sup-addr = <0>;
+			altr,enable-hash = <0>;
+			phy-mode = "sgmii";
+
+			sys_ethernet_mdio: mdio {
+				compatible = "altr,tse-mdio";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				phy0: ethernet-phy@0 {
+					reg = <0>;
+					device_type = "ethernet-phy";
+				};
+			};
+		};
+
+		sys_id: sysid@101814e8 {
+			compatible = "altr,sysid-1.0";
+			reg = <0x101814e8 0x00000008>;
+			id = <182193580>;
+			timestamp = <1506373933>;
+		};
+
+		sys_timer_1: timer@10181420 {
+			compatible = "altr,timer-1.0";
+			reg = <0x10181420 0x00000020>;
+			interrupt-parent = <&sys_cpu>;
+			interrupts = <4>;
+			clock-frequency = <100000000>;
+		};
+
+		sys_timer_2: timer@10181520 {
+			compatible = "altr,timer-1.0";
+			reg = <0x10181520 0x00000020>;
+			interrupt-parent = <&sys_cpu>;
+			interrupts = <3>;
+			clock-frequency = <100000000>;
+		};
+
+		sys_gpio_bd: gpio@101814d0 {
+			compatible = "altr,pio-1.0";
+			reg = <0x101814d0 0x00000010>;
+			interrupt-parent = <&sys_cpu>;
+			interrupts = <6>;
+			altr,gpio-bank-width = <32>;
+			altr,interrupt-type = <4>;
+			altr,interrupt_type = <4>;
+			level_trigger = <1>;
+			resetvalue = <0>;
+			#gpio-cells = <2>;
+			gpio-controller;
+		};
+
+		sys_gpio_in: gpio@101814c0 {
+			compatible = "altr,pio-1.0";
+			reg = <0x101814c0 0x00000010>;
+			interrupt-parent = <&sys_cpu>;
+			interrupts = <5>;
+			altr,gpio-bank-width = <32>;
+			altr,interrupt-type = <4>;
+			altr,interrupt_type = <4>;
+			level_trigger = <1>;
+			resetvalue = <0>;
+			#gpio-cells = <2>;
+			gpio-controller;
+		};
+
+		sys_gpio_out: gpio@10181500 {
+			compatible = "altr,pio-1.0";
+			reg = <0x10181500 0x00000010>;
+			altr,gpio-bank-width = <32>;
+			resetvalue = <0>;
+			#gpio-cells = <2>;
+			gpio-controller;
+		};
+
+		avl_adrv9009_gpio: gpio@10060000 {
+			compatible = "altr,pio-1.0";
+			reg = <0x10060000 0x00000010>;
+			interrupt-parent = <&sys_cpu>;
+			interrupts = <14>;
+			altr,gpio-bank-width = <19>;
+			altr,interrupt-type = <4>;
+			altr,interrupt_type = <4>;
+			level_trigger = <1>;
+			resetvalue = <0>;
+			#gpio-cells = <2>;
+			gpio-controller;
+		};
+
+		sys_spi: spi@10181400 {
+			compatible = "altr,spi-1.0";
+			reg = <0x10181400 0x00000020>;
+			interrupt-parent = <&sys_cpu>;
+			interrupts = <7>;
+
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			clk0_ad9528: ad9528-1@0 {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				#clock-cells = <1>;
+				compatible = "ad9528";
+
+				spi-max-frequency = <10000000>;
+				//adi,spi-3wire-enable;
+				reg = <0>;
+
+				reset-gpios = <&sys_gpio_out 27 0>;
+
+				clock-output-names = "ad9528-1_out0", "ad9528-1_out1", "ad9528-1_out2",
+					"ad9528-1_out3", "ad9528-1_out4", "ad9528-1_out5", "ad9528-1_out6",
+					"ad9528-1_out7", "ad9528-1_out8", "ad9528-1_out9", "ad9528-1_out10",
+					"ad9528-1_out11", "ad9528-1_out12", "ad9528-1_out13";
+
+				adi,vcxo-freq = <122880000>;
+
+				adi,refa-enable;
+				adi,refa-diff-rcv-enable;
+				adi,refa-r-div = <1>;
+				adi,osc-in-cmos-neg-inp-enable;
+
+				/* PLL1 config */
+				adi,pll1-feedback-div = <4>;
+				adi,pll1-charge-pump-current-nA = <5000>;
+
+				/* PLL2 config */
+				adi,pll2-vco-div-m1 = <3>; /* use 5 for 184320000 output device clock */
+				adi,pll2-n2-div = <10>; /* N / M1 */
+				adi,pll2-r1-div = <1>;
+				adi,pll2-charge-pump-current-nA = <805000>;
+
+				/* SYSREF config */
+				adi,sysref-src = <SYSREF_SRC_INTERNAL>;
+				adi,sysref-pattern-mode = <SYSREF_PATTERN_CONTINUOUS>;
+				adi,sysref-k-div = <512>;
+				adi,sysref-request-enable;
+				adi,sysref-nshot-mode = <SYSREF_NSHOT_4_PULSES>;
+				adi,sysref-request-trigger-mode = <SYSREF_LEVEL_HIGH>;
+
+				adi,rpole2 = <RPOLE2_900_OHM>;
+				adi,rzero = <RZERO_1850_OHM>;
+				adi,cpole1 = <CPOLE1_16_PF>;
+
+				adi,status-mon-pin0-function-select = <1>; /* PLL1 & PLL2 Locked */
+				adi,status-mon-pin1-function-select = <7>; /* REFA Correct */
+
+				ad9528_0_c13: channel@13 {
+					reg = <13>;
+					adi,extended-name = "DEV_CLK";
+					adi,driver-mode = <DRIVER_MODE_LVDS>;
+					adi,divider-phase = <0>;
+					adi,channel-divider = <5>;
+					adi,signal-source = <SOURCE_VCO>;
+				};
+
+				ad9528_0_c1: channel@1 {
+					reg = <1>;
+					adi,extended-name = "FMC_CLK";
+					adi,driver-mode = <DRIVER_MODE_LVDS>;
+					adi,divider-phase = <0>;
+					adi,channel-divider = <5>;
+					adi,signal-source = <SOURCE_VCO>;
+				};
+
+				ad9528_0_c12: channel@12 {
+					reg = <12>;
+					adi,extended-name = "DEV_SYSREF";
+					adi,driver-mode = <DRIVER_MODE_LVDS>;
+					adi,divider-phase = <0>;
+					adi,channel-divider = <5>;
+					adi,signal-source = <SOURCE_SYSREF_VCO>;
+				};
+
+				ad9528_0_c3: channel@3 {
+					reg = <3>;
+					adi,extended-name = "FMC_SYSREF";
+					adi,driver-mode = <DRIVER_MODE_LVDS>;
+					adi,divider-phase = <0>;
+					adi,channel-divider = <5>;
+					adi,signal-source = <SOURCE_SYSREF_VCO>;
+				};
+			};
+
+			trx0_adrv9009: adrv9009-phy@1 {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				#clock-cells = <1>;
+				compatible = "adrv9009";
+
+				/* SPI Setup */
+				reg = <1>;
+				spi-max-frequency = <25000000>;
+
+				interrupt-parent = <&sys_gpio_in>;
+				interrupts = <19 IRQ_TYPE_EDGE_RISING>;
+
+				reset-gpios = <&sys_gpio_out 20 0>;
+				test-gpios = <&sys_gpio_out 21 0>;
+				sysref-req-gpios = <&sys_gpio_out 26 0>;
+				rx2-enable-gpios = <&sys_gpio_out 22 0>;
+				rx1-enable-gpios = <&sys_gpio_out 23 0>;
+				tx2-enable-gpios = <&sys_gpio_out 24 0>;
+				tx1-enable-gpios = <&sys_gpio_out 25 0>;
+
+				/* Clocks */
+				clocks = <&axi_adrv9009_rx_jesd>, <&axi_adrv9009_tx_jesd>,
+					<&axi_adrv9009_rx_os_jesd>, <&clk0_ad9528 13>, <&clk0_ad9528 1>;
+				clock-names = "jesd_rx_clk", "jesd_tx_clk", "jesd_rx_os_clk", "dev_clk", "fmc_clk";
+				clock-output-names = "rx_sampl_clk", "rx_os_sampl_clk", "tx_sampl_clk";
+
+				/* JESD204 */
+
+				/* JESD204 RX */
+				adi,jesd204-framer-a-bank-id = <1>;
+				adi,jesd204-framer-a-device-id = <0>;
+				adi,jesd204-framer-a-lane0-id = <0>;
+				adi,jesd204-framer-a-m = <4>;
+				adi,jesd204-framer-a-k = <32>;
+				adi,jesd204-framer-a-f = <4>;
+				adi,jesd204-framer-a-np = <16>;
+				adi,jesd204-framer-a-scramble = <1>;
+				adi,jesd204-framer-a-external-sysref = <1>;
+				adi,jesd204-framer-a-serializer-lanes-enabled = <0x03>;
+				adi,jesd204-framer-a-serializer-lane-crossbar = <0xE4>;
+				adi,jesd204-framer-a-lmfc-offset = <31>;
+				adi,jesd204-framer-a-new-sysref-on-relink = <0>;
+				adi,jesd204-framer-a-syncb-in-select = <0>;
+				adi,jesd204-framer-a-over-sample = <0>;
+				adi,jesd204-framer-a-syncb-in-lvds-mode = <1>;
+				adi,jesd204-framer-a-syncb-in-lvds-pn-invert = <0>;
+				adi,jesd204-framer-a-enable-manual-lane-xbar = <0>;
+
+				/* JESD204 OBS */
+				adi,jesd204-framer-b-bank-id = <0>;
+				adi,jesd204-framer-b-device-id = <0>;
+				adi,jesd204-framer-b-lane0-id = <0>;
+				adi,jesd204-framer-b-m = <2>;
+				adi,jesd204-framer-b-k = <32>;
+				adi,jesd204-framer-b-f = <2>;
+				adi,jesd204-framer-b-np = <16>;
+				adi,jesd204-framer-b-scramble = <1>;
+				adi,jesd204-framer-b-external-sysref = <1>;
+				adi,jesd204-framer-b-serializer-lanes-enabled = <0x0C>;
+				adi,jesd204-framer-b-serializer-lane-crossbar = <0xE4>;
+				adi,jesd204-framer-b-lmfc-offset = <31>;
+				adi,jesd204-framer-b-new-sysref-on-relink = <0>;
+				adi,jesd204-framer-b-syncb-in-select = <1>;
+				adi,jesd204-framer-b-over-sample = <0>;
+				adi,jesd204-framer-b-syncb-in-lvds-mode = <1>;
+				adi,jesd204-framer-b-syncb-in-lvds-pn-invert = <0>;
+				adi,jesd204-framer-b-enable-manual-lane-xbar = <0>;
+
+				/* JESD204 TX */
+				adi,jesd204-deframer-a-bank-id = <0>;
+				adi,jesd204-deframer-a-device-id = <0>;
+				adi,jesd204-deframer-a-lane0-id = <0>;
+				adi,jesd204-deframer-a-m = <4>;
+				adi,jesd204-deframer-a-k = <32>;
+				adi,jesd204-deframer-a-scramble = <1>;
+				adi,jesd204-deframer-a-external-sysref = <1>;
+				adi,jesd204-deframer-a-deserializer-lanes-enabled = <0x0F>;
+				adi,jesd204-deframer-a-deserializer-lane-crossbar = <0xE4>;
+				adi,jesd204-deframer-a-lmfc-offset = <17>;
+				adi,jesd204-deframer-a-new-sysref-on-relink = <0>;
+				adi,jesd204-deframer-a-syncb-out-select = <0>;
+				adi,jesd204-deframer-a-np = <16>;
+				adi,jesd204-deframer-a-syncb-out-lvds-mode = <1>;
+				adi,jesd204-deframer-a-syncb-out-lvds-pn-invert = <0>;
+				adi,jesd204-deframer-a-syncb-out-cmos-slew-rate = <0>;
+				adi,jesd204-deframer-a-syncb-out-cmos-drive-level = <0>;
+				adi,jesd204-deframer-a-enable-manual-lane-xbar = <0>;
+
+				adi,jesd204-ser-amplitude = <15>;
+				adi,jesd204-ser-pre-emphasis = <1>;
+				adi,jesd204-ser-invert-lane-polarity = <0>;
+				adi,jesd204-des-invert-lane-polarity = <0>;
+				adi,jesd204-des-eq-setting = <1>;
+				adi,jesd204-sysref-lvds-mode = <1>;
+				adi,jesd204-sysref-lvds-pn-invert = <0>;
+
+				/* RX */
+
+				adi,rx-profile-rx-fir-gain_db = <(-6)>;
+				adi,rx-profile-rx-fir-num-fir-coefs = <48>;
+				adi,rx-profile-rx-fir-coefs = /bits/ 16 <(-2) (23) (46) (-17) (-104) (10) (208) (23) (-370) (-97) (607) (240) (-942) (-489) (1407) (910) (-2065) (-1637) (3058) (2995) (-4912) (-6526) (9941) (30489) (30489) (9941) (-6526) (-4912) (2995) (3058) (-1637) (-2065) (910) (1407) (-489) (-942) (240) (607) (-97) (-370) (23) (208) (10) (-104) (-17) (46) (23) (-2)>;
+
+				adi,rx-profile-rx-fir-decimation = <2>;
+				adi,rx-profile-rx-dec5-decimation = <4>;
+				adi,rx-profile-rhb1-decimation = <1>;
+				adi,rx-profile-rx-output-rate_khz = <245760>;
+				adi,rx-profile-rf-bandwidth_hz = <200000000>;
+				adi,rx-profile-rx-bbf3d-bcorner_khz = <200000>;
+				adi,rx-profile-rx-adc-profile = /bits/ 16 <182 142 173 90 1280 982 1335 96 1369 48 1012 18 48 48 37 208 0 0 0 0 52 0 7 6 42 0 7 6 42 0 25 27 0 0 25 27 0 0 165 44 31 905>;
+				adi,rx-profile-rx-ddc-mode = <0>;
+
+				adi,rx-nco-shifter-band-a-input-band-width_khz = <0>;
+				adi,rx-nco-shifter-band-a-input-center-freq_khz = <0>;
+				adi,rx-nco-shifter-band-a-nco1-freq_khz = <0>;
+				adi,rx-nco-shifter-band-a-nco2-freq_khz = <0>;
+				adi,rx-nco-shifter-band-binput-band-width_khz = <0>;
+				adi,rx-nco-shifter-band-binput-center-freq_khz = <0>;
+				adi,rx-nco-shifter-band-bnco1-freq_khz = <0>;
+				adi,rx-nco-shifter-band-bnco2-freq_khz = <0>;
+
+				adi,rx-gain-control-gain-mode = <0>;
+				adi,rx-gain-control-rx1-gain-index = <255>;
+				adi,rx-gain-control-rx2-gain-index = <255>;
+				adi,rx-gain-control-rx1-max-gain-index = <255>;
+				adi,rx-gain-control-rx1-min-gain-index = <195>;
+				adi,rx-gain-control-rx2-max-gain-index = <255>;
+				adi,rx-gain-control-rx2-min-gain-index = <195>;
+
+				adi,rx-settings-framer-sel = <0>;
+				adi,rx-settings-rx-channels = <3>;
+
+				/* ORX */
+
+				adi,orx-profile-rx-fir-gain_db = <6>;
+				adi,orx-profile-rx-fir-num-fir-coefs = <24>;
+				adi,orx-profile-rx-fir-coefs = /bits/ 16  <(-10) (7) (-10) (-12) (6) (-12) (16) (-16) (1) (63) (-431) (17235) (-431) (63) (1) (-16) (16) (-12) (6) (-12) (-10) (7) (-10) (0)>;
+				adi,orx-profile-rx-fir-decimation = <1>;
+				adi,orx-profile-rx-dec5-decimation = <4>;
+				adi,orx-profile-rhb1-decimation = <2>;
+				adi,orx-profile-orx-output-rate_khz = <245760>;
+				adi,orx-profile-rf-bandwidth_hz = <200000000>;
+				adi,orx-profile-rx-bbf3d-bcorner_khz = <225000>;
+				adi,orx-profile-orx-low-pass-adc-profile = /bits/ 16  <185 141 172 90 1280 942 1332 90 1368 46 1016 19 48 48 37 208 0 0 0 0 52 0 7 6 42 0 7 6 42 0 25 27 0 0 25 27 0 0 165 44 31 905>;
+				adi,orx-profile-orx-band-pass-adc-profile = /bits/ 16  <0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0>;
+				adi,orx-profile-orx-ddc-mode = <0>;
+				adi,orx-profile-orx-merge-filter = /bits/ 16  <0 0 0 0 0 0 0 0 0 0 0 0>;
+
+				adi,orx-gain-control-gain-mode = <0>;
+				adi,orx-gain-control-orx1-gain-index = <255>;
+				adi,orx-gain-control-orx2-gain-index = <255>;
+				adi,orx-gain-control-orx1-max-gain-index = <255>;
+				adi,orx-gain-control-orx1-min-gain-index = <195>;
+				adi,orx-gain-control-orx2-max-gain-index = <255>;
+				adi,orx-gain-control-orx2-min-gain-index = <195>;
+
+				adi,obs-settings-framer-sel = <1>;
+				adi,obs-settings-obs-rx-channels-enable = <3>;
+				adi,obs-settings-obs-rx-lo-source = <0>;
+
+				/* TX */
+
+				adi,tx-profile-tx-fir-gain_db = <6>;
+				adi,tx-profile-tx-fir-num-fir-coefs = <40>;
+				adi,tx-profile-tx-fir-coefs = /bits/ 16  <(-14) (5) (-9) (6) (-4) (19) (-29) (27) (-30) (46) (-63) (77) (-103) (150) (-218) (337) (-599) (1266) (-2718) (19537) (-2718) (1266) (-599) (337) (-218) (150) (-103) (77) (-63) (46) (-30) (27) (-29) (19) (-4) (6) (-9) (5) (-14) (0)>;
+
+				adi,tx-profile-dac-div = <1>;
+
+				adi,tx-profile-tx-fir-interpolation = <1>;
+				adi,tx-profile-thb1-interpolation = <2>;
+				adi,tx-profile-thb2-interpolation = <2>;
+				adi,tx-profile-thb3-interpolation = <2>;
+				adi,tx-profile-tx-int5-interpolation = <1>;
+				adi,tx-profile-tx-input-rate_khz = <245760>;
+				adi,tx-profile-primary-sig-bandwidth_hz = <100000000>;
+				adi,tx-profile-rf-bandwidth_hz = <225000000>;
+				adi,tx-profile-tx-dac3d-bcorner_khz = <225000>;
+				adi,tx-profile-tx-bbf3d-bcorner_khz = <113000>;
+				adi,tx-profile-loop-back-adc-profile = /bits/ 16 <206 132 168 90 1280 641 1307 53 1359 28 1039 30 48 48 37 210 0 0 0 0 53 0 7 6 42 0 7 6 42 0 25 27 0 0 25 27 0 0 165 44 31 905>;
+
+				adi,tx-settings-deframer-sel = <0>;
+				adi,tx-settings-tx-channels = <3>;
+				adi,tx-settings-tx-atten-step-size = <0>;
+				adi,tx-settings-tx1-atten_md-b = <10000>;
+				adi,tx-settings-tx2-atten_md-b = <10000>;
+				adi,tx-settings-dis-tx-data-if-pll-unlock = <0>;
+
+				/* Clocks */
+
+				adi,dig-clocks-device-clock_khz = <245760>;
+				adi,dig-clocks-clk-pll-vco-freq_khz = <9830400>;
+				adi,dig-clocks-clk-pll-hs-div = <1>;
+				adi,dig-clocks-rf-pll-use-external-lo = <0>;
+				adi,dig-clocks-rf-pll-phase-sync-mode = <0>;
+
+				/* AGC */
+
+				adi,rxagc-peak-agc-under-range-low-interval_ns = <205>;
+				adi,rxagc-peak-agc-under-range-mid-interval = <2>;
+				adi,rxagc-peak-agc-under-range-high-interval = <4>;
+				adi,rxagc-peak-apd-high-thresh = <39>;
+				adi,rxagc-peak-apd-low-gain-mode-high-thresh = <36>;
+				adi,rxagc-peak-apd-low-thresh = <23>;
+				adi,rxagc-peak-apd-low-gain-mode-low-thresh = <19>;
+				adi,rxagc-peak-apd-upper-thresh-peak-exceeded-cnt = <6>;
+				adi,rxagc-peak-apd-lower-thresh-peak-exceeded-cnt = <3>;
+				adi,rxagc-peak-apd-gain-step-attack = <4>;
+				adi,rxagc-peak-apd-gain-step-recovery = <2>;
+				adi,rxagc-peak-enable-hb2-overload = <1>;
+				adi,rxagc-peak-hb2-overload-duration-cnt = <1>;
+				adi,rxagc-peak-hb2-overload-thresh-cnt = <4>;
+				adi,rxagc-peak-hb2-high-thresh = <181>;
+				adi,rxagc-peak-hb2-under-range-low-thresh = <45>;
+				adi,rxagc-peak-hb2-under-range-mid-thresh = <90>;
+				adi,rxagc-peak-hb2-under-range-high-thresh = <128>;
+				adi,rxagc-peak-hb2-upper-thresh-peak-exceeded-cnt = <6>;
+				adi,rxagc-peak-hb2-lower-thresh-peak-exceeded-cnt = <3>;
+				adi,rxagc-peak-hb2-gain-step-high-recovery = <2>;
+				adi,rxagc-peak-hb2-gain-step-low-recovery = <4>;
+				adi,rxagc-peak-hb2-gain-step-mid-recovery = <8>;
+				adi,rxagc-peak-hb2-gain-step-attack = <4>;
+				adi,rxagc-peak-hb2-overload-power-mode = <1>;
+				adi,rxagc-peak-hb2-ovrg-sel = <0>;
+				adi,rxagc-peak-hb2-thresh-config = <3>;
+
+				adi,rxagc-power-power-enable-measurement = <1>;
+				adi,rxagc-power-power-use-rfir-out = <1>;
+				adi,rxagc-power-power-use-bbdc2 = <0>;
+				adi,rxagc-power-under-range-high-power-thresh = <9>;
+				adi,rxagc-power-under-range-low-power-thresh = <2>;
+				adi,rxagc-power-under-range-high-power-gain-step-recovery = <4>;
+				adi,rxagc-power-under-range-low-power-gain-step-recovery = <4>;
+				adi,rxagc-power-power-measurement-duration = <5>;
+				adi,rxagc-power-rx1-tdd-power-meas-duration = <5>;
+				adi,rxagc-power-rx1-tdd-power-meas-delay = <1>;
+				adi,rxagc-power-rx2-tdd-power-meas-duration = <5>;
+				adi,rxagc-power-rx2-tdd-power-meas-delay = <1>;
+				adi,rxagc-power-upper0-power-thresh = <2>;
+				adi,rxagc-power-upper1-power-thresh = <0>;
+				adi,rxagc-power-power-log-shift = <0>;
+
+				adi,rxagc-agc-peak-wait-time = <4>;
+				adi,rxagc-agc-rx1-max-gain-index = <255>;
+				adi,rxagc-agc-rx1-min-gain-index = <195>;
+				adi,rxagc-agc-rx2-max-gain-index = <255>;
+				adi,rxagc-agc-rx2-min-gain-index = <195>;
+				adi,rxagc-agc-gain-update-counter_us = <250>;
+				adi,rxagc-agc-rx1-attack-delay = <10>;
+				adi,rxagc-agc-rx2-attack-delay = <10>;
+				adi,rxagc-agc-slow-loop-settling-delay = <16>;
+				adi,rxagc-agc-low-thresh-prevent-gain = <0>;
+				adi,rxagc-agc-change-gain-if-thresh-high = <1>;
+				adi,rxagc-agc-peak-thresh-gain-control-mode = <1>;
+				adi,rxagc-agc-reset-on-rxon = <0>;
+				adi,rxagc-agc-enable-sync-pulse-for-gain-counter = <0>;
+				adi,rxagc-agc-enable-ip3-optimization-thresh = <0>;
+				adi,rxagc-ip3-over-range-thresh = <31>;
+				adi,rxagc-ip3-over-range-thresh-index = <246>;
+				adi,rxagc-ip3-peak-exceeded-cnt = <4>;
+				adi,rxagc-agc-enable-fast-recovery-loop = <0>;
+
+
+				/* Misc */
+
+				adi,aux-dac-enables = <0x00>; /* Mask */
+
+				adi,aux-dac-vref0 = <3>;
+				adi,aux-dac-resolution0 = <0>;
+				adi,aux-dac-values0 = <0>;
+				adi,aux-dac-vref1 = <3>;
+				adi,aux-dac-resolution1 = <0>;
+				adi,aux-dac-values1 = <0>;
+				adi,aux-dac-vref2 = <3>;
+				adi,aux-dac-resolution2 = <0>;
+				adi,aux-dac-values2 = <0>;
+				adi,aux-dac-vref3 = <3>;
+				adi,aux-dac-resolution3 = <0>;
+				adi,aux-dac-values3 = <0>;
+				adi,aux-dac-vref4 = <3>;
+				adi,aux-dac-resolution4 = <0>;
+				adi,aux-dac-values4 = <0>;
+				adi,aux-dac-vref5 = <3>;
+				adi,aux-dac-resolution5 = <0>;
+				adi,aux-dac-values5 = <0>;
+				adi,aux-dac-vref6 = <3>;
+				adi,aux-dac-resolution6 = <0>;
+				adi,aux-dac-values6 = <0>;
+				adi,aux-dac-vref7 = <3>;
+				adi,aux-dac-resolution7 = <0>;
+				adi,aux-dac-values7 = <0>;
+				adi,aux-dac-vref8 = <3>;
+				adi,aux-dac-resolution8 = <0>;
+				adi,aux-dac-values8 = <0>;
+				adi,aux-dac-vref9 = <3>;
+				adi,aux-dac-resolution9 = <0>;
+				adi,aux-dac-values9 = <0>;
+				adi,aux-dac-vref10 = <3>;
+				adi,aux-dac-resolution10 = <0>;
+				adi,aux-dac-values10 = <0>;
+				adi,aux-dac-vref11 = <3>;
+				adi,aux-dac-resolution11 = <0>;
+				adi,aux-dac-values11 = <0>;
+
+				adi,arm-gpio-config-orx1-tx-sel0-pin-gpio-pin-sel = <0>;
+				adi,arm-gpio-config-orx1-tx-sel0-pin-polarity = <0>;
+				adi,arm-gpio-config-orx1-tx-sel0-pin-enable = <0>;
+
+				adi,arm-gpio-config-orx1-tx-sel1-pin-gpio-pin-sel = <0>;
+				adi,arm-gpio-config-orx1-tx-sel1-pin-polarity = <0>;
+				adi,arm-gpio-config-orx1-tx-sel1-pin-enable = <0>;
+				adi,arm-gpio-config-orx2-tx-sel0-pin-gpio-pin-sel = <0>;
+				adi,arm-gpio-config-orx2-tx-sel0-pin-polarity = <0>;
+				adi,arm-gpio-config-orx2-tx-sel0-pin-enable = <0>;
+
+				adi,arm-gpio-config-orx2-tx-sel1-pin-gpio-pin-sel = <0>;
+				adi,arm-gpio-config-orx2-tx-sel1-pin-polarity = <0>;
+				adi,arm-gpio-config-orx2-tx-sel1-pin-enable = <0>;
+				adi,arm-gpio-config-en-tx-tracking-cals-gpio-pin-sel = <0>;
+				adi,arm-gpio-config-en-tx-tracking-cals-polarity = <0>;
+				adi,arm-gpio-config-en-tx-tracking-cals-enable = <0>;
+
+				adi,orx-lo-cfg-disable-aux-pll-relocking = <0>;
+				adi,orx-lo-cfg-gpio-select = <19>;
+
+				adi,fhm-config-fhm-gpio-pin = <0>;
+				adi,fhm-config-fhm-min-freq_mhz = <100>;
+				adi,fhm-config-fhm-max-freq_mhz = <100>;
+
+				adi,fhm-mode-fhm-enable = <0>;
+				adi,fhm-mode-enable-mcs-sync = <0>;
+				adi,fhm-mode-fhm-trigger-mode = <0>;
+				adi,fhm-mode-fhm-exit-mode = <0>;
+				adi,fhm-mode-fhm-init-frequency_hz = <2450000000>;
+
+				adi,rx1-gain-ctrl-pin-inc-step = <1>;
+				adi,rx1-gain-ctrl-pin-dec-step = <1>;
+				adi,rx1-gain-ctrl-pin-rx-gain-inc-pin = <0>;
+				adi,rx1-gain-ctrl-pin-rx-gain-dec-pin = <1>;
+				adi,rx1-gain-ctrl-pin-enable = <0>;
+
+				adi,rx2-gain-ctrl-pin-inc-step = <1>;
+				adi,rx2-gain-ctrl-pin-dec-step = <1>;
+				adi,rx2-gain-ctrl-pin-rx-gain-inc-pin = <3>;
+				adi,rx2-gain-ctrl-pin-rx-gain-dec-pin = <4>;
+				adi,rx2-gain-ctrl-pin-enable = <0>;
+
+				adi,tx1-atten-ctrl-pin-step-size = <0>;
+				adi,tx1-atten-ctrl-pin-tx-atten-inc-pin = <4>;
+				adi,tx1-atten-ctrl-pin-tx-atten-dec-pin = <5>;
+				adi,tx1-atten-ctrl-pin-enable = <0>;
+
+				adi,tx2-atten-ctrl-pin-step-size = <0>;
+				adi,tx2-atten-ctrl-pin-tx-atten-inc-pin = <6>;
+				adi,tx2-atten-ctrl-pin-tx-atten-dec-pin = <7>;
+				adi,tx2-atten-ctrl-pin-enable = <0>;
+
+				adi,tx-pa-protection-avg-duration = <3>;
+				adi,tx-pa-protection-tx-atten-step = <2>;
+				adi,tx-pa-protection-tx1-power-threshold = <128>;
+				adi,tx-pa-protection-tx2-power-threshold = <128>;
+				adi,tx-pa-protection-peak-count = <4>;
+				adi,tx-pa-protection-tx1-peak-threshold = <16>;
+				adi,tx-pa-protection-tx2-peak-threshold = <16>;
+			};
+		};
+
+		axi_adrv9009_tx_jesd: axi-jesd204-tx@10020000 {
+			compatible = "adi,axi-jesd204-tx-1.0";
+			reg = <0x10020000 0x4000>;
+
+			interrupt-parent = <&sys_cpu>;
+			interrupts = <8>;
+
+			clocks = <&sys_clk>, <&tx_device_clk_pll>, <&axi_adrv9009_adxcvr_tx 0>;
+			clock-names = "s_axi_aclk", "device_clk", "lane_clk";
+
+			adi,octets-per-frame = <2>;
+			adi,frames-per-multiframe = <32>;
+			adi,converter-resolution = <16>;
+			adi,bits-per-sample = <16>;
+			adi,converters-per-device = <4>;
+			adi,control-bits-per-sample = <0>;
+
+			#clock-cells = <0>;
+			clock-output-names = "jesd_tx_lane_clk";
+		};
+
+		axi_adrv9009_rx_jesd: axi-jesd204-rx@10030000 {
+			compatible = "adi,axi-jesd204-rx-1.0";
+			reg = <0x10030000 0x4000>;
+
+			interrupt-parent = <&sys_cpu>;
+			interrupts = <9>;
+
+			clocks = <&sys_clk>, <&rx_device_clk_pll>, <&axi_adrv9009_adxcvr_rx 0>;
+			clock-names = "s_axi_aclk", "device_clk", "lane_clk";
+
+			adi,octets-per-frame = <4>;
+			adi,frames-per-multiframe = <32>;
+
+			#clock-cells = <0>;
+			clock-output-names = "jesd_rx_lane_clk";
+		};
+
+		axi_adrv9009_rx_os_jesd: axi-jesd204-rx@10040000 {
+			compatible = "adi,axi-jesd204-rx-1.0";
+			reg = <0x10040000 0x4000>;
+
+			interrupt-parent = <&sys_cpu>;
+			interrupts = <10>;
+
+			clocks = <&sys_clk>, <&rx_os_device_clk_pll>, <&axi_adrv9009_adxcvr_rx_os 0>;
+			clock-names = "s_axi_aclk", "device_clk", "lane_clk";
+
+			adi,octets-per-frame = <2>;
+			adi,frames-per-multiframe = <32>;
+
+			#clock-cells = <0>;
+			clock-output-names = "jesd_rx_os_lane_clk";
+		};
+
+		axi_adrv9009_adxcvr_tx: axi-adrv9009-tx-xcvr@10024000 {
+			compatible = "adi,altera-adxcvr-1.00.a";
+			reg = <0x10024000 0x00001000>,
+				<0x10026000 0x00001000>,
+				<0x10028000 0x00001000>,
+				<0x10029000 0x00001000>,
+				<0x1002a000 0x00001000>,
+				<0x1002b000 0x00001000>;
+			reg-names = "adxcvr", "atx-pll", "adxcfg-0", "adxcfg-1", "adxcfg-2", "adxcfg-3";
+
+			clocks = <&clk0_ad9528 1>, <&tx_device_clk_pll>;
+			clock-names = "ref", "link";
+
+			#clock-cells = <0>;
+			clock-output-names = "jesd204_tx_lane_clock";
+		};
+
+		axi_adrv9009_adxcvr_rx: axi-adrv9009-rx-xcvr@10034000 {
+			compatible = "adi,altera-adxcvr-1.00.a";
+			reg = <0x10034000 0x00001000>,
+				<0x10038000 0x00001000>,
+				<0x10039000 0x00001000>;
+			reg-names = "adxcvr", "adxcfg-0", "adxcfg-1";
+
+			clocks = <&clk0_ad9528 1>, <&rx_device_clk_pll>;
+			clock-names = "ref", "link";
+
+			#clock-cells = <0>;
+			clock-output-names = "jesd204_rx_lane_clock";
+		};
+
+		axi_adrv9009_adxcvr_rx_os: axi-adrv9009-rx-os-xcvr@10044000 {
+			compatible = "adi,altera-adxcvr-1.00.a";
+			reg = <0x10044000 0x00001000>,
+				<0x10048000 0x00001000>,
+				<0x10049000 0x00001000>;
+			reg-names = "adxcvr", "adxcfg-0", "adxcfg-1";
+
+			clocks = <&clk0_ad9528 1>, <&rx_os_device_clk_pll>;
+			clock-names = "ref", "link";
+
+			#clock-cells = <0>;
+			clock-output-names = "jesd204_rx_os_lane_clock";
+		};
+
+		tx_dma: tx-dmac@1002c000 {
+			compatible = "adi,axi-dmac-1.00.a";
+			reg = <0x1002c000 0x00004000>;
+			interrupt-parent = <&sys_cpu>;
+			interrupts = <11>;
+			#dma-cells = <1>;
+			clocks = <&dma_clk>;
+			clock-names = "dma_clkin";
+
+			adi,channels {
+				#size-cells = <0>;
+				#address-cells = <1>;
+
+				dma-channel@0 {
+					reg = <0>;
+					adi,source-bus-width = <128>;
+					adi,source-bus-type = <0>;
+					adi,destination-bus-width = <128>;
+					adi,destination-bus-type = <1>;
+				};
+			};
+		};
+
+		rx_dma: rx-dmac@1003c000 {
+			compatible = "adi,axi-dmac-1.00.a";
+			reg = <0x1003c000 0x00004000>;
+			interrupt-parent = <&sys_cpu>;
+			interrupts = <12>;
+			#dma-cells = <1>;
+			clocks = <&dma_clk>;
+			clock-names = "dma_clkin";
+
+			adi,channels {
+				#size-cells = <0>;
+				#address-cells = <1>;
+
+				dma-channel@0 {
+					reg = <0>;
+					adi,source-bus-width = <64>;
+					adi,source-bus-type = <2>;
+					adi,destination-bus-width = <128>;
+					adi,destination-bus-type = <0>;
+				};
+			};
+		};
+
+		rx_os_dma: rx-os-dmac@1004c000 {
+			compatible = "adi,axi-dmac-1.00.a";
+			reg = <0x1004c000 0x00004000>;
+			interrupt-parent = <&sys_cpu>;
+			interrupts = <13>;
+			#dma-cells = <1>;
+			clocks = <&dma_clk>;
+			clock-names = "dma_clkin";
+
+			adi,channels {
+				#size-cells = <0>;
+				#address-cells = <1>;
+
+				dma-channel@0 {
+					reg = <0>;
+					adi,source-bus-width = <64>;
+					adi,source-bus-type = <2>;
+					adi,destination-bus-width = <128>;
+					adi,destination-bus-type = <0>;
+				};
+			};
+		};
+
+		axi_adrv9009_core_rx: axi-adrv9009-rx-hpc@10050000 {
+			compatible = "adi,axi-adrv9009-rx-1.0";
+			reg = <0x10050000 0x00008000>;
+			dmas = <&rx_dma 0>;
+			dma-names = "rx";
+			spibus-connected = <&trx0_adrv9009>;
+		};
+
+		axi_adrv9009_core_tx: axi-adrv9009-tx-hpc@10054000 {
+			compatible = "adi,axi-adrv9009-tx-1.0";
+			reg = <0x10054000 0x00004000>;
+			dmas = <&tx_dma 0>;
+			dma-names = "tx";
+			clocks = <&trx0_adrv9009 2>;
+			clock-names = "sampl_clk";
+			spibus-connected = <&trx0_adrv9009>;
+			adi,axi-pl-fifo-enable;
+			plddrbypass-gpios = <&sys_gpio_out 28 0>;
+		};
+
+		axi_adrv9009_core_rx_obs: axi-adrv9009-rx-obs-hpc@10058000 {
+			compatible = "adi,axi-adrv9009-obs-1.0";
+			reg = <0x10058000 0x00001000>;
+			dmas = <&rx_os_dma 0>;
+			dma-names = "rx";
+			clocks = <&trx0_adrv9009 1>;
+			clock-names = "sampl_clk";
+		};
+
+		tx_device_clk_pll: altera-a10-fpll@10025000 {
+			compatible = "altr,a10-fpll";
+			reg = <0x10025000 0x1000>;
+			clocks = <&clk0_ad9528 1>;
+
+			#clock-cells = <0>;
+			clock-output-names = "jesd204_tx_link_clock";
+		};
+
+		rx_device_clk_pll: altera-a10-fpll@10035000 {
+			compatible = "altr,a10-fpll";
+			reg = <0x10035000 0x1000>;
+			clocks = <&clk0_ad9528 1>;
+
+			#clock-cells = <0>;
+			clock-output-names = "jesd204_rx_link_clock";
+		};
+
+		rx_os_device_clk_pll: altera-a10-fpll@10045000 {
+			compatible = "altr,a10-fpll";
+			reg = <0x10045000 0x1000>;
+			clocks = <&clk0_ad9528 1>;
+
+			#clock-cells = <0>;
+			clock-output-names = "jesd204_rx_os_link_clock";
+		};
+	};
+
+	chosen {
+		bootargs = "debug console=ttyJ0,115200";
+	};
+};


### PR DESCRIPTION
Add device-tree source files for A10GX and A10SOC + ADRV9009.
Taken over from "altera_4.14" branch.

Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>