### PR TITLE
iio: adc: adrv9009: Fix Gpio3v3 bit-wise control

### DIFF
--- a/drivers/iio/adc/adrv9009.c
+++ b/drivers/iio/adc/adrv9009.c
@@ -3457,7 +3457,7 @@ static ssize_t adrv9009_debugfs_write(struct file *file,
 				entry->val = val2;
 				ret = TALISE_setGpio3v3PinLevel(phy->talDevice, level);
 			} else if (val >= 0 && val < 12) {
-				ret = TALISE_getGpio3v3PinLevel(phy->talDevice, &level);
+				ret = TALISE_getGpio3v3SetLevel(phy->talDevice, &level);
 				if (ret < 0) {
 					mutex_unlock(&phy->indio_dev->mlock);
 					return ret;


### PR DESCRIPTION
Read modify write must read the Set Level and not the Pin Level.

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>