### PR TITLE
iio: dac: ad5766: add dtoverlay for AD5766

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -132,6 +132,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	rpi-addi9036.dtbo \
 	rpi-adf4371.dtbo \
 	rpi-ad5686.dtbo \
+	rpi-ad5766.dtbo \
 	rpi-ad7124.dtbo \
 	rpi-ad7124-8-all-diff-cs0-int25.dtbo \
 	rpi-ad7190.dtbo \

--- a/arch/arm/boot/dts/overlays/rpi-ad5766-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ad5766-overlay.dts
@@ -1,0 +1,36 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2708", "brcm,bcm2837";
+
+	fragment@0 {
+		target = <&spi0>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			ad5766@0{
+				compatible = "adi,ad5766";
+				reg = <0>;
+				spi-cpol;
+				spi-max-frequency = <1000000>;
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&spidev0>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@2 {
+		target = <&spidev1>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+};


### PR DESCRIPTION
Add device tree overlay to use AD5766 on Raspberry Pi

Signed-off-by: Denis Gheorghescu <denis.gheorghescu@analog.com>