### PR TITLE
Fix vco ranges

### DIFF
--- a/drivers/iio/jesd204/xilinx_transceiver.c
+++ b/drivers/iio/jesd204/xilinx_transceiver.c
@@ -309,13 +309,16 @@ static void xilinx_xcvr_setup_cpll_vco_range(struct xilinx_xcvr *xcvr,
 					     unsigned int *vco_max)
 {
 	if  ((xcvr->type == XILINX_XCVR_TYPE_US_GTH3) |
-	     (xcvr->type == XILINX_XCVR_TYPE_US_GTH4) |
-	     (xcvr->type == XILINX_XCVR_TYPE_US_GTY4)) {
-		if (xcvr->voltage < 850)
+	     (xcvr->type == XILINX_XCVR_TYPE_US_GTH4)) {
+		if ((xcvr->voltage < 850))
 			*vco_max = 4250000;
 		else if ((xcvr->speed_grade / 10) == 1)
 			*vco_max = 4250000;
 	}
+
+	if (xcvr->type == XILINX_XCVR_TYPE_US_GTY4)
+		if ((xcvr->speed_grade / 10) == 1)
+			*vco_max = 4250000;
 }
 
 static void xilinx_xcvr_setup_qpll_vco_range(struct xilinx_xcvr *xcvr,

--- a/drivers/iio/jesd204/xilinx_transceiver.c
+++ b/drivers/iio/jesd204/xilinx_transceiver.c
@@ -324,31 +324,14 @@ static void xilinx_xcvr_setup_qpll_vco_range(struct xilinx_xcvr *xcvr,
 					     unsigned int *vco1_min,
 					     unsigned int *vco1_max)
 {
-	switch (xcvr->type) {
-	case XILINX_XCVR_TYPE_S7_GTX2:
-		if ((xcvr->dev_package == ADI_AXI_FPGA_DEV_FB) |
-		    (xcvr->dev_package == ADI_AXI_FPGA_DEV_SB))
-			*vco0_max = 6600000;
+	if (xcvr->type == XILINX_XCVR_TYPE_S7_GTX2) {
+		if ((xcvr->family == ADI_AXI_FPGA_FAMILY_KINTEX))
+			if ((xcvr->dev_package == ADI_AXI_FPGA_DEV_FB) |
+			    (xcvr->dev_package == ADI_AXI_FPGA_DEV_RF) |
+			    (xcvr->dev_package == ADI_AXI_FPGA_DEV_FF))
+				*vco0_max = 6600000;
 		if ((xcvr->speed_grade / 10) == 2)
 			*vco1_max = 10312500;
-		break;
-	case XILINX_XCVR_TYPE_US_GTH3:
-	case XILINX_XCVR_TYPE_US_GTH4:
-	case XILINX_XCVR_TYPE_US_GTY4:
-		*vco1_min = 8000000;
-		*vco1_max = 13000000;
-		if (((xcvr->voltage < 900) | (xcvr->voltage > 720)) &
-		    ((xcvr->speed_grade / 10) == 1)) {
-			*vco0_max = 12500000;
-			*vco1_max = *vco0_max;
-		}
-		if (xcvr->voltage == 720) {
-			if ((xcvr->speed_grade / 10) == 2)
-				*vco0_max = 12500000;
-			else if ((xcvr->speed_grade / 10) == 1)
-				*vco0_max = 10312500;
-			*vco1_max = *vco0_max;
-		}
 	}
 }
 


### PR DESCRIPTION
This patch set fixes the VCO ranges for CPLL and QPLL. 

Before this they where limited based on some errored presumptions related on lane rate rather than VCO range.

For reference I will sources that were consulted for this information:
**GTX transceivers**:
https://www.xilinx.com/support/documentation/data_sheets/ds191-XC7Z030-XC7Z045-data-sheet.pdf - Table 91
https://www.xilinx.com/support/documentation/data_sheets/ds182_Kintex_7_Data_Sheet.pdf - Table 56
https://www.xilinx.com/support/documentation/data_sheets/ds183_Virtex_7_Data_Sheet.pdf - Table 55

**GTH transceivers:**
https://www.xilinx.com/support/documentation/data_sheets/ds892-kintex-ultrascale-data-sheet.pdf - Table 51
https://www.xilinx.com/support/documentation/data_sheets/ds893-virtex-ultrascale-data-sheet.pdf - Table 51
https://www.xilinx.com/support/documentation/data_sheets/ds922-kintex-ultrascale-plus.pdf - Table 52
3https://www.xilinx.com/support/documentation/data_sheets/ds925-zynq-ultrascale-plus.pdf - Table 99

**GTY transceivers:**
https://www.xilinx.com/support/documentation/data_sheets/ds892-kintex-ultrascale-data-sheet.pdf - Table 69
https://www.xilinx.com/support/documentation/data_sheets/ds893-virtex-ultrascale-data-sheet.pdf - Table 69
https://www.xilinx.com/support/documentation/data_sheets/ds922-kintex-ultrascale-plus.pdf - Table 64
3https://www.xilinx.com/support/documentation/data_sheets/ds925-zynq-ultrascale-plus.pdf - Table 111
https://www.xilinx.com/support/documentation/data_sheets/ds923-virtex-ultrascale-plus.pdf - Table 51