### PR TITLE
iio: frequency: drop non-existing CF_AXI_DDS_AD9140 Kconfig symbol

### DIFF
--- a/drivers/iio/Kconfig.adi
+++ b/drivers/iio/Kconfig.adi
@@ -88,7 +88,6 @@ config IIO_ALL_ADI_DRIVERS
 	select CF_AXI_DDS_AD9144
 	select CF_AXI_DDS_AD9739A
 	select HMC7044
-	select CF_AXI_DDS_AD9140
 	select CF_AXI_DDS_AD9162
 	select CF_AXI_DDS_AD9172
 	select AD916X_AMP

--- a/drivers/iio/frequency/Makefile
+++ b/drivers/iio/frequency/Makefile
@@ -18,7 +18,6 @@ obj-$(CONFIG_CF_AXI_DDS_AD9122) += ad9122.o
 obj-$(CONFIG_CF_AXI_DDS_AD9144) += ad9144.o
 obj-$(CONFIG_CF_AXI_DDS_AD9739A) += ad9739a.o
 obj-$(CONFIG_HMC7044) += hmc7044.o
-obj-$(CONFIG_CF_AXI_DDS_AD9140) += ad9167.o
 obj-$(CONFIG_LTC6952) += ltc6952.o
 
 ad916x_drv-y := ad916x/ad916x_api.o  ad916x/ad916x_irq_api.o  ad916x/ad916x_jesd_api.o  ad916x/ad916x_jesd_test_api.o  ad916x/ad916x_nco_api.o  ad916x/ad916x_reg.o  ad916x/api_errors.o  ad916x/utils.o


### PR DESCRIPTION
This has probably stayed along via various merges. There is no
CF_AXI_DDS_AD9140 Kconfig symbol present, and no ad9167.c file.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>