### PR TITLE
iio: buffer: revert use of bitmap_zalloc()

### DIFF
--- a/drivers/iio/industrialio-buffer.c
+++ b/drivers/iio/industrialio-buffer.c
@@ -270,16 +270,15 @@ int iio_buffer_alloc_scanmask(struct iio_buffer *buffer,
 	if (!indio_dev->masklength)
 		return 0;
 
-	buffer->scan_mask = bitmap_zalloc(indio_dev->masklength, GFP_KERNEL);
+	buffer->scan_mask = kcalloc(BITS_TO_LONGS(indio_dev->masklength),
+		sizeof(*buffer->scan_mask), GFP_KERNEL);
 	if (buffer->scan_mask == NULL)
 		return -ENOMEM;
 
-	buffer->channel_mask = bitmap_zalloc(indio_dev->num_channels,
-					     GFP_KERNEL);
-	if (buffer->channel_mask == NULL) {
-		bitmap_free(buffer->scan_mask);
+	buffer->channel_mask = kcalloc(BITS_TO_LONGS(indio_dev->num_channels),
+		sizeof(*buffer->channel_mask), GFP_KERNEL);
+	if (buffer->channel_mask == NULL)
 		return -ENOMEM;
-	}
 
 	return 0;
 }
@@ -287,8 +286,8 @@ EXPORT_SYMBOL(iio_buffer_alloc_scanmask);
 
 void iio_buffer_free_scanmask(struct iio_buffer *buffer)
 {
-	bitmap_free(buffer->channel_mask);
-	bitmap_free(buffer->scan_mask);
+	kfree(buffer->channel_mask);
+	kfree(buffer->scan_mask);
 }
 EXPORT_SYMBOL(iio_buffer_free_scanmask);
 
@@ -403,7 +402,8 @@ static int iio_channel_mask_set(struct iio_dev *indio_dev,
 	unsigned long *trialmask;
 	unsigned int ch;
 
-	trialmask = bitmap_zalloc(indio_dev->masklength, GFP_KERNEL);
+	trialmask = kcalloc(BITS_TO_LONGS(indio_dev->masklength),
+			    sizeof(*trialmask), GFP_KERNEL);
 	if (trialmask == NULL)
 		return -ENOMEM;
 	if (!indio_dev->masklength) {
@@ -428,13 +428,13 @@ static int iio_channel_mask_set(struct iio_dev *indio_dev,
 	}
 	bitmap_copy(buffer->scan_mask, trialmask, indio_dev->masklength);
 
-	bitmap_free(trialmask);
+	kfree(trialmask);
 
 	return 0;
 
 err_invalid_mask:
 	clear_bit(bit, buffer->channel_mask);
-	bitmap_free(trialmask);
+	kfree(trialmask);
 	return -EINVAL;
 }
 
@@ -763,7 +763,7 @@ static void iio_free_scan_mask(struct iio_dev *indio_dev,
 {
 	/* If the mask is dynamically allocated free it, otherwise do nothing */
 	if (!indio_dev->available_scan_masks)
-		bitmap_free(mask);
+		kfree(mask);
 }
 
 struct iio_device_config {
@@ -836,7 +836,8 @@ static int iio_verify_update(struct iio_dev *indio_dev,
 		strict_scanmask = true;
 
 	/* What scan mask do we actually have? */
-	compound_mask = bitmap_zalloc(indio_dev->masklength, GFP_KERNEL);
+	compound_mask = kcalloc(BITS_TO_LONGS(indio_dev->masklength),
+				sizeof(long), GFP_KERNEL);
 	if (compound_mask == NULL)
 		return -ENOMEM;
 
@@ -861,7 +862,7 @@ static int iio_verify_update(struct iio_dev *indio_dev,
 				    indio_dev->masklength,
 				    compound_mask,
 				    strict_scanmask);
-		bitmap_free(compound_mask);
+		kfree(compound_mask);
 		if (scan_mask == NULL)
 			return -EINVAL;
 	} else {


### PR DESCRIPTION
These got automatically propagated via the auto-sync mechanism.
The bitmap_alloc() functions are not present in an older version of the
kernel (before 4.19).
This change manually reverts that change to 4.14.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>