### PR TITLE
[RFC]arch: arm: boot: dts: Add Pluto Rev. C device tree configuration

### DIFF
--- a/arch/arm/boot/dts/zynq-pluto-sdr-revc.dts
+++ b/arch/arm/boot/dts/zynq-pluto-sdr-revc.dts
@@ -4,14 +4,54 @@
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 
-&axi_i2c0 {
-	current_limiter@5a {
-		compatible = "adi,adm1177";
-		reg = <0x5a>;
-		adi,r-sense-mohm = <50>; /* 50 mOhm */
-		adi,shutdown-threshold-ma = <1059>; /* 1.059 A */
-		adi,vrange-high-enable;
+/* These GPIO hogs are configured by u-boot environment */
+&gpio0 {
+	clock_extern_en {
+		gpio-hog;
+		gpios = <48 0>;
+		output-high;
 	};
+
+	clock_internal_en {
+		gpio-hog;
+		gpios = <48 0>;
+		output-low;
+	};
+};
+
+&amba {
+	axi_spi: axi_quad_spi@7C430000 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		bits-per-word = <8>;
+		compatible = "xlnx,xps-spi-2.00.a";
+		fifo-size = <16>;
+		interrupt-parent = <&intc>;
+		interrupts = <0 55 0>;
+		cs-gpios = <&gpio0 49 0>;
+		num-cs = <0x1>;
+		reg = <0x7C430000 0x10000>;
+		xlnx,num-ss-bits = <0x1>;
+		xlnx,spi-mode = <0>;
+
+		spidev0: spidev@0 {
+			compatible = "spidev";
+			reg = <0>;	/* CE0 */
+			#address-cells = <1>;
+			#size-cells = <0>;
+			spi-max-frequency = <125000000>;
+		};
+	};
+};
+
+&adc0_ad9364 {
+	/* This property is controlled by u-boot environment. */
+	adi,2rx-2tx-mode-enable;
+};
+
+&cf_ad9364_dac_core_0 {
+	/* This property is controlled by u-boot environment. */
+	compatible = "adi,axi-ad9361-dds-6.00.a";
 };
 
 / {
@@ -37,6 +77,5 @@
 			label = "Button";
 			linux,code = <BTN_MISC>;
 		};
-
 	};
 };

--- a/drivers/spi/spi-xilinx.c
+++ b/drivers/spi/spi-xilinx.c
@@ -13,6 +13,7 @@
  * published by the Free Software Foundation.
  */
 
+#include <linux/gpio.h>
 #include <linux/module.h>
 #include <linux/interrupt.h>
 #include <linux/of.h>
@@ -387,6 +388,16 @@ static int xspi_setup(struct spi_device *qspi)
 	if (ret < 0)
 		return ret;
 
+	/*FIXME: Check if this is valid in next Linux LTS*/
+	if (!gpio_is_valid(qspi->cs_gpio)) 
+		dev_warn(&qspi->dev, "%d is not a valid gpio\n",
+			qspi->cs_gpio);
+
+	ret = gpio_direction_output(qspi->cs_gpio, !(qspi->mode & SPI_CS_HIGH));
+	if (ret < 0)
+		dev_warn(&qspi->dev, "could not set CS gpio %d as output\n",
+			qspi->cs_gpio);
+
 	ret = xspi_setup_transfer(qspi, NULL);
 	pm_runtime_put_sync(xqspi->dev);
 
@@ -631,7 +642,7 @@ static int xilinx_spi_probe(struct platform_device *pdev)
 {
 	struct xilinx_spi *xspi;
 	struct resource *res;
-	int ret, num_cs = 0, bits_per_word = 8;
+	int ret, num_cs = 0, bits_per_word = 8, i;
 	struct spi_master *master;
 	struct device_node *nc;
 	u32 tmp, rx_bus_width, fifo_size;
@@ -810,6 +821,27 @@ static int xilinx_spi_probe(struct platform_device *pdev)
 	if (ret) {
 		dev_err(&pdev->dev, "spi_register_master failed\n");
 		goto clk_unprepare_all;
+	}
+
+	/*FIXME: Check if this is valid in next Linux LTS*/
+	if (!master->cs_gpios) {
+		dev_warn(&pdev->dev, "no CS gpios available\n");
+	} else {
+		for (i = 0; i < master->num_chipselect; i++) {
+			if (!gpio_is_valid(master->cs_gpios[i])) {
+				dev_err(&pdev->dev, "%i is not a valid gpio\n",
+					master->cs_gpios[i]);
+				return -EINVAL;
+			}
+
+			ret = devm_gpio_request(&pdev->dev, master->cs_gpios[0],
+						"Xilinx SPI driver");
+			if (ret < 0) {
+				dev_err(&pdev->dev, "can't get CS gpio %i\n",
+					master->cs_gpios[i]);
+				return ret;
+			}
+		}
 	}
 
 	return ret;


### PR DESCRIPTION
This patch adds an external clock option for Pluto Rev. C. Also DDS DAC
core has been modified to support 2 channels.

Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>