### PR TITLE
ci,build: add microblaze device-trees dtb_build_test job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ matrix:
       env: BUILD_TYPE=checkpatch DO_NOT_DOCKERIZE=1
     - env: BUILD_TYPE=dtb_build_test ARCH=arm DO_NOT_DOCKERIZE=1
            DTS_FILES="arch/arm/boot/dts/zynq-*.dts arch/arm/boot/dts/socfpga_*.dts"
+    - env: BUILD_TYPE=dtb_build_test ARCH=microblaze DO_NOT_DOCKERIZE=1
+           DTS_FILES=arch/microblaze/boot/dts/*.dts
     - env: BUILD_TYPE=dtb_build_test ARCH=arm64 DTS_FILES=arch/arm64/boot/dts/xilinx/zynqmp-*.dts DO_NOT_DOCKERIZE=1
     - env: DEFCONFIG=zynq_xcomm_adv7511_defconfig ARCH=arm IMAGE=uImage
            CHECK_ALL_ADI_DRIVERS_HAVE_BEEN_BUILT=1


### PR DESCRIPTION
This was found recently https://github.com/analogdevicesinc/linux/pull/829

Which exposes a small gap in our CI.
This change extends our CI check to try to validate the device-trees.
The actual build for Microblaze may need to be done in a more complex CI
changeset.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>