### PR TITLE
iio: ad9361: return the exact amount of bytes for gain-table

### DIFF
--- a/drivers/iio/adc/ad9361.c
+++ b/drivers/iio/adc/ad9361.c
@@ -9345,27 +9345,27 @@ ad9361_gt_bin_read(struct file *filp, struct kobject *kobj,
 	int ret, j, len = 0;
 	char *tab;
 
-	tab = kzalloc(bin_attr->size, GFP_KERNEL);
+	tab = kzalloc(count, GFP_KERNEL);
 	if (tab == NULL)
 		return -ENOMEM;
 
-	len += snprintf(tab + len, bin_attr->size - len,
+	len += snprintf(tab + len, count - len,
 		"<gaintable AD%i type=%s dest=%d start=%lli end=%lli>\n", 9361,
 		phy->gt_info[ad9361_gt(phy)].split_table ? "SPLIT" : "FULL", 3,
 		phy->gt_info[ad9361_gt(phy)].start,
 		phy->gt_info[ad9361_gt(phy)].end);
 
 	for (j = 0; j < phy->gt_info[ad9361_gt(phy)].max_index; j++)
-		len += snprintf(tab + len, bin_attr->size - len,
+		len += snprintf(tab + len, count - len,
 			"%d, 0x%.2X, 0x%.2X, 0x%.2X\n",
 			phy->gt_info[ad9361_gt(phy)].abs_gain_tbl[j],
 			phy->gt_info[ad9361_gt(phy)].tab[j][0],
 			phy->gt_info[ad9361_gt(phy)].tab[j][1],
 			phy->gt_info[ad9361_gt(phy)].tab[j][2]);
 
-	len += snprintf(tab + len, bin_attr->size - len, "</gaintable>\n");
+	len += snprintf(tab + len, count - len, "</gaintable>\n");
 
-	ret = memory_read_from_buffer(buf, count, &off, tab, bin_attr->size);
+	ret = memory_read_from_buffer(buf, count, &off, tab, len);
 
 	kfree(tab);
 


### PR DESCRIPTION
The reading of the gain-table would always return 4096 bytes. The trailing
data would be garbage.

This change limits the read to the exact amount of data that is read.

The issue was identified when investigating
   https://github.com/analogdevicesinc/libiio/issues/268

When doing:
```
iio_attr -a -d ad9361-phy gain_table_config > out
wc -m out
```

The value of `wc -m out` would be 4096. With the patch, the value is ~1688
bytes [i.e. the amount that is useful].

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>