### PR TITLE
Split buffer_dma.h

### DIFF
--- a/drivers/iio/adc/ad400x.c
+++ b/drivers/iio/adc/ad400x.c
@@ -317,8 +317,6 @@ static int ad400x_buffer_postdisable(struct iio_dev *indio_dev)
 static int hw_submit_block(struct iio_dma_buffer_queue *queue,
 			   struct iio_dma_buffer_block *block)
 {
-	block->block.bytes_used = block->block.size;
-
 	return iio_dmaengine_buffer_submit_block(queue, block, DMA_DEV_TO_MEM);
 }
 

--- a/drivers/iio/adc/ad7768.c
+++ b/drivers/iio/adc/ad7768.c
@@ -12,6 +12,7 @@
 #include <linux/dmaengine.h>
 #include <linux/regulator/consumer.h>
 
+#include <linux/iio/buffer.h>
 #include <linux/iio/iio.h>
 #include <linux/iio/sysfs.h>
 #include <linux/iio/buffer_impl.h>
@@ -324,8 +325,6 @@ static const struct iio_info ad7768_info = {
 static int hw_submit_block(struct iio_dma_buffer_queue *queue,
 	struct iio_dma_buffer_block *block)
 {
-	block->block.bytes_used = block->block.size;
-
 	return iio_dmaengine_buffer_submit_block(queue, block, DMA_DEV_TO_MEM);
 }
 

--- a/drivers/iio/adc/ad_adc.c
+++ b/drivers/iio/adc/ad_adc.c
@@ -30,7 +30,6 @@
 #include <linux/iio/hw_consumer.h>
 
 #include <linux/dma-direction.h>
-#include <linux/iio/buffer_impl.h>
 #include <linux/iio/buffer-dma.h>
 #include <linux/iio/buffer-dmaengine.h>
 
@@ -301,10 +300,8 @@ static int axiadc_hw_consumer_postenable(struct iio_dev *indio_dev)
 static int axiadc_hw_submit_block(struct iio_dma_buffer_queue *queue,
 	struct iio_dma_buffer_block *block)
 {
-	struct iio_dev *indio_dev = queue->driver_data;
+	struct iio_dev *indio_dev = iio_dma_buffer_get_drvdata(queue);
 	struct axiadc_state *st = iio_priv(indio_dev);
-
-	block->block.bytes_used = block->block.size;
 
 	iio_dmaengine_buffer_submit_block(queue, block, DMA_FROM_DEVICE);
 

--- a/drivers/iio/adc/admc_adc.c
+++ b/drivers/iio/adc/admc_adc.c
@@ -37,7 +37,6 @@
 #include <linux/iio/buffer.h>
 
 #include <linux/dma-direction.h>
-#include <linux/iio/buffer_impl.h>
 #include <linux/iio/buffer-dma.h>
 #include <linux/iio/buffer-dmaengine.h>
 
@@ -83,10 +82,8 @@ static inline unsigned int axiadc_read(struct axiadc_state *st, unsigned reg)
 static int axiadc_hw_submit_block(struct iio_dma_buffer_queue *queue,
 	struct iio_dma_buffer_block *block)
 {
-	struct iio_dev *indio_dev = queue->driver_data;
+	struct iio_dev *indio_dev = iio_dma_buffer_get_drvdata(queue);
 	struct axiadc_state *st = iio_priv(indio_dev);
-
-	block->block.bytes_used = block->block.size;
 
 	iio_dmaengine_buffer_submit_block(queue, block, DMA_FROM_DEVICE);
 

--- a/drivers/iio/adc/admc_speed.c
+++ b/drivers/iio/adc/admc_speed.c
@@ -37,7 +37,6 @@
 #include <linux/iio/buffer.h>
 
 #include <linux/dma-direction.h>
-#include <linux/iio/buffer_impl.h>
 #include <linux/iio/buffer-dma.h>
 #include <linux/iio/buffer-dmaengine.h>
 
@@ -83,10 +82,8 @@ static inline unsigned int axiadc_read(struct axiadc_state *st, unsigned reg)
 static int axiadc_hw_submit_block(struct iio_dma_buffer_queue *queue,
 	struct iio_dma_buffer_block *block)
 {
-	struct iio_dev *indio_dev = queue->driver_data;
+	struct iio_dev *indio_dev = iio_dma_buffer_get_drvdata(queue);
 	struct axiadc_state *st = iio_priv(indio_dev);
-
-	block->block.bytes_used = block->block.size;
 
 	iio_dmaengine_buffer_submit_block(queue, block, DMA_FROM_DEVICE);
 

--- a/drivers/iio/adc/cf_axi_adc_core.c
+++ b/drivers/iio/adc/cf_axi_adc_core.c
@@ -28,7 +28,6 @@
 #include <linux/iio/iio.h>
 #include <linux/iio/sysfs.h>
 #include <linux/iio/buffer.h>
-#include <linux/iio/buffer_impl.h>
 #include <linux/iio/buffer-dma.h>
 #include <linux/iio/buffer-dmaengine.h>
 
@@ -103,10 +102,8 @@ EXPORT_SYMBOL_GPL(axiadc_idelay_set);
 static int axiadc_hw_submit_block(struct iio_dma_buffer_queue *queue,
 	struct iio_dma_buffer_block *block)
 {
-	struct iio_dev *indio_dev = queue->driver_data;
+	struct iio_dev *indio_dev = iio_dma_buffer_get_drvdata(queue);
 	struct axiadc_state *st = iio_priv(indio_dev);
-
-	block->block.bytes_used = block->block.size;
 
 	iio_dmaengine_buffer_submit_block(queue, block, DMA_FROM_DEVICE);
 

--- a/drivers/iio/buffer/buffer-dma_impl.h
+++ b/drivers/iio/buffer/buffer-dma_impl.h
@@ -1,0 +1,129 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ *
+ * Copyright (c) 2020 Analog Devices Inc.
+ */
+#ifndef __INDUSTRIALIO_DMA_BUFFER_IMPL_H__
+#define __INDUSTRIALIO_DMA_BUFFER_IMPL_H_
+
+#include <linux/iio/buffer_impl.h>
+#include <linux/list.h>
+#include <linux/kref.h>
+#include <linux/mutex.h>
+#include <linux/spinlock.h>
+#include <linux/types.h>
+
+/**
+ * enum iio_block_state - State of a struct iio_dma_buffer_block
+ * @IIO_BLOCK_STATE_DEQUEUED: Block is not queued
+ * @IIO_BLOCK_STATE_QUEUED: Block is on the incoming queue
+ * @IIO_BLOCK_STATE_ACTIVE: Block is currently being processed by the DMA
+ * @IIO_BLOCK_STATE_DONE: Block is on the outgoing queue
+ * @IIO_BLOCK_STATE_DEAD: Block has been marked as to be freed
+ */
+enum iio_block_state {
+	IIO_BLOCK_STATE_DEQUEUED,
+	IIO_BLOCK_STATE_QUEUED,
+	IIO_BLOCK_STATE_ACTIVE,
+	IIO_BLOCK_STATE_DONE,
+	IIO_BLOCK_STATE_DEAD,
+};
+
+/**
+ * struct iio_dma_buffer_block - IIO buffer block
+ * @head: List head
+ * @block: IIO buffer block
+ * @vaddr: Virtual address of the blocks memory
+ * @phys_addr: Physical address of the blocks memory
+ * @queue: Parent DMA buffer queue
+ * @kref: kref used to manage the lifetime of block
+ * @state: Current state of the block
+ */
+struct iio_dma_buffer_block {
+	/* May only be accessed by the owner of the block */
+	struct list_head head;
+	struct iio_buffer_block block;
+	/*
+	 * Set during allocation, constant thereafter. May be accessed read-only
+	 * by anybody holding a reference to the block.
+	 */
+	void *vaddr;
+	dma_addr_t phys_addr;
+	struct iio_dma_buffer_queue *queue;
+
+	/* Must not be accessed outside the core. */
+	struct kref kref;
+	/*
+	 * Must not be accessed outside the core. Access needs to hold
+	 * queue->list_lock if the block is not owned by the core.
+	 */
+	enum iio_block_state state;
+};
+
+/**
+ * struct iio_dma_buffer_queue_fileio - FileIO state for the DMA buffer
+ * @blocks: Buffer blocks used for fileio
+ * @active_block: Block being used in read()
+ * @pos: Read offset in the active block
+ * @block_size: Size of each block
+ */
+struct iio_dma_buffer_queue_fileio {
+	struct iio_dma_buffer_block *blocks[2];
+	struct iio_dma_buffer_block *active_block;
+	size_t pos;
+	size_t block_size;
+};
+
+/**
+ * struct iio_dma_buffer_queue - DMA buffer base structure
+ * @buffer: IIO buffer base structure
+ * @dev: Parent device
+ * @ops: DMA buffer callbacks
+ * @lock: Protects the incoming list, active and the fields in the fileio
+ *   substruct
+ * @list_lock: Protects lists that contain blocks which can be modified in
+ *   atomic context as well as blocks on those lists. This is the outgoing queue
+ *   list and typically also a list of active blocks in the part that handles
+ *   the DMA controller
+ * @incoming: List of buffers on the incoming queue
+ * @outgoing: List of buffers on the outgoing queue
+ * @active: Whether the buffer is currently active
+ * @driver_data: Driver private data
+ * @poll_wakup_flags: Wake up flags to be used with the buffer wait queue
+ * @num_blocks: Number of IIO buffer blocks in the buffer
+ * @blocks: Group of IIO buffer blocks
+ * @max_offset: Max offset on the DMA buffer until where a block can be found
+ * @fileio: FileIO state
+ */
+struct iio_dma_buffer_queue {
+	struct iio_buffer buffer;
+	struct device *dev;
+	const struct iio_dma_buffer_ops *ops;
+	/*
+	 * Protects the incoming list, active and the fields in the fileio
+	 * substruct.
+	 */
+	struct mutex lock;
+	/*
+	 * Protects lists that contain blocks which can be modified in
+	 * atomic context as well as blocks on those lists. This is the outgoing
+	 * queue list and typically also a list of active blocks in the part
+	 * that handles the DMA controller
+	 */
+	spinlock_t list_lock;
+	struct list_head incoming;
+	struct list_head outgoing;
+
+	u8 active;
+
+	void *driver_data;
+
+	unsigned int poll_wakup_flags;
+
+	unsigned int num_blocks;
+	struct iio_dma_buffer_block **blocks;
+	unsigned int max_offset;
+
+	struct iio_dma_buffer_queue_fileio fileio;
+};
+#endif

--- a/drivers/iio/buffer/industrialio-buffer-dma.c
+++ b/drivers/iio/buffer/industrialio-buffer-dma.c
@@ -780,6 +780,16 @@ static const struct vm_operations_struct iio_dma_buffer_vm_ops = {
 	.close = iio_dma_buffer_mmap_close,
 };
 
+/**
+ * iio_dma_buffer_get_drvdata() - DMA buffer get driver data
+ * @queue: DMA Buffer
+ */
+void *iio_dma_buffer_get_drvdata(const struct iio_dma_buffer_queue *queue)
+{
+	return queue->driver_data;
+}
+EXPORT_SYMBOL_GPL(iio_dma_buffer_get_drvdata);
+
 int iio_dma_buffer_mmap(struct iio_buffer *buffer,
 	struct vm_area_struct *vma)
 {

--- a/drivers/iio/buffer/industrialio-buffer-dma.c
+++ b/drivers/iio/buffer/industrialio-buffer-dma.c
@@ -19,6 +19,7 @@
 #include <linux/dma-mapping.h>
 #include <linux/sizes.h>
 
+#include "buffer-dma_impl.h"
 /*
  * For DMA buffers the storage is sub-divided into so called blocks. Each block
  * has its own memory buffer. The size of the block is the granularity at which

--- a/drivers/iio/buffer/industrialio-buffer-dmaengine.c
+++ b/drivers/iio/buffer/industrialio-buffer-dmaengine.c
@@ -110,6 +110,36 @@ int iio_dmaengine_buffer_submit_block(struct iio_dma_buffer_queue *queue,
 }
 EXPORT_SYMBOL_GPL(iio_dmaengine_buffer_submit_block);
 
+/**
+ * iio_dma_buffer_block_cyclic() - Check if cyclic transfers are enabled
+ * @block: DMA block
+ */
+bool iio_dma_buffer_block_cyclic(const struct iio_dma_buffer_block *block)
+{
+	return !!test_bit(IIO_BUFFER_BLOCK_FLAG_CYCLIC, &block->block.flags);
+}
+EXPORT_SYMBOL_GPL(iio_dma_buffer_block_cyclic);
+
+/**
+ * iio_dma_buffer_block_cyclic_disable() - Disable cyclic transfers
+ * @block: DMA block
+ */
+void iio_dma_buffer_block_cyclic_disable(struct iio_dma_buffer_block *block)
+{
+	clear_bit(IIO_BUFFER_BLOCK_FLAG_CYCLIC, &block->block.flags);
+}
+EXPORT_SYMBOL_GPL(iio_dma_buffer_block_cyclic_disable);
+
+/**
+ * iio_dma_buffer_block_empty() - Check if block is empty
+ * @block: DMA block
+ */
+bool iio_dma_buffer_block_empty(const struct iio_dma_buffer_block *block)
+{
+	return block->block.bytes_used == 0;
+}
+EXPORT_SYMBOL_GPL(iio_dma_buffer_block_empty);
+
 void iio_dmaengine_buffer_abort(struct iio_dma_buffer_queue *queue)
 {
 	struct dmaengine_buffer *dmaengine_buffer =

--- a/drivers/iio/buffer/industrialio-buffer-dmaengine.c
+++ b/drivers/iio/buffer/industrialio-buffer-dmaengine.c
@@ -20,6 +20,8 @@
 #include <linux/iio/buffer-dma.h>
 #include <linux/iio/buffer-dmaengine.h>
 
+#include "buffer-dma_impl.h"
+
 /*
  * The IIO DMAengine buffer combines the generic IIO DMA buffer infrastructure
  * with the DMAengine framework. The generic IIO DMA buffer infrastructure is

--- a/drivers/iio/frequency/cf_axi_dds_buffer_stream.c
+++ b/drivers/iio/frequency/cf_axi_dds_buffer_stream.c
@@ -13,9 +13,9 @@
 #include <linux/dmaengine.h>
 #include <linux/uaccess.h>
 
+#include <linux/iio/buffer.h>
 #include <linux/iio/iio.h>
 #include <linux/iio/sysfs.h>
-#include <linux/iio/buffer_impl.h>
 #include <linux/iio/buffer-dma.h>
 #include <linux/iio/buffer-dmaengine.h>
 
@@ -24,14 +24,15 @@
 static int dds_buffer_submit_block(struct iio_dma_buffer_queue *queue,
 	struct iio_dma_buffer_block *block)
 {
-	struct cf_axi_dds_state *st = iio_priv(queue->driver_data);
+	struct iio_dev *indio_dev = iio_dma_buffer_get_drvdata(queue);
+	struct cf_axi_dds_state *st = iio_priv(indio_dev);
 
-	if (block->block.bytes_used) {
+	if (!iio_dma_buffer_block_empty(block)) {
 		bool enable_fifo = false;
 
 		if (cf_axi_dds_dma_fifo_en(st) &&
-			(block->block.flags & IIO_BUFFER_BLOCK_FLAG_CYCLIC)) {
-			block->block.flags &= ~IIO_BUFFER_BLOCK_FLAG_CYCLIC;
+		    iio_dma_buffer_block_cyclic(block)) {
+			iio_dma_buffer_block_cyclic_disable(block);
 			enable_fifo = true;
 		}
 

--- a/drivers/misc/mathworks/mw_stream_iio_channel.c
+++ b/drivers/misc/mathworks/mw_stream_iio_channel.c
@@ -6,6 +6,7 @@
  * Licensed under the GPL-2.
  */
 
+#include <linux/iio/buffer.h>
 #include <linux/iio/iio.h>
 #include <linux/iio/sysfs.h>
 #include <linux/iio/buffer_impl.h>
@@ -74,7 +75,7 @@ static void mw_stream_iio_chan_ida_remove(void *opaque){
 
 static int mw_stream_iio_buffer_submit_block(struct iio_dma_buffer_queue *queue, struct iio_dma_buffer_block *block)
 {
-	struct iio_dev *indio_dev = queue->driver_data;
+	struct iio_dev *indio_dev = iio_dma_buffer_get_drvdata(queue);
 	struct mw_stream_iio_chandev *mwchan = iio_priv(indio_dev);
 	int direction;
 

--- a/include/linux/iio/buffer-dma.h
+++ b/include/linux/iio/buffer-dma.h
@@ -8,118 +8,13 @@
 #ifndef __INDUSTRIALIO_DMA_BUFFER_H__
 #define __INDUSTRIALIO_DMA_BUFFER_H__
 
-#include <linux/list.h>
-#include <linux/kref.h>
-#include <linux/spinlock.h>
-#include <linux/mutex.h>
-#include <linux/iio/buffer.h>
-#include <linux/iio/buffer_impl.h>
-
+struct iio_dev;
+struct iio_buffer;
 struct iio_dma_buffer_queue;
-struct iio_dma_buffer_ops;
 struct device;
-
-/**
- * enum iio_block_state - State of a struct iio_dma_buffer_block
- * @IIO_BLOCK_STATE_DEQUEUED: Block is not queued
- * @IIO_BLOCK_STATE_QUEUED: Block is on the incoming queue
- * @IIO_BLOCK_STATE_ACTIVE: Block is currently being processed by the DMA
- * @IIO_BLOCK_STATE_DONE: Block is on the outgoing queue
- * @IIO_BLOCK_STATE_DEAD: Block has been marked as to be freed
- */
-enum iio_block_state {
-	IIO_BLOCK_STATE_DEQUEUED,
-	IIO_BLOCK_STATE_QUEUED,
-	IIO_BLOCK_STATE_ACTIVE,
-	IIO_BLOCK_STATE_DONE,
-	IIO_BLOCK_STATE_DEAD,
-};
-
-/**
- * struct iio_dma_buffer_block - IIO buffer block
- * @head: List head
- * @size: Total size of the block in bytes
- * @bytes_used: Number of bytes that contain valid data
- * @vaddr: Virutal address of the blocks memory
- * @phys_addr: Physical address of the blocks memory
- * @queue: Parent DMA buffer queue
- * @kref: kref used to manage the lifetime of block
- * @state: Current state of the block
- */
-struct iio_dma_buffer_block {
-	/* May only be accessed by the owner of the block */
-	struct list_head head;
-	struct iio_buffer_block block;
-
-	/*
-	 * Set during allocation, constant thereafter. May be accessed read-only
-	 * by anybody holding a reference to the block.
-	 */
-	void *vaddr;
-	dma_addr_t phys_addr;
-	struct iio_dma_buffer_queue *queue;
-
-	/* Must not be accessed outside the core. */
-	struct kref kref;
-	/*
-	 * Must not be accessed outside the core. Access needs to hold
-	 * queue->list_lock if the block is not owned by the core.
-	 */
-	enum iio_block_state state;
-};
-
-/**
- * struct iio_dma_buffer_queue_fileio - FileIO state for the DMA buffer
- * @blocks: Buffer blocks used for fileio
- * @active_block: Block being used in read()
- * @pos: Read offset in the active block
- * @block_size: Size of each block
- */
-struct iio_dma_buffer_queue_fileio {
-	struct iio_dma_buffer_block *blocks[2];
-	struct iio_dma_buffer_block *active_block;
-	size_t pos;
-	size_t block_size;
-};
-
-/**
- * struct iio_dma_buffer_queue - DMA buffer base structure
- * @buffer: IIO buffer base structure
- * @dev: Parent device
- * @ops: DMA buffer callbacks
- * @lock: Protects the incoming list, active and the fields in the fileio
- *   substruct
- * @list_lock: Protects lists that contain blocks which can be modified in
- *   atomic context as well as blocks on those lists. This is the outgoing queue
- *   list and typically also a list of active blocks in the part that handles
- *   the DMA controller
- * @incoming: List of buffers on the incoming queue
- * @outgoing: List of buffers on the outgoing queue
- * @active: Whether the buffer is currently active
- * @fileio: FileIO state
- */
-struct iio_dma_buffer_queue {
-	struct iio_buffer buffer;
-	struct device *dev;
-	const struct iio_dma_buffer_ops *ops;
-
-	struct mutex lock;
-	spinlock_t list_lock;
-	struct list_head incoming;
-	struct list_head outgoing;
-
-	bool active;
-
-	void *driver_data;
-
-	unsigned int poll_wakup_flags;
-
-	unsigned int num_blocks;
-	struct iio_dma_buffer_block **blocks;
-	unsigned int max_offset;
-
-	struct iio_dma_buffer_queue_fileio fileio;
-};
+struct iio_dma_buffer_block;
+struct iio_buffer_block;
+struct iio_buffer_block_alloc_req;
 
 /**
  * struct iio_dma_buffer_ops - DMA buffer callback operations
@@ -135,7 +30,6 @@ struct iio_dma_buffer_ops {
 void iio_dma_buffer_block_done(struct iio_dma_buffer_block *block);
 void iio_dma_buffer_block_list_abort(struct iio_dma_buffer_queue *queue,
 	struct list_head *list);
-
 int iio_dma_buffer_enable(struct iio_buffer *buffer,
 	struct iio_dev *indio_dev);
 int iio_dma_buffer_disable(struct iio_buffer *buffer,

--- a/include/linux/iio/buffer-dma.h
+++ b/include/linux/iio/buffer-dma.h
@@ -167,5 +167,5 @@ int iio_dma_buffer_mmap(struct iio_buffer *buffer,
 int iio_dma_buffer_write(struct iio_buffer *buf, size_t n,
 	const char __user *user_buffer);
 bool iio_dma_buffer_space_available(struct iio_buffer *buf);
-
+void *iio_dma_buffer_get_drvdata(const struct iio_dma_buffer_queue *queue);
 #endif

--- a/include/linux/iio/buffer-dmaengine.h
+++ b/include/linux/iio/buffer-dmaengine.h
@@ -21,5 +21,7 @@ void iio_dmaengine_buffer_abort(struct iio_dma_buffer_queue *queue);
 struct iio_buffer *iio_dmaengine_buffer_alloc(struct device *dev,
 	const char *channel, const struct iio_dma_buffer_ops *ops, void *data);
 void iio_dmaengine_buffer_free(struct iio_buffer *buffer);
-
+bool iio_dma_buffer_block_cyclic(const struct iio_dma_buffer_block *block);
+void iio_dma_buffer_block_cyclic_disable(struct iio_dma_buffer_block *block);
+bool iio_dma_buffer_block_empty(const struct iio_dma_buffer_block *block);
 #endif

--- a/include/linux/iio/buffer_impl.h
+++ b/include/linux/iio/buffer_impl.h
@@ -30,7 +30,7 @@ struct iio_buffer_block {
 	__u32 size;
 	__u32 bytes_used;
 	__u32 type;
-	__u32 flags;
+	unsigned long flags;
 	union {
 		__u32 offset;
 	} data;


### PR DESCRIPTION
This series splits buffer-dma.h into a private and public part. This attempts to properly fix the workaround introduced by the commit df99ea3 ("include: iio: buffer-dma: Include buffer_impl.h"). The point here is that, buffer-dma needs to know about struct iio_buffer and struct iio_buffer_block which are defined in buffer_impl.h which is supposed to be private. So, we should not expose the buffer implementation if some driver wants to use buffer dma.