### PR TITLE
hwmon: adm1177: sync with upstream

### DIFF
--- a/Documentation/devicetree/bindings/hwmon/adi,adm1177.yaml
+++ b/Documentation/devicetree/bindings/hwmon/adi,adm1177.yaml
@@ -26,13 +26,16 @@ properties:
     description:
       Phandle to the Avcc power supply
 
-  adi,r-sense-micro-ohms:
+  shunt-resistor-micro-ohms:
     description:
-      The value of curent sense resistor in microohms.
+      The value of curent sense resistor in microohms. If not provided,
+      the current reading and overcurrent alert is disabled.
 
   adi,shutdown-threshold-microamp:
     description:
       Specifies the current level at which an over current alert occurs.
+      If not provided, the overcurrent alert is configured to max ADC range
+      based on shunt-resistor-micro-ohms.
 
   adi,vrange-high-enable:
     description:
@@ -43,8 +46,6 @@ properties:
 required:
   - compatible
   - reg
-  - adi,r-sense-micro-ohms
-  - adi,shutdown-threshold-microamp
 
 examples:
   - |
@@ -57,7 +58,7 @@ examples:
         pwmon@5a {
                 compatible = "adi,adm1177";
                 reg = <0x5a>;
-                adi,r-sense-micro-ohms = <50000>; /* 50 mOhm */
+		shunt-resistor-micro-ohms = <50000>; /* 50 mOhm */
                 adi,shutdown-threshold-microamp = <1059000>; /* 1.059 A */
                 adi,vrange-high-enable;
         };

--- a/Documentation/hwmon/adm1177.rst
+++ b/Documentation/hwmon/adm1177.rst
@@ -1,0 +1,36 @@
+Kernel driver adm1177
+=====================
+
+Supported chips:
+  * Analog Devices ADM1177
+    Prefix: 'adm1177'
+    Datasheet: https://www.analog.com/media/en/technical-documentation/data-sheets/ADM1177.pdf
+
+Author: Beniamin Bia <beniamin.bia@analog.com>
+
+
+Description
+-----------
+
+This driver supports hardware monitoring for Analog Devices ADM1177
+Hot-Swap Controller and Digital Power Monitors with Soft Start Pin.
+
+
+Usage Notes
+-----------
+
+This driver does not auto-detect devices. You will have to instantiate the
+devices explicitly. Please see Documentation/i2c/instantiating-devices for
+details.
+
+
+Sysfs entries
+-------------
+
+The following attributes are supported. Current maxim attribute
+is read-write, all other attributes are read-only.
+
+in0_input		Measured voltage in microvolts.
+
+curr1_input		Measured current in microamperes.
+curr1_max_alarm		Overcurrent alarm in microamperes.


### PR DESCRIPTION
Sync the driver with the upstream version.

Signed-off-by: Beniamin Bia <beniamin.bia@analog.com>