### PR TITLE
iio: amplifiers: sync with upstream changes

### DIFF
--- a/drivers/iio/amplifiers/ad8366.c
+++ b/drivers/iio/amplifiers/ad8366.c
@@ -210,9 +210,22 @@ static int ad8366_write_raw(struct iio_dev *indio_dev,
 	return ret;
 }
 
+static int ad8366_write_raw_get_fmt(struct iio_dev *indio_dev,
+				    struct iio_chan_spec const *chan,
+				    long mask)
+{
+	switch (mask) {
+	case IIO_CHAN_INFO_HARDWAREGAIN:
+		return IIO_VAL_INT_PLUS_MICRO_DB;
+	default:
+		return -EINVAL;
+	}
+}
+
 static const struct iio_info ad8366_info = {
 	.read_raw = &ad8366_read_raw,
 	.write_raw = &ad8366_write_raw,
+	.write_raw_get_fmt = &ad8366_write_raw_get_fmt,
 };
 
 #define AD8366_CHAN(_channel) {				\

--- a/drivers/iio/amplifiers/hmc425a.c
+++ b/drivers/iio/amplifiers/hmc425a.c
@@ -2,76 +2,71 @@
 /*
  * HMC425A and similar Gain Amplifiers
  *
- * Copyright 2019 Analog Devices Inc.
+ * Copyright 2020 Analog Devices Inc.
  */
 
 #include <linux/device.h>
-#include <linux/kernel.h>
-#include <linux/slab.h>
-#include <linux/sysfs.h>
-#include <linux/regulator/consumer.h>
-#include <linux/gpio/consumer.h>
 #include <linux/err.h>
-#include <linux/module.h>
+#include <linux/gpio/consumer.h>
 #include <linux/iio/iio.h>
 #include <linux/iio/sysfs.h>
-#include <linux/platform_device.h>
+#include <linux/kernel.h>
+#include <linux/module.h>
 #include <linux/of_device.h>
 #include <linux/of_platform.h>
-
-#define HMC425A_NR_GPIOS	6
+#include <linux/platform_device.h>
+#include <linux/slab.h>
+#include <linux/regulator/consumer.h>
+#include <linux/sysfs.h>
 
 enum hmc425a_type {
 	ID_HMC425A,
 };
 
