### PR TITLE
iio: hmc425a: Prepare driver for upstream

### DIFF
--- a/drivers/iio/amplifiers/hmc425a.c
+++ b/drivers/iio/amplifiers/hmc425a.c
@@ -6,72 +6,72 @@
  */
 
 #include <linux/device.h>
-#include <linux/kernel.h>
-#include <linux/slab.h>
-#include <linux/sysfs.h>
-#include <linux/regulator/consumer.h>
-#include <linux/gpio/consumer.h>
 #include <linux/err.h>
-#include <linux/module.h>
+#include <linux/gpio/consumer.h>
 #include <linux/iio/iio.h>
 #include <linux/iio/sysfs.h>
-#include <linux/platform_device.h>
+#include <linux/kernel.h>
+#include <linux/module.h>
 #include <linux/of_device.h>
 #include <linux/of_platform.h>
-
-#define HMC425A_NR_GPIOS	6
+#include <linux/platform_device.h>
+#include <linux/slab.h>
+#include <linux/regulator/consumer.h>
+#include <linux/sysfs.h>
 
 enum hmc425a_type {
 	ID_HMC425A,
 };
 
-struct hmc425a_info {
-	int gain_min;
-	int gain_max;
+struct hmc425a_chip_info {
+	const struct iio_chan_spec	*channels;
+	unsigned int			num_channels;
+	unsigned int			num_gpios;
+	int				gain_min;
+	int				gain_max;
+	int				default_gain;
 };
 
 struct hmc425a_state {
-	struct regulator *reg;
-	struct mutex lock; /* protect sensor state */
-	struct hmc425a_info *info;
-	struct gpio_descs *gpios;
-	enum hmc425a_type type;
-	u32 value;
-};
-
-static struct hmc425a_info hmc425a_infos[] = {
-	[ID_HMC425A] = {
-		.gain_min = -31500,
-		.gain_max = 0,
-	},
+	struct	regulator *reg;
+	struct	mutex lock; /* protect sensor state */
+	struct	hmc425a_chip_info *chip_info;
+	struct	gpio_descs *gpios;
+	enum	hmc425a_type type;
+	u32	gain;
 };
 
 static int hmc425a_write(struct iio_dev *indio_dev, u32 value)
 {
 	struct hmc425a_state *st = iio_priv(indio_dev);
-	int i, values[HMC425A_NR_GPIOS];
+	int i, *values;
 
-	for (i = 0; i < st->gpios->ndescs; i++)
+	values = kmalloc_array(st->chip_info->num_gpios, sizeof(int),
+			       GFP_KERNEL);
+	if (!values)
+		return -ENOMEM;
+
+	for (i = 0; i < st->chip_info->num_gpios; i++)
 		values[i] = (value >> i) & 1;
 
 	gpiod_set_array_value_cansleep(st->gpios->ndescs, st->gpios->desc,
 				       values);
-
+	kfree(values);
 	return 0;
 }
 
 static int hmc425a_read_raw(struct iio_dev *indio_dev,
-			   struct iio_chan_spec const *chan, int *val,
-			   int *val2, long m)
+			    struct iio_chan_spec const *chan, int *val,
+			    int *val2, long m)
 {
 	struct hmc425a_state *st = iio_priv(indio_dev);
-	int ret;
 	int code, gain = 0;
+	int ret;
 
 	mutex_lock(&st->lock);
 	switch (m) {
 	case IIO_CHAN_INFO_HARDWAREGAIN:
-		code = st->value;
+		code = st->gain;
 
 		switch (st->type) {
 		case ID_HMC425A:
@@ -98,7 +98,7 @@ static int hmc425a_write_raw(struct iio_dev *indio_dev,
 			    long mask)
 {
 	struct hmc425a_state *st = iio_priv(indio_dev);
-	struct hmc425a_info *inf = st->info;
+	struct hmc425a_chip_info *inf = st->chip_info;
 	int code = 0, gain;
 	int ret;
 
@@ -120,9 +120,9 @@ static int hmc425a_write_raw(struct iio_dev *indio_dev,
 	mutex_lock(&st->lock);
 	switch (mask) {
 	case IIO_CHAN_INFO_HARDWAREGAIN:
-		st->value = code;
+		st->gain = code;
 
-		ret = hmc425a_write(indio_dev, st->value);
+		ret = hmc425a_write(indio_dev, st->gain);
 		break;
 	default:
 		ret = -EINVAL;
@@ -150,17 +150,35 @@ static const struct iio_chan_spec hmc425a_channels[] = {
 
 /* Match table for of_platform binding */
 static const struct of_device_id hmc425a_of_match[] = {
-	{ .compatible = "adi,hmc425a", .data = (void *) ID_HMC425A },
+	{ .compatible = "adi,hmc425a", .data = (void *)ID_HMC425A },
 	{},
 };
 MODULE_DEVICE_TABLE(of, hmc425a_of_match);
 
+static void hmc425a_remove(void *data)
+{
+	struct hmc425a_state *st = data;
+
+	regulator_disable(st->reg);
+}
+
+static struct hmc425a_chip_info hmc425a_chip_info_tbl[] = {
+	[ID_HMC425A] = {
+		.channels = hmc425a_channels,
+		.num_channels = ARRAY_SIZE(hmc425a_channels),
+		.num_gpios = 6,
+		.gain_min = -31500,
+		.gain_max = 0,
+		.default_gain = -0x40, /* set default gain -31.5db*/
+	},
+};
+
 static int hmc425a_probe(struct platform_device *pdev)
 {
-	struct iio_dev *indio_dev;
-	const struct of_device_id *id;
-	struct hmc425a_state *st;
 	struct device_node *np = pdev->dev.of_node;
+	const struct of_device_id *id;
+	struct iio_dev *indio_dev;
+	struct hmc425a_state *st;
 	int ret;
 
 	indio_dev = devm_iio_device_alloc(&pdev->dev, sizeof(*st));
@@ -168,6 +186,16 @@ static int hmc425a_probe(struct platform_device *pdev)
 		return -ENOMEM;
 
 	st = iio_priv(indio_dev);
+	id = of_match_device(hmc425a_of_match, &pdev->dev);
+	if (!id)
+		ret = -ENODEV;
+
+	st->type = (enum hmc425a_type)id->data;
+
+	st->chip_info = &hmc425a_chip_info_tbl[st->type];
+	indio_dev->num_channels = st->chip_info->num_channels;
+	indio_dev->channels = st->chip_info->channels;
+	st->gain = st->chip_info->default_gain;
 
 	st->gpios = devm_gpiod_get_array(&pdev->dev, "ctrl", GPIOD_OUT_LOW);
 	if (IS_ERR(st->gpios)) {
@@ -177,9 +205,9 @@ static int hmc425a_probe(struct platform_device *pdev)
 		return ret;
 	}
 
-	if (st->gpios->ndescs != HMC425A_NR_GPIOS) {
+	if (st->gpios->ndescs != st->chip_info->num_gpios) {
 		dev_err(&pdev->dev, "%d GPIOs needed to operate\n",
-			HMC425A_NR_GPIOS);
+			st->chip_info->num_gpios);
 		return -ENODEV;
 	}
 
@@ -188,62 +216,20 @@ static int hmc425a_probe(struct platform_device *pdev)
 		ret = regulator_enable(st->reg);
 		if (ret)
 			return ret;
+		ret = devm_add_action_or_reset(&pdev->dev, hmc425a_remove, st);
+		if (ret)
+			return ret;
 	}
 
 	platform_set_drvdata(pdev, indio_dev);
 	mutex_init(&st->lock);
 
-	id = of_match_device(hmc425a_of_match, &pdev->dev);
-	if (!id) {
-		ret = -ENODEV;
-		goto error_disable_reg;
-	}
-
-	st->type = (enum hmc425a_type)id->data;
-
-	switch (st->type) {
-	case ID_HMC425A:
-		indio_dev->channels = hmc425a_channels;
-		indio_dev->num_channels = ARRAY_SIZE(hmc425a_channels);
-		st->value = 0x3F;
-		break;
-	default:
-		dev_err(&pdev->dev, "Invalid device ID\n");
-		ret = -EINVAL;
-		goto error_disable_reg;
-	}
-
-	st->info = &hmc425a_infos[st->type];
 	indio_dev->dev.parent = &pdev->dev;
 	indio_dev->name = np->name;
 	indio_dev->info = &hmc425a_info;
 	indio_dev->modes = INDIO_DIRECT_MODE;
 
-	ret = iio_device_register(indio_dev);
-	if (ret)
-		goto error_disable_reg;
-
-	return 0;
-
-error_disable_reg:
-	if (!IS_ERR(st->reg))
-		regulator_disable(st->reg);
-
-	return ret;
-}
-
-static int hmc425a_remove(struct platform_device *pdev)
-{
-	struct iio_dev *indio_dev = platform_get_drvdata(pdev);
-	struct hmc425a_state *st = iio_priv(indio_dev);
-	struct regulator *reg = st->reg;
-
-	iio_device_unregister(indio_dev);
-
-	if (!IS_ERR(reg))
-		regulator_disable(reg);
-
-	return 0;
+	return devm_iio_device_register(&pdev->dev, indio_dev);
 }
 
 static struct platform_driver hmc425a_driver = {
@@ -252,7 +238,6 @@ static struct platform_driver hmc425a_driver = {
 		.of_match_table = hmc425a_of_match,
 	},
 	.probe = hmc425a_probe,
-	.remove = hmc425a_remove,
 };
 module_platform_driver(hmc425a_driver);
 


### PR DESCRIPTION
This patch fixes checkpatch complains, add a better strategy for chip info
structure and improves the overall structure of the code.

Signed-off-by: Beniamin Bia <beniamin.bia@analog.com>