### PR TITLE
ci,build: add allmodconfig build rule

### DIFF
--- a/ci/travis/run-build.sh
+++ b/ci/travis/run-build.sh
@@ -190,6 +190,14 @@ build_default() {
 	}
 }
 
+build_allmodconfig() {
+	APT_LIST="$APT_LIST git"
+
+	apt_update_install $APT_LIST
+	make allmodconfig
+	make -j$NUM_JOBS
+}
+
 build_checkpatch() {
 	apt_install python-ply
 	if [ -n "$TRAVIS_BRANCH" ]; then


### PR DESCRIPTION
This build rule ('make allmodconfig') is part of the standard kernel build
to try to build everything as a kmod.

Building as kmod yields different results, since some module macros become
active.

This change introduces a small helper script to run inside a Jenkins CI
build. This build time takes quite a lot to run, so Travis-CI provides
insufficient resources to run it.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>