### PR TITLE
iio: jesd204: axi_adxcvr: Remove the CLK_SET_RATE_GATE flag

### DIFF
--- a/drivers/iio/jesd204/axi_adxcvr.c
+++ b/drivers/iio/jesd204/axi_adxcvr.c
@@ -426,7 +426,7 @@ static int adxcvr_clk_register(struct device *dev,
 
 	init.name = clk_names[0];
 	init.ops = &clkout_ops;
-	init.flags = CLK_SET_RATE_GATE | CLK_SET_RATE_PARENT;
+	init.flags = CLK_SET_RATE_PARENT;
 
 	init.parent_names = (parent_name ? &parent_name : NULL);
 	init.num_parents = (parent_name ? 1 : 0);


### PR DESCRIPTION
... for fixing the dynamic reconfiguration.

Once a clock with the CLK_SET_RATE_GATE flag enabled is prepared, it
becomes protected, so any rate change is no longer possible (until it
is unprepared). This behavior was introduced by: https://github.com/analogdevicesinc/linux/commit/9461f7b33d11cbbf5ce79c3c03d0da9d42dfce92

Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>