### PR TITLE
[2019_R1] arch: microblaze: rename '/include/' -> '#include'

### DIFF
--- a/arch/microblaze/boot/dts/kc705.dts
+++ b/arch/microblaze/boot/dts/kc705.dts
@@ -1,2 +1,2 @@
 /dts-v1/;
-/include/ "kc705.dtsi"
+#include "kc705.dtsi"

--- a/arch/microblaze/boot/dts/kc705_ad9467_fmc.dts
+++ b/arch/microblaze/boot/dts/kc705_ad9467_fmc.dts
@@ -1,6 +1,6 @@
 
 /dts-v1/;
-/include/ "kc705.dtsi"
+#include "kc705.dtsi"
 
 #define fmc_i2c fmc_lpc_iic
 #define fmc_spi axi_spi

--- a/arch/microblaze/boot/dts/kc705_fmcdaq2.dts
+++ b/arch/microblaze/boot/dts/kc705_fmcdaq2.dts
@@ -1,6 +1,6 @@
 
 /dts-v1/;
-/include/ "kc705.dtsi"
+#include "kc705.dtsi"
 
 #define fmc_i2c fmc_hpc_iic
 #define fmc_spi axi_spi

--- a/arch/microblaze/boot/dts/kc705_fmcjesdadc1.dts
+++ b/arch/microblaze/boot/dts/kc705_fmcjesdadc1.dts
@@ -1,6 +1,6 @@
 
 /dts-v1/;
-/include/ "kc705.dtsi"
+#include "kc705.dtsi"
 
 #define fmc_i2c fmc_hpc_iic
 #define fmc_spi axi_spi

--- a/arch/microblaze/boot/dts/kc705_fmcomms1.dts
+++ b/arch/microblaze/boot/dts/kc705_fmcomms1.dts
@@ -1,6 +1,6 @@
 
 /dts-v1/;
-/include/ "kc705.dtsi"
+#include "kc705.dtsi"
 
 #define fmc_i2c fmc_lpc_iic
 

--- a/arch/microblaze/boot/dts/kc705_fmcomms2-3.dts
+++ b/arch/microblaze/boot/dts/kc705_fmcomms2-3.dts
@@ -1,6 +1,6 @@
 
 /dts-v1/;
-/include/ "kc705.dtsi"
+#include "kc705.dtsi"
 
 #define fmc_i2c fmc_lpc_iic
 #define fmc_spi axi_spi

--- a/arch/microblaze/boot/dts/kc705_fmcomms4.dts
+++ b/arch/microblaze/boot/dts/kc705_fmcomms4.dts
@@ -1,6 +1,6 @@
 
 /dts-v1/;
-/include/ "kc705.dtsi"
+#include "kc705.dtsi"
 
 #define fmc_i2c fmc_lpc_iic
 #define fmc_spi axi_spi

--- a/arch/microblaze/boot/dts/kcu105.dts
+++ b/arch/microblaze/boot/dts/kcu105.dts
@@ -1,2 +1,2 @@
 /dts-v1/;
-/include/ "kcu105.dtsi"
+#include "kcu105.dtsi"

--- a/arch/microblaze/boot/dts/kcu105_adrv9371x.dts
+++ b/arch/microblaze/boot/dts/kcu105_adrv9371x.dts
@@ -1,6 +1,6 @@
 
 /dts-v1/;
-/include/ "kcu105.dtsi"
+#include "kcu105.dtsi"
 
 #define fmc_i2c fmc_hpc_iic
 #define fmc_spi axi_spi

--- a/arch/microblaze/boot/dts/kcu105_fmcdaq2.dts
+++ b/arch/microblaze/boot/dts/kcu105_fmcdaq2.dts
@@ -1,6 +1,6 @@
 
 /dts-v1/;
-/include/ "kcu105.dtsi"
+#include "kcu105.dtsi"
 
 #define fmc_i2c fmc_hpc_iic
 #define fmc_spi axi_spi

--- a/arch/microblaze/boot/dts/kcu105_fmcdaq3.dts
+++ b/arch/microblaze/boot/dts/kcu105_fmcdaq3.dts
@@ -1,6 +1,6 @@
 
 /dts-v1/;
-/include/ "kcu105.dtsi"
+#include "kcu105.dtsi"
 
 #define fmc_i2c fmc_hpc_iic
 #define fmc_spi axi_spi

--- a/arch/microblaze/boot/dts/kcu105_fmcomms2-3.dts
+++ b/arch/microblaze/boot/dts/kcu105_fmcomms2-3.dts
@@ -1,6 +1,6 @@
 
 /dts-v1/;
-/include/ "kcu105.dtsi"
+#include "kcu105.dtsi"
 
 #define fmc_i2c fmc_lpc_iic
 #define fmc_spi axi_spi

--- a/arch/microblaze/boot/dts/kcu105_fmcomms4.dts
+++ b/arch/microblaze/boot/dts/kcu105_fmcomms4.dts
@@ -1,6 +1,6 @@
 
 /dts-v1/;
