### PR TITLE
iio: frequency: axi-dds: remove dp-disable logic

### DIFF
--- a/drivers/iio/frequency/cf_axi_dds.c
+++ b/drivers/iio/frequency/cf_axi_dds.c
@@ -83,7 +83,6 @@ struct cf_axi_dds_state {
 	struct gpio_desc		*interpolation_gpio;
 
 	bool				standalone;
-	bool				dp_disable;
 	bool				enable;
 	bool				pl_dma_fifo_en;
 	enum fifo_ctrl			gpio_dma_fifo_ctrl;
@@ -998,7 +997,6 @@ static struct cf_axi_dds_chip_info cf_axi_dds_chip_info_tbl[] = {
 			CF_AXI_DDS_CHAN(3, 0, "2B"),
 		},
 		.num_channels = 7,
-		.num_dp_disable_channels = 3,
 		.num_dds_channels = 4,
 		.num_buf_channels = 2,
 	},
@@ -1034,7 +1032,6 @@ static struct cf_axi_dds_chip_info cf_axi_dds_chip_info_tbl[] = {
 			CF_AXI_DDS_CHAN(3, 0, "2B"),
 		},
 		.num_channels = 7,
-		.num_dp_disable_channels = 3,
 		.num_dds_channels = 4,
 		.num_buf_channels = 2,
 	},
@@ -1064,7 +1061,6 @@ static struct cf_axi_dds_chip_info cf_axi_dds_chip_info_tbl[] = {
 			CF_AXI_DDS_CHAN(7, 0, "4B"),
 		},
 		.num_channels = 13,
-		.num_dp_disable_channels = 5,
 		.num_dds_channels = 8,
 		.num_buf_channels = 4,
 	},
@@ -1094,7 +1090,6 @@ static struct cf_axi_dds_chip_info cf_axi_dds_chip_info_tbl[] = {
 			CF_AXI_DDS_CHAN(7, 0, "4B"),
 		},
 		.num_channels = 13,
-		.num_dp_disable_channels = 5,
 		.num_dds_channels = 8,
 		.num_buf_channels = 4,
 	},
@@ -1118,7 +1113,6 @@ static struct cf_axi_dds_chip_info cf_axi_dds_chip_info_tbl[] = {
 			CF_AXI_DDS_CHAN(3, 0, "2B"),
 		},
 		.num_channels = 7,
-		.num_dp_disable_channels = 3,
 		.num_dds_channels = 4,
 		.num_buf_channels = 2,
 	},
@@ -1156,7 +1150,6 @@ static struct cf_axi_dds_chip_info cf_axi_dds_chip_info_tbl[] = {
 			CF_AXI_DDS_CHAN(3, 0, "TX1_Q_F2"),
 		},
 		.num_channels = 6,
-		.num_dp_disable_channels = 2,
 		.num_dds_channels = 4,
 		.num_buf_channels = 2,
 	},
@@ -1178,7 +1171,6 @@ static struct cf_axi_dds_chip_info cf_axi_dds_chip_info_tbl[] = {
 
 		},
 		.num_channels = 12,
-		.num_dp_disable_channels = 4,
 		.num_dds_channels = 8,
 		.num_buf_channels = 4,
 	},
@@ -1205,7 +1197,6 @@ static struct cf_axi_dds_chip_info cf_axi_dds_chip_info_tbl[] = {
 			CF_AXI_DDS_CHAN(11, 0, "6B"),
 		},
 		.num_channels = 18,
-		.num_dp_disable_channels = 6,
 		.num_dds_channels = 12,
 		.num_buf_channels = 6,
 	},
@@ -1491,7 +1482,6 @@ static int cf_axi_dds_setup_chip_info_tbl(struct cf_axi_dds_state *st,
 	}
 
 	st->chip_info_generated.num_channels = c;
-	st->chip_info_generated.num_dp_disable_channels = m;
 	st->chip_info_generated.num_dds_channels = i;
 	st->chip_info_generated.num_buf_channels = m;
 	st->chip_info_generated.name = name;
