### PR TITLE
axi-adc,arch,ad9467: use 'adi,axi-adc-10.0.a' compat string

### DIFF
--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad9467-fmc-250ebz.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad9467-fmc-250ebz.dts
@@ -38,7 +38,7 @@
 	};
 
 	cf_ad9467_core_0: cf-ad9467-core-lpc@44a00000 {
-		compatible = "xlnx,cf-ad9467-core-1.00.a";
+		compatible = "adi,axi-adc-10.0.a";
 		reg = <0x44A00000 0x10000>;
 		dmas = <&rx_dma 0>;
 		dma-names = "rx";

--- a/arch/microblaze/boot/dts/kc705_ad9467_fmc.dts
+++ b/arch/microblaze/boot/dts/kc705_ad9467_fmc.dts
@@ -18,7 +18,7 @@
 
 &amba_pl {
 	axi_ad9467: cf-ad9467-core-lpc@44a00000 {
-		compatible = "xlnx,cf-ad9467-core-1.00.a";
+		compatible = "adi,axi-adc-10.0.a";
 		reg = <0x44a00000 0x10000>;
 		xlnx,s-axi-min-size = <0x0000FFFF>;
 		dmas = <&rx_dma 0>;

--- a/drivers/iio/adc/cf_axi_adc_core.c
+++ b/drivers/iio/adc/cf_axi_adc_core.c
@@ -703,7 +703,6 @@ static const struct axiadc_core_info axi_adc_10_0_a_info = {
 
 /* Match table for of_platform binding */
 static const struct of_device_id axiadc_of_match[] = {
-	{ .compatible = "xlnx,cf-ad9467-core-1.00.a", .data = &axi_adc_10_0_a_info },
 	{ .compatible =	"xlnx,axi-ad9234-1.00.a", .data = &axi_adc_10_0_a_info },
 	{ .compatible =	"xlnx,axi-ad9250-1.00.a", .data = &axi_adc_10_0_a_info },
 	{ .compatible =	"xlnx,axi-ad9434-1.00.a", .data = &axi_adc_10_0_a_info },


### PR DESCRIPTION
This change replaces all uses of 'xlnx,cf-ad9467-core-1.00.a' with
'adi,axi-adc-10.0.a'.

The aim is to unify usage and cleanup the AXI ADC driver.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>