### PR TITLE
dts: zynq-pluto-sdr: Update digital-interface-tune-skip-mode info

### DIFF
--- a/arch/arm/boot/dts/zynq-pluto-sdr.dtsi
+++ b/arch/arm/boot/dts/zynq-pluto-sdr.dtsi
@@ -224,8 +224,7 @@
 		adi,full-port-enable;
 		adi,digital-interface-tune-fir-disable;
 
-		/* Temporary workaround - HDL issue? need to investigate further */
-		adi,digital-interface-tune-skip-mode = <0>; /* SKIP TX */
+		adi,digital-interface-tune-skip-mode = <0>; /* TUNE RX & TX */
 		adi,tx-fb-clock-delay = <0>;
 		adi,tx-data-delay = <9>;
 		adi,swap-ports-enable;


### PR DESCRIPTION
The initial mode (1), for which the comment was true, was updated by
https://github.com/analogdevicesinc/linux/commit/3b42735e3ef9195fb9070e291b278dcbb93fe395 .

Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>