### PR TITLE
ci,travis: allow failures for checkpatch & sync-branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,19 +12,24 @@ notifications:
     on_success: change
     on_failure: always
 
-env:
-  matrix:
-  - BUILD_TYPE=sync_branches_with_master_travis DO_NOT_DOCKERIZE=1
-  - BUILD_TYPE=checkpatch DO_NOT_DOCKERIZE=1
-  - BUILD_TYPE=dtb_build_test ARCH=arm DTS_FILES=arch/arm/boot/dts/zynq-*.dts DO_NOT_DOCKERIZE=1
-  - BUILD_TYPE=dtb_build_test ARCH=arm64 DTS_FILES=arch/arm64/boot/dts/xilinx/zynqmp-*.dts DO_NOT_DOCKERIZE=1
-  - DEFCONFIG=zynq_xcomm_adv7511_defconfig ARCH=arm IMAGE=uImage
-    CHECK_ALL_ADI_DRIVERS_HAVE_BEEN_BUILT=1
-  - DEFCONFIG=zynq_pluto_defconfig ARCH=arm IMAGE=uImage
-  - DEFCONFIG=zynq_sidekiqz2_defconfig ARCH=arm IMAGE=uImage
-  - DEFCONFIG=adi_zynqmp_defconfig ARCH=arm64 IMAGE=Image
-    CHECK_ALL_ADI_DRIVERS_HAVE_BEEN_BUILT=1
-  - DEFCONFIG=zynq_m2k_defconfig ARCH=arm IMAGE=uImage
+matrix:
+  include:
+    - sync_branches: 1
+      env: BUILD_TYPE=sync_branches_with_master_travis DO_NOT_DOCKERIZE=1
+    - checkpatch: 1
+      env: BUILD_TYPE=checkpatch DO_NOT_DOCKERIZE=1
+    - env: BUILD_TYPE=dtb_build_test ARCH=arm DTS_FILES=arch/arm/boot/dts/zynq-*.dts DO_NOT_DOCKERIZE=1
+    - env: BUILD_TYPE=dtb_build_test ARCH=arm64 DTS_FILES=arch/arm64/boot/dts/xilinx/zynqmp-*.dts DO_NOT_DOCKERIZE=1
+    - env: DEFCONFIG=zynq_xcomm_adv7511_defconfig ARCH=arm IMAGE=uImage
+           CHECK_ALL_ADI_DRIVERS_HAVE_BEEN_BUILT=1
+    - env: DEFCONFIG=zynq_pluto_defconfig ARCH=arm IMAGE=uImage
+    - env: DEFCONFIG=zynq_sidekiqz2_defconfig ARCH=arm IMAGE=uImage
+    - env: DEFCONFIG=adi_zynqmp_defconfig ARCH=arm64 IMAGE=Image
+           CHECK_ALL_ADI_DRIVERS_HAVE_BEEN_BUILT=1
+    - env: DEFCONFIG=zynq_m2k_defconfig ARCH=arm IMAGE=uImage
+  allow_failures:
+    - sync_branches: 1
+    - checkpatch: 1
 
 script:
   - ./ci/travis/run-build-docker.sh


### PR DESCRIPTION
We want to move to philosophy where we have a
build-MUST-be-green-to-merge-code.

Github is great that it can actually implement this check. But in Travis-CI
the sync-branches & checkpatch builds frequently fail, and they are
sometimes nearly impossible to get green.

Travis-CI allows the specification of builds that are **allowed_failures**.
This is great, as Github can be notified that the build passed, even if
these 2 may have failed.

The sync-branches actually fails only on the master branch [since it
actually runs only for the master branch]. We would get less spam now with
this change.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>