### PR TITLE
jesd204: Add encoder sysfs attr

### DIFF
--- a/drivers/iio/jesd204/axi_jesd204.h
+++ b/drivers/iio/jesd204/axi_jesd204.h
@@ -12,7 +12,14 @@
 enum jesd204_encoder {
 	JESD204_ENCODER_UNKNOWN,
 	JESD204_ENCODER_8B10B,
-	JESD204_ENCODER_64B66B
+	JESD204_ENCODER_64B66B,
+	JESD204_ENCODER_MAX,
+};
+
+static const char *axi_jesd204_encoder_label[JESD204_ENCODER_MAX] = {
+	"unknown",
+	"8b10b",
+	"64b66b"
 };
 
 #endif

--- a/drivers/iio/jesd204/axi_jesd204_rx.c
+++ b/drivers/iio/jesd204/axi_jesd204_rx.c
@@ -211,6 +211,16 @@ static ssize_t axi_jesd204_rx_status_read(struct device *dev,
 
 static DEVICE_ATTR(status, 0444, axi_jesd204_rx_status_read, NULL);
 
+static ssize_t encoder_show(struct device *dev, struct device_attribute *attr,
+			    char *buf)
+{
+	struct axi_jesd204_rx *jesd = dev_get_drvdata(dev);
+
+	return sprintf(buf, "%s", axi_jesd204_encoder_label[jesd->encoder]);
+}
+
+static DEVICE_ATTR_RO(encoder);
+
 static const char *const axi_jesd204_rx_lane_status_label[] = {
 	"INIT",
 	"CHECK",
@@ -748,6 +758,8 @@ static int axi_jesd204_rx_probe(struct platform_device *pdev)
 	/* backward compatibility with older HDL cores */
 	if (jesd->encoder == JESD204_ENCODER_UNKNOWN)
 		jesd->encoder = JESD204_ENCODER_8B10B;
+	else if (jesd->encoder >= JESD204_ENCODER_MAX)
+		goto err_axi_clk_disable;
 
 	ret = axi_jesd204_rx_apply_config(jesd, &config);
 	if (ret)
@@ -811,6 +823,7 @@ static int axi_jesd204_rx_probe(struct platform_device *pdev)
 	}
 
 	device_create_file(&pdev->dev, &dev_attr_status);
+	device_create_file(&pdev->dev, &dev_attr_encoder);
 
 	return 0;
 


### PR DESCRIPTION
This patch adds a sysfs attribute to read the encoding scheme being used.

Signed-off-by: Nuno Sá <nuno.sa@analog.com>