### PR TITLE
arm64: dts: fmcomms5: Specify correct compatible string for dac_core_0

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9361-fmcomms5.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9361-fmcomms5.dts
@@ -89,7 +89,7 @@
 		};
 
 		cf_ad9361_dac_core_0: cf-ad9361-dds-core-lpc@99024000 {
-			compatible = "adi,axi-ad9361-dds-6.00.a";
+			compatible = "adi,axi-ad9361x2-dds-6.00.a";
 			reg = <0x99024000 0x1000>;
 			clocks = <&adc0_ad9361 13>;
 			clock-names = "sampl_clk";


### PR DESCRIPTION
For the master HDL core with DMA, a different compatible string must be
used to enable all 8 required buffer channels (otherwise, only 4 are
enabled).

Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>