### PR TITLE
iio: adc: ad9361: Fix ad9361_set_trx_clock_chain()

### DIFF
--- a/drivers/iio/adc/ad9361.c
+++ b/drivers/iio/adc/ad9361.c
@@ -4073,6 +4073,7 @@ static int ad9361_set_trx_clock_chain(struct ad9361_rf_phy *phy,
 {
 	struct device *dev = &phy->spi->dev;
 	struct ad9361_rf_phy_state *st = phy->state;
+	struct axiadc_converter *conv = spi_get_drvdata(phy->spi);
 	int ret, i, j, n;
 
 	dev_dbg(&phy->spi->dev, "%s", __func__);
@@ -4142,12 +4143,12 @@ static int ad9361_set_trx_clock_chain(struct ad9361_rf_phy *phy,
 
 	if ((!phy->pdata->dig_interface_tune_fir_disable &&
 		!(st->bypass_tx_fir && st->bypass_rx_fir)) &&
-		!phy->pdata->bb_clk_change_dig_tune_en)
+		!phy->pdata->bb_clk_change_dig_tune_en && conv)
 		ret = ad9361_dig_tune(phy, 0, SKIP_STORE_RESULT);
 	if (ret < 0)
 		return ret;
 
-	if (phy->pdata->bb_clk_change_dig_tune_en)
+	if (phy->pdata->bb_clk_change_dig_tune_en && conv)
 		ret = ad9361_dig_tune(phy, 0, 0);
 	if (ret < 0)
 		return ret;


### PR DESCRIPTION
ad9361_dig_tune() shouldn't be called if conv is not available. This
situation occurs when ad9361_setup() is called by ad9361_probe()
(axi_converver is not yet registered using ad9361_register_axi_converter).

Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>