-/include/ "kcu105.dtsi"
+#include "kcu105.dtsi"
 
 #define fmc_i2c fmc_lpc_iic
 #define fmc_spi axi_spi

--- a/arch/microblaze/boot/dts/vc707.dts
+++ b/arch/microblaze/boot/dts/vc707.dts
@@ -1,2 +1,2 @@
 /dts-v1/;
-/include/ "vc707.dtsi"
+#include "vc707.dtsi"

--- a/arch/microblaze/boot/dts/vc707_ad6676evb.dts
+++ b/arch/microblaze/boot/dts/vc707_ad6676evb.dts
@@ -1,6 +1,6 @@
 
 /dts-v1/;
-/include/ "vc707.dtsi"
+#include "vc707.dtsi"
 
 #define fmc_i2c fmc1_hpc_iic
 #define fmc_spi axi_spi

--- a/arch/microblaze/boot/dts/vc707_fmcadc2.dts
+++ b/arch/microblaze/boot/dts/vc707_fmcadc2.dts
@@ -1,6 +1,6 @@
 
 /dts-v1/;
-/include/ "vc707.dtsi"
+#include "vc707.dtsi"
 
 #define fmc_i2c fmc1_hpc_iic
 #define fmc_spi axi_spi

--- a/arch/microblaze/boot/dts/vc707_fmcadc5.dts
+++ b/arch/microblaze/boot/dts/vc707_fmcadc5.dts
@@ -1,6 +1,6 @@
 
 /dts-v1/;
-/include/ "vc707.dtsi"
+#include "vc707.dtsi"
 
 #define fmc_i2c fmc1_hpc_iic
 #define fmc_spi axi_spi

--- a/arch/microblaze/boot/dts/vc707_fmcdaq2.dts
+++ b/arch/microblaze/boot/dts/vc707_fmcdaq2.dts
@@ -1,6 +1,6 @@
 
 /dts-v1/;
-/include/ "vc707.dtsi"
+#include "vc707.dtsi"
 
 #define fmc_i2c fmc1_hpc_iic
 #define fmc_spi axi_spi

--- a/arch/microblaze/boot/dts/vc707_fmcjesdadc1.dts
+++ b/arch/microblaze/boot/dts/vc707_fmcjesdadc1.dts
@@ -1,6 +1,6 @@
 
 /dts-v1/;
-/include/ "vc707.dtsi"
+#include "vc707.dtsi"
 
 #define fmc_i2c fmc1_hpc_iic
 #define fmc_spi axi_spi

--- a/arch/microblaze/boot/dts/vc707_fmcomms1.dts
+++ b/arch/microblaze/boot/dts/vc707_fmcomms1.dts
@@ -1,6 +1,6 @@
 
 /dts-v1/;
-/include/ "vc707.dtsi"
+#include "vc707.dtsi"
 
 #define fmc_i2c fmc1_hpc_iic
 

--- a/arch/microblaze/boot/dts/vc707_fmcomms2-3.dts
+++ b/arch/microblaze/boot/dts/vc707_fmcomms2-3.dts
@@ -1,6 +1,6 @@
 
 /dts-v1/;
-/include/ "vc707.dtsi"
+#include "vc707.dtsi"
 
 #define fmc_i2c fmc1_hpc_iic
 #define fmc_spi axi_spi

--- a/arch/microblaze/boot/dts/vc707_fmcomms4.dts
+++ b/arch/microblaze/boot/dts/vc707_fmcomms4.dts
@@ -1,6 +1,6 @@
 
 /dts-v1/;
-/include/ "vc707.dtsi"
+#include "vc707.dtsi"
 
 #define fmc_i2c fmc1_hpc_iic
 #define fmc_spi axi_spi

--- a/arch/microblaze/boot/dts/vcu118.dts
+++ b/arch/microblaze/boot/dts/vcu118.dts
@@ -1,2 +1,2 @@
 /dts-v1/;
-/include/ "vcu118.dtsi"
+#include "vcu118.dtsi"

--- a/arch/microblaze/boot/dts/vcu118_dual_ad9208.dts
+++ b/arch/microblaze/boot/dts/vcu118_dual_ad9208.dts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 /dts-v1/;
-/include/ "vcu118.dtsi"
+#include "vcu118.dtsi"
 
 #define fmc_i2c fmcp_hspc_iic
 #define fmc_spi axi_spi

--- a/arch/microblaze/boot/dts/vcu118_fmcdaq3.dts
+++ b/arch/microblaze/boot/dts/vcu118_fmcdaq3.dts
@@ -1,6 +1,6 @@
 
 /dts-v1/;
-/include/ "vcu118.dtsi"
+#include "vcu118.dtsi"
 
 #define fmc_i2c fmcp_hspc_iic
 #define fmc_spi axi_spi


### PR DESCRIPTION
The #include directive is a bit more flexible/permissive when including a
mix of DTs and C header files with dt-binding macros.

We did the same for ARM [Zynq] DTs.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>