### PR TITLE
Revert "usb: gadget: f_fs: Fix use-after-free in ffs_free_inst"

### DIFF
--- a/drivers/usb/gadget/function/f_fs.c
+++ b/drivers/usb/gadget/function/f_fs.c
@@ -3674,7 +3674,6 @@ static void ffs_closed(struct ffs_data *ffs)
 		goto done;
 
 	ffs_obj->desc_ready = false;
-	ffs_obj->ffs_data = NULL;
 
 	if (test_and_clear_bit(FFS_FL_CALL_CLOSED_CALLBACK, &ffs->flags) &&
 	    ffs_obj->ffs_closed_callback)


### PR DESCRIPTION
During Pluto test we encountered the following scenario when triggering a
device reboot:

PC is at ffs_data_clear+0x7c/0x100
LR is at ffs_data_clear+0x2c/0x100
pc : [<c045aa84>]    lr : [<c045aa34>]    psr: 20000013
sp : df4e7f48  ip : 00000000  fp : beddce80
r10: 00000034  r9 : df4e6000  r8 : c0a89220
r7 : df4b041c  r6 : df55d940  r5 : cbee5580  r4 : cbde6400
r3 : 00018520  r2 : 05000400  r1 : cbde645c  r0 : c0a2c294
Flags: nzCv  IRQs on  FIQs on  Mode SVC_32  ISA ARM  Segment none
Control: 18c5387d  Table: 0b71804a  DAC: 00000051
Process umount (pid: 3191, stack limit = 0xaf223aee)
Stack: (0xdf4e7f48 to 0xdf4e8000)
7f40:                   cbde6400 ffffffff df55d940 c045ab14 cbde6400 c045b604
7f60: cbed3400 c0a2c2c0 df55d940 c01e76c4 df4b0400 df55ddb8 df55d940 c02020e0
7f80: 00000000 c0135238 c0101204 ffffe000 df4e7fb0 00000034 c0101204 c010abfc
7fa0: 000d28b0 000d28e8 00000030 c010106c 00000000 00000000 80000000 7366665f
7fc0: 000d28b0 000d28e8 00000030 00000034 000d22c8 00000000 00000020 beddce80
7fe0: 000d1244 beddccac 00063ab8 b6e4a40c 20000010 000d28d0 00000000 00000000
[<c045aa84>] (ffs_data_clear) from [<c045ab14>] (ffs_data_reset+0xc/0x50)
[<c045ab14>] (ffs_data_reset) from [<c045b604>] (ffs_data_closed+0x90/0xac)
[<c045b604>] (ffs_data_closed) from [<c01e76c4>] (deactivate_locked_super+0x4c/0x7c)
[<c01e76c4>] (deactivate_locked_super) from [<c02020e0>] (cleanup_mnt+0x4c/0x6c)
[<c02020e0>] (cleanup_mnt) from [<c0135238>] (task_work_run+0x9c/0xac)
[<c0135238>] (task_work_run) from [<c010abfc>] (do_work_pending+0xa8/0xd4)
[<c010abfc>] (do_work_pending) from [<c010106c>] (slow_work_pending+0xc/0x20)
Exception stack(0xdf4e7fb0 to 0xdf4e7ff8)
7fa0:                                     00000000 00000000 80000000 7366665f
7fc0: 000d28b0 000d28e8 00000030 00000034 000d22c8 00000000 00000020 beddce80
7fe0: 000d1244 beddccac 00063ab8 b6e4a40c 20000010 000d28d0
Code: e5933018 e3530000 0a00000d e59f007c (e5926024)
---[ end trace 25c18490021bee81 ]---

The revert of the following patch will fix this issue.

This reverts commit cdafb6d8b8da7fde266f79b3287ac221aa841879.

I also created a Jira task if we want to tackle this more in the future.