### PR TITLE
drivers: char: axi-intr-monitor: fix kmod build

### DIFF
--- a/drivers/char/axi-intr-monitor.c
+++ b/drivers/char/axi-intr-monitor.c
@@ -209,7 +209,7 @@ static struct of_device_id axi_intr_mon_of_match[] = {
 	{ .compatible = "adi,axi-intr-monitor-1.00.a", },
 	{ /* end of table */}
 };
-MODULE_DEVICE_TABLE(of, xdevcfg_of_match);
+MODULE_DEVICE_TABLE(of, axi_intr_mon_of_match);
 
 static struct platform_driver axi_intr_mon_driver = {
 	.probe = axi_intr_mon_probe,


### PR DESCRIPTION
This fix was caught by the 'make allmodconfig' build.
The 'xdevcfg_of_match' name looks like a copy-paste error. This change
fixes that.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>