### PR TITLE
ad9162: Support temperature sensor readings

### DIFF
--- a/Documentation/devicetree/bindings/iio/frequency/ad916x.yaml
+++ b/Documentation/devicetree/bindings/iio/frequency/ad916x.yaml
@@ -63,6 +63,16 @@ properties:
       - maximum: 40000
     maxItems: 1
 
+  adi,temperature-single-point-calibration:
+    description:
+      Single point calibration tuple for the temperature sensor. It should be
+      a pair of temperature (in degrees celsius) and a raw value correspondent
+      to the sensor reading for the given temperature.
+    allOf:
+      - $ref: /schemas/types.yaml#/definitions/int32-array
+      - minItems: 2
+        maxItems: 2
+
 patternProperties:
   "^($clock-names-)?clock-scales":
     description:

--- a/drivers/iio/frequency/cf_axi_dds.h
+++ b/drivers/iio/frequency/cf_axi_dds.h
@@ -257,6 +257,7 @@ struct cf_axi_converter {
 	unsigned long 	cs_modes[17];
 	int		temp_calib;
 	unsigned		temp_calib_code;
+	int		temp_slope;
 	int		(*read)(struct spi_device *spi, unsigned reg);
 	int		(*write)(struct spi_device *spi,
 				 unsigned reg, unsigned val);


### PR DESCRIPTION
This patch adds support for reading the die temperature. The part needs a single point calibration in order to get correct readings. The patch adds to mechanisms for this:
    
1.  Do it at runtime using in_tempX_single_point_calib. Writing this file with a reference/known temperature will cause the driver to read the raw  value, creating the calibration point.
2.  Add the calibration point as a devicetree parameter.