### PR TITLE
jesd204: add initial framework bits (part 1)

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -7988,6 +7988,14 @@ S:	Maintained
 F:	drivers/hwmon/jc42.c
 F:	Documentation/hwmon/jc42
 
+JESD204 SUBSYSTEM AND DRIVERS
+M:	Alexandru Ardelean <alexandru.ardelean@analog.com>
+L:	linux-iio@vger.kernel.org
+T:	git https://github.com/analogdevicesinc/linux
+S:	Maintained
+F:	Documentation/devicetree/bindings/iio/
+F:	drivers/jesd204/
+
 JFS FILESYSTEM
 M:	Dave Kleikamp <shaggy@kernel.org>
 L:	jfs-discussion@lists.sourceforge.net

--- a/drivers/Kconfig
+++ b/drivers/Kconfig
@@ -167,6 +167,8 @@ source "drivers/memory/Kconfig"
 
 source "drivers/iio/Kconfig"
 
+source "drivers/jesd204/Kconfig"
+
 source "drivers/ntb/Kconfig"
 
 source "drivers/vme/Kconfig"

--- a/drivers/Makefile
+++ b/drivers/Makefile
@@ -165,6 +165,7 @@ obj-$(CONFIG_PM_DEVFREQ)	+= devfreq/
 obj-$(CONFIG_EXTCON)		+= extcon/
 obj-$(CONFIG_MEMORY)		+= memory/
 obj-$(CONFIG_IIO)		+= iio/
+obj-$(CONFIG_JESD204)		+= jesd204/
 obj-$(CONFIG_VME_BUS)		+= vme/
 obj-$(CONFIG_IPACK_BUS)		+= ipack/
 obj-$(CONFIG_NTB)		+= ntb/

--- a/drivers/iio/jesd204/Kconfig
+++ b/drivers/iio/jesd204/Kconfig
@@ -1,7 +1,4 @@
 
-menuconfig JESD204
-	tristate "JESD204 High-Speed Serial Interface Support"
-
 if JESD204
 
 config ALTERA_ARRIA10_JESD204_PHY

--- a/drivers/jesd204/Kconfig
+++ b/drivers/jesd204/Kconfig
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: GPL-2.0+
+#
+# JESD204 framework configuration
+#
+
+menuconfig JESD204
+	tristate "JESD204 High-Speed Serial Interface Framework"
+	depends on OF
+	help
+	  The JESD204 is a "Serial Interface for data converters"
+	  which describes a serialized interface between data converters
+	  and logic devices. It contains normative information to enable
+	  chip designers to implement devices that communicate with other
+	  devices covered by this specification.
+
+	  The JESD204 framework provides a unified model for supporting
+	  initialization and operation of JESD204 transceivers, which aims
+	  at reducing complexity when managing these types of devices.

--- a/drivers/jesd204/Makefile
+++ b/drivers/jesd204/Makefile
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0+
+#
+# Makefile for the JESD204 core.
+#
+
+obj-$(CONFIG_JESD204) += jesd204.o
+jesd204-y := \
+	jesd204-core.o

--- a/drivers/jesd204/jesd204-core.c
+++ b/drivers/jesd204/jesd204-core.c
@@ -54,6 +54,23 @@ static struct jesd204_dev *jesd204_dev_alloc(struct device_node *np)
 	return jdev;
 }
 
+static struct jesd204_dev *jesd204_dev_find_by_of_node(struct device_node *np)
+{
+	struct jesd204_dev *jdev = NULL, *jdev_it;
+
+	if (!np)
+		return NULL;
+
+	list_for_each_entry(jdev_it, &jesd204_device_list, list) {
+		if (jdev_it->np == np) {
+			jdev = jdev_it;
+			break;
+		}
+	}
+
+	return jdev;
+}
+
 static int jesd204_of_create_devices(void)
 {
 	struct jesd204_dev *jdev;
@@ -77,6 +94,38 @@ unlock:
 	return ret;
 }
 
