### PR TITLE
drivers: uio_dmem_genirq: sync with upstream

### DIFF
--- a/drivers/uio/uio_dmem_genirq.c
+++ b/drivers/uio/uio_dmem_genirq.c
@@ -214,18 +214,15 @@ static int uio_dmem_genirq_probe(struct platform_device *pdev)
 	priv->pdev = pdev;
 	mutex_init(&priv->alloc_lock);
 
-	/* Multiple IRQs are not supported */
 	if (!uioinfo->irq) {
+		/* Multiple IRQs are not supported */
 		ret = platform_get_irq(pdev, 0);
-		uioinfo->irq = ret;
 		if (ret == -ENXIO && pdev->dev.of_node)
-			uioinfo->irq = UIO_IRQ_NONE;
-		else if (ret < 0) {
-			dev_err(&pdev->dev, "failed to get IRQ\n");
+			ret = UIO_IRQ_NONE;
+		else if (ret < 0)
 			goto bad1;
-		}
+		uioinfo->irq = ret;
 	}
-
 	uiomem = &uioinfo->mem[0];
 
 	for (i = 0; i < pdev->num_resources; ++i) {


### PR DESCRIPTION
This change got upstreamed as commit 3ec1bd7693ee5bb ("uio: fix irq init
with dt support & irq not defined").

In the ADI tree this also exists as 45ec4148b2903
("drivers/uio/uio_dmem_genirq.c: UIO_IRQ_NONE is a valid option for
uioinfo->irq.").

This change syncs to upstream.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>