### PR TITLE
iio: axi-adc: misc cleanups of the driver

### DIFF
--- a/drivers/iio/adc/cf_axi_adc.h
+++ b/drivers/iio/adc/cf_axi_adc.h
@@ -300,15 +300,7 @@ struct axiadc_converter {
 
 
 
-static inline struct axiadc_converter *to_converter(struct device *dev)
-{
-	struct axiadc_converter *conv = spi_get_drvdata(to_spi_device(dev));
-
-	if (conv)
-		return conv;
-
-	return ERR_PTR(-ENODEV);
-};
+struct axiadc_converter *to_converter(struct device *dev);
 
 struct axiadc_spidev {
 	struct device_node *of_nspi;
@@ -319,32 +311,14 @@ struct axiadc_spidev {
  * IO accessors
  */
 
-static inline void axiadc_write(struct axiadc_state *st, unsigned reg, unsigned val)
-{
-	iowrite32(val, st->regs + reg);
-}
+void axiadc_write(struct axiadc_state *st, unsigned int reg, unsigned int val);
+unsigned int axiadc_read(struct axiadc_state *st, unsigned int reg);
+void axiadc_slave_write(struct axiadc_state *st, unsigned int reg,
+			unsigned int val);
+unsigned int axiadc_slave_read(struct axiadc_state *st, unsigned int reg);
 
-static inline unsigned int axiadc_read(struct axiadc_state *st, unsigned reg)
-{
-	return ioread32(st->regs + reg);
-}
-
-static inline void axiadc_slave_write(struct axiadc_state *st, unsigned reg, unsigned val)
-{
-	iowrite32(val, st->slave_regs + reg);
-}
-
-static inline unsigned int axiadc_slave_read(struct axiadc_state *st, unsigned reg)
-{
-	return ioread32(st->slave_regs + reg);
-}
-
-
-static inline void axiadc_idelay_set(struct axiadc_state *st,
-				unsigned lane, unsigned val)
-{
-	axiadc_write(st, ADI_REG_DELAY(lane), val);
-}
+void axiadc_idelay_set(struct axiadc_state *st, unsigned int lane,
+		       unsigned int val);
 
 int axiadc_set_pnsel(struct axiadc_state *st, int channel, enum adc_pn_sel sel);
 enum adc_pn_sel axiadc_get_pnsel(struct axiadc_state *st,

--- a/drivers/iio/adc/cf_axi_adc.h
+++ b/drivers/iio/adc/cf_axi_adc.h
@@ -343,15 +343,7 @@ static inline unsigned int axiadc_slave_read(struct axiadc_state *st, unsigned r
 static inline void axiadc_idelay_set(struct axiadc_state *st,
 				unsigned lane, unsigned val)
 {
-	if (ADI_AXI_PCORE_VER_MAJOR(st->pcore_version) > 8) {
-		axiadc_write(st, ADI_REG_DELAY(lane), val);
-	} else {
-		axiadc_write(st, ADI_REG_DELAY_CNTRL, 0);
-		axiadc_write(st, ADI_REG_DELAY_CNTRL,
-				ADI_DELAY_ADDRESS(lane)
-				| ADI_DELAY_WDATA(val)
-				| ADI_DELAY_SEL);
-	}
+	axiadc_write(st, ADI_REG_DELAY(lane), val);
 }
 
 int axiadc_set_pnsel(struct axiadc_state *st, int channel, enum adc_pn_sel sel);

--- a/drivers/iio/adc/cf_axi_adc_core.c
+++ b/drivers/iio/adc/cf_axi_adc_core.c
@@ -108,11 +108,6 @@ enum adc_pn_sel axiadc_get_pnsel(struct axiadc_state *st,
 	}
 }
 
-static void axiadc_toggle_scale_offset_en(struct axiadc_state *st)
-{
-	return;
-}
-
 static unsigned int axiadc_num_phys_channels(struct axiadc_state *st)
 {
 	struct axiadc_converter *conv = to_converter(st->dev_spi);
@@ -490,8 +485,6 @@ static int axiadc_write_raw(struct iio_dev *indio_dev,
 
 		axiadc_write(st, ADI_REG_CHAN_CNTRL_2(channel), tmp);
 
-		axiadc_toggle_scale_offset_en(st);
-
 		return 0;
 
 	case IIO_CHAN_INFO_HIGH_PASS_FILTER_3DB_FREQUENCY:
@@ -524,7 +517,6 @@ static int axiadc_write_raw(struct iio_dev *indio_dev,
 		tmp |= ADI_DCFILT_OFFSET((short)val);
 
 		axiadc_write(st, ADI_REG_CHAN_CNTRL_1(channel), tmp);
-		axiadc_toggle_scale_offset_en(st);
 		return 0;
 
 	case IIO_CHAN_INFO_SAMP_FREQ:

--- a/drivers/iio/adc/cf_axi_adc_core.c
+++ b/drivers/iio/adc/cf_axi_adc_core.c
@@ -37,6 +37,47 @@ struct axiadc_core_info {
 	unsigned int version;
 };
 
+struct axiadc_converter *to_converter(struct device *dev)
+{
+	struct axiadc_converter *conv = spi_get_drvdata(to_spi_device(dev));
+
+	if (conv)
+		return conv;
+
+	return ERR_PTR(-ENODEV);
+}
+EXPORT_SYMBOL_GPL(to_converter);
+
+void axiadc_write(struct axiadc_state *st, unsigned reg, unsigned val)
+{
+	iowrite32(val, st->regs + reg);
+}
+EXPORT_SYMBOL_GPL(axiadc_write);
+
+unsigned int axiadc_read(struct axiadc_state *st, unsigned reg)
+{
+	return ioread32(st->regs + reg);
+}
+EXPORT_SYMBOL_GPL(axiadc_read);
+
+void axiadc_slave_write(struct axiadc_state *st, unsigned reg, unsigned val)
+{
+	iowrite32(val, st->slave_regs + reg);
+}
+EXPORT_SYMBOL_GPL(axiadc_slave_write);
+
+unsigned int axiadc_slave_read(struct axiadc_state *st, unsigned reg)
+{
+	return ioread32(st->slave_regs + reg);
+}
+EXPORT_SYMBOL_GPL(axiadc_slave_read);
+
+void axiadc_idelay_set(struct axiadc_state *st, unsigned lane, unsigned val)
+{
+	axiadc_write(st, ADI_REG_DELAY(lane), val);
+}
+EXPORT_SYMBOL_GPL(axiadc_idelay_set);
+
 static int axiadc_chan_to_regoffset(struct iio_chan_spec const *chan)
 {
 	if (chan->modified)


### PR DESCRIPTION
This change-set:
* removes the empty axiadc_toggle_scale_offset_en() func
* removes left-over support for old cores
* moves inline functions to the driver; the intent is to make `struct axiadc_state` opaque

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>