### PR TITLE
arch: arm: cn0363: add license + project tags

### DIFF
--- a/arch/arm/boot/dts/zynq-zed-adv7511-cn0363.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-cn0363.dts
@@ -1,3 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices CN0363
+ * https://www.analog.com/en/design-center/reference-designs/circuits-from-the-lab/CN0363.html
+ *
+ * hdl_project: <cn0363/zed>
+ * board_revision: <>
+ *
+ * Copyright (C) 2020 Analog Devices Inc.
+ */
 /dts-v1/;
 
 #include "zynq-zed.dtsi"


### PR DESCRIPTION
This change adds license and project tags to the CN0363 device-tree
on zed platform.

Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>