### PR TITLE
Rename adm1177

### DIFF
--- a/ci/travis/adi_zynqmp_defconfig_compile_exceptions
+++ b/ci/travis/adi_zynqmp_defconfig_compile_exceptions
@@ -42,3 +42,4 @@ drivers/media/platform/imageon-bridge.o
 drivers/gpio/gpio-adi-daq1.o
 drivers/iio/jesd204/axi_jesd204b_gt.o
 drivers/iio/jesd204/axi_jesd204b_v51.o
+drivers/iio/adc/adm1177.o

--- a/ci/travis/zynq_xcomm_adv7511_defconfig_compile_exceptions
+++ b/ci/travis/zynq_xcomm_adv7511_defconfig_compile_exceptions
@@ -37,3 +37,4 @@ drivers/misc/xilinx_lcd.o
 sound/pci/ac97/ac97_codec.o
 sound/pci/ac97/ac97_proc.o
 sound/soc/codecs/ad1980.o
+drivers/iio/adc/adm1177.o

--- a/drivers/iio/Kconfig.adi
+++ b/drivers/iio/Kconfig.adi
@@ -33,7 +33,6 @@ config IIO_ALL_ADI_DRIVERS
 	select AD7887
 	select AD799X
 	select AD9963
-	select ADM1177
 	select CF_AXI_ADC
 	select AD9208
 	select AD9081

--- a/drivers/iio/adc/adm1177.c
+++ b/drivers/iio/adc/adm1177.c
@@ -232,7 +232,7 @@ MODULE_DEVICE_TABLE(of, nau7802_dt_ids);
 
 static struct i2c_driver adm1177_driver = {
 	.driver = {
-		.name = KBUILD_MODNAME,
+		.name = "adm1177-iio",
 		.of_match_table = adm1177_dt_ids,
 	},
 	.probe = adm1177_probe,


### PR DESCRIPTION
The iio adm1177 driver was removed and replaced by hwmon driver for pluto.