### PR TITLE
arch: arm64, microblaze, nios2: add license + project tags

### DIFF
--- a/arch/arm/boot/dts/socfpga_arria10_socdk_adrv9371.dts
+++ b/arch/arm/boot/dts/socfpga_arria10_socdk_adrv9371.dts
@@ -1,0 +1,315 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Complete Radio Card platform containing AD9371
+ * Link: https://wiki.analog.com/resources/eval/user-guides/mykonos/quickstart
+ *
+ * hdl_project: <adrv9371x/a10soc>
+ * board_revision: <A>
+ *
+ * Copyright 2016-2019 Analog Devices Inc.
+ */
+/dts-v1/;
+#include "socfpga_arria10_socdk.dtsi"
+#include <dt-bindings/iio/frequency/ad9528.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+
+&mmc {
+	status = "okay";
+	num-slots = <1>;
+	cap-sd-highspeed;
+	broken-cd;
+	bus-width = <4>;
+	altr,dw-mshc-ciu-div = <3>;
+	altr,dw-mshc-sdr-timing = <0 3>;
+};
+
+/ {
+	clocks {
+		sys_clk: sys_clk {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <100000000>;
+			clock-output-names = "system_clock";
+		};
+
+		dma_clk: dma_clk {
+			#clock-cells = <0x0>;
+			compatible = "fixed-clock";
+			clock-frequency = <250000000>;
+			clock-output-names = "dma_clk";
+		};
+	};
+
+	soc {
+		sys_hps_bridges: bridge@ff200000 {
+			compatible = "simple-bus";
+			reg = <0xff200000 0x00200000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges = <0x00000000 0xff200000 0x00200000>;
+
+			sys_gpio_out: gpio@20 {
+				compatible = "altr,pio-1.0";
+				reg = <0x00000020 0x00000010>;
+				altr,gpio-bank-width = <32>;
+				resetvalue = <0>;
+				#gpio-cells = <2>;
+				gpio-controller;
+			};
+
+			sys_spi: spi@40 {
+				compatible = "altr,spi-1.0";
+				reg = <0x00000040 0x00000020>;
+				interrupt-parent = <&intc>;
+				interrupts = <0 26 IRQ_TYPE_LEVEL_HIGH>;
+				#address-cells = <0x1>;
+				#size-cells = <0x0>;
+			};
+
+			axi_ad9371_tx_jesd: axi-jesd204-tx@20000 {
+				compatible = "adi,axi-jesd204-tx-1.0";
+				reg = <0x00020000 0x4000>;
+
+				interrupt-parent = <&intc>;
+				interrupts = <0 28 IRQ_TYPE_LEVEL_HIGH>;
+
+				clocks = <&sys_clk>, <&tx_device_clk_pll>, <&axi_ad9371_tx_xcvr>;
+				clock-names = "s_axi_aclk", "device_clk", "lane_clk";
+
+				adi,octets-per-frame = <2>;
+				adi,frames-per-multiframe = <32>;
+				adi,converter-resolution = <14>;
+				adi,bits-per-sample = <16>;
+				adi,converters-per-device = <4>;
+				adi,control-bits-per-sample = <2>;
+
+				#clock-cells = <0>;
+				clock-output-names = "jesd_tx_lane_clk";
+			};
+
+			axi_ad9371_rx_jesd: axi-jesd204-rx@30000 {
+				compatible = "adi,axi-jesd204-rx-1.0";
+				reg = <0x00030000 0x4000>;
+
+				interrupt-parent = <&intc>;
+				interrupts = <0 27 IRQ_TYPE_LEVEL_HIGH>;
+
+				clocks = <&sys_clk>, <&rx_device_clk_pll>, <&axi_ad9371_rx_xcvr>;
+				clock-names = "s_axi_aclk", "device_clk", "lane_clk";
+
+				adi,octets-per-frame = <4>;
+				adi,frames-per-multiframe = <32>;
+				adi,converter-resolution = <16>;
+				adi,bits-per-sample = <16>;
+				adi,converters-per-device = <4>;
+
+				#clock-cells = <0>;
+				clock-output-names = "jesd_rx_lane_clk";
+			};
+
+			axi_ad9371_rx_os_jesd: axi-jesd204-rx@40000 {
+				compatible = "adi,axi-jesd204-rx-1.0";
+				reg = <0x00040000 0x4000>;
+
+				interrupt-parent = <&intc>;
+				interrupts = <0 29 IRQ_TYPE_LEVEL_HIGH>;
+
+				clocks = <&sys_clk>, <&rx_os_device_clk_pll>, <&axi_ad9371_rx_os_xcvr>;
+				clock-names = "s_axi_aclk", "device_clk", "lane_clk";
+
+				adi,octets-per-frame = <2>;
+				adi,frames-per-multiframe = <32>;
+				adi,converter-resolution = <16>;
+				adi,bits-per-sample = <16>;
+				adi,converters-per-device = <4>;
+
+				#clock-cells = <0>;
+				clock-output-names = "jesd_rx_os_lane_clk";
+			};
+
+			axi_ad9371_tx_xcvr: axi-ad9371-tx-xcvr@24000 {
+				compatible = "adi,altera-adxcvr-1.00.a";
+				reg = <0x00024000 0x00001000>,
+					<0x00026000 0x00001000>,
+					<0x00028000 0x00001000>,
+					<0x00029000 0x00001000>,
+					<0x0002a000 0x00001000>,
+					<0x0002b000 0x00001000>;
+				reg-names = "adxcvr", "atx-pll", "adxcfg-0", "adxcfg-1", "adxcfg-2", "adxcfg-3";
+
+				clocks = <&clk0_ad9528 1>, <&tx_device_clk_pll>;
+				clock-names = "ref", "link";
+
+				#clock-cells = <0>;
+				clock-output-names = "jesd204_tx_lane_clock";
+			};
+
+			axi_ad9371_rx_xcvr: axi-ad9371-rx-xcvr@34000 {
+				compatible = "adi,altera-adxcvr-1.00.a";
+				reg = <0x00034000 0x00001000>,
+					<0x00038000 0x00001000>,
+					<0x00039000 0x00001000>;
+				reg-names = "adxcvr", "adxcfg-0", "adxcfg-1";
+
+				clocks = <&clk0_ad9528 1>, <&rx_device_clk_pll>;
+				clock-names = "ref", "link";
+
+				#clock-cells = <0>;
+				clock-output-names = "jesd204_rx_lane_clock";
+			};
+
+			axi_ad9371_rx_os_xcvr: axi-ad9371-rx-os-xcvr@44000 {
+				compatible = "adi,altera-adxcvr-1.00.a";
+				reg = <0x00044000 0x00001000>,
+					<0x00048000 0x00001000>,
+					<0x00049000 0x00001000>;
+				reg-names = "adxcvr", "adxcfg-0", "adxcfg-1";
+
+				clocks = <&clk0_ad9528 1>, <&rx_os_device_clk_pll>;
+				clock-names = "ref", "link";
+
+				#clock-cells = <0>;
+				clock-output-names = "jesd204_rx_os_lane_clock";
+			};
+
+			axi_ad9371_tx_dma: axi-ad9371-tx-dma@2c000 {
+				compatible = "adi,axi-dmac-1.00.a";
+				reg = <0x0002c000 0x00004000>;
+				interrupt-parent = <&intc>;
+				interrupts = <0 30 IRQ_TYPE_LEVEL_HIGH>;
+				#dma-cells = <1>;
+				clocks = <&dma_clk>;
+
+				adi,channels {
+					#size-cells = <0>;
+					#address-cells = <1>;
+					dma-channel@0 {
+						reg = <0>;
+						adi,source-bus-width = <128>;
+						adi,source-bus-type = <0>;
+						adi,destination-bus-width = <128>;
+						adi,destination-bus-type = <1>;
+					};
+				};
+			};
+
+			axi_ad9371_rx_dma: axi-ad9371-rx-dma@3c000 {
+				compatible = "adi,axi-dmac-1.00.a";
+				reg = <0x0003c000 0x00004000>;
+				interrupt-parent = <&intc>;
+				interrupts = <0 31 IRQ_TYPE_LEVEL_HIGH>;
+				#dma-cells = <1>;
+				clocks = <&dma_clk>;
+
+				adi,channels {
+					#size-cells = <0>;
+					#address-cells = <1>;
+					dma-channel@0 {
+						reg = <0>;
+						adi,source-bus-width = <64>;
+						adi,source-bus-type = <2>;
+						adi,destination-bus-width = <128>;
+						adi,destination-bus-type = <0>;
+					};
+				};
+			};
+
+			axi_ad9371_rx_os_dma: axi-ad9371-rx-os-dma@4c000 {
+				compatible = "adi,axi-dmac-1.00.a";
+				reg = <0x0004c000 0x00004000>;
+				interrupt-parent = <&intc>;
+				interrupts = <0 32 IRQ_TYPE_LEVEL_HIGH>;
+				#dma-cells = <1>;
+				clocks = <&dma_clk>;
+
+				adi,channels {
+					#size-cells = <0>;
+					#address-cells = <1>;
+					dma-channel@0 {
+						reg = <0>;
+						adi,source-bus-width = <64>;
+						adi,source-bus-type = <2>;
+						adi,destination-bus-width = <128>;
+						adi,destination-bus-type = <0>;
+					};
+				};
+			};
+
+			axi_ad9371_rx: axi-ad9371-rx-hpc@50000 {
+				compatible = "adi,axi-ad9371-rx-1.0";
+				reg = <0x00050000 0x00008000>;
+				dmas = <&axi_ad9371_rx_dma 0>;
+				dma-names = "rx";
+				spibus-connected = <&trx0_ad9371>;
+			};
+
+			axi_ad9371_tx: axi-ad9371-tx-hpc@54000 {
+				compatible = "adi,axi-ad9371-tx-1.0";
+				reg = <0x00054000 0x00004000>;
+				dmas = <&axi_ad9371_tx_dma 0>;
+				dma-names = "tx";
+				clocks = <&trx0_ad9371 2>;
+				clock-names = "sampl_clk";
+				spibus-connected = <&trx0_ad9371>;
+				adi,axi-pl-fifo-enable;
+				plddrbypass-gpios = <&sys_gpio_out 28 0>;
+			};
+
+			xcvr_rx_os_core: axi-ad9371-rx-obs-hpc@58000 {
+				compatible = "adi,axi-ad9371-obs-1.0";
+				reg = <0x00058000 0x00001000>;
+				dmas = <&axi_ad9371_rx_os_dma 0>;
+				dma-names = "rx";
+				clocks = <&trx0_ad9371 1>;
+				clock-names = "sampl_clk";
+			};
+
+			tx_device_clk_pll: altera-a10-fpll@25000 {
+				compatible = "altr,a10-fpll";
+				reg = <0x00025000 0x1000>;
+				clocks = <&clk0_ad9528 1>;
+
+				#clock-cells = <0>;
+				clock-output-names = "jesd204_tx_link_clock";
+			};
+
+			rx_device_clk_pll: altera-a10-fpll@35000 {
+				compatible = "altr,a10-fpll";
+				reg = <0x00035000 0x1000>;
+				clocks = <&clk0_ad9528 1>;
+
+				#clock-cells = <0>;
+				clock-output-names = "jesd204_rx_link_clock";
+			};
+
+			rx_os_device_clk_pll: altera-a10-fpll@45000 {
+				compatible = "altr,a10-fpll";
+				reg = <0x00045000 0x1000>;
+				clocks = <&clk0_ad9528 1>;
+
+				#clock-cells = <0>;
+				clock-output-names = "jesd204_rx_os_link_clock";
+			};
+		};
+	};
+};
+
+#define fmc_spi sys_spi
+
+#include "adi-adrv9371.dtsi"
+
+&clk0_ad9528 {
+	reg = <0>;
+	reset-gpios = <&sys_gpio_out 27 0>;
+};
+
+&trx0_ad9371 {
+	reg = <1>;
+	reset-gpios = <&sys_gpio_out 20 0>;
+	test-gpios = <&sys_gpio_out 21 0>;
+	sysref_req-gpios = <&sys_gpio_out 26 0>;
+	rx2_enable-gpios = <&sys_gpio_out 22 0>;
+	rx1_enable-gpios = <&sys_gpio_out 23 0>;
+	tx2_enable-gpios = <&sys_gpio_out 24 0>;
+	tx1_enable-gpios = <&sys_gpio_out 25 0>;
+};

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9371.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9371.dts
@@ -1,3 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD9371
+ * Link: https://wiki.analog.com/resources/eval/user-guides/mykonos/quickstart
+ *
+ * hdl_project: <adrv9371x/zcu102>
+ * board_revision: <A>
+ *
+ * Copyright 2016-2020 Analog Devices Inc.
+ */
 #include "zynqmp-zcu102-rev1.0.dts"
 #include <dt-bindings/interrupt-controller/irq.h>
 

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9375.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9375.dts
@@ -1,9 +1,12 @@
+// SPDX-License-Identifier: GPL-2.0
 /*
- * Devicetree for AD9375 RF Transceiver
+ * AD9375
+ * Link: https://wiki.analog.com/resources/eval/user-guides/mykonos/quickstart
  *
- * Copyright 2018 Analog Devices Inc.
+ * hdl_project: <adrv9371x/zcu102>
+ * board_revision: <A>
  *
- * Licensed under the GPL-2.
+ * Copyright 2016-2020 Analog Devices Inc.
  */
 
 #include "zynqmp-zcu102-rev10-adrv9371.dts"

