### PR TITLE
arch: arm: arradio: add license + project tags

### DIFF
--- a/arch/arm/boot/dts/socfpga_cyclone5_sockit_arradio.dts
+++ b/arch/arm/boot/dts/socfpga_cyclone5_sockit_arradio.dts
@@ -1,3 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * ARRADIO AD9361 HSMC board
+ * Link: https://wiki.analog.com/resources/eval/user-guides/arradio
+ *
+ * hdl_project: <arradio/c5soc>
+ * board_revision: <>
+ *
+ * Copyright 2020 Analog Devices Inc.
+ */
 #include <dt-bindings/interrupt-controller/irq.h>
 
 #include "socfpga_cyclone5.dtsi"


### PR DESCRIPTION
This change adds license and project tags to the arradio device-tree
on c5soc platform.

Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>