### PR TITLE
hwmon: adm1177: Sync with upstream version

### DIFF
--- a/Documentation/devicetree/bindings/hwmon/adi,adm1177.yaml
+++ b/Documentation/devicetree/bindings/hwmon/adi,adm1177.yaml
@@ -58,7 +58,7 @@ examples:
         pwmon@5a {
                 compatible = "adi,adm1177";
                 reg = <0x5a>;
-		shunt-resistor-micro-ohms = <50000>; /* 50 mOhm */
+                shunt-resistor-micro-ohms = <50000>; /* 50 mOhm */
                 adi,shutdown-threshold-microamp = <1059000>; /* 1.059 A */
                 adi,vrange-high-enable;
         };

--- a/drivers/hwmon/adm1177.c
+++ b/drivers/hwmon/adm1177.c
@@ -63,7 +63,7 @@ static int adm1177_write_alert_thr(struct adm1177_state *st,
 
 	ret = i2c_smbus_write_byte_data(st->client, ADM1177_REG_ALERT_TH,
 					val);
-	if (!ret)
+	if (ret)
 		return ret;
 
 	st->alert_threshold_ua = alert_threshold_ua;


### PR DESCRIPTION
This patch sync the adm1177 hwmon driver with the upstream version.

Signed-off-by: Beniamin Bia <beniamin.bia@analog.com>