--- a/arch/microblaze/boot/dts/kcu105_adrv9371x.dts
+++ b/arch/microblaze/boot/dts/kcu105_adrv9371x.dts
@@ -1,4 +1,13 @@
-
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * AD9371
+ * Link: https://wiki.analog.com/resources/eval/user-guides/mykonos/quickstart
+ *
+ * hdl_project: <adrv9371x/kcu105>
+ * board_revision: <A>
+ *
+ * Copyright 2016-2020 Analog Devices Inc.
+ */
 /dts-v1/;
 /include/ "kcu105.dtsi"
 

--- a/arch/nios2/boot/dts/a10gx_adrv9371.dts
+++ b/arch/nios2/boot/dts/a10gx_adrv9371.dts
@@ -1,0 +1,520 @@
+/dts-v1/;
+
+#include <dt-bindings/iio/frequency/ad9528.h>
+
+/ {
+	model = "ALTR,system_bd";
+	compatible = "ALTR,system_bd";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		sys_cpu: cpu@0 {
+			device_type = "cpu";
+			compatible = "altr,nios2-1.1";
+			reg = <0x00000000>;
+			interrupt-controller;
+			#interrupt-cells = <1>;
+			altr,exception-addr = <3221225504>;
+			altr,fast-tlb-miss-addr = <3491762176>;
+			altr,has-initda = <1>;
+			altr,has-mmu = <1>;
+			altr,has-mul = <1>;
+			altr,implementation = "fast";
+			altr,pid-num-bits = <8>;
+			altr,reset-addr = <3221225472>;
+			altr,tlb-num-entries = <128>;
+			altr,tlb-num-ways = <16>;
+			altr,tlb-ptr-sz = <7>;
+			clock-frequency = <100000000>;
+			dcache-line-size = <32>;
+			dcache-size = <32768>;
+			icache-line-size = <32>;
+			icache-size = <32768>;
+		};
+	};
+
+	memory {
+		device_type = "memory";
+		reg = <0x00000000 0x10000000>,
+			<0x10140000 0x00028000>,
+			<0x10200000 0x00028000>;
+	};
+
+	clocks {
+		sys_clk: sys_clk {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <100000000>;
+			clock-output-names = "system_clock";
+		};
+
+		dma_clk: dma_clk {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <266520000>;
+			clock-output-names = "dma_clock";
+		};
+	};
+
+	sopc0: sopc {
+		device_type = "soc";
+		ranges;
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "ALTR,avalon", "simple-bus";
+		bus-frequency = <100000000>;
+
+		sys_uart: serial@101814f0 {
+			compatible = "altr,juart-1.0";
+			reg = <0x101814f0 0x00000008>;
+			interrupt-parent = <&sys_cpu>;
+			interrupts = <2>;
+		};
+
+		sys_ethernet: ethernet@10181000 {
+			compatible = "altr,tse-msgdma-1.0", "altr,tse-1.0";
+			reg = <0x10181000 0x00000400>,
+				<0x101814a0 0x00000020>,
+				<0x10181440 0x00000020>,
+				<0x101814e0 0x00000008>,
+				<0x10181480 0x00000020>,
+				<0x10181460 0x00000020>;
+			reg-names = "control_port", "rx_csr", "rx_desc", "rx_resp", "tx_csr", "tx_desc";
+			interrupt-parent = <&sys_cpu>;
+			interrupts = <0 1>;
+			interrupt-names = "rx_irq", "tx_irq";
+			ALTR,rx-fifo-depth = <4096>;
+			ALTR,tx-fifo-depth = <4096>;
+			rx-fifo-depth = <16384>;
+			tx-fifo-depth = <16384>;
+			address-bits = <48>;
+			max-frame-size = <1518>;
+			local-mac-address = [B2 94 3D 6E 11 8F];
+			altr,enable-sup-addr = <0>;
+			altr,enable-hash = <0>;
+			phy-mode = "sgmii";
+
+			sys_ethernet_mdio: mdio {
+				compatible = "altr,tse-mdio";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				phy0: ethernet-phy@0 {
+					reg = <0>;
+					device_type = "ethernet-phy";
+				};
+			};
+		};
+
+		sys_id: sysid@101814e8 {
+			compatible = "altr,sysid-1.0";
+			reg = <0x101814e8 0x00000008>;
+			id = <182193580>;
+			timestamp = <1506373933>;
+		};
+
+		sys_timer_1: timer@10181420 {
+			compatible = "altr,timer-1.0";
+			reg = <0x10181420 0x00000020>;
+			interrupt-parent = <&sys_cpu>;
+			interrupts = <4>;
+			clock-frequency = <100000000>;
+		};
+
+		sys_timer_2: timer@10181520 {
+			compatible = "altr,timer-1.0";
+			reg = <0x10181520 0x00000020>;
+			interrupt-parent = <&sys_cpu>;
+			interrupts = <3>;
+			clock-frequency = <100000000>;
+		};
+
+		sys_gpio_bd: gpio@101814d0 {
+			compatible = "altr,pio-1.0";
+			reg = <0x101814d0 0x00000010>;
+			interrupt-parent = <&sys_cpu>;
+			interrupts = <6>;
+			altr,gpio-bank-width = <32>;
+			altr,interrupt-type = <4>;
+			altr,interrupt_type = <4>;
+			level_trigger = <1>;
+			resetvalue = <0>;
+			#gpio-cells = <2>;
+			gpio-controller;
+		};
+
+		sys_gpio_in: gpio@101814c0 {
+			compatible = "altr,pio-1.0";
+			reg = <0x101814c0 0x00000010>;
+			interrupt-parent = <&sys_cpu>;
+			interrupts = <5>;
+			altr,gpio-bank-width = <32>;
+			altr,interrupt-type = <4>;
+			altr,interrupt_type = <4>;
+			level_trigger = <1>;
+			resetvalue = <0>;
+			#gpio-cells = <2>;
+			gpio-controller;
+		};
+
+		sys_gpio_out: gpio@10181500 {
+			compatible = "altr,pio-1.0";
+			reg = <0x10181500 0x00000010>;
+			altr,gpio-bank-width = <32>;
+			resetvalue = <0>;
+			#gpio-cells = <2>;
+			gpio-controller;
+		};
+
+		avl_ad9371_gpio: gpio@10060000 {
+			compatible = "altr,pio-1.0";
+			reg = <0x10060000 0x00000010>;
+			interrupt-parent = <&sys_cpu>;
+			interrupts = <14>;
+			altr,gpio-bank-width = <19>;
+			altr,interrupt-type = <4>;
+			altr,interrupt_type = <4>;
+			level_trigger = <1>;
+			resetvalue = <0>;
+			#gpio-cells = <2>;
+			gpio-controller;
+		};
+
+		sys_spi: spi@10181400 {
+			compatible = "altr,spi-1.0";
+			reg = <0x10181400 0x00000020>;
+			interrupt-parent = <&sys_cpu>;
+			interrupts = <7>;
+
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			clk0_ad9528: ad9528-1@0 {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				#clock-cells = <1>;
+				compatible = "ad9528";
+
+				reset-gpios = <&sys_gpio_out 27 0>;
+
+				//spi-cpol;
+				//spi-cpha;
+				spi-max-frequency = <10000000>;
+				//adi,spi-3wire-enable;
+				reg = <0>;
+
+				clock-output-names = "ad9528-1_out0", "ad9528-1_out1", "ad9528-1_out2", "ad9528-1_out3", "ad9528-1_out4", "ad9528-1_out5", "ad9528-1_out6", "ad9528-1_out7", "ad9528-1_out8", "ad9528-1_out9", "ad9528-1_out10", "ad9528-1_out11", "ad9528-1_out12", "ad9528-1_out13";
+				adi,vcxo-freq = <122880000>;
+
+				adi,refa-enable;
+				adi,refa-diff-rcv-enable;
+				adi,refa-r-div = <1>;
+				adi,osc-in-cmos-neg-inp-enable;
+
+				/* PLL1 config */
+				adi,pll1-feedback-div = <4>;
+				adi,pll1-charge-pump-current-nA = <5000>;
+
+				/* PLL2 config */
+				adi,pll2-ndiv-a-cnt = <2>; /* N = 30 */
+				adi,pll2-ndiv-b-cnt = <7>;
+				adi,pll2-vco-diff-m1 = <3>; /* use 5 for 184320000 output device clock */
+				adi,pll2-n2-div = <10>; /* N / M1 */
+				adi,pll2-r1-div = <1>;
+				adi,pll2-charge-pump-current-nA = <805000>;
+
+				/* SYSREF config */
+				adi,sysref-src = <SYSREF_SRC_INTERNAL>;
+				adi,sysref-pattern-mode = <SYSREF_PATTERN_CONTINUOUS>;
+				adi,sysref-k-div = <512>;
+				adi,sysref-request-enable;
+				adi,sysref-nshot-mode = <SYSREF_NSHOT_4_PULSES>;
+				adi,sysref-request-trigger-mode = <SYSREF_LEVEL_HIGH>;
+
+				adi,rpole2 = <RPOLE2_900_OHM>;
+				adi,rzero = <RZERO_1850_OHM>;
+				adi,cpole1 = <CPOLE1_16_PF>;
+
+				adi,status-mon-pin0-function-select = <1>; /* PLL1 & PLL2 Locked */
+				adi,status-mon-pin1-function-select = <7>; /* REFA Correct */
+
+				ad9528_0_c13: channel@13 {
+					reg = <13>;
+					adi,extended-name = "DEV_CLK";
+					adi,driver-mode = <DRIVER_MODE_LVDS>;
+					adi,divider-phase = <0>;
+					adi,channel-divider = <10>;
+					adi,signal-source = <SOURCE_VCO>;
+				};
+
+				ad9528_0_c1: channel@1 {
+					reg = <1>;
+					adi,extended-name = "FMC_CLK";
+					adi,driver-mode = <DRIVER_MODE_LVDS>;
+					adi,divider-phase = <0>;
+					adi,channel-divider = <10>;
+					adi,signal-source = <SOURCE_VCO>;
+				};
+
+				ad9528_0_c12: channel@12 {
+					reg = <12>;
+					adi,extended-name = "DEV_SYSREF";
+					adi,driver-mode = <DRIVER_MODE_LVDS>;
+					adi,divider-phase = <0>;
+					adi,channel-divider = <10>;
+					adi,signal-source = <SOURCE_SYSREF_VCO>;
+				};
+
+				ad9528_0_c3: channel@3 {
+					reg = <3>;
+					adi,extended-name = "FMC_SYSREF";
+					adi,driver-mode = <DRIVER_MODE_LVDS>;
+					adi,divider-phase = <0>;
+					adi,channel-divider = <10>;
+					adi,signal-source = <SOURCE_SYSREF_VCO>;
+				};
+			};
+
+			trx0_ad9371: ad9371-phy@1 {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				#clock-cells = <1>;
+				compatible = "ad9371";
+
+				reset-gpios = <&sys_gpio_out 20 0>;
+				test-gpios = <&sys_gpio_out 21 0>;
+				sysref_req-gpios = <&sys_gpio_out 26 0>;
+				rx2_enable-gpios = <&sys_gpio_out 22 0>;
+				rx1_enable-gpios = <&sys_gpio_out 23 0>;
+				tx2_enable-gpios = <&sys_gpio_out 24 0>;
+				tx1_enable-gpios = <&sys_gpio_out 25 0>;
+
+				/* SPI Setup */
+				reg = <1>;
+				spi-max-frequency = <25000000>;
+
+				/* Clocks */
+				clocks = <&axi_ad9371_rx_jesd>, <&axi_ad9371_tx_jesd>, <&axi_ad9371_rx_os_jesd>, <&clk0_ad9528 13>, <&clk0_ad9528 1>;
+				clock-names = "jesd_rx_clk", "jesd_tx_clk", "jesd_rx_os_clk", "dev_clk", "fmc_clk";
+				clock-output-names = "rx_sampl_clk", "rx_os_sampl_clk", "tx_sampl_clk";
+			};
+		};
+
+		axi_ad9371_tx_jesd: axi-jesd204-tx@10020000 {
+			compatible = "adi,axi-jesd204-tx-1.0";
+			reg = <0x10020000 0x4000>;
+
+			interrupt-parent = <&sys_cpu>;
+			interrupts = <8>;
+
+			clocks = <&sys_clk>, <&tx_device_clk_pll>, <&axi_ad9371_tx_xcvr>;
+			clock-names = "s_axi_aclk", "device_clk", "lane_clk";
+
+			adi,octets-per-frame = <2>;
+			adi,frames-per-multiframe = <32>;
+			adi,converter-resolution = <14>;
+			adi,bits-per-sample = <16>;
+			adi,converters-per-device = <4>;
+			adi,control-bits-per-sample = <2>;
+
+			#clock-cells = <0>;
+			clock-output-names = "jesd_tx_lane_clk";
+		};
+
+		axi_ad9371_rx_jesd: axi-jesd204-rx@10030000 {
+			compatible = "adi,axi-jesd204-rx-1.0";
+			reg = <0x10030000 0x4000>;
+
+			interrupt-parent = <&sys_cpu>;
+			interrupts = <9>;
+
+			clocks = <&sys_clk>, <&rx_device_clk_pll>, <&axi_ad9371_rx_xcvr>;
+			clock-names = "s_axi_aclk", "device_clk", "lane_clk";
+
+			adi,octets-per-frame = <4>;
+			adi,frames-per-multiframe = <32>;
+			adi,converter-resolution = <16>;
+			adi,bits-per-sample = <16>;
+			adi,converters-per-device = <4>;
+
+			#clock-cells = <0>;
+			clock-output-names = "jesd_rx_lane_clk";
+		};
+
+		axi_ad9371_rx_os_jesd: axi-jesd204-rx@10040000 {
+			compatible = "adi,axi-jesd204-rx-1.0";
+			reg = <0x10040000 0x4000>;
+
+			interrupt-parent = <&sys_cpu>;
+			interrupts = <10>;
+
+			clocks = <&sys_clk>, <&rx_os_device_clk_pll>, <&axi_ad9371_rx_os_xcvr>;
+			clock-names = "s_axi_aclk", "device_clk", "lane_clk";
+
+			adi,octets-per-frame = <2>;
+			adi,frames-per-multiframe = <32>;
+			adi,converter-resolution = <16>;
+			adi,bits-per-sample = <16>;
+			adi,converters-per-device = <4>;
+
+			#clock-cells = <0>;
+			clock-output-names = "jesd_rx_os_lane_clk";
+		};
+
+		axi_ad9371_tx_xcvr: axi-ad9371-tx-xcvr@10024000 {
+			compatible = "adi,altera-adxcvr-1.00.a";
+			reg = <0x10024000 0x00001000>,
+				<0x10026000 0x00001000>,
+				<0x10028000 0x00001000>,
+				<0x10029000 0x00001000>,
+				<0x1002a000 0x00001000>,
+				<0x1002b000 0x00001000>;
+			reg-names = "adxcvr", "atx-pll", "adxcfg-0", "adxcfg-1", "adxcfg-2", "adxcfg-3";
+
+			clocks = <&clk0_ad9528 1>, <&tx_device_clk_pll>;
+			clock-names = "ref", "link";
+
+			#clock-cells = <0>;
+			clock-output-names = "jesd204_tx_lane_clock";
+		};
+
+		axi_ad9371_rx_xcvr: axi-ad9371-rx-xcvr@10034000 {
+			compatible = "adi,altera-adxcvr-1.00.a";
+			reg = <0x10034000 0x00001000>,
+				<0x10038000 0x00001000>,
+				<0x10039000 0x00001000>;
+			reg-names = "adxcvr", "adxcfg-0", "adxcfg-1";
+
+			clocks = <&clk0_ad9528 1>, <&rx_device_clk_pll>;
+			clock-names = "ref", "link";
+
+			#clock-cells = <0>;
+			clock-output-names = "jesd204_rx_lane_clock";
+		};
+
+		axi_ad9371_rx_os_xcvr: axi-ad9371-rx-os-xcvr@10044000 {
+			compatible = "adi,altera-adxcvr-1.00.a";
+			reg = <0x10044000 0x00001000>,
+				<0x10048000 0x00001000>,
+				<0x10049000 0x00001000>;
+			reg-names = "adxcvr", "adxcfg-0", "adxcfg-1";
+
+			clocks = <&clk0_ad9528 1>, <&rx_os_device_clk_pll>;
+			clock-names = "ref", "link";
+
+			#clock-cells = <0>;
+			clock-output-names = "jesd204_rx_os_lane_clock";
+		};
+
+		axi_ad9371_tx_dma: axi-ad9371-tx-dma@1002c000 {
+			compatible = "adi,axi-dmac-1.00.a";
+			reg = <0x1002c000 0x00004000>;
+			interrupt-parent = <&sys_cpu>;
+			interrupts = <11>;
+			#dma-cells = <1>;
+			clocks = <&dma_clk>;
+			clock-names = "dma_clkin";
+
+			dma-channel {
+				adi,source-bus-width = <128>;
+				adi,destination-bus-width = <128>;
+				adi,type = <1>;
+				adi,cyclic;
+			};
+		};
+
+		axi_ad9371_rx_dma: axi-ad9371-rx-dma@1003c000 {
+			compatible = "adi,axi-dmac-1.00.a";
+			reg = <0x1003c000 0x00004000>;
+			interrupt-parent = <&sys_cpu>;
+			interrupts = <12>;
+			#dma-cells = <1>;
+			clocks = <&dma_clk>;
+			clock-names = "dma_clkin";
+
+			dma-channel {
+				adi,source-bus-width = <64>;
+				adi,destination-bus-width = <128>;
+				adi,type = <0>;
+			};
+		};
+
+		axi_ad9371_rx_os_dma: axi-ad9371-rx-os-dma@1004c000 {
+			compatible = "adi,axi-dmac-1.00.a";
+			reg = <0x1004c000 0x00004000>;
+			interrupt-parent = <&sys_cpu>;
+			interrupts = <13>;
+			#dma-cells = <1>;
+			clocks = <&dma_clk>;
+			clock-names = "dma_clkin";
+
+			dma-channel {
+				adi,source-bus-width = <64>;
+				adi,destination-bus-width = <128>;
+				adi,type = <0>;
+			};
+		};
+
+		axi_ad9371_rx: axi-ad9371-rx-hpc@10050000 {
+			compatible = "adi,axi-ad9371-rx-1.0";
+			reg = <0x10050000 0x00008000>;
+			dmas = <&axi_ad9371_rx_dma 0>;
+			dma-names = "rx";
+			spibus-connected = <&trx0_ad9371>;
+		};
+
+		axi_ad9371_tx: axi-ad9371-tx-hpc@10054000 {
+			compatible = "adi,axi-ad9371-tx-1.0";
+			reg = <0x10054000 0x00004000>;
+			dmas = <&axi_ad9371_tx_dma 0>;
+			dma-names = "tx";
+			clocks = <&trx0_ad9371 2>;
+			clock-names = "sampl_clk";
+			spibus-connected = <&trx0_ad9371>;
+			plddrbypass-gpios = <&sys_gpio_out 28 0>;
+		};
+
+		xcvr_rx_os_core: axi-ad9371-rx-obs-hpc@10058000 {
+			compatible = "adi,axi-ad9371-obs-1.0";
+			reg = <0x10058000 0x00001000>;
+			dmas = <&axi_ad9371_rx_os_dma 0>;
+			dma-names = "rx";
+			clocks = <&trx0_ad9371 1>;
+			clock-names = "sampl_clk";
+		};
+
+		tx_device_clk_pll: altera-a10-fpll@10025000 {
+			compatible = "altr,a10-fpll";
+			reg = <0x10025000 0x1000>;
+			clocks = <&clk0_ad9528 1>;
+
+			#clock-cells = <0>;
+			clock-output-names = "jesd204_tx_link_clock";
+		};
+
+		rx_device_clk_pll: altera-a10-fpll@10035000 {
+			compatible = "altr,a10-fpll";
+			reg = <0x10035000 0x1000>;
+			clocks = <&clk0_ad9528 1>;
+
+			#clock-cells = <0>;
+			clock-output-names = "jesd204_rx_link_clock";
+		};
+
+		rx_os_device_clk_pll: altera-a10-fpll@10045000 {
+			compatible = "altr,a10-fpll";
+			reg = <0x10045000 0x1000>;
+			clocks = <&clk0_ad9528 1>;
+
+			#clock-cells = <0>;
+			clock-output-names = "jesd204_rx_os_link_clock";
+		};
+	};
+
+	chosen {
+		bootargs = "debug console=ttyJ0,115200";
+	};
+};

--- a/arch/nios2/boot/dts/a10gx_adrv9371.dts
+++ b/arch/nios2/boot/dts/a10gx_adrv9371.dts
@@ -1,3 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Complete Radio Card platform containing AD9371
+ * Link: https://wiki.analog.com/resources/eval/user-guides/mykonos/quickstart
+ *
+ * hdl_project: <adrv9371x/a10gx>
+ * board_revision: <A>
+ *
+ * Copyright 2016-2019 Analog Devices Inc.
+ */
 /dts-v1/;
 
 #include <dt-bindings/iio/frequency/ad9528.h>


### PR DESCRIPTION
This patch set add device-tree source files for A10GX and A10SOC + ADRV9371.
Taken over from "altera_4.14" branch.

Also adds license and project tags to the adrv9371/5 device-trees on ZCU102, 
A10SOC and A10GX platforms.

Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>