### PR TITLE
iio: axi-adc: re-add dp_disable logic & hard-code it to false

### DIFF
--- a/drivers/iio/adc/cf_axi_adc.h
+++ b/drivers/iio/adc/cf_axi_adc.h
@@ -178,6 +178,8 @@ enum adc_data_sel {
 #define ADI_USR_DECIMATION_N(x)			(((x) & 0xFFFF) << 0)
 #define ADI_TO_USR_DECIMATION_N(x)		(((x) >> 0) & 0xFFFF)
 
+#define ADI_REG_ADC_DP_DISABLE 			0x00C0
+
 /* PCORE Version > 8.00 */
 #define ADI_REG_DELAY(l)				(0x0800 + (l) * 0x4)
 

--- a/drivers/iio/adc/cf_axi_adc.h
+++ b/drivers/iio/adc/cf_axi_adc.h
@@ -178,8 +178,6 @@ enum adc_data_sel {
 #define ADI_USR_DECIMATION_N(x)			(((x) & 0xFFFF) << 0)
 #define ADI_TO_USR_DECIMATION_N(x)		(((x) >> 0) & 0xFFFF)
 
-#define ADI_REG_ADC_DP_DISABLE 			0x00C0
-
 /* PCORE Version > 8.00 */
 #define ADI_REG_DELAY(l)				(0x0800 + (l) * 0x4)
 

--- a/drivers/iio/adc/cf_axi_adc_core.c
+++ b/drivers/iio/adc/cf_axi_adc_core.c
@@ -865,7 +865,7 @@ static int axiadc_probe(struct platform_device *pdev)
 
 	platform_set_drvdata(pdev, indio_dev);
 
-	st->dp_disable = axiadc_read(st, ADI_REG_ADC_DP_DISABLE);
+	st->dp_disable = false; /* FIXME: resolve later which reg & bit to read for this */
 
 	conv = to_converter(st->dev_spi);
 	if (IS_ERR(conv)) {


### PR DESCRIPTION
The register at address 0x00C0 is now the PPS counter. We shouldn't read it
in order to do any datapath disable. For now, setting the 'dp_disable' to
false to prevent any potential issues with it.

Also, removing the definition of the old `ADI_REG_ADC_DP_DISABLE`, which
isn't correct anymore.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>