### PR TITLE
arch: arm: arria10_socdk_ad9172_fmc: Update DMA channel

### DIFF
--- a/arch/arm/boot/dts/socfpga_arria10_socdk_ad9172_fmc.dts
+++ b/arch/arm/boot/dts/socfpga_arria10_socdk_ad9172_fmc.dts
@@ -67,13 +67,17 @@
 				interrupts = <0 30 4>;
 				clocks = <&dma_clk>;
 
-				dma-channel {
-					adi,source-bus-width = <64>;
-					adi,source-bus-type = <0>;
-					adi,destination-bus-width = <128>;
-					adi,destination-bus-type = <1>;
-					adi,type = <1>;
-					adi,cyclic;
+				adi,channels {
+					#size-cells = <0>;
+					#address-cells = <1>;
+
+					dma-channel@0 {
+						reg = <0>;
+						adi,source-bus-width = <64>;
+						adi,source-bus-type = <0>;
+						adi,destination-bus-width = <128>;
+						adi,destination-bus-type = <1>;
+					};
 				};
 			};
 


### PR DESCRIPTION
According to current version of dma-axi-dmac.c.

adi,type and adi,cyclic were completely removed since they are not used
anymore. The DMA capabilities are automatically discovered by the
driver.

Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>