### PR TITLE
arch: microblaze: adi-adrv9371.dtsi: Fix non-existent reference

### DIFF
--- a/arch/microblaze/boot/dts/adi-adrv9371.dtsi
+++ b/arch/microblaze/boot/dts/adi-adrv9371.dtsi
@@ -97,8 +97,8 @@
 		spi-max-frequency = <25000000>;
 
 		/* Clocks */
-		clocks = <&axi_adrv9009_rx_jesd>, <&axi_adrv9009_tx_jesd>,
-			<&axi_adrv9009_rx_os_jesd>, <&clk0_ad9528 13>,
+		clocks = <&axi_ad9371_rx_jesd>, <&axi_ad9371_tx_jesd>,
+			<&axi_ad9371_rx_os_jesd>, <&clk0_ad9528 13>,
 			<&clk0_ad9528 1>, <&clk0_ad9528 12>, <&clk0_ad9528 3>;
 		clock-names = "jesd_rx_clk", "jesd_tx_clk", "jesd_rx_os_clk",
 			"dev_clk", "fmc_clk", "sysref_dev_clk",


### PR DESCRIPTION
Probably the result of a bad copy-paste, the trx0_ad9371 clocks had
references to non existent nodes (axi_adrv9009_*).

Fixes: 2b0ee592d662 ("iio: adc: ad9371: Add support for setting the SYSREF
rate")
Signed-off-by: Nuno Sá <nuno.sa@analog.com>