### PR TITLE
iio: axi-adc: remove dp_disable logic

### DIFF
--- a/drivers/iio/adc/cf_axi_adc.h
+++ b/drivers/iio/adc/cf_axi_adc.h
@@ -178,8 +178,6 @@ enum adc_data_sel {
 #define ADI_USR_DECIMATION_N(x)			(((x) & 0xFFFF) << 0)
 #define ADI_TO_USR_DECIMATION_N(x)		(((x) >> 0) & 0xFFFF)
 
-#define ADI_REG_ADC_DP_DISABLE 			0x00C0
-
 /* PCORE Version > 8.00 */
 #define ADI_REG_DELAY(l)				(0x0800 + (l) * 0x4)
 
@@ -218,7 +216,6 @@ struct axiadc_state {
 	unsigned			pcore_version;
 	unsigned			decimation_factor;
 	unsigned int                    oversampling_ratio;
-	bool				dp_disable;
 	unsigned long long		adc_clk;
 	unsigned			have_slave_channels;
 	bool				additional_channel;


### PR DESCRIPTION
This change was added via commit dce736008005d "drivers/iio/adc/cf_axi_adc:
add support for ADC_DP_DISABLE".

The problem is that at address ADI_REG_ADC_DP_DISABLE (0x00C0), the reg is
now something else.
It's ADI_REG_CLOCKS_PER_PPS.

This change removes the logic.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>