### PR TITLE
Adm1266 add initial support

### DIFF
--- a/Documentation/devicetree/bindings/hwmon/adi,adm1266.yaml
+++ b/Documentation/devicetree/bindings/hwmon/adi,adm1266.yaml
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/hwmon/adi,adm1266.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
+
+title: Analog Devices ADM1266 Cascadable Super Sequencer with Margin
+  Control and Fault Recording
+
+maintainers:
+  - Alexandru Tachici <alexandru.tachici@analog.com>
+
+description: |
+  Analog Devices ADM1266 Cascadable Super Sequencer with Margin
+  Control and Fault Recording.
+  https://www.analog.com/media/en/technical-documentation/data-sheets/ADM1266.pdf
+
+properties:
+  compatible:
+    enum:
+      - adi,adm1266
+
+  reg:
+    description: |
+      I2C address of slave device.
+    items:
+      minimum: 0x40
+      maximum: 0x4F
+
+  avcc-supply:
+    description:
+      Phandle to the Avcc power supply.
+
+  adi,connected-adm1266:
+    description: |
+      Represents other ADM1266 devices cascaded through the IDB. Can be
+      cascaded with maximum 15 other adm1266s.
+    $ref: "/schemas/types.yaml#/definitions/phandle"
+
+required:
+  - compatible
+  - reg
+
+examples:
+  - |
+    i2c0 {
+        #address-cells = <1>;
+        #size-cells = <0>;
+
+        adm1266@40 {
+                compatible = "adi,adm1266";
+                reg = <0x40>;
+                #address-cells = <1>;
+                #size-cells = <0>;
+        };
+    };
+...

--- a/Documentation/hwmon/adm1266.rst
+++ b/Documentation/hwmon/adm1266.rst
@@ -1,0 +1,35 @@
+Kernel driver adm1266
+=====================
+
+Supported chips:
+  * Analog Devices ADM1266
+    Prefix: 'adm1266'
+    Datasheet: https://www.analog.com/media/en/technical-documentation/data-sheets/ADM1266.pdf
+
+Author: Alexandru Tachici <alexandru.tachici@analog.com>
+
+
+Description
+-----------
+
+This driver supports hardware monitoring for Analog Devices ADM1266 sequencer.
+
+ADM1266 is a sequencer that features voltage readback from 17 channels via an
+integrated 12 bit SAR ADC, accessed using a PMBus interface.
+
+The driver is a client driver to the core PMBus driver. Please see
+Documentation/hwmon/pmbus for details on PMBus client drivers.
+
+
+Sysfs entries
+-------------
+
+The following attributes are supported. Limits are read-write, history reset
+attributes are write-only, all other attributes are read-only.
+
+inX_label		"voutx"
+inX_input		Measured voltage.
+inX_min			Minimum Voltage.
+inX_max			Maximum voltage.
+inX_min_alarm		Voltage low alarm.
+inX_max_alarm		Voltage high alarm.

--- a/drivers/hwmon/Kconfig.adi
+++ b/drivers/hwmon/Kconfig.adi
@@ -3,6 +3,9 @@
 
 config HWMON_ALL_ADI_DRIVERS
 	tristate "Build all Analog Devices HWMON Drivers"
+	select CRC8
+	select PMBUS
+	select SENSORS_PMBUS
 	select SENSORS_AD7314
 	select SENSORS_AD7414
 	select SENSORS_AXI_FAN_CONTROL
@@ -13,6 +16,7 @@ config HWMON_ALL_ADI_DRIVERS
 	select SENSORS_ADM1029
 	select SENSORS_ADM1031
 	select SENSORS_ADM1177
+	select SENSORS_ADM1266
 	select SENSORS_ADM1275
 	select SENSORS_ADM9240
 	select SENSORS_ADT7310

--- a/drivers/hwmon/pmbus/Kconfig
+++ b/drivers/hwmon/pmbus/Kconfig
@@ -4,7 +4,7 @@
 
 menuconfig PMBUS
 	tristate "PMBus support"
-	depends on I2C
+	depends on I2C && CRC8
 	default n
 	help
 	  Say yes here if you want to enable PMBus support.

--- a/drivers/hwmon/pmbus/Kconfig
+++ b/drivers/hwmon/pmbus/Kconfig
@@ -26,6 +26,15 @@ config SENSORS_PMBUS
 	  This driver can also be built as a module. If so, the module will
 	  be called pmbus.
 