-struct hmc425a_info {
-	int gain_min;
-	int gain_max;
+struct hmc425a_chip_info {
+	const char			*name;
+	const struct iio_chan_spec	*channels;
+	unsigned int			num_channels;
+	unsigned int			num_gpios;
+	int				gain_min;
+	int				gain_max;
+	int				default_gain;
 };
 
 struct hmc425a_state {
-	struct regulator *reg;
-	struct mutex lock; /* protect sensor state */
-	struct hmc425a_info *info;
-	struct gpio_descs *gpios;
-	enum hmc425a_type type;
-	u32 value;
-};
-
-static struct hmc425a_info hmc425a_infos[] = {
-	[ID_HMC425A] = {
-		.gain_min = -31500,
-		.gain_max = 0,
-	},
+	struct	regulator *reg;
+	struct	mutex lock; /* protect sensor state */
+	struct	hmc425a_chip_info *chip_info;
+	struct	gpio_descs *gpios;
+	enum	hmc425a_type type;
+	u32	gain;
 };
 
 static int hmc425a_write(struct iio_dev *indio_dev, u32 value)
 {
 	struct hmc425a_state *st = iio_priv(indio_dev);
-	int i, values[HMC425A_NR_GPIOS];
+	int i, values[6];
 
 	for (i = 0; i < st->gpios->ndescs; i++)
 		values[i] = (value >> i) & 1;
 
 	gpiod_set_array_value_cansleep(st->gpios->ndescs, st->gpios->desc,
 				       values);
-
 	return 0;
 }
 
 static int hmc425a_read_raw(struct iio_dev *indio_dev,
-			   struct iio_chan_spec const *chan, int *val,
-			   int *val2, long m)
+			    struct iio_chan_spec const *chan, int *val,
+			    int *val2, long m)
 {
 	struct hmc425a_state *st = iio_priv(indio_dev);
-	int ret;
 	int code, gain = 0;
+	int ret;
 
 	mutex_lock(&st->lock);
 	switch (m) {
 	case IIO_CHAN_INFO_HARDWAREGAIN:
-		code = st->value;
+		code = st->gain;
 
 		switch (st->type) {
 		case ID_HMC425A:
@@ -79,7 +74,6 @@ static int hmc425a_read_raw(struct iio_dev *indio_dev,
 			break;
 		}
 
-		/* Values in dB */
 		*val = gain / 1000;
 		*val2 = (gain % 1000) * 1000;
 
@@ -94,15 +88,14 @@ static int hmc425a_read_raw(struct iio_dev *indio_dev,
 };
 
 static int hmc425a_write_raw(struct iio_dev *indio_dev,
-			    struct iio_chan_spec const *chan, int val, int val2,
-			    long mask)
+			     struct iio_chan_spec const *chan, int val,
+			     int val2, long mask)
 {
 	struct hmc425a_state *st = iio_priv(indio_dev);
-	struct hmc425a_info *inf = st->info;
+	struct hmc425a_chip_info *inf = st->chip_info;
 	int code = 0, gain;
 	int ret;
 
-	/* Values in dB */
 	if (val < 0)
 		gain = (val * 1000) - (val2 / 1000);
 	else
@@ -120,9 +113,9 @@ static int hmc425a_write_raw(struct iio_dev *indio_dev,
 	mutex_lock(&st->lock);
 	switch (mask) {
 	case IIO_CHAN_INFO_HARDWAREGAIN:
-		st->value = code;
+		st->gain = code;
 
-		ret = hmc425a_write(indio_dev, st->value);
+		ret = hmc425a_write(indio_dev, st->gain);
 		break;
 	default:
 		ret = -EINVAL;
@@ -132,16 +125,31 @@ static int hmc425a_write_raw(struct iio_dev *indio_dev,
 	return ret;
 }
 
+static int hmc425a_write_raw_get_fmt(struct iio_dev *indio_dev,
+				     struct iio_chan_spec const *chan,
+				     long mask)
+{
+	switch (mask) {
+	case IIO_CHAN_INFO_HARDWAREGAIN:
+		return IIO_VAL_INT_PLUS_MICRO_DB;
+	default:
+		return -EINVAL;
+	}
+}
+
 static const struct iio_info hmc425a_info = {
 	.read_raw = &hmc425a_read_raw,
 	.write_raw = &hmc425a_write_raw,
+	.write_raw_get_fmt = &hmc425a_write_raw_get_fmt,
 };
 
-#define HMC425A_CHAN(_channel)                                          \
-{                                                                      \
-	.type = IIO_VOLTAGE, .output = 1, .indexed = 1,                \
-	.channel = _channel,                                           \
-	.info_mask_separate = BIT(IIO_CHAN_INFO_HARDWAREGAIN),         \
+#define HMC425A_CHAN(_channel)						\
+{									\
+	.type = IIO_VOLTAGE,						\
+	.output = 1,							\
+	.indexed = 1,							\
+	.channel = _channel,						\
+	.info_mask_separate = BIT(IIO_CHAN_INFO_HARDWAREGAIN),		\
 }
 
 static const struct iio_chan_spec hmc425a_channels[] = {
@@ -150,24 +158,48 @@ static const struct iio_chan_spec hmc425a_channels[] = {
 
 /* Match table for of_platform binding */
 static const struct of_device_id hmc425a_of_match[] = {
-	{ .compatible = "adi,hmc425a", .data = (void *) ID_HMC425A },
+	{ .compatible = "adi,hmc425a", .data = (void *)ID_HMC425A },
 	{},
 };
 MODULE_DEVICE_TABLE(of, hmc425a_of_match);
 
+static void hmc425a_reg_disable(void *data)
+{
+	struct hmc425a_state *st = data;
+
+	regulator_disable(st->reg);
+}
+
+static struct hmc425a_chip_info hmc425a_chip_info_tbl[] = {
+	[ID_HMC425A] = {
+		.name = "hmc425a",
+		.channels = hmc425a_channels,
+		.num_channels = ARRAY_SIZE(hmc425a_channels),
+		.num_gpios = 6,
+		.gain_min = -31500,
+		.gain_max = 0,
+		.default_gain = -0x40, /* set default gain -31.5db*/
+	},
+};
+
 static int hmc425a_probe(struct platform_device *pdev)
 {
 	struct iio_dev *indio_dev;
-	const struct of_device_id *id;
 	struct hmc425a_state *st;
-	struct device_node *np = pdev->dev.of_node;
 	int ret;
 
 	indio_dev = devm_iio_device_alloc(&pdev->dev, sizeof(*st));
-	if (indio_dev == NULL)
+	if (!indio_dev)
 		return -ENOMEM;
 
 	st = iio_priv(indio_dev);
+	st->type = (enum hmc425a_type)of_device_get_match_data(&pdev->dev);
+
+	st->chip_info = &hmc425a_chip_info_tbl[st->type];
+	indio_dev->num_channels = st->chip_info->num_channels;
+	indio_dev->channels = st->chip_info->channels;
+	indio_dev->name = st->chip_info->name;
+	st->gain = st->chip_info->default_gain;
 
 	st->gpios = devm_gpiod_get_array(&pdev->dev, "ctrl", GPIOD_OUT_LOW);
 	if (IS_ERR(st->gpios)) {
@@ -177,73 +209,30 @@ static int hmc425a_probe(struct platform_device *pdev)
 		return ret;
 	}
 
-	if (st->gpios->ndescs != HMC425A_NR_GPIOS) {
+	if (st->gpios->ndescs != st->chip_info->num_gpios) {
 		dev_err(&pdev->dev, "%d GPIOs needed to operate\n",
-			HMC425A_NR_GPIOS);
+			st->chip_info->num_gpios);
 		return -ENODEV;
 	}
 
-	st->reg = devm_regulator_get(&pdev->dev, "vcc");
-	if (!IS_ERR(st->reg)) {
-		ret = regulator_enable(st->reg);
-		if (ret)
-			return ret;
-	}
+	st->reg = devm_regulator_get(&pdev->dev, "vcc-supply");
+	if (IS_ERR(st->reg))
+		return PTR_ERR(st->reg);
 
-	platform_set_drvdata(pdev, indio_dev);
+	ret = regulator_enable(st->reg);
+	if (ret)
+		return ret;
+	ret = devm_add_action_or_reset(&pdev->dev, hmc425a_reg_disable, st);
+	if (ret)
+		return ret;
+
 	mutex_init(&st->lock);
 
-	id = of_match_device(hmc425a_of_match, &pdev->dev);
-	if (!id) {
-		ret = -ENODEV;
-		goto error_disable_reg;
-	}
-
-	st->type = (enum hmc425a_type)id->data;
-
-	switch (st->type) {
-	case ID_HMC425A:
-		indio_dev->channels = hmc425a_channels;
-		indio_dev->num_channels = ARRAY_SIZE(hmc425a_channels);
-		st->value = 0x3F;
-		break;
-	default:
-		dev_err(&pdev->dev, "Invalid device ID\n");
-		ret = -EINVAL;
-		goto error_disable_reg;
-	}
-
-	st->info = &hmc425a_infos[st->type];
 	indio_dev->dev.parent = &pdev->dev;
-	indio_dev->name = np->name;
 	indio_dev->info = &hmc425a_info;
 	indio_dev->modes = INDIO_DIRECT_MODE;
 
-	ret = iio_device_register(indio_dev);
-	if (ret)
-		goto error_disable_reg;
-
-	return 0;
-
-error_disable_reg:
-	if (!IS_ERR(st->reg))
-		regulator_disable(st->reg);
-
-	return ret;
-}
-
-static int hmc425a_remove(struct platform_device *pdev)
-{
-	struct iio_dev *indio_dev = platform_get_drvdata(pdev);
-	struct hmc425a_state *st = iio_priv(indio_dev);
-	struct regulator *reg = st->reg;
-
-	iio_device_unregister(indio_dev);
-
-	if (!IS_ERR(reg))
-		regulator_disable(reg);
-
-	return 0;
+	return devm_iio_device_register(&pdev->dev, indio_dev);
 }
 
 static struct platform_driver hmc425a_driver = {
@@ -252,11 +241,9 @@ static struct platform_driver hmc425a_driver = {
 		.of_match_table = hmc425a_of_match,
 	},
 	.probe = hmc425a_probe,
-	.remove = hmc425a_remove,
 };
 module_platform_driver(hmc425a_driver);
 
 MODULE_AUTHOR("Michael Hennerich <michael.hennerich@analog.com>");
-MODULE_DESCRIPTION(
-	"Analog Devices HMC425A and similar GPIO control Gain Amplifiers");
+MODULE_DESCRIPTION("Analog Devices HMC425A and similar GPIO control Gain Amplifiers");
 MODULE_LICENSE("GPL v2");

--- a/drivers/iio/industrialio-core.c
+++ b/drivers/iio/industrialio-core.c
@@ -786,17 +786,18 @@ static ssize_t iio_read_channel_info_avail(struct device *dev,
 }
 
 /**
- * iio_str_to_fixpoint() - Parse a fixed-point number from a string
+ * __iio_str_to_fixpoint() - Parse a fixed-point number from a string
  * @str: The string to parse
  * @fract_mult: Multiplier for the first decimal place, should be a power of 10
  * @integer: The integer part of the number
  * @fract: The fractional part of the number
+ * @scale_db: True if this should parse as dB
  *
  * Returns 0 on success, or a negative error code if the string could not be
  * parsed.
  */
-int iio_str_to_fixpoint(const char *str, int fract_mult,
-	int *integer, int *fract)
+static int __iio_str_to_fixpoint(const char *str, int fract_mult,
+				 int *integer, int *fract, bool scale_db)
 {
 	int i = 0, f = 0;
 	bool integer_part = true, negative = false;
@@ -827,9 +828,13 @@ int iio_str_to_fixpoint(const char *str, int fract_mult,
 				break;
 			else
 				return -EINVAL;
-		} else if (!strcmp(str, " dB")) {
+		} else if (!strncmp(str, " dB", sizeof(" dB") - 1) && scale_db) {
 			/* Ignore the dB suffix */
 			str += sizeof(" dB") - 1;
+			continue;
+		} else if (!strncmp(str, "dB", sizeof("dB") - 1) && scale_db) {
+			/* Ignore the dB suffix */
+			str += sizeof("dB") - 1;
 			continue;
 		} else if (*str == '.' && integer_part) {
 			integer_part = false;
@@ -851,6 +856,22 @@ int iio_str_to_fixpoint(const char *str, int fract_mult,
 
 	return 0;
 }
+
+/**
+ * iio_str_to_fixpoint() - Parse a fixed-point number from a string
+ * @str: The string to parse
+ * @fract_mult: Multiplier for the first decimal place, should be a power of 10
+ * @integer: The integer part of the number
+ * @fract: The fractional part of the number
+ *
+ * Returns 0 on success, or a negative error code if the string could not be
+ * parsed.
+ */
+int iio_str_to_fixpoint(const char *str, int fract_mult,
+			int *integer, int *fract)
+{
+	return __iio_str_to_fixpoint(str, fract_mult, integer, fract, false);
+}
 EXPORT_SYMBOL_GPL(iio_str_to_fixpoint);
 
 static ssize_t iio_write_channel_info(struct device *dev,
@@ -863,6 +884,7 @@ static ssize_t iio_write_channel_info(struct device *dev,
 	int ret, fract_mult = 100000;
 	int integer, fract = 0;
 	bool is_char = false;
+	bool scale_db = false;
 
 	/* Assumes decimal - precision based on number of digits */
 	if (!indio_dev->info->write_raw)
@@ -874,6 +896,9 @@ static ssize_t iio_write_channel_info(struct device *dev,
 		case IIO_VAL_INT:
 			fract_mult = 0;
 			break;
+		case IIO_VAL_INT_PLUS_MICRO_DB:
+			scale_db = true;
+			/* fall through */
 		case IIO_VAL_INT_PLUS_MICRO:
 			fract_mult = 100000;
 			break;
@@ -898,6 +923,10 @@ static ssize_t iio_write_channel_info(struct device *dev,
 		if (ret)
 			return ret;
 	}
+	ret = __iio_str_to_fixpoint(buf, fract_mult, &integer, &fract,
+				    scale_db);
+	if (ret)
+		return ret;
 
 	ret = indio_dev->info->write_raw(indio_dev, this_attr->c,
 					 integer, fract, this_attr->address);

--- a/drivers/iio/industrialio-core.c
+++ b/drivers/iio/industrialio-core.c
@@ -614,6 +614,8 @@ static ssize_t __iio_format_value(char *buf, size_t len, unsigned int type,
 		}
 		return l;
 	}
+	case IIO_VAL_CHAR:
+		return snprintf(buf, len, "%c", (char)vals[0]);
 	default:
 		return 0;
 	}
@@ -859,7 +861,8 @@ static ssize_t iio_write_channel_info(struct device *dev,
 	struct iio_dev *indio_dev = dev_to_iio_dev(dev);
 	struct iio_dev_attr *this_attr = to_iio_dev_attr(attr);
 	int ret, fract_mult = 100000;
-	int integer, fract;
+	int integer, fract = 0;
+	bool is_char = false;
 
 	/* Assumes decimal - precision based on number of digits */
 	if (!indio_dev->info->write_raw)
@@ -877,13 +880,24 @@ static ssize_t iio_write_channel_info(struct device *dev,
 		case IIO_VAL_INT_PLUS_NANO:
 			fract_mult = 100000000;
 			break;
+		case IIO_VAL_CHAR:
+			is_char = true;
+			break;
 		default:
 			return -EINVAL;
 		}
 
-	ret = iio_str_to_fixpoint(buf, fract_mult, &integer, &fract);
-	if (ret)
-		return ret;
+	if (is_char) {
+		char ch;
+
+		if (sscanf(buf, "%c", &ch) != 1)
+			return -EINVAL;
+		integer = ch;
+	} else {
+		ret = iio_str_to_fixpoint(buf, fract_mult, &integer, &fract);
+		if (ret)
+			return ret;
+	}
 
 	ret = indio_dev->info->write_raw(indio_dev, this_attr->c,
 					 integer, fract, this_attr->address);

--- a/include/linux/iio/types.h
+++ b/include/linux/iio/types.h
@@ -28,6 +28,7 @@ enum iio_event_info {
 #define IIO_VAL_INT_MULTIPLE 5
 #define IIO_VAL_FRACTIONAL 10
 #define IIO_VAL_FRACTIONAL_LOG2 11
+#define IIO_VAL_CHAR 12
 
 enum iio_available_type {
 	IIO_AVAIL_LIST,


### PR DESCRIPTION
This changeset syncs the recent changes for the iio amplifiers with upstream.

For HMC425A gpiod_set_array_value_cansleep() call was kept unchanged since it differs from recent upstream where the API changed.

Also, backported `iio: core: add char type for sysfs attributes` to make the `iio: core: Handle 'dB' suffix in core` patch easier to apply on ADI code.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>