### PR TITLE
arch: arm64, arm, nios2: dts: adrv9009: add license + project tags

### DIFF
--- a/arch/arm/boot/dts/socfpga_arria10_socdk_adrv9009.dts
+++ b/arch/arm/boot/dts/socfpga_arria10_socdk_adrv9009.dts
@@ -1,3 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices ADRV9009
+ * https://wiki.analog.com/resources/eval/user-guides/adrv9009
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9009
+ * https://wiki.analog.com/resources/tools-software/linux-software/adrv9009_advanced_plugin
+ *
+ * hdl_project: <adrv9009/a10soc>
+ * board_revision: <>
+ *
+ * Copyright (C) 2019 Analog Devices Inc.
+ */
 /dts-v1/;
 #include "socfpga_arria10_socdk.dtsi"
 #include <dt-bindings/iio/frequency/ad9528.h>

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9008-1.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9008-1.dts
@@ -1,9 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0
 /*
- * dts file for ADRV9008-1 on Xilinx ZynqMP ZCU102 Rev 1.0
+ * Analog Devices ADRV9008-1
+ * https://wiki.analog.com/resources/eval/user-guides/adrv9009
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9009
+ * https://wiki.analog.com/resources/tools-software/linux-software/adrv9009_advanced_plugin
  *
- * Copyright (C) 2018 Analog Devices Inc.
+ * hdl_project: <adrv9009/zcu102>
+ * board_revision: <>
  *
- * Licensed under the GPL-2.
+ * Copyright (C) 2019 Analog Devices Inc.
  */
 #include "zynqmp-zcu102-rev1.0.dts"
 #include <dt-bindings/interrupt-controller/irq.h>

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9008-2.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9008-2.dts
@@ -1,9 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0
 /*
- * dts file for ADRV9008-2 on Xilinx ZynqMP ZCU102 Rev 1.0
+ * Analog Devices ADRV9008-2
+ * https://wiki.analog.com/resources/eval/user-guides/adrv9009
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9009
+ * https://wiki.analog.com/resources/tools-software/linux-software/adrv9009_advanced_plugin
  *
- * Copyright (C) 2018 Analog Devices Inc.
+ * hdl_project: <adrv9009/zcu102>
+ * board_revision: <>
  *
- * Licensed under the GPL-2.
+ * Copyright (C) 2019 Analog Devices Inc.
  */
 #include "zynqmp-zcu102-rev1.0.dts"
 #include <dt-bindings/interrupt-controller/irq.h>

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9009.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9009.dts
@@ -1,3 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices ADRV9009
+ * https://wiki.analog.com/resources/eval/user-guides/adrv9009
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9009
+ * https://wiki.analog.com/resources/tools-software/linux-software/adrv9009_advanced_plugin
+ *
+ * hdl_project: <adrv9009/zcu102>
+ * board_revision: <>
+ *
+ * Copyright (C) 2019 Analog Devices Inc.
+ */
 #include "zynqmp-zcu102-rev1.0.dts"
 #include <dt-bindings/interrupt-controller/irq.h>
 

--- a/arch/nios2/boot/dts/a10gx_adrv9009.dts
+++ b/arch/nios2/boot/dts/a10gx_adrv9009.dts
@@ -1,3 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices ADRV9009
+ * https://wiki.analog.com/resources/eval/user-guides/adrv9009
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9009
+ * https://wiki.analog.com/resources/tools-software/linux-software/adrv9009_advanced_plugin
+ *
+ * hdl_project: <adrv9009/a10gx>
+ * board_revision: <>
+ *
+ * Copyright (C) 2019 Analog Devices Inc.
+ */
 /dts-v1/;
 
 #include <dt-bindings/iio/frequency/ad9528.h>


### PR DESCRIPTION
This change adds license and project tags to the adrv9009 device-trees
on ZCU102, A10SOC and A10GX platforms.

Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>