### PR TITLE
iio: imu: adis: sync with upstream

### DIFF
--- a/drivers/iio/gyro/adis16136.c
+++ b/drivers/iio/gyro/adis16136.c
@@ -467,6 +467,24 @@ static const char * const adis16136_status_error_msgs[] = {
 	[ADIS16136_DIAG_STAT_FLASH_CHKSUM_FAIL] = "Flash checksum error",
 };
 
+static const struct adis_data adis16136_data = {
+	.diag_stat_reg = ADIS16136_REG_DIAG_STAT,
+	.glob_cmd_reg = ADIS16136_REG_GLOB_CMD,
+	.msc_ctrl_reg = ADIS16136_REG_MSC_CTRL,
+
+	.self_test_mask = ADIS16136_MSC_CTRL_SELF_TEST,
+	.self_test_reg = ADIS16136_REG_MSC_CTRL,
+
+	.read_delay = 10,
+	.write_delay = 10,
+
+	.status_error_msgs = adis16136_status_error_msgs,
+	.status_error_mask = BIT(ADIS16136_DIAG_STAT_FLASH_UPDATE_FAIL) |
+		BIT(ADIS16136_DIAG_STAT_SPI_FAIL) |
+		BIT(ADIS16136_DIAG_STAT_SELF_TEST_FAIL) |
+		BIT(ADIS16136_DIAG_STAT_FLASH_CHKSUM_FAIL),
+};
+
 enum adis16136_id {
 	ID_ADIS16133,
 	ID_ADIS16135,
@@ -514,22 +532,12 @@ static struct adis_data *adis16136_adis_data_alloc(struct adis16136 *st,
 {
 	struct adis_data *data;
 
-	data = devm_kzalloc(dev, sizeof(struct adis_data), GFP_KERNEL);
+	data = devm_kmalloc(dev, sizeof(struct adis_data), GFP_KERNEL);
 	if (!data)
 		return ERR_PTR(-ENOMEM);
 
-	data->msc_ctrl_reg = ADIS16136_REG_MSC_CTRL;
-	data->glob_cmd_reg = ADIS16136_REG_GLOB_CMD;
-	data->diag_stat_reg = ADIS16136_REG_DIAG_STAT;
-	data->self_test_mask = ADIS16136_MSC_CTRL_SELF_TEST;
-	data->self_test_reg = ADIS16136_REG_MSC_CTRL;
-	data->read_delay = 10;
-	data->write_delay = 10;
-	data->status_error_msgs = adis16136_status_error_msgs;
-	data->status_error_mask = BIT(ADIS16136_DIAG_STAT_FLASH_UPDATE_FAIL) |
-				BIT(ADIS16136_DIAG_STAT_SPI_FAIL) |
-				BIT(ADIS16136_DIAG_STAT_SELF_TEST_FAIL) |
-				BIT(ADIS16136_DIAG_STAT_FLASH_CHKSUM_FAIL);
+	memcpy(data, &adis16136_data, sizeof(*data));
+
 	data->timeouts = st->chip_info->timeouts;
 
 	return data;

--- a/drivers/iio/imu/Kconfig
+++ b/drivers/iio/imu/Kconfig
@@ -25,6 +25,9 @@ config ADIS16460
 	  Say yes here to build support for Analog Devices ADIS16460 inertial
 	  sensor.
 
+	  To compile this driver as a module, choose M here: the module will be
+	  called adis16460.
+
 config ADIS16475
 	tristate "Analog Devices ADIS16475 and similar IMU driver"
 	depends on SPI

--- a/drivers/iio/imu/adis16400.c
+++ b/drivers/iio/imu/adis16400.c
@@ -1121,6 +1121,35 @@ static const char * const adis16400_status_error_msgs[] = {
 	[ADIS16400_DIAG_STAT_POWER_LOW] = "Power supply below 4.75V",
 };
 
+static const struct adis_data adis16400_data = {
+	.msc_ctrl_reg = ADIS16400_MSC_CTRL,
+	.glob_cmd_reg = ADIS16400_GLOB_CMD,
+	.diag_stat_reg = ADIS16400_DIAG_STAT,
+
+	.read_delay = 50,
+	.write_delay = 50,
+
+	.self_test_mask = ADIS16400_MSC_CTRL_MEM_TEST,
+	.self_test_reg = ADIS16400_MSC_CTRL,
+
+	.status_error_msgs = adis16400_status_error_msgs,
+	.status_error_mask = BIT(ADIS16400_DIAG_STAT_ZACCL_FAIL) |
+		BIT(ADIS16400_DIAG_STAT_YACCL_FAIL) |
+		BIT(ADIS16400_DIAG_STAT_XACCL_FAIL) |
+		BIT(ADIS16400_DIAG_STAT_XGYRO_FAIL) |
+		BIT(ADIS16400_DIAG_STAT_YGYRO_FAIL) |
+		BIT(ADIS16400_DIAG_STAT_ZGYRO_FAIL) |
+		BIT(ADIS16400_DIAG_STAT_ALARM2) |
+		BIT(ADIS16400_DIAG_STAT_ALARM1) |
+		BIT(ADIS16400_DIAG_STAT_FLASH_CHK) |
+		BIT(ADIS16400_DIAG_STAT_SELF_TEST) |
+		BIT(ADIS16400_DIAG_STAT_OVERFLOW) |
+		BIT(ADIS16400_DIAG_STAT_SPI_FAIL) |
+		BIT(ADIS16400_DIAG_STAT_FLASH_UPT) |
+		BIT(ADIS16400_DIAG_STAT_POWER_HIGH) |
+		BIT(ADIS16400_DIAG_STAT_POWER_LOW),
+};
+
 static void adis16400_setup_chan_mask(struct adis16400_state *st)
 {
 	const struct adis16400_chip_info *chip_info = st->variant;
@@ -1140,33 +1169,12 @@ static struct adis_data *adis16400_adis_data_alloc(struct adis16400_state *st,
 {
 	struct adis_data *data;
 
-	data = devm_kzalloc(dev, sizeof(struct adis_data), GFP_KERNEL);
+	data = devm_kmalloc(dev, sizeof(struct adis_data), GFP_KERNEL);
 	if (!data)
 		return ERR_PTR(-ENOMEM);
 
-	data->msc_ctrl_reg = ADIS16400_MSC_CTRL;
-	data->glob_cmd_reg = ADIS16400_GLOB_CMD;
-	data->diag_stat_reg = ADIS16400_DIAG_STAT;
-	data->read_delay = 50;
-	data->write_delay = 50;
-	data->self_test_mask = ADIS16400_MSC_CTRL_MEM_TEST;
-	data->self_test_reg = ADIS16400_MSC_CTRL;
-	data->status_error_msgs = adis16400_status_error_msgs;
-	data->status_error_mask = BIT(ADIS16400_DIAG_STAT_ZACCL_FAIL) |
-				BIT(ADIS16400_DIAG_STAT_YACCL_FAIL) |
-				BIT(ADIS16400_DIAG_STAT_XACCL_FAIL) |
-				BIT(ADIS16400_DIAG_STAT_XGYRO_FAIL) |
-				BIT(ADIS16400_DIAG_STAT_YGYRO_FAIL) |
-				BIT(ADIS16400_DIAG_STAT_ZGYRO_FAIL) |
-				BIT(ADIS16400_DIAG_STAT_ALARM2) |
-				BIT(ADIS16400_DIAG_STAT_ALARM1) |
-				BIT(ADIS16400_DIAG_STAT_FLASH_CHK) |
-				BIT(ADIS16400_DIAG_STAT_SELF_TEST) |
-				BIT(ADIS16400_DIAG_STAT_OVERFLOW) |
-				BIT(ADIS16400_DIAG_STAT_SPI_FAIL) |
-				BIT(ADIS16400_DIAG_STAT_FLASH_UPT) |
-				BIT(ADIS16400_DIAG_STAT_POWER_HIGH) |
-				BIT(ADIS16400_DIAG_STAT_POWER_LOW);
+	memcpy(data, &adis16400_data, sizeof(*data));
+
 	data->timeouts = st->variant->timeouts;
 
 	return data;

--- a/drivers/iio/imu/adis16475.c
+++ b/drivers/iio/imu/adis16475.c
@@ -806,6 +806,31 @@ static struct adis_burst adis16475_burst = {
 	.write_delay = 5,
 };
 
+static const struct adis_data adis16475_data = {
+	.msc_ctrl_reg = ADIS16475_REG_MSG_CTRL,
+	.glob_cmd_reg = ADIS16475_REG_GLOB_CMD,
+	.diag_stat_reg = ADIS16475_REG_DIAG_STAT,
+	.prod_id_reg = ADIS16475_REG_PROD_ID,
+
+	.self_test_mask = BIT(2),
+	.self_test_reg = ADIS16475_REG_GLOB_CMD,
+
+	.cs_change_delay = 16,
+	.read_delay = 5,
+	.write_delay = 5,
+
+	.status_error_msgs = adis16475_status_error_msgs,
+	.status_error_mask = BIT(ADIS16475_DIAG_STAT_DATA_PATH) |
+		BIT(ADIS16475_DIAG_STAT_FLASH_MEM) |
+		BIT(ADIS16475_DIAG_STAT_SPI) |
+		BIT(ADIS16475_DIAG_STAT_STANDBY) |
+		BIT(ADIS16475_DIAG_STAT_SENSOR) |
+		BIT(ADIS16475_DIAG_STAT_MEMORY) |
+		BIT(ADIS16475_DIAG_STAT_CLK),
+
+	.enable_irq = adis16475_enable_irq
+};
+
 static u16 adis16475_validate_crc(const u8 *buffer, const u16 crc,
 				  const bool burst32)
 {
@@ -1087,28 +1112,12 @@ static struct adis_data *adis16475_adis_data_alloc(struct adis16475 *st,
 {
 	struct adis_data *data;
 
-	data = devm_kzalloc(dev, sizeof(struct adis_data), GFP_KERNEL);
+	data = devm_kmalloc(dev, sizeof(struct adis_data), GFP_KERNEL);
 	if (!data)
 		return ERR_PTR(-ENOMEM);
 
-	data->msc_ctrl_reg = ADIS16475_REG_MSG_CTRL;
-	data->glob_cmd_reg = ADIS16475_REG_GLOB_CMD;
-	data->diag_stat_reg = ADIS16475_REG_DIAG_STAT;
-	data->prod_id_reg = ADIS16475_REG_PROD_ID;
-	data->self_test_mask = BIT(2);
-	data->self_test_reg = ADIS16475_REG_GLOB_CMD;
-	data->cs_change_delay = 16;
-	data->read_delay = 5;
-	data->write_delay = 5;
-	data->status_error_msgs = adis16475_status_error_msgs;
-	data->status_error_mask = BIT(ADIS16475_DIAG_STAT_DATA_PATH) |
-				BIT(ADIS16475_DIAG_STAT_FLASH_MEM) |
-				BIT(ADIS16475_DIAG_STAT_SPI) |
-				BIT(ADIS16475_DIAG_STAT_STANDBY) |
-				BIT(ADIS16475_DIAG_STAT_SENSOR) |
-				BIT(ADIS16475_DIAG_STAT_MEMORY) |
-				BIT(ADIS16475_DIAG_STAT_CLK);
-	data->enable_irq = adis16475_enable_irq;
+	memcpy(data, &adis16475_data, sizeof(*data));
+
 	data->timeouts = st->info->timeouts;
 
 	return data;

--- a/drivers/iio/imu/adis16480.c
+++ b/drivers/iio/imu/adis16480.c
@@ -1266,6 +1266,32 @@ static const char * const adis16480_status_error_msgs[] = {
 	[ADIS16480_DIAG_STAT_BARO_FAIL] = "Barometer self-test failure",
 };
 
+static const struct adis_data adis16480_data = {
+	.diag_stat_reg = ADIS16480_REG_DIAG_STS,
+	.glob_cmd_reg = ADIS16480_REG_GLOB_CMD,
+	.has_paging = true,
+
+	.read_delay = 5,
+	.write_delay = 5,
+
+	.self_test_mask = BIT(1),
+	.self_test_reg = ADIS16480_REG_GLOB_CMD,
+
+	.status_error_msgs = adis16480_status_error_msgs,
+	.status_error_mask = BIT(ADIS16480_DIAG_STAT_XGYRO_FAIL) |
+		BIT(ADIS16480_DIAG_STAT_YGYRO_FAIL) |
+		BIT(ADIS16480_DIAG_STAT_ZGYRO_FAIL) |
+		BIT(ADIS16480_DIAG_STAT_XACCL_FAIL) |
+		BIT(ADIS16480_DIAG_STAT_YACCL_FAIL) |
+		BIT(ADIS16480_DIAG_STAT_ZACCL_FAIL) |
+		BIT(ADIS16480_DIAG_STAT_XMAGN_FAIL) |
+		BIT(ADIS16480_DIAG_STAT_YMAGN_FAIL) |
+		BIT(ADIS16480_DIAG_STAT_ZMAGN_FAIL) |
+		BIT(ADIS16480_DIAG_STAT_BARO_FAIL),
+
+	.enable_irq = adis16480_enable_irq,
+};
+
 static int adis16480_config_irq_pin(struct device_node *of_node,
 				    struct adis16480 *st)
 {
@@ -1421,30 +1447,12 @@ static struct adis_data *adis16480_adis_data_alloc(struct adis16480 *st,
 {
 	struct adis_data *data;
 
-	data = devm_kzalloc(dev, sizeof(struct adis_data), GFP_KERNEL);
+	data = devm_kmalloc(dev, sizeof(struct adis_data), GFP_KERNEL);
 	if (!data)
 		return ERR_PTR(-ENOMEM);
 
-	data->glob_cmd_reg = ADIS16480_REG_GLOB_CMD;
-	data->diag_stat_reg = ADIS16480_REG_DIAG_STS;
-	data->prod_id_reg = ADIS16480_REG_PROD_ID;
-	data->has_paging = true;
-	data->self_test_mask = BIT(1);
-	data->self_test_reg = ADIS16480_REG_GLOB_CMD;
-	data->read_delay = 5;
-	data->write_delay = 5;
-	data->status_error_msgs = adis16480_status_error_msgs;
-	data->status_error_mask = BIT(ADIS16480_DIAG_STAT_XGYRO_FAIL) |
-				BIT(ADIS16480_DIAG_STAT_YGYRO_FAIL) |
-				BIT(ADIS16480_DIAG_STAT_ZGYRO_FAIL) |
-				BIT(ADIS16480_DIAG_STAT_XACCL_FAIL) |
-				BIT(ADIS16480_DIAG_STAT_YACCL_FAIL) |
-				BIT(ADIS16480_DIAG_STAT_ZACCL_FAIL) |
-				BIT(ADIS16480_DIAG_STAT_XMAGN_FAIL) |
-				BIT(ADIS16480_DIAG_STAT_YMAGN_FAIL) |
-				BIT(ADIS16480_DIAG_STAT_ZMAGN_FAIL) |
-				BIT(ADIS16480_DIAG_STAT_BARO_FAIL);
-	data->enable_irq = adis16480_enable_irq;
+	memcpy(data, &adis16480_data, sizeof(*data));
+
 	data->timeouts = st->chip_info->timeouts;
 
 	return data;

--- a/drivers/iio/imu/adis16480.c
+++ b/drivers/iio/imu/adis16480.c
@@ -959,7 +959,6 @@ static const struct adis16480_chip_info adis16480_chip_info[] = {
 		.max_dec_rate = 2048,
 		.filter_freqs = adis16480_def_filter_freqs,
 		.timeouts = &adis16480_timeouts,
-
 	},
 	[ADIS16485] = {
 		.channels = adis16485_channels,

--- a/drivers/iio/imu/adis_buffer.c
+++ b/drivers/iio/imu/adis_buffer.c
@@ -193,6 +193,7 @@ error_buffer_cleanup:
 	return ret;
 }
 EXPORT_SYMBOL_GPL(adis_setup_buffer_and_trigger);
+
 /**
  * devm_adis_setup_buffer_and_trigger() - Sets up buffer and trigger for the managed adis device
  * @adis: The adis device
@@ -227,6 +228,7 @@ devm_adis_setup_buffer_and_trigger(struct adis *adis, struct iio_dev *indio_dev,
 	return 0;
 }
 EXPORT_SYMBOL_GPL(devm_adis_setup_buffer_and_trigger);
+
 /**
  * adis_cleanup_buffer_and_trigger() - Free buffer and trigger resources
  * @adis: The adis device.

--- a/drivers/iio/imu/adis_trigger.c
+++ b/drivers/iio/imu/adis_trigger.c
@@ -96,6 +96,7 @@ error_free_trig:
 	return ret;
 }
 EXPORT_SYMBOL_GPL(adis_probe_trigger);
+
 /**
  * devm_adis_probe_trigger() - Sets up trigger for a managed adis device
  * @adis: The adis device
@@ -129,6 +130,7 @@ int devm_adis_probe_trigger(struct adis *adis, struct iio_dev *indio_dev)
 	return devm_iio_trigger_register(&adis->spi->dev, adis->trig);
 }
 EXPORT_SYMBOL_GPL(devm_adis_probe_trigger);
+
 /**
  * adis_remove_trigger() - Remove trigger for a adis devices
  * @adis: The adis device


### PR DESCRIPTION
This change syncs the ADIS drivers closer with upstream.
The adis16475 is not upstreamed, but has been adapted to a version that has been accepted upstream (for adis16136,16400,16480).

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>