### PR TITLE
ci,build: exit early if branch has an open PR

### DIFF
--- a/ci/travis/run-build-docker.sh
+++ b/ci/travis/run-build-docker.sh
@@ -4,6 +4,7 @@ set -e
 . ./ci/travis/lib.sh
 
 ENV_VARS="BUILD_TYPE DEFCONFIG ARCH CROSS_COMPILE DTS_FILES IMAGE"
+ENV_VARS="$ENV_VARS TRAVIS_COMMIT TRAVIS_PULL_REQUEST"
 
 if [ "$DO_NOT_DOCKERIZE" = "1" ] ; then
 	. ./ci/travis/run-build.sh

--- a/ci/travis/run-build.sh
+++ b/ci/travis/run-build.sh
@@ -14,12 +14,48 @@ if [ -f "${FULL_BUILD_DIR}/env" ] ; then
 	. "${FULL_BUILD_DIR}/env"
 fi
 
+# allow this to be configurable; we may want to run it elsewhere
+REPO_SLUG=${REPO_SLUG:-analogdevicesinc/linux}
+
 # Run once for the entire script
 sudo apt-get -qq update
 
 apt_install() {
 	sudo apt-get install -y $@
 }
+
+get_pull_requests_urls() {
+	wget -q -O- https://api.github.com/repos/${REPO_SLUG}/pulls | jq -r '.[].commits_url'
+}
+
+get_pull_request_commits_sha() {
+	wget -q -O- $1 | jq -r '.[].sha'
+}
+
+branch_has_pull_request() {
+	if [ "$TRAVIS_PULL_REQUEST" = "true" ] ; then
+		return 1
+	fi
+	apt_install jq
+
+	for pr_url in $(get_pull_requests_urls) ; do
+		for sha in $(get_pull_request_commits_sha $pr_url) ; do
+			if [ "$sha" = "$TRAVIS_COMMIT" ] ; then
+				TRAVIS_OPEN_PR=$pr_url
+				export TRAVIS_OPEN_PR
+				return 0
+			fi
+		done
+	done
+
+	return 1
+}
+
+# Exit early to save some build time
+if branch_has_pull_request ; then
+	echo_green "Not running build for branch; there is an open PR @ $TRAVIS_OPEN_PR"
+	exit 0
+fi
 
 if [ -z "$NUM_JOBS" ] ; then
 	NUM_JOBS=$(getconf _NPROCESSORS_ONLN)

--- a/ci/travis/run-build.sh
+++ b/ci/travis/run-build.sh
@@ -268,6 +268,7 @@ build_sync_branches_with_master_travis() {
 	[ -n "$TRAVIS_PULL_REQUEST" ] || return 0
 	[ "$TRAVIS_PULL_REQUEST" == "false" ] || return 0
 	[ "$TRAVIS_BRANCH" == "master" ] || return 0
+	[ "$TRAVIS_REPO_SLUG" == "analogdevicesinc/linux" ] || return 0
 
 	git remote set-url $ORIGIN "git@github.com:analogdevicesinc/linux.git"
 	openssl aes-256-cbc -d -in ci/travis/deploy_key.enc -out /tmp/deploy_key -base64 -K $encrypt_key -iv $encrypt_iv

--- a/ci/travis/run-build.sh
+++ b/ci/travis/run-build.sh
@@ -14,6 +14,13 @@ if [ -f "${FULL_BUILD_DIR}/env" ] ; then
 	. "${FULL_BUILD_DIR}/env"
 fi
 
+# Run once for the entire script
+sudo apt-get -qq update
+
+apt_install() {
+	sudo apt-get install -y $@
+}
+
 if [ -z "$NUM_JOBS" ] ; then
 	NUM_JOBS=$(getconf _NPROCESSORS_ONLN)
 	NUM_JOBS=${NUM_JOBS:-1}
@@ -64,10 +71,7 @@ if [ "$ARCH" == "arm" ] ; then
 fi
 
 apt_update_install() {
-	sudo -s <<-EOF
-		apt-get -qq update
-		apt-get -y install $@
-	EOF
+	apt_install $@
 	adjust_kcflags_against_gcc
 }
 
@@ -125,6 +129,7 @@ build_default() {
 }
 
 build_checkpatch() {
+	apt_install python-ply
 	if [ -n "$TRAVIS_BRANCH" ]; then
 		__update_git_ref "${TRAVIS_BRANCH}" "${TRAVIS_BRANCH}"
 	fi


### PR DESCRIPTION
The situation is a bit complicated.
Travis-CI allows us to enable/disable builds for PRs & and for pushed
branches/tags.

If we disable builds for PRs, we won't get any build-runs from external
forks (external contributions).

If we disable builds for branches, people won't get a chance to have the CI
do a check before opening up a PR.

If we enable both, each re-spin of a PR requires up to 2 hours to do both
builds.

A compromise solution, is to implement a check on our build-script to exit
early if we detect that for a branch/tag we have an open PR. It's not
perfect, but should reduce some time.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>