### PR TITLE
iio: frequency: axi-dds: remove dp-disable logic

### DIFF
--- a/drivers/iio/frequency/cf_axi_dds.h
+++ b/drivers/iio/frequency/cf_axi_dds.h
@@ -103,9 +103,6 @@ enum dds_data_select {
 
 #define ADI_REG_DAC_GP_CONTROL	0x00BC
 
-#define ADI_REG_DAC_DP_DISABLE	0x00C0
-#define ADI_DAC_DP_DISABLE	(1 << 0)
-
 /* JESD TPL */
 
 #define ADI_REG_TPL_CNTRL		0x0200
@@ -226,7 +223,6 @@ struct cf_axi_dds_chip_info {
 	const char *name;
 	unsigned int num_channels;
 	unsigned int num_dds_channels;
-	unsigned int num_dp_disable_channels;
 	unsigned int num_buf_channels;
 	unsigned num_shadow_slave_channels;
 	const unsigned long *scan_masks;


### PR DESCRIPTION
This logic is similar to the one in the AXI ADC.
It's been in here for a while, and there doesn't seem to be something to
drive it. So remove it.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>