### PR TITLE
ci,build: arm: build socfpga device-trees on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,8 @@ matrix:
       env: BUILD_TYPE=sync_branches_with_master_travis DO_NOT_DOCKERIZE=1
     - checkpatch: 1
       env: BUILD_TYPE=checkpatch DO_NOT_DOCKERIZE=1
-    - env: BUILD_TYPE=dtb_build_test ARCH=arm DTS_FILES=arch/arm/boot/dts/zynq-*.dts DO_NOT_DOCKERIZE=1
+    - env: BUILD_TYPE=dtb_build_test ARCH=arm DO_NOT_DOCKERIZE=1
+           DTS_FILES="arch/arm/boot/dts/zynq-*.dts arch/arm/boot/dts/socfpga_*.dts"
     - env: BUILD_TYPE=dtb_build_test ARCH=arm64 DTS_FILES=arch/arm64/boot/dts/xilinx/zynqmp-*.dts DO_NOT_DOCKERIZE=1
     - env: DEFCONFIG=zynq_xcomm_adv7511_defconfig ARCH=arm IMAGE=uImage
            CHECK_ALL_ADI_DRIVERS_HAVE_BEEN_BUILT=1


### PR DESCRIPTION
On master we typically builds Zynq (ARM) & ZynqMP (ARM64) device-trees,
because we traditionally had only Xilinx as our master.

Now that we plan to move some Intel/Altera boards to master, we also need
to make sure that the device-trees are building.

This change extends the test [for the ARM architecture] to include these
device-trees as well.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>