### PR TITLE
arch: arm64: dts: adrv9009zu11eg: add license + project tags

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-reva-adrv2crr-fmc-reva-sync.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-reva-adrv2crr-fmc-reva-sync.dts
@@ -1,11 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0
 /*
- * dts file for ADRV2CRR-FMC using ADRV9009-ZU11EG System on Module
+ * ADRV2CRR-FMC using ADRV9009-ZU11EG System on Module
+ *
+ * https://wiki.analog.com/resources/eval/user-guides/adrv9009
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9009
+ * https://wiki.analog.com/resources/tools-software/linux-software/adrv9009_advanced_plugin
+ * https://wiki.analog.com/resources/eval/user-guides/adrv9009-zu11eg/adrv2crr-fmc_carrier_board
+ *
+ * hdl_project: <adrv9009zu11eg/adrv2crr_fmc>
+ * board_revision: <A>
  *
  * Copyright (C) 2019 Analog Devices Inc.
- *
- * Licensed under the GPL-2.
  */
-
 #include "zynqmp-adrv9009-zu11eg-reva-adrv2crr-fmc-reva.dts"
 
 &spi0 {

--- a/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-reva-adrv2crr-fmc-reva.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-reva-adrv2crr-fmc-reva.dts
@@ -1,9 +1,16 @@
+// SPDX-License-Identifier: GPL-2.0
 /*
- * dts file for ADRV2CRR-FMC using ADRV9009-ZU11EG System on Module
+ * ADRV2CRR-FMC using ADRV9009-ZU11EG System on Module
+ *
+ * https://wiki.analog.com/resources/eval/user-guides/adrv9009
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9009
+ * https://wiki.analog.com/resources/tools-software/linux-software/adrv9009_advanced_plugin
+ * https://wiki.analog.com/resources/eval/user-guides/adrv9009-zu11eg/adrv2crr-fmc_carrier_board
+ *
+ * hdl_project: <adrv9009zu11eg/adrv2crr_fmc>
+ * board_revision: <A>
  *
  * Copyright (C) 2019 Analog Devices Inc.
- *
- * Licensed under the GPL-2.
  */
 
 /*

--- a/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-revb-adrv2crr-fmc-revb-sync.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-revb-adrv2crr-fmc-revb-sync.dts
@@ -1,9 +1,16 @@
 // SPDX-License-Identifier: GPL-2.0
 /*
- * dts file for ADRV2CRR-FMC using ADRV9009-ZU11EG Rev.B System on Module
+ * ADRV2CRR-FMC using ADRV9009-ZU11EG Rev.B System on Module
+ *
+ * https://wiki.analog.com/resources/eval/user-guides/adrv9009
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9009
+ * https://wiki.analog.com/resources/tools-software/linux-software/adrv9009_advanced_plugin
+ * https://wiki.analog.com/resources/eval/user-guides/adrv9009-zu11eg/adrv2crr-fmc_carrier_board
+ *
+ * hdl_project: <adrv9009zu11eg/adrv2crr_fmc>
+ * board_revision: <B>
  *
  * Copyright (C) 2019 Analog Devices Inc.
- *
  */
 
 #include "zynqmp-adrv9009-zu11eg-reva-adrv2crr-fmc-reva-sync.dts"

--- a/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-revb-adrv2crr-fmc-revb.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-revb-adrv2crr-fmc-revb.dts
@@ -1,9 +1,16 @@
 // SPDX-License-Identifier: GPL-2.0
 /*
- * dts file for ADRV2CRR-FMC using ADRV9009-ZU11EG Rev.B System on Module
+ * ADRV2CRR-FMC using ADRV9009-ZU11EG Rev.B System on Module
+ *
+ * https://wiki.analog.com/resources/eval/user-guides/adrv9009
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9009
+ * https://wiki.analog.com/resources/tools-software/linux-software/adrv9009_advanced_plugin
+ * https://wiki.analog.com/resources/eval/user-guides/adrv9009-zu11eg/adrv2crr-fmc_carrier_board
+ *
+ * hdl_project: <adrv9009zu11eg/adrv2crr_fmc>
+ * board_revision: <B>
  *
  * Copyright (C) 2019 Analog Devices Inc.
- *
  */
 
 #include "zynqmp-adrv9009-zu11eg-reva-adrv2crr-fmc-reva.dts"


### PR DESCRIPTION
This change adds license and project tags to the adrv9009zu11eg
device-trees.

Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>