### PR TITLE
dts: overlays: Add dt overlay for AD5677R

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -131,6 +131,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	rpi-adau1761.dtbo \
 	rpi-addi9036.dtbo \
 	rpi-adf4371.dtbo \
+	rpi-ad5677r.dtbo \
 	rpi-ad5686.dtbo \
 	rpi-ad5766.dtbo \
 	rpi-ad7124.dtbo \

--- a/arch/arm/boot/dts/overlays/rpi-ad5677r-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ad5677r-overlay.dts
@@ -1,0 +1,34 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2708";
+
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			adc_vref: fixedregulator@0 {
+				compatible = "regulator-fixed";
+				regulator-name = "fixed-supply";
+				regulator-min-microvolt = <2500000>;
+				regulator-max-microvolt = <2500000>;
+				regulator-boot-on;
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&i2c1>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			ad5677r@0f{
+				compatible = "adi,ad5677r";
+				reg = <0x0f>;
+				vcc-supply = <&adc_vref>;
+			};
+		};
+	};
+};


### PR DESCRIPTION
This patch adds a device tree example for AD5677R nanoDAC+.

Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>