### PR TITLE
iio: ad9361,ad9371,adrv9009: remove support for old cores

### DIFF
--- a/drivers/iio/adc/ad9371_conv.c
+++ b/drivers/iio/adc/ad9371_conv.c
@@ -138,28 +138,18 @@ int ad9371_hdl_loopback(struct ad9371_rf_phy *phy, bool enable)
 	version = axiadc_read(st, 0x4000);
 
 	/* Still there but implemented a bit different */
-	if (ADI_AXI_PCORE_VER_MAJOR(version) > 7)
-		addr = 0x4418;
-	else
-		addr = 0x4414;
+	addr = 0x4418;
 
 	for (chan = 0; chan < conv->chip_info->num_channels; chan++) {
 		reg = axiadc_read(st, addr + (chan) * 0x40);
 
-		if (ADI_AXI_PCORE_VER_MAJOR(version) > 7) {
-			if (enable && reg != 0x8) {
-				conv->scratch_reg[chan] = reg;
-				reg = 0x8;
-			} else if (reg == 0x8) {
-				reg = conv->scratch_reg[chan];
-			}
-		} else {
-		/* DAC_LB_ENB If set enables loopback of receive data */
-			if (enable)
-				reg |= BIT(1);
-			else
-				reg &= ~BIT(1);
+		if (enable && reg != 0x8) {
+			conv->scratch_reg[chan] = reg;
+			reg = 0x8;
+		} else if (reg == 0x8) {
+			reg = conv->scratch_reg[chan];
 		}
+
 		axiadc_write(st, addr + (chan) * 0x40, reg);
 	}
 

--- a/drivers/iio/adc/adrv9009_conv.c
+++ b/drivers/iio/adc/adrv9009_conv.c
@@ -167,28 +167,17 @@ int adrv9009_hdl_loopback(struct adrv9009_rf_phy *phy, bool enable)
 	st = iio_priv(conv->indio_dev);
 	version = axiadc_read(st, 0x4000);
 
-	/* Still there but implemented a bit different */
-	if (ADI_AXI_PCORE_VER_MAJOR(version) > 7)
-		addr = 0x4418;
-	else
-		addr = 0x4414;
+	addr = 0x4418;
 
 	for (chan = 0; chan < conv->chip_info->num_channels; chan++) {
 		reg = axiadc_read(st, addr + (chan) * 0x40);
 
-		if (ADI_AXI_PCORE_VER_MAJOR(version) > 7) {
-			if (enable && reg != 0x8) {
-				conv->scratch_reg[chan] = reg;
-				reg = 0x8;
-			} else if (reg == 0x8)
-				reg = conv->scratch_reg[chan];
-		} else {
-			/* DAC_LB_ENB If set enables loopback of receive data */
-			if (enable)
-				reg |= BIT(1);
-			else
-				reg &= ~BIT(1);
-		}
+		if (enable && reg != 0x8) {
+			conv->scratch_reg[chan] = reg;
+			reg = 0x8;
+		} else if (reg == 0x8)
+			reg = conv->scratch_reg[chan];
+
 		axiadc_write(st, addr + (chan) * 0x40, reg);
 	}
 


### PR DESCRIPTION
The code was likely written for ad9361 and duplicated for ad9371 and
adrv9009.
Quite a few version checks are there, but for 9371 and 9009 it's likely
that those cores never had support for these chips. And for 9361 we
shouldn't support this in master, so just drop it.

This cleans up the drivers a bit.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>