### PR TITLE
dts: overlays: ad7124 all channels diff overlay

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -133,6 +133,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	rpi-adf4371.dtbo \
 	rpi-ad5686.dtbo \
 	rpi-ad7124.dtbo \
+	rpi-ad7124-8-all-diff-cs0-int25.dtbo \
 	rpi-ad7190.dtbo \
 	rpi-ad738x.dtbo \
 	rpi-ad7768-1.dtbo \

--- a/arch/arm/boot/dts/overlays/rpi-ad7124-8-all-diff-cs0-int25-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ad7124-8-all-diff-cs0-int25-overlay.dts
@@ -1,0 +1,109 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709";
+
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			vref: fixedregulator@0 {
+				compatible = "regulator-fixed";
+				regulator-name = "fixed-supply";
+				regulator-min-microvolt = <2500000>;
+				regulator-max-microvolt = <2500000>;
+				regulator-boot-on;
+			};
+		};
+	};
+
+	fragment@1 {
+		target-path = "/";
+		__overlay__ {
+			clocks {
+				ad7124_mclk: clock@0 {
+					#clock-cells = <0>;
+					compatible = "fixed-clock";
+					clock-frequency = <614400>;
+				};
+			};
+		};
+	};
+
+	fragment@2 {
+		target = <&spi0>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			ad7124@0 {
+				compatible = "adi,ad7124-8";
+				reg = <0>;
+				spi-max-frequency = <5000000>;
+				interrupts = <25 2>;
+				interrupt-parent = <&gpio>;
+				refin1-supply = <&vref>;
+				clocks = <&ad7124_mclk>;
+				clock-names = "mclk";
+
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				channel@0 {
+					reg = <0>;
+					diff-channels = <0 1>;
+				};
+
+				channel@1 {
+					reg = <1>;
+					diff-channels = <2 3>;
+				};
+
+				channel@2 {
+					reg = <2>;
+					diff-channels = <4 5>;
+				};
+
+				channel@3 {
+					reg = <3>;
+					diff-channels = <6 7>;
+				};
+
+				channel@4 {
+					reg = <4>;
+					diff-channels = <8 9>;
+				};
+
+				channel@5 {
+					reg = <5>;
+					diff-channels = <10 11>;
+				};
+
+				channel@6 {
+					reg = <6>;
+					diff-channels = <12 13>;
+				};
+
+				channel@7 {
+					reg = <7>;
+					diff-channels = <14 15>;
+				};
+			};
+		};
+	};
+
+	fragment@3 {
+		target = <&spidev0>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@4 {
+		target = <&spidev1>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+};


### PR DESCRIPTION
This is an overlay for the ad7124-8 with all channels in
differential mode and internal reference.

Signed-off-by: Alexandru Tachici <alexandru.tachici@analog.com>