### PR TITLE
arch: arm64, arm: add license + project tags cn0506

### DIFF
--- a/arch/arm/boot/dts/adi-cn0506-socfpga-mii.dtsi
+++ b/arch/arm/boot/dts/adi-cn0506-socfpga-mii.dtsi
@@ -1,0 +1,39 @@
+/ {
+	aliases {
+		ethernet0 = &gmac0;
+		ethernet1 = &gmac1;
+		ethernet2 = &gmac2;
+	};
+};
+
+&gmac1 {
+	status = "okay";
+	phy-mode = "mii";
+	phy-handle = <&ethernet_gmac1_phy1>;
+
+	mdio {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "snps,dwmac-mdio";
+
+		ethernet_gmac1_phy1: ethernet-phy@1 {
+			reg = <1>;
+		};
+	};
+};
+
+&gmac2 {
+	status = "okay";
+	phy-mode = "mii";
+	phy-handle = <&ethernet_gmac2_phy2>;
+
+	mdio {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "snps,dwmac-mdio";
+
+		ethernet_gmac2_phy2: ethernet-phy@2 {
+			reg = <2>;
+		};
+	};
+};

--- a/arch/arm/boot/dts/adi-cn0506-socfpga-rgmii.dtsi
+++ b/arch/arm/boot/dts/adi-cn0506-socfpga-rgmii.dtsi
@@ -1,0 +1,41 @@
+/ {
+	aliases {
+		ethernet0 = &gmac0;
+		ethernet1 = &gmac1;
+		ethernet2 = &gmac2;
+	};
+};
+
+&gmac1 {
+	status = "okay";
+	phy-mode = "rgmii-id";
+	mac-mode = "gmii";
+	phy-handle = <&ethernet_gmac1_phy1>;
+
+	mdio {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "snps,dwmac-mdio";
+
+		ethernet_gmac1_phy1: ethernet-phy@1 {
+			reg = <1>;
+		};
+	};
+};
+
+&gmac2 {
+	status = "okay";
+	phy-mode = "rgmii-id";
+	mac-mode = "gmii";
+	phy-handle = <&ethernet_gmac2_phy2>;
+
+	mdio {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "snps,dwmac-mdio";
+
+		ethernet_gmac2_phy2: ethernet-phy@2 {
+			reg = <2>;
+		};
+	};
+};

--- a/arch/arm/boot/dts/socfpga_arria10_socdk_cn0506_mii.dts
+++ b/arch/arm/boot/dts/socfpga_arria10_socdk_cn0506_mii.dts
@@ -1,3 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * ADIN PHY FMC board
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/net-phy/adin
+ *
+ * hdl_project: <cn0506_mii/a10soc>
+ * board_revision: <>
+ *
+ * Copyright 2020 Analog Devices Inc.
+ */
 /dts-v1/;
 #include "socfpga_arria10_socdk.dtsi"
 

--- a/arch/arm/boot/dts/socfpga_arria10_socdk_cn0506_mii.dts
+++ b/arch/arm/boot/dts/socfpga_arria10_socdk_cn0506_mii.dts
@@ -1,0 +1,14 @@
+/dts-v1/;
+#include "socfpga_arria10_socdk.dtsi"
+
+#include "adi-cn0506-socfpga-mii.dtsi"
+
+&mmc {
+	status = "okay";
+	num-slots = <1>;
+	cap-sd-highspeed;
+	broken-cd;
+	bus-width = <4>;
+	altr,dw-mshc-ciu-div = <3>;
+	altr,dw-mshc-sdr-timing = <0 3>;
+};

--- a/arch/arm/boot/dts/socfpga_arria10_socdk_cn0506_rgmii.dts
+++ b/arch/arm/boot/dts/socfpga_arria10_socdk_cn0506_rgmii.dts
@@ -1,3 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * ADIN PHY FMC Board
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/net-phy/adin
+ *
+ * hdl_project: <cn0506_rgmii/a10soc>
+ * board_revision: <>
+ *
+ * Copyright 2020 Analog Devices Inc.
+ */
 /dts-v1/;
 #include "socfpga_arria10_socdk.dtsi"
 

--- a/arch/arm/boot/dts/socfpga_arria10_socdk_cn0506_rgmii.dts
+++ b/arch/arm/boot/dts/socfpga_arria10_socdk_cn0506_rgmii.dts
@@ -1,0 +1,14 @@
+/dts-v1/;
+#include "socfpga_arria10_socdk.dtsi"
+
+#include "adi-cn0506-socfpga-rgmii.dtsi"
+
+&mmc {
+	status = "okay";
+	num-slots = <1>;
+	cap-sd-highspeed;
+	broken-cd;
+	bus-width = <4>;
+	altr,dw-mshc-ciu-div = <3>;
+	altr,dw-mshc-sdr-timing = <0 3>;
+};

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-cn0506-mii.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-cn0506-mii.dts
@@ -1,3 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * ADIN PHY FMC board
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/net-phy/adin
+ *
+ * hdl_project: <cn0506_mii/zc706>
+ * board_revision: <>
+ *
+ * Copyright 2020 Analog Devices Inc.
+ */
 /dts-v1/;
 
 #include "zynq-zc706.dtsi"

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-cn0506-rgmii.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-cn0506-rgmii.dts
@@ -1,3 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * ADIN PHY FMC board
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/net-phy/adin
+ *
+ * hdl_project: <cn0506_rgmii/zc706>
+ * board_revision: <>
+ *
+ * Copyright 2020 Analog Devices Inc.
+ */
 /dts-v1/;
 
 #include "zynq-zc706.dtsi"

--- a/arch/arm/boot/dts/zynq-zed-adv7511-cn0506-mii.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-cn0506-mii.dts
@@ -1,3 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * ADIN PHY FMC board
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/net-phy/adin
+ *
+ * hdl_project: <cn0506_mii/zed>
+ * board_revision: <>
+ *
+ * Copyright 2020 Analog Devices Inc.
+ */
 /dts-v1/;
 
 #include "zynq-zed.dtsi"

--- a/arch/arm/boot/dts/zynq-zed-adv7511-cn0506-rgmii.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-cn0506-rgmii.dts
@@ -1,3 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * ADIN PHY FMC board
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/net-phy/adin
+ *
+ * hdl_project: <cn0506_rgmii/zed>
+ * board_revision: <>
+ *
+ * Copyright 2020 Analog Devices Inc.
+ */
 /dts-v1/;
 
 #include "zynq-zed.dtsi"

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-cn0506-mii.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-cn0506-mii.dts
@@ -1,3 +1,12 @@
-
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * ADIN PHY FMC board
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/net-phy/adin
+ *
+ * hdl_project: <cn0506_mii/zcu102>
+ * board_revision: <>
+ *
+ * Copyright 2020 Analog Devices Inc.
+ */
 #include "zynqmp-zcu102-rev1.0.dts"
 #include "adi-cn0506-mii.dtsi"

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-cn0506-rgmii.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-cn0506-rgmii.dts
@@ -1,3 +1,12 @@
-
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * ADIN PHY FMC board
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/net-phy/adin
+ *
+ * hdl_project: <cn0506_rgmii/zcu102>
+ * board_revision: <>
+ *
+ * Copyright 2020 Analog Devices Inc.
+ */
 #include "zynqmp-zcu102-rev1.0.dts"
 #include "adi-cn0506-rgmii.dtsi"


### PR DESCRIPTION
This patch set add device-tree source files for A10SOC + cn0506.
Taken over from "altera_4.14" branch.

Also adds license and project tags to the cn0506 device-trees on ZC706, ZCU102, ZED and A10SOC platforms.

Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>