### PR TITLE
jesd204: add basic finite-state-machine logic + linux bus register (part 2)

### DIFF
--- a/drivers/jesd204/Makefile
+++ b/drivers/jesd204/Makefile
@@ -5,4 +5,5 @@
 
 obj-$(CONFIG_JESD204) += jesd204.o
 jesd204-y := \
+	jesd204-fsm.o \
 	jesd204-core.o

--- a/drivers/jesd204/jesd204-core.c
+++ b/drivers/jesd204/jesd204-core.c
@@ -11,6 +11,7 @@
 #include <linux/module.h>
 #include <linux/device.h>
 #include <linux/of.h>
+#include <linux/property.h>
 #include <linux/slab.h>
 
 #include "jesd204-priv.h"
@@ -25,6 +26,11 @@ static LIST_HEAD(jesd204_topologies);
 
 static unsigned int jesd204_device_count;
 static unsigned int jesd204_topologies_count;
+
+static inline bool dev_is_jesd204_dev(struct device *dev)
+{
+	return device_property_read_bool(dev, "jesd204-device");
+}
 
 static struct jesd204_dev *jesd204_dev_alloc(struct device_node *np)
 {
@@ -108,6 +114,9 @@ struct jesd204_dev *jesd204_dev_register(struct device *dev,
 		dev_err(dev, "Invalid register arguments\n");
 		return ERR_PTR(-EINVAL);
 	}
+
+	if (!dev_is_jesd204_dev(dev))
+		return NULL;
 
 	mutex_lock(&jesd204_device_list_lock);
 
@@ -194,6 +203,9 @@ struct jesd204_dev *devm_jesd204_dev_register(struct device *dev,
 					      const struct jesd204_dev_data *i)
 {
 	struct jesd204_dev **jdevp, *jdev;
+
+	if (!dev_is_jesd204_dev(dev))
+		return NULL;
 
 	jdevp = devres_alloc(devm_jesd204_dev_unreg, sizeof(*jdevp),
 			     GFP_KERNEL);

--- a/drivers/jesd204/jesd204-core.c
+++ b/drivers/jesd204/jesd204-core.c
@@ -15,6 +15,10 @@
 
 #include "jesd204-priv.h"
 
+static struct bus_type jesd204_bus_type = {
+	.name = "jesd204",
+};
+
 static DEFINE_MUTEX(jesd204_device_list_lock);
 static LIST_HEAD(jesd204_device_list);
 static LIST_HEAD(jesd204_topologies);
@@ -243,6 +247,12 @@ static int __init jesd204_init(void)
 
 	mutex_init(&jesd204_device_list_lock);
 
+	ret  = bus_register(&jesd204_bus_type);
+	if (ret < 0) {
+		pr_err("could not register bus type\n");
+		return ret;
+	}
+
 	ret = jesd204_of_create_devices();
 	if (ret < 0)
 		goto error_unreg_devices;
@@ -259,6 +269,7 @@ static void __exit jesd204_exit(void)
 {
 	jesd204_of_unregister_devices();
 	mutex_destroy(&jesd204_device_list_lock);
+	bus_unregister(&jesd204_bus_type);
 }
 
 subsys_initcall(jesd204_init);

--- a/drivers/jesd204/jesd204-core.c
+++ b/drivers/jesd204/jesd204-core.c
@@ -27,6 +27,11 @@ static LIST_HEAD(jesd204_topologies);
 static unsigned int jesd204_device_count;
 static unsigned int jesd204_topologies_count;
 
+struct list_head *jesd204_topologies_get(void)
+{
+	return &jesd204_topologies;
+}
+
 static inline bool dev_is_jesd204_dev(struct device *dev)
 {
 	return device_property_read_bool(dev, "jesd204-device");
@@ -195,6 +200,7 @@ static int jesd204_of_device_create_cons(struct jesd204_dev *jdev)
 
 static int jesd204_of_create_devices(void)
 {
+	struct jesd204_dev_top *jdev_top;
 	struct jesd204_dev *jdev;
 	struct device_node *np;
 	int ret;
@@ -212,6 +218,14 @@ static int jesd204_of_create_devices(void)
 
 	list_for_each_entry(jdev, &jesd204_device_list, entry) {
 		ret = jesd204_of_device_create_cons(jdev);
+		if (ret)
+			goto unlock;
+	}
+
+	list_for_each_entry(jdev_top, &jesd204_topologies, entry) {
+		jdev = &jdev_top->jdev;
+
+		ret = jesd204_init_topology(jdev_top);
 		if (ret)
 			goto unlock;
 	}

--- a/drivers/jesd204/jesd204-core.c
+++ b/drivers/jesd204/jesd204-core.c
@@ -34,7 +34,7 @@ static struct jesd204_dev *jesd204_dev_alloc(struct device_node *np)
 			return ERR_PTR(-ENOMEM);
 
 		jdev = &jdev_top->jdev;
-		list_add(&jdev_top->list, &jesd204_topologies);
+		list_add(&jdev_top->entry, &jesd204_topologies);
 		jesd204_topologies_count++;
 	} else {
 		jdev = kzalloc(sizeof(*jdev), GFP_KERNEL);
@@ -48,7 +48,7 @@ static struct jesd204_dev *jesd204_dev_alloc(struct device_node *np)
 	jdev->np = of_node_get(np);
 	kref_init(&jdev->ref);
 
-	list_add(&jdev->list, &jesd204_device_list);
+	list_add(&jdev->entry, &jesd204_device_list);
 	jesd204_device_count++;
 
 	return jdev;
@@ -61,7 +61,7 @@ static struct jesd204_dev *jesd204_dev_find_by_of_node(struct device_node *np)
 	if (!np)
 		return NULL;
 
-	list_for_each_entry(jdev_it, &jesd204_device_list, list) {
+	list_for_each_entry(jdev_it, &jesd204_device_list, entry) {
 		if (jdev_it->np == np) {
 			jdev = jdev_it;
 			break;
@@ -130,7 +130,7 @@ static void jesd204_of_unregister_devices(void)
 {
 	struct jesd204_dev *jdev, *j;
 
-	list_for_each_entry_safe(jdev, j, &jesd204_device_list, list) {
+	list_for_each_entry_safe(jdev, j, &jesd204_device_list, entry) {
 		jesd204_dev_unregister(jdev);
 	}
 }
@@ -149,13 +149,13 @@ static void __jesd204_dev_release(struct kref *ref)
 	if (jdev->is_top) {
 		jdev_top = jesd204_dev_top_dev(jdev);
 		if (jdev_top) {
-			list_del(&jdev_top->list);
+			list_del(&jdev_top->entry);
 			jesd204_topologies_count--;
 		}
 	} else
 		jdev_top = NULL;
 
-	list_del(&jdev->list);
+	list_del(&jdev->entry);
 	of_node_put(jdev->np);
 
 	if (jdev_top)

--- a/drivers/jesd204/jesd204-fsm.c
+++ b/drivers/jesd204/jesd204-fsm.c
@@ -1,0 +1,347 @@
+// SPDX-License-Identifier: GPL-2.0+
+/**
+ * The JESD204 framework - finite state machine logic
+ *
+ * Copyright (c) 2019 Analog Devices Inc.
+ */
+
+#include <linux/kernel.h>
+#include <linux/device.h>
+#include <linux/of.h>
+
+#include "jesd204-priv.h"
+
+typedef int (*jesd204_cb_con_priv)(struct jesd204_dev *jdev,
+				   struct jesd204_dev_con_out *con,
+				   void *data);
+
+/**
+ * struct jesd204_fsm_data - JESD204 device state change data
+ * @jdev_top			top JESD204 for which this state change
+ * @propagated_cb	callback to propagate to trigger state change
+ */
+struct jesd204_fsm_data {
+	struct jesd204_dev_top	*jdev_top;
+	jesd204_cb_con_priv	fsm_change_cb;
+	bool			inputs;
+};
+
+typedef int (*jesd204_propagated_cb)(struct jesd204_dev *jdev,
+				     struct jesd204_dev_con_out *con,
+				     struct jesd204_fsm_data *data);
+
+const char *jesd204_state_str(enum jesd204_dev_state state)
+{
+	switch (state) {
+	case JESD204_STATE_ERROR:
+		return "error";
+	case JESD204_STATE_UNINIT:
+		return "uninitialized";
+	case JESD204_STATE_INITIALIZED:
+		return "initialized";
+	default:
+		return "<unknown>";
+	}
+}
+
+static int jesd204_dev_set_error(struct jesd204_dev *jdev,
+				 struct jesd204_dev_con_out *con,
+				 int err)
+{
+	struct jesd204_dev_top *jdev_top;
+
+	if (err == 0)
+		return 0;
+
+	if (con)
+		con->error = err;
+
+	jdev_top = jesd204_dev_top_dev(jdev);
+	if (jdev_top)
+		jdev_top->error = err;
+
+	return err;
+}
+
+static int jesd204_dev_propagate_cb_inputs(struct jesd204_dev *jdev,
+					   jesd204_propagated_cb propagated_cb,
+					   struct jesd204_fsm_data *data)
+{
+	struct jesd204_dev_con_out *con = NULL;
+	unsigned int i;
+	int ret = 0;
+
+	for (i = 0; i < jdev->inputs_count; i++) {
+		con = jdev->inputs[i];
+
+		ret = jesd204_dev_propagate_cb_inputs(con->owner,
+						      propagated_cb, data);
+		if (ret)
+			break;
+		ret = propagated_cb(con->owner, con, data);
+		if (ret)
+			break;
+	}
+
+	return jesd204_dev_set_error(jdev, con, ret);
+}
+
+static int jesd204_dev_propagate_cb_outputs(struct jesd204_dev *jdev,
+					    jesd204_propagated_cb propagated_cb,
+					    struct jesd204_fsm_data *data)
+{
+	struct jesd204_dev_con_out *con = NULL;
+	struct jesd204_dev_list_entry *e;
+	int ret = 0;
+
+	list_for_each_entry(con, &jdev->outputs, entry) {
+		list_for_each_entry(e, &con->dests, entry) {
+			ret = propagated_cb(e->jdev, con, data);
+			if (ret)
+				goto done;
+			ret = jesd204_dev_propagate_cb_outputs(e->jdev,
+							       propagated_cb,
+							       data);
+			if (ret)
+				goto done;
+		}
+	}
+
+done:
+	return jesd204_dev_set_error(jdev, con, ret);
+}
+
+static inline int jesd204_dev_propagate_cb(struct jesd204_dev *jdev,
+					   jesd204_propagated_cb propagated_cb,
+					   struct jesd204_fsm_data *data)
+{
+	int ret;
+
+	data->inputs = true;
+	ret = jesd204_dev_propagate_cb_inputs(jdev, propagated_cb, data);
+	if (ret)
+		goto out;
+
+	data->inputs = false;
+	ret = jesd204_dev_propagate_cb_outputs(jdev, propagated_cb, data);
+	if (ret)
+		goto out;
+
+	ret = propagated_cb(jdev, NULL, data);
+out:
+	return jesd204_dev_set_error(jdev, NULL, ret);
+}
+
+static void __jesd204_dev_top_fsm_change_cb(struct kref *ref)
+{
+	struct jesd204_dev_top *jdev_top;
+	struct jesd204_dev *jdev;
+	int ret;
+
+	jdev_top = container_of(ref, typeof(*jdev_top), cb_ref);
+	jdev = &jdev_top->jdev;
+
+	jdev_top->cur_state = jdev_top->nxt_state;
+	if (jdev_top->error) {
+		dev_err(jdev->dev, "jesd got error from topology %d\n",
+			jdev_top->error);
+		jdev_top->cur_state = JESD204_STATE_ERROR;
+		goto out;
+	}
+
+	if (jdev_top->fsm_complete_cb) {
+		ret = jdev_top->fsm_complete_cb(jdev, jdev_top->cb_data);
+		jesd204_dev_set_error(jdev, NULL, ret);
+		if (ret) {
+			dev_err(jdev->dev, "error from completion cb %d, state %s\n",
+				ret, jesd204_state_str(jdev_top->cur_state));
+			jdev_top->cur_state = JESD204_STATE_ERROR;
+			goto out;
+		}
+	}
+
+out:
+	/**
+	 * Reset nxt_state ; so that other devices won't run another
+	 * state change
+	 */
+	jdev_top->nxt_state = JESD204_STATE_UNINIT;
+	jdev_top->cb_data = NULL;
+}
+
+static int jesd204_dev_validate_cur_state(struct jesd204_dev_top *jdev_top,
+					  struct jesd204_dev *jdev,
+					  struct jesd204_dev_con_out *c,
+					  enum jesd204_dev_state state)
+{
+	if (state != jdev_top->cur_state) {
+		dev_warn(jdev->dev,
+			 "invalid jesd state: %s, exp: %s, nxt: %s\n",
+			 jesd204_state_str(state),
+			 jesd204_state_str(jdev_top->cur_state),
+			 jesd204_state_str(jdev_top->nxt_state));
+		return jesd204_dev_set_error(jdev, c, -EINVAL);
+	}
+
+	return 0;
+}
+
+static int jesd204_dev_update_con_state(struct jesd204_dev *jdev,
+					struct jesd204_dev_top *jdev_top,
+					struct jesd204_dev_con_out *c)
+{
+	int ret;
+
+	if (!c || c->state == jdev_top->nxt_state)
+		return 0;
+
+	if (c->jdev_top) {
+		if (c->jdev_top->nxt_state == JESD204_STATE_UNINIT)
+			return 0;
+		if (c->jdev_top != jdev_top)
+			return 0;
+		kref_get(&c->jdev_top->cb_ref);
+	}
+
+	ret = jesd204_dev_validate_cur_state(jdev_top, jdev, c, c->state);
+	if (ret)
+		return ret;
+
+	c->state = jdev_top->nxt_state;
+	if (c->jdev_top)
+		kref_put(&c->jdev_top->cb_ref,
+			 __jesd204_dev_top_fsm_change_cb);
+
+	return 0;
+}
+
+static int jesd204_fsm_cb(struct jesd204_dev *jdev,
+			  struct jesd204_dev_con_out *con,
+			  struct jesd204_fsm_data *s)
+{
+	struct jesd204_dev_top *jdev_top = s->jdev_top;
+	int ret;
+
+	kref_get(&jdev_top->cb_ref);
+
+	if (s->fsm_change_cb) {
+		ret = s->fsm_change_cb(jdev, con, jdev_top->cb_data);
+		if (ret < 0)
+			return ret;
+	} else {
+		ret = JESD204_STATE_CHANGE_DONE;
+	}
+
+	if (ret == JESD204_STATE_CHANGE_DONE) {
+		ret = jesd204_dev_update_con_state(jdev, jdev_top, con);
+		kref_put(&jdev_top->cb_ref,  __jesd204_dev_top_fsm_change_cb);
+	} else {
+		ret = 0;
+	}
+
+	return ret;
+}
+
+static int __jesd204_fsm(struct jesd204_dev *jdev,
+			 struct jesd204_dev_top *jdev_top,
+			 enum jesd204_dev_state cur_state,
+			 enum jesd204_dev_state nxt_state,
+			 jesd204_cb_con_priv fsm_change_cb,
+			 void *cb_data,
+			 jesd204_cb_priv fsm_complete_cb)
+{
+	struct jesd204_fsm_data data;
+	int ret;
+
+	ret = jesd204_dev_validate_cur_state(jdev_top, jdev, NULL, cur_state);
+	if (ret)
+		return ret;
+
+	kref_init(&jdev_top->cb_ref);
+
+	memset(&data, 0, sizeof(data));
+	data.fsm_change_cb = fsm_change_cb;
+	data.jdev_top = jdev_top;
+
+	jdev_top->fsm_complete_cb = fsm_complete_cb;
+	jdev_top->nxt_state = nxt_state;
+	jdev_top->cb_data = cb_data;
+
+	ret = jesd204_dev_propagate_cb(jdev,
+				       jesd204_fsm_cb,
+				       &data);
+
+	kref_put(&jdev_top->cb_ref, __jesd204_dev_top_fsm_change_cb);
+
+	return ret;
+}
+
+static bool jesd204_dev_has_con_in_topology(struct jesd204_dev *jdev,
+					    struct jesd204_dev_top *jdev_top)
+{
+	struct jesd204_dev_con_out *c;
+	int i;
+
+	list_for_each_entry(c, &jdev->outputs, entry) {
+		if (c->jdev_top == jdev_top)
+			return true;
+	}
+
+	for (i = 0; i < jdev->inputs_count; i++) {
+		c = jdev->inputs[i];
+		if (c->jdev_top == jdev_top)
+			return true;
+	}
+
+	return false;
+}
+
+static int jesd204_fsm(struct jesd204_dev *jdev,
+		       enum jesd204_dev_state cur_state,
+		       enum jesd204_dev_state nxt_state,
+		       jesd204_cb_con_priv fsm_change_cb,
+		       void *cb_data,
+		       jesd204_cb_priv fsm_complete_cb)
+{
+	struct list_head *jesd204_topologies = jesd204_topologies_get();
+	struct jesd204_dev_top *jdev_top = jesd204_dev_top_dev(jdev);
+	int ret;
+
+	if (jdev_top)
+		return __jesd204_fsm(jdev, jdev_top,
+				     cur_state, nxt_state, fsm_change_cb,
+				     cb_data, fsm_complete_cb);
+
+	list_for_each_entry(jdev_top, jesd204_topologies, entry) {
+		if (!jesd204_dev_has_con_in_topology(jdev, jdev_top))
+			continue;
+
+		ret = __jesd204_fsm(jdev, jdev_top,
+				    cur_state, nxt_state, fsm_change_cb,
+				    cb_data, fsm_complete_cb);
+		if (ret)
+			return ret;
+	}
+
+	return 0;
+}
+
+static int jesd204_dev_initialize_cb(struct jesd204_dev *jdev,
+				     struct jesd204_dev_con_out *con,
+				     void *data)
+{
+	if (con)
+		con->jdev_top = data;
+
+	return JESD204_STATE_CHANGE_DONE;
+}
+
+int jesd204_init_topology(struct jesd204_dev_top *jdev_top)
+{
+	if (!jdev_top)
+		return -EINVAL;
+
+	return jesd204_fsm(&jdev_top->jdev,
+			   JESD204_STATE_UNINIT, JESD204_STATE_INITIALIZED,
+			   jesd204_dev_initialize_cb, jdev_top, NULL);
+}

--- a/drivers/jesd204/jesd204-priv.h
+++ b/drivers/jesd204/jesd204-priv.h
@@ -14,6 +14,37 @@ struct jesd204_dev;
 struct jesd204_dev_top;
 
 /**
+ * struct jesd204_dev_list_entry - Entry for a JESD204 device in a list
+ * @entry		list entry for a device to keep a list of devices
+ * @jdev		pointer to JESD204 device for this list entry
+ */
+struct jesd204_dev_list_entry {
+	struct list_head		entry;
+	struct jesd204_dev		*jdev;
+};
+
+/**
+ * struct jesd204_dev_con_out - Output connection of a JESD204 device
+ * @entry		list entry for a device to keep a list of connections
+ * @owner		pointer to JESD204 device to which this connection
+ *			belongs to
+ * @jdev_top		pointer to JESD204 top device, to which this connection
+ *			belongs to
+ * @dests		list of JESD204 devices this connection is connected
+ *			as input
+ * @dests_count		number of connected JESD204 devices to this output
+ * @of			device-tree reference and arguments for this connection
+ */
+struct jesd204_dev_con_out {
+	struct list_head		entry;
+	struct jesd204_dev		*owner;
+	struct jesd204_dev_top		*jdev_top;
+	struct list_head		dests;
+	unsigned int			dests_count;
+	struct of_phandle_args		of;
+};
+
+/**
  * struct jesd204_dev - JESD204 device
  * @entry		list entry for the framework to keep a list of devices
  * @is_top		true if this device is a top device in a topology of
@@ -22,6 +53,12 @@ struct jesd204_dev_top;
  * @dev			device that registers itself as a JESD204 device
  * @np			reference in the device-tree for this JESD204 device
  * @ref			ref count for this JESD204 device
+ * @inputs		array of pointers to output connections from other
+ *			devices
+ * @inputs_count	number of @inputs in the array
+ * @outputs		list of output connections that take input from this
+ *			device
+ * @outputs_count	number of @outputs in the list
  */
 struct jesd204_dev {
 	struct list_head		entry;
@@ -31,6 +68,11 @@ struct jesd204_dev {
 	struct device			*dev;
 	struct device_node		*np;
 	struct kref			ref;
+
+	struct jesd204_dev_con_out	**inputs;
+	unsigned int			inputs_count;
+	struct list_head		outputs;
+	unsigned int			outputs_count;
 };
 
 /**

--- a/drivers/jesd204/jesd204-priv.h
+++ b/drivers/jesd204/jesd204-priv.h
@@ -15,7 +15,7 @@ struct jesd204_dev_top;
 
 /**
  * struct jesd204_dev - JESD204 device
- * @list		list entry for the framework to keep a list of devices
+ * @entry		list entry for the framework to keep a list of devices
  * @is_top		true if this device is a top device in a topology of
  *			devices that make up a JESD204 link (typically the
  *			device that is the ADC, DAC, or transceiver)
@@ -24,7 +24,7 @@ struct jesd204_dev_top;
  * @ref			ref count for this JESD204 device
  */
 struct jesd204_dev {
-	struct list_head		list;
+	struct list_head		entry;
 
 	bool				is_top;
 
@@ -35,12 +35,12 @@ struct jesd204_dev {
 
 /**
  * struct jesd204_dev_top - JESD204 top device (in a JESD204 topology)
- * @list		list entry for the framework to keep a list of top
+ * @entry		list entry for the framework to keep a list of top
  *			devices (and implicitly topologies)
  * @jdev		JESD204 device data
  */
 struct jesd204_dev_top {
-	struct list_head		list;
+	struct list_head		entry;
 
 	struct jesd204_dev		jdev;
 };

--- a/include/linux/jesd204/jesd204.h
+++ b/include/linux/jesd204/jesd204.h
@@ -9,6 +9,14 @@
 
 struct jesd204_dev;
 
+enum jesd204_state_change_result {
+	JESD204_STATE_CHANGE_ERROR = -1,
+	JESD204_STATE_CHANGE_DEFER = 0,
+	JESD204_STATE_CHANGE_DONE,
+};
+
+typedef int (*jesd204_cb)(struct jesd204_dev *jdev);
+
 /**
  * struct jesd204_dev_data - JESD204 device initialization data
  */


### PR DESCRIPTION
This changeset integrates a few more bits of the framework.
Essentially here:
* the connections between devices are created from DT; at the time of the initial writing DT was used; conversion to more abstract DT/ACPI compat layer will be done later
* we try not to use the term link == connection; to avoid confusion between JESD204 links
   * a `connection` refers to the connection/link between 2 devices in terms of clock/inputs 
   * a `link` is a JESD204 link

The FSM should handle most of the logic/work-load of the framework when needing to configure/reconfigure links.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>