### PR TITLE
arch: arm64, microblaze, nios2: add license + project tags DAQ2

### DIFF
--- a/arch/arm/boot/dts/socfpga_arria10_socdk_daq2.dts
+++ b/arch/arm/boot/dts/socfpga_arria10_socdk_daq2.dts
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Highspeed JESD-compatible data acquisition system
+ * Link: https://wiki.analog.com/resources/eval/user-guides/ad-fmcdaq2-ebz
+ *
+ * hdl_project: <daq2/a10soc>
+ * board_revision: <C>
+ *
+ * Copyright 2016-2019 Analog Devices Inc.
+ */
+/dts-v1/;
+#include "socfpga_arria10_socdk.dtsi"
+#include <dt-bindings/interrupt-controller/irq.h>
+
+&mmc {
+	status = "okay";
+	num-slots = <1>;
+	cap-sd-highspeed;
+	broken-cd;
+	bus-width = <4>;
+	altr,dw-mshc-ciu-div = <3>;
+	altr,dw-mshc-sdr-timing = <0 3>;
+};
+
+/ {
+	clocks {
+		sys_clk: sys_clk@2 {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <100000000>;
+			clock-output-names = "system_clock";
+		};
+
+		dma_clk: dma_clk@4 {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <166666667>;
+			clock-output-names = "dma_clock";
+		};
+	};
+
+	soc {
+		sys_hps_bridges: bridge@ff200000 {
+			compatible = "altr,bridge-16.0", "simple-bus";
+			reg = <0xff200000 0x00200000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges = <0x00000000 0xff200000 0x00200000>;
+
+			sys_gpio_in: sys-gpio-in@0 {
+				compatible = "altr,pio-16.0", "altr,pio-1.0";
+				reg = <0x00 0x10>;
+				#gpio-cells = <2>;
+				gpio-controller;
+			};
+
+			sys_gpio_out: sys-gpio-out@20 {
+				compatible = "altr,pio-16.0", "altr,pio-1.0";
+				reg = <0x20 0x10>;
+				#gpio-cells = <2>;
+				gpio-controller;
+			};
+
+			sys_spi: spi@40 {
+				compatible = "altr,spi-16.0", "altr,spi-1.0";
+				reg = <0x40 0x20>;
+				interrupt-parent = <&intc>;
+				interrupts = <0 26 IRQ_TYPE_LEVEL_HIGH>;
+				#address-cells = <0x1>;
+				#size-cells = <0x0>;
+			};
+
+			rx_dma: rx-dmac@4c000 {
+				compatible = "adi,axi-dmac-1.00.a";
+				reg = <0x4c000 0x4000>;
+				#dma-cells = <1>;
+				interrupt-parent = <&intc>;
+				interrupts = <0 29 IRQ_TYPE_LEVEL_HIGH>;
+				clocks = <&dma_clk>;
+
+				adi,channels {
+					#size-cells = <0>;
+					#address-cells = <1>;
+					dma-channel@0 {
+						reg = <0>;
+						adi,source-bus-width = <128>;
+						adi,source-bus-type = <1>;
+						adi,destination-bus-width = <128>;
+						adi,destination-bus-type = <0>;
+					};
+				};
+			};
+
+			tx_dma: tx-dmac@2c000 {
+				compatible = "adi,axi-dmac-1.00.a";
+				reg = <0x2c000 0x4000>;
+				#dma-cells = <1>;
+				interrupt-parent = <&intc>;
+				interrupts = <0 30 IRQ_TYPE_LEVEL_HIGH>;
+				clocks = <&dma_clk>;
+
+				adi,channels {
+					#size-cells = <0>;
+					#address-cells = <1>;
+					dma-channel@0 {
+						reg = <0>;
+						adi,source-bus-width = <128>;
+						adi,source-bus-type = <0>;
+						adi,destination-bus-width = <128>;
+						adi,destination-bus-type = <1>;
+					adi,cyclic;
+					};
+				};
+			};
+
+			axi_ad9144_core: axi-ad9144-hpc@34000 {
+				compatible = "adi,axi-ad9144-1.0";
+				reg = <0x34000 0x4000>;
+				dmas = <&tx_dma 0>;
+				dma-names = "tx";
+				spibus-connected = <&dac0_ad9144>;
+				adi,axi-pl-fifo-enable;
+				plddrbypass-gpios = <&sys_gpio_out 12 0>;
+			};
+
+			axi_ad9144_jesd: axi-jesd204-tx@20000 {
+				compatible = "adi,axi-jesd204-tx-1.0";
+				reg = <0x20000 0x4000>;
+
+				interrupt-parent = <&intc>;
+				interrupts = <0 28 IRQ_TYPE_LEVEL_HIGH>;
+
+				clocks = <&sys_clk>, <&tx_device_clk_pll>, <&axi_ad9144_xcvr>;
+				clock-names = "s_axi_aclk", "device_clk", "lane_clk";
+
+				adi,octets-per-frame = <1>;
+				adi,frames-per-multiframe = <32>;
+				adi,converter-resolution = <16>;
+				adi,bits-per-sample = <16>;
+				adi,converters-per-device = <2>;
+
+				#clock-cells = <0>;
+				clock-output-names = "jesd_dac_lane_clk";
+			};
+
+			axi_ad9680_core: axi-ad9680-hpc@50000 {
+				compatible = "adi,axi-ad9680-1.0";
+				reg = <0x50000 0x10000>;
+				dmas = <&rx_dma 0>;
+				dma-names = "rx";
+				spibus-connected = <&adc0_ad9680>;
+			};
+
+			axi_ad9680_jesd: axi-jesd204-rx@40000 {
+				compatible = "adi,axi-jesd204-rx-1.0";
+				reg = <0x40000 0x4000>;
+
+				interrupt-parent = <&intc>;
+				interrupts = <0 27 IRQ_TYPE_LEVEL_HIGH>;
+
+				clocks = <&sys_clk>, <&rx_device_clk_pll>, <&axi_ad9680_xcvr>;
+				clock-names = "s_axi_aclk", "device_clk", "lane_clk";
+
+				adi,octets-per-frame = <1>;
+				adi,frames-per-multiframe = <32>;
+
+				#clock-cells = <0>;
+				clock-output-names = "jesd_adc_lane_clk";
+			};
+
+			axi_ad9144_xcvr: axi-ad9144-xcvr@24000 {
+				compatible = "adi,altera-adxcvr-1.00.a";
+				reg = <0x24000 0x0001000>,
+				      <0x26000 0x1000>,
+				      <0x28000 0x1000>,
+				      <0x29000 0x1000>,
+				      <0x2a000 0x1000>,
+				      <0x2b000 0x1000>;
+				reg-names = "adxcvr", "atx-pll", "adxcfg-0", "adxcfg-1", "adxcfg-2", "adxcfg-3";
+
+				#clock-cells = <0>;
+				clocks = <&clk0_ad9523 9>, <&tx_device_clk_pll>;
+				clock-names = "ref", "link";
+				clock-output-names = "jesd204_tx_lane_clock";
+			};
+
+			axi_ad9680_xcvr: axi-ad9680-xcvr@44000 {
+				compatible = "adi,altera-adxcvr-1.00.a";
+				reg = <0x44000 0x1000>,
+				      <0x48000 0x1000>,
+				      <0x49000 0x1000>,
+				      <0x4a000 0x1000>,
+				      <0x4b000 0x1000>;
+				reg-names = "adxcvr", "adxcfg-0", "adxcfg-1", "adxcfg-2", "adxcfg-3";
+
+				#clock-cells = <0>;
+				clocks = <&clk0_ad9523 4>, <&rx_device_clk_pll>;
+				clock-names = "ref", "link";
+				clock-output-names = "jesd204_rx_lane_clock";
+			};
+
+			tx_device_clk_pll: altera-a10-fpll@25000 {
+				compatible = "altr,a10-fpll";
+				reg = <0x25000 0x1000>;
+				#clock-cells = <0>;
+				clocks = <&clk0_ad9523 9>;
+				clock-output-names = "jesd204_tx_link_clock";
+			};
+
+			rx_device_clk_pll: altera-a10-fpll@45000 {
+				compatible = "altr,a10-fpll";
+				reg = <0x45000 0x1000>;
+				#clock-cells = <0>;
+				clocks = <&clk0_ad9523 4>;
+				clock-output-names = "jesd204_rx_link_clock";
+			};
+		};
+	};
+};
+
+#define fmc_spi sys_spi
+
+#include "adi-daq2.dtsi"
+
+&adc0_ad9680 {
+	powerdown-gpios = <&sys_gpio_out 10 0>;
+//	fastdetect-a-gpios = <&sys_gpio_in 4 0>;
+//	fastdetect-b-gpios = <&sys_gpio_in 3 0>;
+};
+
+&dac0_ad9144 {
+	txen-gpios = <&sys_gpio_out 9 0>;
+	reset-gpios = <&sys_gpio_out 8 0>;
+	irq-gpios = <&sys_gpio_in 2 0>;
+};
+
+&clk0_ad9523 {
+	sync-gpios = <&sys_gpio_out 6 0>;
+	status0-gpios = <&sys_gpio_in 0 0>;
+	status1-gpios = <&sys_gpio_in 1 0>;
+};
+
+/*
+ * Set FPGA ref clocks to 333.33 MHz. Allows to generate a wider range of lane
+ * rates.
+ */
+&ad9523_0_c4 {
+	adi,channel-divider = <3>;
+};
+
+&ad9523_0_c9 {
+	adi,channel-divider = <3>;
+};

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-fmcdaq2.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-fmcdaq2.dts
@@ -1,9 +1,12 @@
+// SPDX-License-Identifier: GPL-2.0
 /*
- * dts file for FMCOMMS2/3 AD9361 on Xilinx ZynqMP ZCU102 Rev 1.0
+ * Analog Devices AD-FMCDAQ2-EBZ
+ * Link: https://wiki.analog.com/resources/eval/user-guides/ad-fmcdaq2-ebz
  *
- * Copyright (C) 2016-2017 Analog Devices Inc.
+ * hdl_project: <daq2/zcu102>
+ * board_revision: <>
  *
- * Licensed under the GPL-2.
+ * Copyright 2016-2020 Analog Devices Inc.
  */
 
 #include "zynqmp-zcu102-rev1.0.dts"

