### PR TITLE
MAINTAINERS: polish file a bit after some merges

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -873,7 +873,7 @@ L:	linux-iio@vger.kernel.org
 W:	http://ez.analog.com/community/linux-device-drivers
 S:	Supported
 F:	drivers/iio/adc/ad7124.c
-F:	Documentation/devicetree/bindings/iio/adc/adi,ad7124.txt
+F:	Documentation/devicetree/bindings/iio/adc/adi,ad7124.yaml
 
 ANALOG DEVICES INC AD7606 DRIVER
 M:	Stefan Popa <stefan.popa@analog.com>

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -859,22 +859,6 @@ S:	Supported
 F:	drivers/iio/dac/ad400x.c
 F:	Documentation/devicetree/bindings/iio/adc/ad400x.txt
 
-ANALOG DEVICES INC AD5686 DRIVER
-M:	Stefan Popa <stefan.popa@analog.com>
-L:	linux-pm@vger.kernel.org
-W:	http://ez.analog.com/community/linux-device-drivers
-S:	Supported
-F:	drivers/iio/dac/ad5686*
-F:	drivers/iio/dac/ad5696*
-
-ANALOG DEVICES INC AD5758 DRIVER
-M:	Stefan Popa <stefan.popa@analog.com>
-L:	linux-iio@vger.kernel.org
-W:	http://ez.analog.com/community/linux-device-drivers
-S:	Supported
-F:	drivers/iio/dac/ad5758.c
-F:	Documentation/devicetree/bindings/iio/dac/ad5758.txt
-
 ANALOG DEVICES INC AD5770R DRIVER
 M:	Mircea Caprioru <mircea.caprioru@analog.com>
 L:	linux-iio@vger.kernel.org


### PR DESCRIPTION
This changeset polishes the MAINTAINERS file a bit.
2 drivers show up twice as a result of merge commits.

These changes (and a few others) come as a results of compressing the adi-4.19.0 branch; which was reduced from ~1400 commits to ~770 commits. Many of them were squashed, since they're not upstreamed [yet].

Also, since Xilinx has moved their master to kernel 5.4, we need to get ready/prepared for the move/merge to 5.4 which should come along in a few months.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>