### PR TITLE
iio: axi-dds: temporarily hardcode dp_disable to false

### DIFF
--- a/drivers/iio/frequency/cf_axi_dds.c
+++ b/drivers/iio/frequency/cf_axi_dds.c
@@ -1713,7 +1713,7 @@ static int cf_axi_dds_probe(struct platform_device *pdev)
 
 	st->standalone = info->standalone;
 	st->version = dds_read(st, ADI_AXI_REG_VERSION);
-	st->dp_disable = dds_read(st, ADI_REG_DAC_DP_DISABLE);
+	st->dp_disable = false; /* FIXME: resolve later which reg & bit to read for this */
 
 	if (ADI_AXI_PCORE_VER_MAJOR(st->version) >
 		ADI_AXI_PCORE_VER_MAJOR(info->version)) {

--- a/drivers/iio/frequency/cf_axi_dds.h
+++ b/drivers/iio/frequency/cf_axi_dds.h
@@ -103,9 +103,6 @@ enum dds_data_select {
 
 #define ADI_REG_DAC_GP_CONTROL	0x00BC
 
-#define ADI_REG_DAC_DP_DISABLE	0x00C0
-#define ADI_DAC_DP_DISABLE	(1 << 0)
-
 /* JESD TPL */
 
 #define ADI_REG_TPL_CNTRL		0x0200


### PR DESCRIPTION
The register at address 0x00C0 is now the PPS counter. We shouldn't read it
in order to do any datapath disable. For now, setting the 'dp_disable' to
false to prevent any potential issues with it.

Also, removing the definition of the old `ADI_REG_DAC_DP_DISABLE`, which
isn't correct anymore.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>