@@ -1713,7 +1703,6 @@ static int cf_axi_dds_probe(struct platform_device *pdev)
 
 	st->standalone = info->standalone;
 	st->version = dds_read(st, ADI_AXI_REG_VERSION);
-	st->dp_disable = dds_read(st, ADI_REG_DAC_DP_DISABLE);
 
 	if (ADI_AXI_PCORE_VER_MAJOR(st->version) >
 		ADI_AXI_PCORE_VER_MAJOR(info->version)) {
@@ -1732,9 +1721,7 @@ static int cf_axi_dds_probe(struct platform_device *pdev)
 	indio_dev->name = np->name;
 	indio_dev->channels = st->chip_info->channel;
 	indio_dev->modes = INDIO_DIRECT_MODE;
-	indio_dev->num_channels = (st->dp_disable ?
-		st->chip_info->num_dp_disable_channels :
-		st->chip_info->num_channels);
+	indio_dev->num_channels = st->chip_info->num_channels;
 
 	st->iio_info = cf_axi_dds_info;
 	if (conv)
@@ -1791,7 +1778,7 @@ static int cf_axi_dds_probe(struct platform_device *pdev)
 
 	cf_axi_dds_datasel(st, -1, DATA_SEL_DDS);
 
-	if (!st->dp_disable) {
+	{
 		u32 scale, frequency, phase, i;
 
 		scale = 0x1000; /* 0.250 */
@@ -1844,7 +1831,7 @@ static int cf_axi_dds_probe(struct platform_device *pdev)
 	cf_axi_dds_start_sync(st);
 	cf_axi_dds_sync_frame(indio_dev);
 
-	if (!st->dp_disable && !dds_read(st, ADI_AXI_REG_ID)) {
+	if (!dds_read(st, ADI_AXI_REG_ID)) {
 
 		if (st->chip_info->num_shadow_slave_channels) {
 			u32 regs[2];
@@ -1924,7 +1911,7 @@ static int cf_axi_dds_remove(struct platform_device *pdev)
 
 	iio_device_unregister(indio_dev);
 
-	if (!st->dp_disable && !dds_read(st, ADI_AXI_REG_ID) &&
+	if (!dds_read(st, ADI_AXI_REG_ID) &&
 		of_find_property(pdev->dev.of_node, "dmas", NULL))
 		cf_axi_dds_unconfigure_buffer(indio_dev);
 

--- a/drivers/iio/frequency/cf_axi_dds.h
+++ b/drivers/iio/frequency/cf_axi_dds.h
@@ -103,9 +103,6 @@ enum dds_data_select {
 
 #define ADI_REG_DAC_GP_CONTROL	0x00BC
 
-#define ADI_REG_DAC_DP_DISABLE	0x00C0
-#define ADI_DAC_DP_DISABLE	(1 << 0)
-
 /* JESD TPL */
 
 #define ADI_REG_TPL_CNTRL		0x0200
@@ -226,7 +223,6 @@ struct cf_axi_dds_chip_info {
 	const char *name;
 	unsigned int num_channels;
 	unsigned int num_dds_channels;
-	unsigned int num_dp_disable_channels;
 	unsigned int num_buf_channels;
 	unsigned num_shadow_slave_channels;
 	const unsigned long *scan_masks;


### PR DESCRIPTION
There may be some datapath disable logic in the HDL cores, but this
implementation is not it.

This logic seems to try to read this information from register 0x00C0 -
ADI_REG_DAC_DP_DISABLE, which is not the same as register 0x000C -
REG_CONFIG). 0x00C0 should now be the PPS counter in all DAC/ADC HDL cores.

Also, bit 0 in register REG_CONFIG (0x000C) is actually
IQCORRECTION_DISABLE, and not anything related to ADI_DAC_DP_DISABLE.

This logic does not seem to cause any malfunction at the moment. But it's a
good idea to remove it, since nothing about it [in HDL] suggests that this
should be datapath-disable. If we need to do any datapath-disable, we may
need to re-implement it using REG_CONFIG.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>