+config SENSORS_ADM1266
+	tristate "Analog Devices ADM1266 Sequencer"
+	help
+	  If you say yes here you get hardware monitoring support for Analog
+	  Devices ADM1266 Cascadable Super Sequencer.
+
+	  This driver can also be built as a module. If so, the module will
+	  be called adm1266.
+
 config SENSORS_ADM1275
 	tristate "Analog Devices ADM1275 and compatibles"
 	default n

--- a/drivers/hwmon/pmbus/Makefile
+++ b/drivers/hwmon/pmbus/Makefile
@@ -5,6 +5,7 @@
 
 obj-$(CONFIG_PMBUS)		+= pmbus_core.o
 obj-$(CONFIG_SENSORS_PMBUS)	+= pmbus.o
+obj-$(CONFIG_SENSORS_ADM1266)	+= adm1266.o
 obj-$(CONFIG_SENSORS_ADM1275)	+= adm1275.o
 obj-$(CONFIG_SENSORS_IBM_CFFPS)	+= ibm-cffps.o
 obj-$(CONFIG_SENSORS_IR35221)	+= ir35221.o

--- a/drivers/hwmon/pmbus/adm1266.c
+++ b/drivers/hwmon/pmbus/adm1266.c
@@ -19,6 +19,8 @@
 #include "pmbus.h"
 
 #define ADM1266_PDIO_CONFIG	0xD4
+#define ADM1266_GO_COMMAND	0xD8
+#define ADM1266_READ_STATE	0xD9
 #define ADM1266_GPIO_CONFIG	0xE1
 #define ADM1266_PDIO_STATUS	0xE9
 #define ADM1266_GPIO_STATUS	0xEA
@@ -40,6 +42,7 @@ struct adm1266_data {
 	struct pmbus_driver_info info;
 	struct gpio_chip gc;
 	struct i2c_client *client;
+	struct dentry *debugfs_dir;
 };
 
 static const unsigned int adm1266_gpio_mapping[ADM1266_GPIO_NR][2] = {
@@ -221,6 +224,48 @@ static inline int adm1266_config_gpio(struct adm1266_data *data)
 }
 #endif
 
