### PR TITLE
drm: adv7511: do 4 regmap_bulk_read() calls for EDID 

### DIFF
--- a/drivers/gpu/drm/bridge/adv7511/adv7511_drv.c
+++ b/drivers/gpu/drm/bridge/adv7511/adv7511_drv.c
@@ -531,7 +531,7 @@ static int adv7511_get_edid_block(void *data, u8 *buf, unsigned int block,
 				  size_t len)
 {
 	struct adv7511 *adv7511 = data;
-	int ret;
+	int ret, off;
 
 	if (len > 128)
 		return -EINVAL;
@@ -553,10 +553,12 @@ static int adv7511_get_edid_block(void *data, u8 *buf, unsigned int block,
 				return ret;
 		}
 
-		ret = regmap_bulk_read(adv7511->regmap_edid, 0,
-				       adv7511->edid_buf, 256);
-		if (ret < 0)
-			return ret;
+		for (off = 0; off < 256; off+= 64) {
+			ret = regmap_bulk_read(adv7511->regmap_edid, off,
+					       &adv7511->edid_buf[off], 64);
+			if (ret < 0)
+				return ret;
+		}
 
 		adv7511->current_edid_segment = block / 2;
 	}

--- a/drivers/gpu/drm/bridge/adv7511/adv7511_drv.c
+++ b/drivers/gpu/drm/bridge/adv7511/adv7511_drv.c
@@ -555,6 +555,8 @@ static int adv7511_get_edid_block(void *data, u8 *buf, unsigned int block,
 
 		ret = regmap_bulk_read(adv7511->regmap_edid, 0,
 				       adv7511->edid_buf, 256);
+		if (ret < 0)
+			return ret;
 
 		adv7511->current_edid_segment = block / 2;
 	}


### PR DESCRIPTION
Previously, 4 x i2c_transfer() calls used to be done, to read the EDID.
This does the same thing using regmap_bulk_read().

The i2c-cadence driver can only do 252 bytes, and some i2c controllers can
do 64-byte transfer-sizes.

The issue that is visible [without this change] is that the resolution
[read-back from the monitor] is reduced to a minimal [640x480].

I tried to see whether we can extend that 252-byte-transfer limit, but that
is a bit too difficult, because it requires too many i2c framework changes
that wouldn't make sense.
The i2c controller is configured to issue an i2c transfer, then an
interrupt shoots to notify that it completed.

Fixes 6a83880: ("drm: bridge: adv7511: Implement regmap for EDID memory map")
Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>