### PR TITLE
[RFC] Add burst mode support to the default trigger handler

### DIFF
--- a/drivers/iio/imu/adis16400.c
+++ b/drivers/iio/imu/adis16400.c
@@ -1192,9 +1192,11 @@ static int adis16400_probe(struct spi_device *spi)
 	if (!(st->variant->flags & ADIS16400_NO_BURST)) {
 		adis16400_setup_chan_mask(st);
 		indio_dev->available_scan_masks = st->avail_scan_mask;
+		/* all output channels but the timestamp */
+		adis16400_burst.burst_len = (indio_dev->num_channels - 1) * 2;
 		st->adis.burst = &adis16400_burst;
 		if (st->variant->flags & ADIS16400_BURST_DIAG_STAT)
-			st->adis.burst->extra_len = sizeof(u16);
+			st->adis.burst->burst_len += sizeof(u16);
 	}
 
 	adis16400_data = &st->variant->adis_data;

--- a/drivers/iio/imu/adis16475.c
+++ b/drivers/iio/imu/adis16475.c
@@ -794,14 +794,8 @@ static const char * const adis16475_status_error_msgs[] = {
 static struct adis_burst adis16475_burst = {
 	.en = true,
 	.reg_cmd = ADIS16475_REG_GLOB_CMD,
-	/*
-	 * adis_update_scan_mode_burst() sets the burst length in respect with
-	 * the number of channels and allocates 16 bits for each. However,
-	 * adis1647x devices also need space for DIAG_STAT, DATA_CNTR or
-	 * TIME_STAMP (depending on the clock mode but for us these bytes are
-	 * don't care...) and CRC.
-	 */
-	.extra_len = 3 * sizeof(u16),
+	/* By default we have 10 elements with 2 bytes each */
+	.burst_len = ADIS16475_BURST_MAX_DATA * sizeof(u16),
 	.read_delay = 5,
 	.write_delay = 5,
 };
@@ -1097,7 +1091,7 @@ static int adis16475_burst_config(struct adis16475 *st)
 	 * In 32bit mode we need extra 2 bytes for all gyro and accel
 	 * channels.
 	 */
-	adis16475_burst.extra_len += 6 * sizeof(u16);
+	adis16475_burst.burst_len += 6 * sizeof(u16);
 burst16:
 	st->adis.burst = &adis16475_burst;
 	/* it's enabled by default so spi max speed needs to be 1MHz */

--- a/drivers/iio/imu/adis16480.c
+++ b/drivers/iio/imu/adis16480.c
@@ -175,15 +175,8 @@ struct adis16480 {
 static struct adis_burst adis16495_burst = {
 	.en = true,
 	.reg_cmd = ADIS16495_REG_BURST_CMD,
-	/*
-	 * adis_update_scan_mode_burst() sets the burst length in respect with
-	 * the number of channels and allocates 16 bits for each. However, for
-	 * adis1649x devices, the data for each channel is composed of a 16-bit
-	 * low and 16-bit high part. Besides this, the burst sequence contains
-	 * data for BURST_ID, SYS_E_FLAG, TIME_STAMP, CRC_LWR, CRC_UPR, one or
-	 * two don't care segments.
-	 */
-	.extra_len = 12 * sizeof(u16),
+	/* By default we have 20 elements with 2 bytes each */
+	.burst_len = ADIS16495_BURST_MAX_DATA * sizeof(u16),
 	.read_delay = 5,
 	.write_delay = 5,
 };
@@ -1496,7 +1489,7 @@ static int adis16480_probe(struct spi_device *spi)
 	/* If burst mode is supported, enable it by default */
 	if (st->chip_info->burst) {
 		st->adis.burst = st->chip_info->burst;
-		st->adis.burst->extra_len = st->chip_info->burst->extra_len;
+		st->adis.burst->burst_len = st->chip_info->burst->burst_len;
 		indio_dev->info = &adis16495_info;
 	}
 

--- a/drivers/iio/imu/adis_buffer.c
+++ b/drivers/iio/imu/adis_buffer.c
@@ -23,12 +23,8 @@ static int adis_update_scan_mode_burst(struct iio_dev *indio_dev,
 	const unsigned long *scan_mask)
 {
 	struct adis *adis = iio_device_get_drvdata(indio_dev);
-	unsigned int burst_length;
 	u8 *tx;
-
-	/* All but the timestamp channel */
-	burst_length = (indio_dev->num_channels - 1) * sizeof(u16);
-	burst_length += adis->burst->extra_len;
+	const u32 burst_length = adis->burst->burst_len;
 
 	adis->xfer = kcalloc(2, sizeof(*adis->xfer), GFP_KERNEL);
 	if (!adis->xfer)

--- a/include/linux/iio/imu/adis.h
+++ b/include/linux/iio/imu/adis.h
@@ -474,12 +474,12 @@ int adis_single_conversion(struct iio_dev *indio_dev,
  * struct adis_burst - ADIS data for burst transfers
  * @en			burst mode enabled
  * @reg_cmd		register command that triggers burst
- * @extra_len		extra length to account in the SPI RX buffer
+ * @burst_len		length of the burst data
  */
 struct adis_burst {
 	bool		en;
 	unsigned int	reg_cmd;
-	unsigned int	extra_len;
+	size_t		burst_len;
 	unsigned int	read_delay;
 	unsigned int	write_delay;
 };

--- a/include/linux/iio/imu/adis.h
+++ b/include/linux/iio/imu/adis.h
@@ -475,6 +475,18 @@ int adis_single_conversion(struct iio_dev *indio_dev,
  * @en			burst mode enabled
  * @reg_cmd		register command that triggers burst
  * @burst_len		length of the burst data
+ * @fixup_buffer	Some devices have some trailing data before the real
+ *			sensor data. This callback is intended for those devices
+ *			so that, driver's can set the @offset and real
+ *			@data_len to be used.
+ * @validate_checksum	Validates the data checksum. @data is a points to the
+ *			beginning of valid data. @data_len is the data length
+ *			which might not be equal to @burst_len.
+ * @map_to_iio_buffer	Maps the received burst data to an iio buffer matching
+ *			the curren scan_mask. @offset is the offset to valid
+ *			data in the buffer. It's zero if no @fixup_buffer
+ *			is available. @iio_buffer is the output buffer to be
+ *			passed to iio.
  */
 struct adis_burst {
 	bool		en;
@@ -482,6 +494,10 @@ struct adis_burst {
 	size_t		burst_len;
 	unsigned int	read_delay;
 	unsigned int	write_delay;
+	int (*fixup_buffer)(struct adis *adis, u32 *offset, size_t *data_len);
+	bool (*validate_checksum)(const void *data, const size_t data_len);
+	void (*map_to_iio_buffer)(struct adis *adis, const u32 offset,
+				  void **iio_buffer);
 };
 
 int


### PR DESCRIPTION
This series extends the default trigger handler to support burst mode. So far, users supportting burst mode had to define their own custom handlers because the buffer received in burst mode is, almost always, never compatible with the current scan_mask leading to invalid data being pushed to iio and userland. This also leads to code duplication since, things like doing the spi read/changing adis pages are pretty generic and the library can handle that.
    
With this mind, some new callbacks are added to the `struct adis_burst` so that, users can make use of the default trigger handler. The most important callback is the `map_to_iio_buffer()` which maps the received burst data to something that iio is expecting...

The last patch just adds adis16475 has as first user (as an example). This driver is currently  in the process of being mainlined, so we might sync it first before applying this changes.

This is just to have a first impression/discussion on this...