--- a/arch/microblaze/boot/dts/kc705_fmcdaq2.dts
+++ b/arch/microblaze/boot/dts/kc705_fmcdaq2.dts
@@ -1,4 +1,13 @@
-
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD-FMCDAQ2-EBZ
+ * Link: https://wiki.analog.com/resources/eval/user-guides/ad-fmcdaq2-ebz
+ *
+ * hdl_project: <daq2/kc705>
+ * board_revision: <>
+ *
+ * Copyright 2016-2020 Analog Devices Inc.
+ */
 /dts-v1/;
 /include/ "kc705.dtsi"
 

--- a/arch/microblaze/boot/dts/kcu105_fmcdaq2.dts
+++ b/arch/microblaze/boot/dts/kcu105_fmcdaq2.dts
@@ -1,4 +1,13 @@
-
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD-FMCDAQ2-EBZ
+ * Link: https://wiki.analog.com/resources/eval/user-guides/ad-fmcdaq2-ebz
+ *
+ * hdl_project: <daq2/kcu105>
+ * board_revision: <>
+ *
+ * Copyright 2016-2020 Analog Devices Inc.
+ */
 /dts-v1/;
 /include/ "kcu105.dtsi"
 

--- a/arch/nios2/boot/dts/a10gx_daq2.dts
+++ b/arch/nios2/boot/dts/a10gx_daq2.dts
@@ -1,0 +1,430 @@
+/dts-v1/;
+
+/ {
+	model = "ALTR,system_bd";
+	compatible = "ALTR,system_bd";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		sys_cpu: cpu@0 {
+			device_type = "cpu";
+			compatible = "altr,nios2-1.1";
+			reg = <0x00000000>;
+			interrupt-controller;
+			#interrupt-cells = <1>;
+			altr,exception-addr = <3221225504>;
+			altr,fast-tlb-miss-addr = <3491762176>;
+			altr,has-initda = <1>;
+			altr,has-mmu = <1>;
+			altr,has-mul = <1>;
+			altr,implementation = "fast";
+			altr,pid-num-bits = <8>;
+			altr,reset-addr = <3221225472>;
+			altr,tlb-num-entries = <128>;
+			altr,tlb-num-ways = <16>;
+			altr,tlb-ptr-sz = <7>;
+			clock-frequency = <100000000>;
+			dcache-line-size = <32>;
+			dcache-size = <32768>;
+			icache-line-size = <32>;
+			icache-size = <32768>;
+		};
+	};
+
+	memory {
+		device_type = "memory";
+		reg = <0x00000000 0x10000000>,
+			<0x10140000 0x00028000>,
+			<0x10200000 0x00028000>;
+	};
+
+	clocks {
+		sys_clk: sys_clk {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <100000000>;
+			clock-output-names = "system_clock";
+		};
+
+		dma_clk: dma_clk {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <226652000>;
+			clock-output-names = "dma_clock";
+		};
+	};
+
+	sopc0: sopc {
+		device_type = "soc";
+		ranges;
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "ALTR,avalon", "simple-bus";
+		bus-frequency = <100000000>;
+
+		sys_uart: serial@101814f0 {
+			compatible = "altr,juart-1.0";
+			reg = <0x101814f0 0x00000008>;
+			interrupt-parent = <&sys_cpu>;
+			interrupts = <2>;
+		};
+
+		sys_ethernet: ethernet@10181000 {
+			compatible = "altr,tse-msgdma-1.0", "altr,tse-1.0";
+			reg = <0x10181000 0x00000400>,
+				<0x101814a0 0x00000020>,
+				<0x10181440 0x00000020>,
+				<0x101814e0 0x00000008>,
+				<0x10181480 0x00000020>,
+				<0x10181460 0x00000020>;
+			reg-names = "control_port", "rx_csr", "rx_desc", "rx_resp", "tx_csr", "tx_desc";
+			interrupt-parent = <&sys_cpu>;
+			interrupts = <0 1>;
+			interrupt-names = "rx_irq", "tx_irq";
+			ALTR,rx-fifo-depth = <4096>;
+			ALTR,tx-fifo-depth = <4096>;
+			rx-fifo-depth = <16384>;
+			tx-fifo-depth = <16384>;
+			address-bits = <48>;
+			max-frame-size = <1518>;
+			local-mac-address = [B2 94 3D 6E 11 8F];
+			altr,enable-sup-addr = <0>;
+			altr,enable-hash = <0>;
+			phy-mode = "sgmii";
+
+			sys_ethernet_mdio: mdio {
+				compatible = "altr,tse-mdio";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				phy0: ethernet-phy@0 {
+					reg = <0>;
+					device_type = "ethernet-phy";
+				};
+			};
+		};
+
+		sys_id: sysid@101814e8 {
+			compatible = "altr,sysid-1.0";
+			reg = <0x101814e8 0x00000008>;
+			id = <182193580>;
+			timestamp = <1506373933>;
+		};
+
+		sys_timer_1: timer@10181420 {
+			compatible = "altr,timer-1.0";
+			reg = <0x10181420 0x00000020>;
+			interrupt-parent = <&sys_cpu>;
+			interrupts = <4>;
+			clock-frequency = <100000000>;
+		};
+
+		sys_timer_2: timer@10181520 {
+			compatible = "altr,timer-1.0";
+			reg = <0x10181520 0x00000020>;
+			interrupt-parent = <&sys_cpu>;
+			interrupts = <3>;
+			clock-frequency = <100000000>;
+		};
+
+		sys_gpio_bd: gpio@101814d0 {
+			compatible = "altr,pio-1.0";
+			reg = <0x101814d0 0x00000010>;
+			interrupt-parent = <&sys_cpu>;
+			interrupts = <6>;
+			altr,gpio-bank-width = <32>;
+			altr,interrupt-type = <4>;
+			altr,interrupt_type = <4>;
+			level_trigger = <1>;
+			resetvalue = <0>;
+			#gpio-cells = <2>;
+			gpio-controller;
+		};
+
+		sys_gpio_in: gpio@101814c0 {
+			compatible = "altr,pio-1.0";
+			reg = <0x101814c0 0x00000010>;
+			interrupt-parent = <&sys_cpu>;
+			interrupts = <5>;
+			altr,gpio-bank-width = <32>;
+			altr,interrupt-type = <4>;
+			altr,interrupt_type = <4>;
+			level_trigger = <1>;
+			resetvalue = <0>;
+			#gpio-cells = <2>;
+			gpio-controller;
+		};
+
+		sys_gpio_out: gpio@10181500 {
+			compatible = "altr,pio-1.0";
+			reg = <0x10181500 0x00000010>;
+			altr,gpio-bank-width = <32>;
+			resetvalue = <0>;
+			#gpio-cells = <2>;
+			gpio-controller;
+		};
+
+		sys_spi: spi@10181400 {
+			compatible = "altr,spi-1.0";
+			reg = <0x10181400 0x00000020>;
+			interrupt-parent = <&sys_cpu>;
+			interrupts = <7>;
+
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			clk0_ad9523: ad9523-1@0 {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				#clock-cells = <1>;
+				compatible = "ad9523-1";
+				reg = <0>;
+
+				sync-gpios = <&sys_gpio_out 6 0>;
+
+				spi-max-frequency = <10000000>;
+				clock-output-names = "ad9523-1_out0", "ad9523-1_out1", "ad9523-1_out2", "ad9523-1_out3", "ad9523-1_out4", "ad9523-1_out5", "ad9523-1_out6", "ad9523-1_out7", "ad9523-1_out8", "ad9523-1_out9", "ad9523-1_out10", "ad9523-1_out11", "ad9523-1_out12", "ad9523-1_out13";
+				adi,vcxo-freq = <125000000>;
+				adi,spi-3wire-enable;
+				adi,pll1-bypass-enable;
+				adi,osc-in-diff-enable;
+
+				adi,pll2-charge-pump-current-nA = <413000>;
+				adi,pll2-ndiv-a-cnt = <0>;
+				adi,pll2-ndiv-b-cnt = <6>;
+
+				adi,pll2-r2-div = <1>;
+				adi,pll2-vco-diff-m1 = <3>;
+
+				adi,rpole2 = <0>;
+				adi,rzero = <7>;
+				adi,cpole1 = <2>;
+
+				ad9523_0_c1:channel@1 {
+					reg = <1>;
+					adi,extended-name = "ADC_CLK";
+					adi,driver-mode = <3>;
+					adi,divider-phase = <1>;
+					adi,channel-divider = <1>;
+				};
+				ad9523_0_c4:channel@4 {
+					reg = <4>;
+					adi,extended-name = "ADC_CLK_FMC";
+					adi,driver-mode = <3>;
+					adi,divider-phase = <1>;
+					adi,channel-divider = <2>;
+				};
+
+				ad9523_0_c5:channel@5 {
+					reg = <5>;
+					adi,extended-name = "ADC_SYSREF";
+					adi,driver-mode = <3>;
+					adi,divider-phase = <1>;
+					adi,channel-divider = <128>;
+				};
+
+				ad9523_0_c6:channel@6 {
+					reg = <6>;
+					adi,extended-name = "CLKD_ADC_SYSREF";
+					adi,driver-mode = <3>;
+					adi,divider-phase = <1>;
+					adi,channel-divider = <128>;
+				};
+
+				ad9523_0_c7:channel@7 {
+					reg = <7>;
+					adi,extended-name = "CLKD_DAC_SYSREF";
+					adi,driver-mode = <3>;
+					adi,divider-phase = <1>;
+					adi,channel-divider = <128>;
+				};
+
+				ad9523_0_c8:channel@8 {
+					reg = <8>;
+					adi,extended-name = "DAC_SYSREF";
+					adi,driver-mode = <3>;
+					adi,divider-phase = <1>;
+					adi,channel-divider = <128>;
+				};
+
+				ad9523_0_c9:channel@9 {
+					reg = <9>;
+					adi,extended-name = "FMC_DAC_REF_CLK";
+					adi,driver-mode = <3>;
+					adi,divider-phase = <1>;
+					adi,channel-divider = <2>;
+				};
+
+				ad9523_0_c13:channel@13 {
+					reg = <13>;
+					adi,extended-name = "DAC_CLK";
+					adi,driver-mode = <3>;
+					adi,divider-phase = <1>;
+					adi,channel-divider = <1>;
+				};
+			};
+
+			dac0_ad9144: ad9144@1 {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				compatible = "ad9144";
+				reg = <1>;
+				spi-max-frequency = <1000000>;
+				clocks = <&axi_ad9144_jesd>, <&clk0_ad9523 13>, <&clk0_ad9523 8>;
+				clock-names = "jesd_dac_clk", "dac_clk", "dac_sysref";
+				txen-gpios = <&sys_gpio_out 9 0>;
+				reset-gpios = <&sys_gpio_out 8 0>;
+			};
+
+			adc0_ad9680: ad9680@2 {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				compatible = "ad9680";
+				reg = <2>;
+				spi-max-frequency = <1000000>;
+				clocks = <&axi_ad9680_jesd>, <&clk0_ad9523 1>, <&clk0_ad9523 5>;
+				clock-names = "jesd_adc_clk", "adc_clk", "adc_sysref";
+				powerdown-gpios = <&sys_gpio_out 10 0>;
+			};
+		};
+
+		rx_dma: rx-dmac@1004c000 {
+			compatible = "adi,axi-dmac-1.00.a";
+			reg = <0x1004c000 0x4000>;
+			#dma-cells = <1>;
+			interrupt-parent = <&sys_cpu>;
+			interrupts = <10>;
+			clocks = <&dma_clk>;
+
+			dma-channel {
+				adi,source-bus-width = <128>;
+				adi,destination-bus-width = <128>;
+				adi,type = <0>;
+			};
+		};
+
+		tx_dma: tx-dmac@1002c000 {
+			compatible = "adi,axi-dmac-1.00.a";
+			reg = <0x1002c000 0x4000>;
+			#dma-cells = <1>;
+			interrupt-parent = <&sys_cpu>;
+			interrupts = <11>;
+			clocks = <&dma_clk>;
+
+			dma-channel {
+				adi,source-bus-width = <128>;
+				adi,destination-bus-width = <128>;
+				adi,type = <1>;
+				adi,cyclic;
+			};
+		};
+
+		axi_ad9144_core: axi-ad9144-hpc@10034000 {
+			compatible = "adi,axi-ad9144-1.0";
+			reg = <0x10034000 0x4000>;
+			dmas = <&tx_dma 0>;
+			dma-names = "tx";
+			spibus-connected = <&dac0_ad9144>;
+			adi,axi-pl-fifo-enable;
+		};
+
+		axi_ad9144_jesd: axi-jesd204-tx@10020000 {
+			compatible = "adi,axi-jesd204-tx-1.0";
+			reg = <0x10020000 0x4000>;
+
+			interrupt-parent = <&sys_cpu>;
+			interrupts = <9>;
+
+			clocks = <&sys_clk>, <&tx_device_clk_pll>, <&axi_ad9144_xcvr>;
+			clock-names = "s_axi_aclk", "device_clk", "lane_clk";
+
+			adi,octets-per-frame = <1>;
+			adi,frames-per-multiframe = <32>;
+			adi,converter-resolution = <16>;
+			adi,bits-per-sample = <16>;
+			adi,converters-per-device = <2>;
+
+			#clock-cells = <0>;
+			clock-output-names = "jesd_dac_lane_clk";
+		};
+
+		axi_ad9680_core: axi-ad9680-hpc@10050000 {
+			compatible = "adi,axi-ad9680-1.0";
+			reg = <0x10050000 0x10000>;
+			dmas = <&rx_dma 0>;
+			dma-names = "rx";
+			spibus-connected = <&adc0_ad9680>;
+		};
+
+		axi_ad9680_jesd: axi-jesd204-rx@10040000 {
+			compatible = "adi,axi-jesd204-rx-1.0";
+			reg = <0x10040000 0x4000>;
+
+			interrupt-parent = <&sys_cpu>;
+			interrupts = <8>;
+
+			clocks = <&sys_clk>, <&rx_device_clk_pll>, <&axi_ad9680_xcvr>;
+			clock-names = "s_axi_aclk", "device_clk", "lane_clk";
+
+			adi,octets-per-frame = <1>;
+			adi,frames-per-multiframe = <32>;
+
+			#clock-cells = <0>;
+			clock-output-names = "jesd_adc_lane_clk";
+		};
+
+		axi_ad9144_xcvr: axi-ad9144-xcvr@10024000 {
+			compatible = "adi,altera-adxcvr-1.00.a";
+			reg = <0x10024000 0x0001000>,
+				<0x10026000 0x00001000>,
+				<0x10028000 0x00001000>,
+				<0x10029000 0x00001000>,
+				<0x1002a000 0x00001000>,
+				<0x1002b000 0x00001000>;
+			reg-names = "adxcvr", "atx-pll", "adxcfg-0", "adxcfg-1", "adxcfg-2", "adxcfg-3";
+
+			#clock-cells = <0>;
+			clocks = <&clk0_ad9523 9>, <&tx_device_clk_pll>, <&clk0_ad9523 7>;
+			clock-names = "ref", "link", "sysref";
+			clock-output-names = "jesd204_tx_lane_clock";
+		};
+
+		axi_ad9680_xcvr: axi-ad9680-xcvr@10044000 {
+			compatible = "adi,altera-adxcvr-1.00.a";
+			reg = <0x10044000 0x00001000>,
+				<0x10048000 0x00001000>,
+				<0x10049000 0x00001000>,
+				<0x1004a000 0x00001000>,
+				<0x1004b000 0x00001000>;
+			reg-names = "adxcvr", "adxcfg-0", "adxcfg-1", "adxcfg-2", "adxcfg-3";
+
+			#clock-cells = <0>;
+			clocks = <&clk0_ad9523 4>, <&rx_device_clk_pll>, <&clk0_ad9523 6>;
+			clock-names = "ref", "link", "sysref";
+			clock-output-names = "jesd204_rx_lane_clock";
+		};
+
+		tx_device_clk_pll: altera-a10-fpll@10025000 {
+			compatible = "altr,a10-fpll";
+			reg = <0x10025000 0x1000>;
+			#clock-cells = <0>;
+			clocks = <&clk0_ad9523 9>;
+			clock-output-names = "jesd204_tx_link_clock";
+		};
+
+		rx_device_clk_pll: altera-a10-fpll@10045000 {
+			compatible = "altr,a10-fpll";
+			reg = <0x10045000 0x1000>;
+			#clock-cells = <0>;
+			clocks = <&clk0_ad9523 4>;
+			clock-output-names = "jesd204_rx_link_clock";
+		};
+	};
+
+	chosen {
+		bootargs = "debug console=ttyJ0,115200";
+	};
+};

--- a/arch/nios2/boot/dts/a10gx_daq2.dts
+++ b/arch/nios2/boot/dts/a10gx_daq2.dts
@@ -1,3 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD-FMCDAQ2-EBZ
+ * Link: https://wiki.analog.com/resources/eval/user-guides/ad-fmcdaq2-ebz
+ *
+ * hdl_project: <daq2/a10gx>
+ * board_revision: <>
+ *
+ * Copyright 2016-2020 Analog Devices Inc.
+ */
 /dts-v1/;
 
 / {


### PR DESCRIPTION
This patch set add device-tree source files for A10SOC/GX + DAQ2.
Taken over from "altera_4.14" branch.

Also adds license and project tags to the DAQ2 device-trees on ZCU102, KC705, KCU105
and A10GX platforms.

Signed-off-by: Bogdan Togorean bogdan.togorean@analog.com