### PR TITLE
iio: dac: ad5766: remove useless cases

### DIFF
--- a/drivers/iio/dac/ad5766.c
+++ b/drivers/iio/dac/ad5766.c
@@ -105,14 +105,6 @@ static int ad5766_write_raw(struct iio_dev *indio_dev,
 			return -EINVAL;
 		val <<= chan->scan_type.shift;
 		break;
-	case IIO_CHAN_INFO_CALIBBIAS:
-		if (val >= 128 || val < -128)
-			return -EINVAL;
-		break;
-	case IIO_CHAN_INFO_CALIBSCALE:
-		if (val >= 32 || val < -32)
-			return -EINVAL;
-		break;
 	default:
 		return -EINVAL;
 	}


### PR DESCRIPTION
remove useless cases (`IIO_CHAN_INFO_CALIBBIAS` and
`IIO_CHAN_INFO_CALIBSCALE`) in function `ad5766_write_raw`

Signed-off-by: Denis Gheorghescu <denis.gheorghescu@analog.com>