+struct jesd204_dev *jesd204_dev_register(struct device *dev,
+					 const struct jesd204_dev_data *init)
+{
+	struct jesd204_dev *jdev;
+	int ret;
+
+	if (!dev || !init) {
+		dev_err(dev, "Invalid register arguments\n");
+		return ERR_PTR(-EINVAL);
+	}
+
+	mutex_lock(&jesd204_device_list_lock);
+
+	jdev = jesd204_dev_find_by_of_node(dev->of_node);
+	if (!jdev) {
+		dev_err(dev, "Device has no configuration node\n");
+		ret = -ENODEV;
+		goto err;
+	}
+
+	jdev->dev = get_device(dev);
+
+	mutex_unlock(&jesd204_device_list_lock);
+
+	return jdev;
+err:
+	mutex_unlock(&jesd204_device_list_lock);
+
+	return ERR_PTR(ret);
+}
+EXPORT_SYMBOL(jesd204_dev_register);
+
 static void jesd204_of_unregister_devices(void)
 {
 	struct jesd204_dev *jdev, *j;
@@ -93,6 +142,9 @@ static void __jesd204_dev_release(struct kref *ref)
 	struct jesd204_dev_top *jdev_top;
 
 	mutex_lock(&jesd204_device_list_lock);
+
+	if (jdev->dev)
+		put_device(jdev->dev);
 
 	if (jdev->is_top) {
 		jdev_top = jesd204_dev_top_dev(jdev);

--- a/drivers/jesd204/jesd204-core.c
+++ b/drivers/jesd204/jesd204-core.c
@@ -9,14 +9,120 @@
 
 #include <linux/kernel.h>
 #include <linux/module.h>
+#include <linux/device.h>
+#include <linux/of.h>
+#include <linux/slab.h>
+
+#include "jesd204-priv.h"
+
+static DEFINE_MUTEX(jesd204_device_list_lock);
+static LIST_HEAD(jesd204_device_list);
+
+static unsigned int jesd204_device_count;
+
+static struct jesd204_dev *jesd204_dev_alloc(struct device_node *np)
+{
+	struct jesd204_dev *jdev;
+
+	jdev = kzalloc(sizeof(*jdev), GFP_KERNEL);
+	if (!jdev)
+		return ERR_PTR(-ENOMEM);
+
+	kref_get(&jdev->ref);
+
+	jdev->np = of_node_get(np);
+	kref_init(&jdev->ref);
+
+	list_add(&jdev->list, &jesd204_device_list);
+	jesd204_device_count++;
+
+	return jdev;
+}
+
+static int jesd204_of_create_devices(void)
+{
+	struct jesd204_dev *jdev;
+	struct device_node *np;
+	int ret;
+
+	mutex_lock(&jesd204_device_list_lock);
+
+	ret = 0;
+	for_each_node_with_property(np, "jesd204-device") {
+		jdev = jesd204_dev_alloc(np);
+		if (IS_ERR(jdev)) {
+			ret = PTR_ERR(jdev);
+			goto unlock;
+		}
+	}
+
+unlock:
+	mutex_unlock(&jesd204_device_list_lock);
+
+	return ret;
+}
+
+static void jesd204_of_unregister_devices(void)
+{
+	struct jesd204_dev *jdev, *j;
+
+	list_for_each_entry_safe(jdev, j, &jesd204_device_list, list) {
+		jesd204_dev_unregister(jdev);
+	}
+}
+
+/* Free memory allocated. */
+static void __jesd204_dev_release(struct kref *ref)
+{
+	struct jesd204_dev *jdev = container_of(ref, struct jesd204_dev, ref);
+
+	mutex_lock(&jesd204_device_list_lock);
+
+	list_del(&jdev->list);
+	of_node_put(jdev->np);
+
+	kfree(jdev);
+
+	jesd204_device_count--;
+
+	mutex_unlock(&jesd204_device_list_lock);
+}
+
+/**
+ * jesd204_dev_unregister() - unregister a device from the JESD204 subsystem
+ * @jdev:		Device structure representing the device.
+ **/
+void jesd204_dev_unregister(struct jesd204_dev *jdev)
+{
+	if (IS_ERR_OR_NULL(jdev))
+		return;
+
+	kref_put(&jdev->ref, __jesd204_dev_release);
+}
+EXPORT_SYMBOL(jesd204_dev_unregister);
 
 static int __init jesd204_init(void)
 {
+	int ret;
+
+	mutex_init(&jesd204_device_list_lock);
+
+	ret = jesd204_of_create_devices();
+	if (ret < 0)
+		goto error_unreg_devices;
+
 	return 0;
+
+error_unreg_devices:
+	jesd204_of_unregister_devices();
+	pr_err("framework error: %d\n", ret);
+	return ret;
 }
 
 static void __exit jesd204_exit(void)
 {
+	jesd204_of_unregister_devices();
+	mutex_destroy(&jesd204_device_list_lock);
 }
 
 subsys_initcall(jesd204_init);

--- a/drivers/jesd204/jesd204-core.c
+++ b/drivers/jesd204/jesd204-core.c
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-2.0+
+/**
+ * The JESD204 framework - core logic
+ *
+ * Copyright (c) 2019 Analog Devices Inc.
+ */
+
+#define pr_fmt(fmt) "jesd204: " fmt
+
+#include <linux/kernel.h>
+#include <linux/module.h>
+
+static int __init jesd204_init(void)
+{
+	return 0;
+}
+
+static void __exit jesd204_exit(void)
+{
+}
+
+subsys_initcall(jesd204_init);
+module_exit(jesd204_exit);
+
+MODULE_AUTHOR("Alexandru Ardelean <alexandru.ardelean@analog.com>");
+MODULE_DESCRIPTION("JESD204 framework core");
+MODULE_LICENSE("GPL");

--- a/drivers/jesd204/jesd204-core.c
+++ b/drivers/jesd204/jesd204-core.c
@@ -181,6 +181,62 @@ void jesd204_dev_unregister(struct jesd204_dev *jdev)
 }
 EXPORT_SYMBOL(jesd204_dev_unregister);
 
+static void devm_jesd204_dev_unreg(struct device *dev, void *res)
+{
+	jesd204_dev_unregister(*(struct jesd204_dev **)res);
+}
+
+struct jesd204_dev *devm_jesd204_dev_register(struct device *dev,
+					      const struct jesd204_dev_data *i)
+{
+	struct jesd204_dev **jdevp, *jdev;
+
+	jdevp = devres_alloc(devm_jesd204_dev_unreg, sizeof(*jdevp),
+			     GFP_KERNEL);
+	if (!jdevp)
+		return ERR_PTR(-ENOMEM);
+
+	jdev = jesd204_dev_register(dev, i);
+	if (!IS_ERR(jdev)) {
+		*jdevp = jdev;
+		devres_add(dev, jdevp);
+	} else {
+		devres_free(jdevp);
+	}
+
+	return jdev;
+}
+EXPORT_SYMBOL_GPL(devm_jesd204_dev_register);
+
+static int devm_jesd204_dev_match(struct device *dev, void *res, void *data)
+{
+	struct jesd204_dev **r = res;
+
+	if (!r || !*r) {
+		WARN_ON(!r || !*r);
+		return 0;
+	}
+
+	return *r == data;
+}
+
+/**
+ * devm_jesd204_dev_unregister - Resource-managed jesd204_dev_unregister()
+ * @dev:	Device this jesd204_dev belongs to
+ * @jdev:	the jesd204_dev associated with the device
+ *
+ * Unregister jesd204_dev registered with devm_jesd204_dev_register().
+ */
+void devm_jesd204_dev_unregister(struct device *dev, struct jesd204_dev *jdev)
+{
+	int rc;
+
+	rc = devres_release(dev, devm_jesd204_dev_unreg,
+			    devm_jesd204_dev_match, jdev);
+	WARN_ON(rc);
+}
+EXPORT_SYMBOL_GPL(devm_jesd204_dev_unregister);
+
 static int __init jesd204_init(void)
 {
 	int ret;

--- a/drivers/jesd204/jesd204-priv.h
+++ b/drivers/jesd204/jesd204-priv.h
@@ -1,0 +1,28 @@
+/* SPDX-License-Identifier: GPL-2.0+ */
+/**
+ * The JESD204 framework
+ *
+ * Copyright (c) 2019 Analog Devices Inc.
+ */
+
+#ifndef _JESD204_PRIV_H_
+#define _JESD204_PRIV_H_
+
+#include <linux/jesd204/jesd204.h>
+
+struct jesd204_dev;
+
+/**
+ * struct jesd204_dev - JESD204 device
+ * @list		list entry for the framework to keep a list of devices
+ * @np			reference in the device-tree for this JESD204 device
+ * @ref			ref count for this JESD204 device
+ */
+struct jesd204_dev {
+	struct list_head		list;
+
+	struct device_node		*np;
+	struct kref			ref;
+};
+
+#endif /* _JESD204_PRIV_H_ */

--- a/drivers/jesd204/jesd204-priv.h
+++ b/drivers/jesd204/jesd204-priv.h
@@ -19,6 +19,7 @@ struct jesd204_dev_top;
  * @is_top		true if this device is a top device in a topology of
  *			devices that make up a JESD204 link (typically the
  *			device that is the ADC, DAC, or transceiver)
+ * @dev			device that registers itself as a JESD204 device
  * @np			reference in the device-tree for this JESD204 device
  * @ref			ref count for this JESD204 device
  */
@@ -27,6 +28,7 @@ struct jesd204_dev {
 
 	bool				is_top;
 
+	struct device			*dev;
 	struct device_node		*np;
 	struct kref			ref;
 };

--- a/drivers/jesd204/jesd204-priv.h
+++ b/drivers/jesd204/jesd204-priv.h
@@ -11,18 +11,44 @@
 #include <linux/jesd204/jesd204.h>
 
 struct jesd204_dev;
+struct jesd204_dev_top;
 
 /**
  * struct jesd204_dev - JESD204 device
  * @list		list entry for the framework to keep a list of devices
+ * @is_top		true if this device is a top device in a topology of
+ *			devices that make up a JESD204 link (typically the
+ *			device that is the ADC, DAC, or transceiver)
  * @np			reference in the device-tree for this JESD204 device
  * @ref			ref count for this JESD204 device
  */
 struct jesd204_dev {
 	struct list_head		list;
 
+	bool				is_top;
+
 	struct device_node		*np;
 	struct kref			ref;
 };
+
+/**
+ * struct jesd204_dev_top - JESD204 top device (in a JESD204 topology)
+ * @list		list entry for the framework to keep a list of top
+ *			devices (and implicitly topologies)
+ * @jdev		JESD204 device data
+ */
+struct jesd204_dev_top {
+	struct list_head		list;
+
+	struct jesd204_dev		jdev;
+};
+
+static inline struct jesd204_dev_top *jesd204_dev_top_dev(
+		struct jesd204_dev *jdev)
+{
+	if (!jdev || !jdev->is_top)
+		return NULL;
+	return container_of(jdev, struct jesd204_dev_top, jdev);
+}
 
 #endif /* _JESD204_PRIV_H_ */

--- a/include/linux/jesd204/jesd204.h
+++ b/include/linux/jesd204/jesd204.h
@@ -19,8 +19,11 @@ struct jesd204_dev_data {
 
 struct jesd204_dev *jesd204_dev_register(struct device *dev,
 					 const struct jesd204_dev_data *init);
+struct jesd204_dev *devm_jesd204_dev_register(struct device *dev,
+					      const struct jesd204_dev_data *i);
 
 void jesd204_dev_unregister(struct jesd204_dev *jdev);
+void devm_jesd204_unregister(struct device *dev, struct jesd204_dev *jdev);
 
 #else /* !IS_ENABLED(CONFIG_JESD204) */
 
@@ -31,6 +34,15 @@ static inline struct jesd204_dev *jesd204_dev_register(
 }
 
 static inline void jesd204_dev_unregister(struct jesd204_dev *jdev) {}
+
+static inline struct jesd204_dev *devm_jesd204_dev_register(
+		struct device *dev, const struct jesd204_dev_data *init)
+{
+	return NULL;
+}
+
+static inline void devm_jesd204_unregister(struct device *dev,
+	       struct jesd204_dev *jdev) {}
 
 #endif /* IS_ENABLED(CONFIG_JESD204) */
 

--- a/include/linux/jesd204/jesd204.h
+++ b/include/linux/jesd204/jesd204.h
@@ -1,0 +1,22 @@
+/* SPDX-License-Identifier: GPL-2.0+ */
+/**
+ * The JESD204 framework
+ *
+ * Copyright (c) 2019 Analog Devices Inc.
+ */
+#ifndef _JESD204_H_
+#define _JESD204_H_
+
+struct jesd204_dev;
+
+#if IS_ENABLED(CONFIG_JESD204)
+
+void jesd204_dev_unregister(struct jesd204_dev *jdev);
+
+#else /* !IS_ENABLED(CONFIG_JESD204) */
+
+static inline void jesd204_dev_unregister(struct jesd204_dev *jdev) {}
+
+#endif /* IS_ENABLED(CONFIG_JESD204) */
+
+#endif

--- a/include/linux/jesd204/jesd204.h
+++ b/include/linux/jesd204/jesd204.h
@@ -9,11 +9,26 @@
 
 struct jesd204_dev;
 
+/**
+ * struct jesd204_dev_data - JESD204 device initialization data
+ */
+struct jesd204_dev_data {
+};
+
 #if IS_ENABLED(CONFIG_JESD204)
+
+struct jesd204_dev *jesd204_dev_register(struct device *dev,
+					 const struct jesd204_dev_data *init);
 
 void jesd204_dev_unregister(struct jesd204_dev *jdev);
 
 #else /* !IS_ENABLED(CONFIG_JESD204) */
+
+static inline struct jesd204_dev *jesd204_dev_register(
+		struct device *dev, const struct jesd204_dev_data *init)
+{
+	return NULL;
+}
 
 static inline void jesd204_dev_unregister(struct jesd204_dev *jdev) {}
 


### PR DESCRIPTION
This changeset adds the first bits of the JESD204 framework.
More to come later.
The DAQ2 will be used as base to integrate it.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>