### PR TITLE
 iio: imu: adis16480: sync upstream & re-add prod_id reg

### DIFF
--- a/drivers/iio/imu/adis16480.c
+++ b/drivers/iio/imu/adis16480.c
@@ -1389,7 +1389,7 @@ static int adis16480_ext_clk_config(struct adis16480 *st,
 	 * has two assignments, the enable bit for a lower priority function
 	 * automatically resets to zero (disabling the lower priority function).
 	 */
-	if (pin == (val & ADIS16480_DRDY_SEL_MSK))
+	if (pin == ADIS16480_DRDY_SEL(val))
 		dev_warn(&st->adis.spi->dev,
 			"DIO%x pin supports only one function at a time\n",
 			pin + 1);

--- a/drivers/iio/imu/adis16480.c
+++ b/drivers/iio/imu/adis16480.c
@@ -1269,6 +1269,7 @@ static const char * const adis16480_status_error_msgs[] = {
 static const struct adis_data adis16480_data = {
 	.diag_stat_reg = ADIS16480_REG_DIAG_STS,
 	.glob_cmd_reg = ADIS16480_REG_GLOB_CMD,
+	.prod_id_reg = ADIS16480_REG_PROD_ID,
 	.has_paging = true,
 
 	.read_delay = 5,


### PR DESCRIPTION
This changeset syncs a change from upstream. It was done differently in the ADI tree for the pin check.

And re-adds the prod_id reg back. Was removed by accident in #827 

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>