### PR TITLE
iio: frequency: Kconfig: fix alphabetical order for ADF43XX chips

### DIFF
--- a/drivers/iio/frequency/Kconfig
+++ b/drivers/iio/frequency/Kconfig
@@ -160,16 +160,16 @@ config ADF4350
 	  To compile this driver as a module, choose M here: the
 	  module will be called adf4350.
 
-config ADF5355
-	tristate "Analog Devices ADF5355/ADF4355 Wideband Synthesizers"
+config ADF4360
+	tristate "Analog Devices ADF4360 Wideband Synthesizers"
 	depends on SPI
 	depends on COMMON_CLK
 	help
-	  Say yes here to build support for Analog Devices ADF5355/ADF4355
+	  Say yes here to build support for Analog Devices ADF4360
 	  Wideband Synthesizers. The driver provides direct access via sysfs.
 
 	  To compile this driver as a module, choose M here: the
-	  module will be called adf5355.
+	  module will be called adf4360.
 
 config ADF4371
 	tristate "Analog Devices ADF4371/ADF4372 Wideband Synthesizers"
@@ -182,15 +182,15 @@ config ADF4371
 	  To compile this driver as a module, choose M here: the
 	  module will be called adf4371.
 
-config ADF4360
-	tristate "Analog Devices ADF4360 Wideband Synthesizers"
+config ADF5355
+	tristate "Analog Devices ADF5355/ADF4355 Wideband Synthesizers"
 	depends on SPI
 	depends on COMMON_CLK
 	help
-	  Say yes here to build support for Analog Devices ADF4360
+	  Say yes here to build support for Analog Devices ADF5355/ADF4355
 	  Wideband Synthesizers. The driver provides direct access via sysfs.
 
 	  To compile this driver as a module, choose M here: the
-	  module will be called adf4360.
+	  module will be called adf5355.
 endmenu
 endmenu


### PR DESCRIPTION
ADF4360 driver goes before ADF4371.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>