+static int adm1266_get_state_op(void *pdata, u64 *state)
+{
+	struct adm1266_data *data = pdata;
+	int ret;
+
+	ret = i2c_smbus_read_word_data(data->client, ADM1266_READ_STATE);
+	if (ret < 0)
+		return ret;
+
+	*state = ret;
+
+	return 0;
+}
+
+static int adm1266_set_go_command_op(void *pdata, u64 val)
+{
+	struct adm1266_data *data = pdata;
+	u8 reg;
+
+	reg = FIELD_GET(GENMASK(4, 0), val);
+
+	return i2c_smbus_write_word_data(data->client, ADM1266_GO_COMMAND, reg);
+}
+
+DEFINE_SIMPLE_ATTRIBUTE(go_command_fops, NULL, adm1266_set_go_command_op,
+			"%llu\n");
+DEFINE_SIMPLE_ATTRIBUTE(read_state_fops, adm1266_get_state_op, NULL, "%llu\n");
+
+static void adm1266_debug_init(struct adm1266_data *data)
+{
+	struct dentry *root;
+	char dir_name[30];
+
+	sprintf(dir_name, "adm1266-%x_debugfs", data->client->addr);
+	root = debugfs_create_dir(dir_name, NULL);
+	data->debugfs_dir = root;
+	debugfs_create_file("go_command", 0200, root, data,
+			    &go_command_fops);
+	debugfs_create_file("read_state", 0400, root, data,
+			    &read_state_fops);
+}
+
 static int adm1266_probe(struct i2c_client *client,
 			 const struct i2c_device_id *id)
 {
@@ -240,6 +285,8 @@ static int adm1266_probe(struct i2c_client *client,
 	ret = adm1266_config_gpio(data);
 	if (ret < 0)
 		return ret;
+
+	adm1266_debug_init(data);
 
 	info = &data->info;
 	info->pages = 17;

--- a/drivers/hwmon/pmbus/adm1266.c
+++ b/drivers/hwmon/pmbus/adm1266.c
@@ -14,14 +14,19 @@
 #include <linux/init.h>
 #include <linux/kernel.h>
 #include <linux/module.h>
+#include <linux/nvmem-consumer.h>
+#include <linux/nvmem-provider.h>
 #include <linux/slab.h>
 
 #include "pmbus.h"
 
+#define ADM1266_BLACKBOX_CONFIG	0xD3
 #define ADM1266_PDIO_CONFIG	0xD4
 #define ADM1266_GO_COMMAND	0xD8
 #define ADM1266_READ_STATE	0xD9
+#define ADM1266_READ_BLACKBOX	0xDE
 #define ADM1266_GPIO_CONFIG	0xE1
+#define ADM1266_BLACKBOX_INFO	0xE6
 #define ADM1266_PDIO_STATUS	0xE9
 #define ADM1266_GPIO_STATUS	0xEA
 
@@ -38,11 +43,25 @@
 #define ADM1266_PDIO_GLITCH_FILT(x)	FIELD_GET(GENMASK(12, 9), x)
 #define ADM1266_PDIO_OUT_CFG(x)		FIELD_GET(GENMASK(2, 0), x)
 
+#define ADM1266_BLACKBOX_OFFSET		0x7F700
+#define ADM1266_BLACKBOX_SIZE		64
+
 struct adm1266_data {
 	struct pmbus_driver_info info;
 	struct gpio_chip gc;
 	struct i2c_client *client;
 	struct dentry *debugfs_dir;
+	struct nvmem_config nvmem_config;
+	struct nvmem_device *nvmem;
+	u8 *dev_mem;
+};
+
+static const struct nvmem_cell_info adm1266_nvmem_cells[] = {
+	{
+		.name           = "blackbox",
+		.offset         = ADM1266_BLACKBOX_OFFSET,
+		.bytes          = 2048,
+	},
 };
 
 static const unsigned int adm1266_gpio_mapping[ADM1266_GPIO_NR][2] = {
@@ -248,6 +267,28 @@ static int adm1266_set_go_command_op(void *pdata, u64 val)
 	return i2c_smbus_write_word_data(data->client, ADM1266_GO_COMMAND, reg);
 }
 
+static int adm1266_blackbox_information_read(struct seq_file *s, void *pdata)
+{
+	struct device *dev = s->private;
+	struct i2c_client *client = to_i2c_client(dev);
+	u8 read_buf[PMBUS_BLOCK_MAX + 1];
+	unsigned int latest_id;
+	int ret;
+
+	ret = i2c_smbus_read_block_data(client, ADM1266_BLACKBOX_INFO,
+					read_buf);
+	if (ret < 0)
+		return ret;
+
+	seq_puts(s, "BLACKBOX_INFORMATION:\n");
+	latest_id = read_buf[0] + (read_buf[1] << 8);
+	seq_printf(s, "Black box ID: %x\n", latest_id);
+	seq_printf(s, "Logic index: %x\n", read_buf[2]);
+	seq_printf(s, "Record count: %x\n", read_buf[3]);
+
+	return 0;
+}
+
 DEFINE_SIMPLE_ATTRIBUTE(go_command_fops, NULL, adm1266_set_go_command_op,
 			"%llu\n");
 DEFINE_SIMPLE_ATTRIBUTE(read_state_fops, adm1266_get_state_op, NULL, "%llu\n");
@@ -264,6 +305,120 @@ static void adm1266_debug_init(struct adm1266_data *data)
 			    &go_command_fops);
 	debugfs_create_file("read_state", 0400, root, data,
 			    &read_state_fops);
+	debugfs_create_devm_seqfile(&data->client->dev, "blackbox_information",
+				    root, adm1266_blackbox_information_read);
+}
+
+static int adm1266_nvmem_read_blackbox(struct adm1266_data *data, u8 *buf)
+{
+	u8 write_buf[PMBUS_BLOCK_MAX + 1];
+	u8 read_buf[PMBUS_BLOCK_MAX + 1];
+	int record_count;
+	int ret;
+	int i;
+
+	ret = i2c_smbus_read_block_data(data->client, ADM1266_BLACKBOX_INFO,
+					read_buf);
+	if (ret < 0)
+		return ret;
+
+	record_count = read_buf[3];
+
+	for (i = 0; i < record_count; i++) {
+		write_buf[0] = i;
+		ret = pmbus_block_wr(data->client, ADM1266_READ_BLACKBOX, 1,
+				     write_buf, buf);
+		if (ret < 0)
+			return ret;
+
+		buf += ADM1266_BLACKBOX_SIZE;
+	}
+
+	return 0;
+}
+
+static bool adm1266_cell_is_accessed(const struct nvmem_cell_info *mem_cell,
+				     unsigned int offset, size_t bytes)
+{
+	unsigned int start_addr = offset;
+	unsigned int end_addr = offset + bytes;
+	unsigned int cell_start = mem_cell->offset;
+	unsigned int cell_end = mem_cell->offset + mem_cell->bytes;
+
+	if (start_addr <= cell_end && cell_start <= end_addr)
+		return true;
+
+	return false;
+}
+
+static int adm1266_read_mem_cell(struct adm1266_data *data,
+				 const struct nvmem_cell_info *mem_cell)
+{
+	u8 *mem_offset;
+	int ret;
+
+	switch (mem_cell->offset) {
+	case ADM1266_BLACKBOX_OFFSET:
+		mem_offset = data->dev_mem + mem_cell->offset;
+		ret = adm1266_nvmem_read_blackbox(data, mem_offset);
+		if (ret)
+			dev_err(&data->client->dev, "Could not read blackbox!");
+		return ret;
+	default:
+		return -EINVAL;
+	}
+}
+
+static int adm1266_nvmem_read(void *priv, unsigned int offset, void *val,
+			      size_t bytes)
+{
+	const struct nvmem_cell_info *mem_cell;
+	struct adm1266_data *data = priv;
+	int ret;
+	int i;
+
+	for (i = 0; i < data->nvmem_config.ncells; i++) {
+		mem_cell = &adm1266_nvmem_cells[i];
+		if (adm1266_cell_is_accessed(mem_cell, offset, bytes)) {
+			ret = adm1266_read_mem_cell(data, mem_cell);
+			if (ret < 0)
+				return ret;
+		}
+	}
+
+	memcpy(val, data->dev_mem + offset, bytes);
+
+	return 0;
+}
+
+static int adm1266_config_nvmem(struct adm1266_data *data)
+{
+	data->nvmem_config.name = dev_name(&data->client->dev);
+	data->nvmem_config.dev = &data->client->dev;
+	data->nvmem_config.root_only = true;
+	data->nvmem_config.read_only = true;
+	data->nvmem_config.owner = THIS_MODULE;
+	data->nvmem_config.reg_read = adm1266_nvmem_read;
+	data->nvmem_config.cells = adm1266_nvmem_cells;
+	data->nvmem_config.ncells = ARRAY_SIZE(adm1266_nvmem_cells);
+	data->nvmem_config.priv = data;
+	data->nvmem_config.stride = 1;
+	data->nvmem_config.word_size = 1;
+	data->nvmem_config.size = 0x80000;
+
+	data->nvmem = nvmem_register(&data->nvmem_config);
+	if (IS_ERR(data->nvmem)) {
+		dev_err(&data->client->dev, "Could not register nvmem!");
+		return PTR_ERR(data->nvmem);
+	}
+
+	data->dev_mem = devm_kzalloc(&data->client->dev,
+				     data->nvmem_config.size,
+				     GFP_KERNEL);
+	if (!data->dev_mem)
+		return -ENOMEM;
+
+	return 0;
 }
 
 static int adm1266_probe(struct i2c_client *client,
@@ -283,6 +438,10 @@ static int adm1266_probe(struct i2c_client *client,
 	data->client = client;
 
 	ret = adm1266_config_gpio(data);
+	if (ret < 0)
+		return ret;
+
+	ret = adm1266_config_nvmem(data);
 	if (ret < 0)
 		return ret;
 

--- a/drivers/hwmon/pmbus/adm1266.c
+++ b/drivers/hwmon/pmbus/adm1266.c
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * ADM1266 - Cascadable Super Sequencer with Margin
+ * Control and Fault Recording
+ *
+ * Copyright 2020 Analog Devices Inc.
+ */
+
+#include <linux/i2c.h>
+#include <linux/init.h>
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/slab.h>
+
+#include "pmbus.h"
+
+static int adm1266_probe(struct i2c_client *client,
+			 const struct i2c_device_id *id)
+{
+	struct pmbus_driver_info *info;
+	u32 funcs;
+	int i;
+
+	info = devm_kzalloc(&client->dev, sizeof(struct pmbus_driver_info),
+			    GFP_KERNEL);
+
+	info->pages = 17;
+	info->format[PSC_VOLTAGE_OUT] = linear;
+	funcs = PMBUS_HAVE_VOUT | PMBUS_HAVE_STATUS_VOUT;
+	for (i = 0; i < info->pages; i++)
+		info->func[i] = funcs;
+
+	return pmbus_do_probe(client, id, info);
+}
+
+static const struct of_device_id adm1266_of_match[] = {
+	{ .compatible = "adi,adm1266" },
+	{ },
+};
+MODULE_DEVICE_TABLE(of, adm1266_of_match);
+
+static const struct i2c_device_id adm1266_id[] = {
+	{ "adm1266", 0 },
+	{ }
+};
+MODULE_DEVICE_TABLE(i2c, adm1266_id);
+
+static struct i2c_driver adm1266_driver = {
+	.driver = {
+		   .name = "adm1266",
+		   .of_match_table = adm1266_of_match,
+		  },
+	.probe = adm1266_probe,
+	.remove = pmbus_do_remove,
+	.id_table = adm1266_id,
+};
+
+module_i2c_driver(adm1266_driver);
+
+MODULE_AUTHOR("Alexandru Tachici <alexandru.tachici@analog.com>");
+MODULE_DESCRIPTION("PMBus driver for Analog Devices ADM1266");
+MODULE_LICENSE("GPL v2");

--- a/drivers/hwmon/pmbus/adm1266.c
+++ b/drivers/hwmon/pmbus/adm1266.c
@@ -6,7 +6,11 @@
  * Copyright 2020 Analog Devices Inc.
  */
 
+#include <linux/bitfield.h>
+#include <linux/debugfs.h>
+#include <linux/gpio/driver.h>
 #include <linux/i2c.h>
+#include <linux/i2c-smbus.h>
 #include <linux/init.h>
 #include <linux/kernel.h>
 #include <linux/module.h>
@@ -14,16 +18,230 @@
 
 #include "pmbus.h"
 
+#define ADM1266_PDIO_CONFIG	0xD4
+#define ADM1266_GPIO_CONFIG	0xE1
+#define ADM1266_PDIO_STATUS	0xE9
+#define ADM1266_GPIO_STATUS	0xEA
+
+/* ADM1266 GPIO defines */
+#define ADM1266_GPIO_NR			9
+#define ADM1266_GPIO_FUNCTIONS(x)	FIELD_GET(BIT(0), x)
+#define ADM1266_GPIO_INPUT_EN(x)	FIELD_GET(BIT(2), x)
+#define ADM1266_GPIO_OUTPUT_EN(x)	FIELD_GET(BIT(3), x)
+#define ADM1266_GPIO_OPEN_DRAIN(x)	FIELD_GET(BIT(4), x)
+
+/* ADM1266 PDIO defines */
+#define ADM1266_PDIO_NR			16
+#define ADM1266_PDIO_PIN_CFG(x)		FIELD_GET(GENMASK(15, 13), x)
+#define ADM1266_PDIO_GLITCH_FILT(x)	FIELD_GET(GENMASK(12, 9), x)
+#define ADM1266_PDIO_OUT_CFG(x)		FIELD_GET(GENMASK(2, 0), x)
+
+struct adm1266_data {
+	struct pmbus_driver_info info;
+	struct gpio_chip gc;
+	struct i2c_client *client;
+};
+
+static const unsigned int adm1266_gpio_mapping[ADM1266_GPIO_NR][2] = {
+	{1, 0},
+	{2, 1},
+	{3, 2},
+	{4, 8},
+	{5, 9},
+	{6, 10},
+	{7, 11},
+	{8, 6},
+	{9, 7},
+};
+
+static const char *adm1266_names[ADM1266_GPIO_NR + ADM1266_PDIO_NR] = {
+	"GPIO1", "GPIO2", "GPIO3", "GPIO4", "GPIO5", "GPIO6", "GPIO7", "GPIO8",
+	"GPIO9", "PDIO1", "PDIO2", "PDIO3", "PDIO4", "PDIO5", "PDIO6",
+	"PDIO7", "PDIO8", "PDIO9", "PDIO10", "PDIO11", "PDIO12", "PDIO13",
+	"PDIO14", "PDIO15", "PDIO16",
+};
+
+#if IS_ENABLED(CONFIG_GPIOLIB)
+static int adm1266_gpio_get(struct gpio_chip *chip, unsigned int offset)
+{
+	struct adm1266_data *data = gpiochip_get_data(chip);
+	u8 read_buf[PMBUS_BLOCK_MAX + 1];
+	unsigned long pins_status;
+	unsigned int pmbus_cmd;
+	int ret;
+
+	if (offset < ADM1266_GPIO_NR)
+		pmbus_cmd = ADM1266_GPIO_STATUS;
+	else
+		pmbus_cmd = ADM1266_PDIO_STATUS;
+
+	ret = i2c_smbus_read_block_data(data->client, pmbus_cmd,
+					read_buf);
+	if (ret < 0)
+		return ret;
+
+	pins_status = read_buf[0] + (read_buf[1] << 8);
+	if (offset < ADM1266_GPIO_NR)
+		return test_bit(adm1266_gpio_mapping[offset][1], &pins_status);
+	else
+		return test_bit(offset - ADM1266_GPIO_NR, &pins_status);
+}
+
+static int adm1266_gpio_get_multiple(struct gpio_chip *chip,
+				     unsigned long *mask,
+				     unsigned long *bits)
+{
+	struct adm1266_data *data = gpiochip_get_data(chip);
+	u8 gpio_data[PMBUS_BLOCK_MAX + 1];
+	u8 pdio_data[PMBUS_BLOCK_MAX + 1];
+	unsigned long gpio_status;
+	unsigned long pdio_status;
+	unsigned int gpio_nr;
+	int ret;
+
+	ret = i2c_smbus_read_block_data(data->client, ADM1266_GPIO_STATUS,
+					gpio_data);
+	if (ret < 0)
+		return ret;
+
+	ret = i2c_smbus_read_block_data(data->client, ADM1266_PDIO_STATUS,
+					pdio_data);
+	if (ret < 0)
+		return ret;
+
+	gpio_status = gpio_data[0] + (gpio_data[1] << 8);
+	pdio_status = pdio_data[0] + (pdio_data[1] << 8);
+	*bits = 0;
+	for_each_set_bit(gpio_nr, mask, ADM1266_GPIO_NR) {
+		if (test_bit(adm1266_gpio_mapping[gpio_nr][1], &gpio_status))
+			set_bit(gpio_nr, bits);
+	}
+
+	for_each_set_bit_from(gpio_nr, mask,
+			      ADM1266_GPIO_NR + ADM1266_PDIO_STATUS) {
+		if (test_bit(gpio_nr - ADM1266_GPIO_NR, &pdio_status))
+			set_bit(gpio_nr, bits);
+	}
+
+	return 0;
+}
+
+static void adm1266_gpio_dbg_show(struct seq_file *s, struct gpio_chip *chip)
+{
+	struct adm1266_data *data = gpiochip_get_data(chip);
+	u8 write_buf[PMBUS_BLOCK_MAX + 1];
+	u8 read_buf[PMBUS_BLOCK_MAX + 1];
+	unsigned long gpio_config;
+	unsigned long pdio_config;
+	unsigned long pin_cfg;
+	int ret;
+	int i;
+
+	for (i = 0; i < ADM1266_GPIO_NR; i++) {
+		write_buf[0] = adm1266_gpio_mapping[i][1];
+		ret = pmbus_block_wr(data->client, ADM1266_GPIO_CONFIG, 1,
+				     write_buf, read_buf);
+		if (ret < 0)
+			dev_err(&data->client->dev, "GPIOs scan failed(%d).\n",
+				ret);
+
+		gpio_config = read_buf[0];
+		seq_puts(s, adm1266_names[i]);
+
+		seq_puts(s, " ( ");
+		if (!ADM1266_GPIO_FUNCTIONS(gpio_config)) {
+			seq_puts(s, "high-Z )\n");
+			continue;
+		}
+		if (ADM1266_GPIO_INPUT_EN(gpio_config))
+			seq_puts(s, "input ");
+		if (ADM1266_GPIO_OUTPUT_EN(gpio_config))
+			seq_puts(s, "output ");
+		if (ADM1266_GPIO_OPEN_DRAIN(gpio_config))
+			seq_puts(s, "open-drain )\n");
+		else
+			seq_puts(s, "push-pull )\n");
+	}
+
+	write_buf[0] = 0xFF;
+	ret = pmbus_block_wr(data->client, ADM1266_PDIO_CONFIG, 1, write_buf,
+			     read_buf);
+	if (ret < 0)
+		dev_err(&data->client->dev, "PDIOs scan failed(%d).\n", ret);
+
+	for (i = 0; i < ADM1266_PDIO_NR; i++) {
+		seq_puts(s, adm1266_names[ADM1266_GPIO_NR + i]);
+
+		pdio_config = read_buf[2 * i];
+		pdio_config += (read_buf[2 * i + 1] << 8);
+		pin_cfg = ADM1266_PDIO_PIN_CFG(pdio_config);
+
+		seq_puts(s, " ( ");
+		if (!pin_cfg || pin_cfg > 5) {
+			seq_puts(s, "high-Z )\n");
+			continue;
+		}
+
+		if (pin_cfg & BIT(0))
+			seq_puts(s, "output ");
+
+		if (pin_cfg & BIT(1))
+			seq_puts(s, "input ");
+
+		seq_puts(s, ")\n");
+	}
+}
+
+static int adm1266_config_gpio(struct adm1266_data *data)
+{
+	const char *name = dev_name(&data->client->dev);
+	int ret;
+
+	data->gc.label = name;
+	data->gc.parent = &data->client->dev;
+	data->gc.owner = THIS_MODULE;
+	data->gc.base = -1;
+	data->gc.names = adm1266_names;
+	data->gc.ngpio = ADM1266_PDIO_NR + ADM1266_GPIO_NR;
+	data->gc.get = adm1266_gpio_get;
+	data->gc.get_multiple = adm1266_gpio_get_multiple;
+	data->gc.dbg_show = adm1266_gpio_dbg_show;
+
+	ret = devm_gpiochip_add_data(&data->client->dev, &data->gc, data);
+	if (ret)
+		dev_err(&data->client->dev, "GPIO registering failed (%d)\n",
+			ret);
+
+	return ret;
+}
+#else
+static inline int adm1266_config_gpio(struct adm1266_data *data)
+{
+	return 0;
+}
+#endif
+
 static int adm1266_probe(struct i2c_client *client,
 			 const struct i2c_device_id *id)
 {
 	struct pmbus_driver_info *info;
+	struct adm1266_data *data;
 	u32 funcs;
+	int ret;
 	int i;
 
-	info = devm_kzalloc(&client->dev, sizeof(struct pmbus_driver_info),
+	data = devm_kzalloc(&client->dev, sizeof(struct adm1266_data),
 			    GFP_KERNEL);
+	if (!data)
+		return -ENOMEM;
 
+	data->client = client;
+
+	ret = adm1266_config_gpio(data);
+	if (ret < 0)
+		return ret;
+
+	info = &data->info;
 	info->pages = 17;
 	info->format[PSC_VOLTAGE_OUT] = linear;
 	funcs = PMBUS_HAVE_VOUT | PMBUS_HAVE_STATUS_VOUT;

--- a/drivers/hwmon/pmbus/pmbus.h
+++ b/drivers/hwmon/pmbus/pmbus.h
@@ -374,6 +374,8 @@ enum pmbus_sensor_classes {
 
 #define PMBUS_PAGE_VIRTUAL	BIT(31)
 
+#define PMBUS_BLOCK_MAX		255
+
 enum pmbus_data_format { linear = 0, direct, vid };
 enum vrm_version { vr11 = 0, vr12, vr13 };
 
@@ -439,6 +441,8 @@ extern const struct regulator_ops pmbus_regulator_ops;
 
 void pmbus_clear_cache(struct i2c_client *client);
 int pmbus_set_page(struct i2c_client *client, int page);
+int pmbus_block_wr(struct i2c_client *client, u8 cmd, u8 w_len, u8 *data_w,
+		   u8 *data_r);
 int pmbus_read_word_data(struct i2c_client *client, int page, u8 reg);
 int pmbus_write_word_data(struct i2c_client *client, int page, u8 reg, u16 word);
 int pmbus_read_byte_data(struct i2c_client *client, int page, u8 reg);

--- a/drivers/hwmon/pmbus/pmbus_core.c
+++ b/drivers/hwmon/pmbus/pmbus_core.c
@@ -19,6 +19,7 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
+#include <linux/crc8.h>
 #include <linux/debugfs.h>
 #include <linux/kernel.h>
 #include <linux/math64.h>
@@ -56,6 +57,8 @@
 #define PB_NUM_STATUS_REG	(PB_STATUS_VMON_BASE + 1)
 
 #define PMBUS_NAME_SIZE		24
+
+DECLARE_CRC8_TABLE(pmbus_crc_table);
 
 struct pmbus_sensor {
 	struct pmbus_sensor *next;
@@ -185,6 +188,98 @@ int pmbus_set_page(struct i2c_client *client, int page)
 	return 0;
 }
 EXPORT_SYMBOL_GPL(pmbus_set_page);
+
+static void i2c_pmbus_try_get_dmabuf(struct i2c_msg *msg)
+{
+	unsigned char *dma_buf;
+
+	dma_buf = kzalloc(PMBUS_BLOCK_MAX + 3, GFP_KERNEL);
+	if (!dma_buf)
+		return;
+
+	msg->buf = dma_buf;
+	msg->flags |= I2C_M_DMA_SAFE;
+}
+
+/* Block Write/Read command.
+ * @client: Handle to slave device
+ * @cmd: Byte interpreted by slave
+ * @w_len: Size of write data block; PMBus allows at most 255 bytes
+ * @data_w: byte array which will be written.
+ * @data_r: Byte array into which data will be read; big enough to hold
+ *	the data returned by the slave. PMBus allows at most 255 bytes.
+ *
+ * Different from Block Read as it sends data and waits for the slave to
+ * return a value dependent on that data. The protocol is simply a Write Block
+ * followed by a Read Block without the Read-Block command field and the
+ * Write-Block STOP bit.
+ *
+ * Returns number of bytes read or negative errno.
+ */
+int pmbus_block_wr(struct i2c_client *client, u8 cmd, u8 w_len,
+		   u8 *data_w, u8 *data_r)
+{
+	u8 write_buf[PMBUS_BLOCK_MAX + 1];
+	u8 read_buf[PMBUS_BLOCK_MAX + 1];
+	struct i2c_msg msgs[2] = {
+		{
+			.addr = client->addr,
+			.flags = 0,
+			.buf = write_buf,
+			.len = w_len + 2,
+		},
+		{
+			.addr = client->addr,
+			.flags = I2C_M_RD,
+			.buf = read_buf,
+			.len = PMBUS_BLOCK_MAX,
+		}
+	};
+	u8 addr = 0;
+	u8 crc = 0;
+	int ret;
+
+	i2c_pmbus_try_get_dmabuf(&msgs[0]);
+	i2c_pmbus_try_get_dmabuf(&msgs[1]);
+
+	msgs[0].buf[0] = cmd;
+	msgs[0].buf[1] = w_len;
+	memcpy(&msgs[0].buf[2], data_w, w_len);
+
+	ret = i2c_transfer(client->adapter, msgs, 2);
+	if (ret != 2) {
+		dev_err(&client->dev, "I2C transfer error.");
+		goto cleanup;
+	}
+
+	if (client->flags & I2C_CLIENT_PEC) {
+		addr = i2c_8bit_addr_from_msg(&msgs[0]);
+		crc = crc8(pmbus_crc_table, &addr, 1, crc);
+		crc = crc8(pmbus_crc_table, msgs[0].buf,  msgs[0].len, crc);
+
+		addr = i2c_8bit_addr_from_msg(&msgs[1]);
+		crc = crc8(pmbus_crc_table, &addr, 1, crc);
+		crc = crc8(pmbus_crc_table, msgs[1].buf,  msgs[1].buf[0] + 1,
+			   crc);
+
+		if (crc != msgs[1].buf[msgs[1].buf[0] + 1]) {
+			ret = -EBADMSG;
+			goto cleanup;
+		}
+	}
+
+	memcpy(data_r, &msgs[1].buf[1], msgs[1].buf[0]);
+	ret = msgs[1].buf[0];
+
+cleanup:
+	if (msgs[0].flags & I2C_M_DMA_SAFE)
+		kfree(msgs[0].buf);
+	if (msgs[1].flags & I2C_M_DMA_SAFE)
+		kfree(msgs[1].buf);
+
+	return ret;
+}
+EXPORT_SYMBOL_GPL(pmbus_block_wr);
 
 int pmbus_write_byte(struct i2c_client *client, int page, u8 value)
 {
@@ -2315,6 +2410,8 @@ int pmbus_do_probe(struct i2c_client *client, const struct i2c_device_id *id,
 	data = devm_kzalloc(dev, sizeof(*data), GFP_KERNEL);
 	if (!data)
 		return -ENOMEM;
+
+	crc8_populate_msb(pmbus_crc_table, 0x7);
 
 	i2c_set_clientdata(client, data);
 	mutex_init(&data->update_lock);


### PR DESCRIPTION
Add initial pmbus probing driver for the adm1266 Cascadable
Super Sequencer with Margin Control and Fault Recording.
Driver is currently using the pmbus_core, creating sysfs
files under hwmon for inputs: vh1->vh4 and vp1->vp13.