### PR TITLE
iio: m2k-logic-analyzer: cleanup error & remove paths

### DIFF
--- a/drivers/iio/logic/m2k-logic-analyzer.c
+++ b/drivers/iio/logic/m2k-logic-analyzer.c
@@ -880,11 +880,7 @@ static int m2k_la_probe(struct platform_device *pdev)
 
 	iio_device_set_drvdata(indio_dev_rx, m2k_la);
 
-	ret = devm_iio_device_register(&pdev->dev, indio_dev_rx);
-	if (ret)
-		return ret;
-
-	return 0;
+	return devm_iio_device_register(&pdev->dev, indio_dev_rx);
 }
 
 static int m2k_la_remove(struct platform_device *pdev)

--- a/drivers/iio/logic/m2k-logic-analyzer.c
+++ b/drivers/iio/logic/m2k-logic-analyzer.c
@@ -892,7 +892,6 @@ static int m2k_la_remove(struct platform_device *pdev)
 	struct iio_dev *indio_dev = platform_get_drvdata(pdev);
 	struct m2k_la *m2k_la = iio_priv(indio_dev);
 
-	iio_device_unregister(indio_dev);
 	if (!m2k_la->powerdown)
 		clk_disable_unprepare(m2k_la->clk);
 

--- a/drivers/iio/logic/m2k-logic-analyzer.c
+++ b/drivers/iio/logic/m2k-logic-analyzer.c
@@ -781,6 +781,14 @@ static const struct iio_buffer_setup_ops m2k_la_tx_setup_ops = {
 	.postdisable = m2k_la_tx_postdisable,
 };
 
+static void m2k_la_disable_clk(void *data)
+{
+	struct m2k_la *m2k_la = data;
+
+	if (!m2k_la->powerdown)
+		clk_disable_unprepare(m2k_la->clk);
+}
+
 static int m2k_la_probe(struct platform_device *pdev)
 {
 	struct iio_dev *indio_dev, *indio_dev_tx, *indio_dev_rx;
@@ -813,6 +821,10 @@ static int m2k_la_probe(struct platform_device *pdev)
 		return -EINVAL;
 
 	m2k_la->powerdown = false;
+
+	ret = devm_add_action_or_reset(&pdev->dev, m2k_la_disable_clk, m2k_la);
+	if (ret)
+		return ret;
 
 	mem = platform_get_resource(pdev, IORESOURCE_MEM, 0);
 	m2k_la->regs = devm_ioremap_resource(&pdev->dev, mem);
@@ -883,17 +895,6 @@ static int m2k_la_probe(struct platform_device *pdev)
 	return devm_iio_device_register(&pdev->dev, indio_dev_rx);
 }
 
-static int m2k_la_remove(struct platform_device *pdev)
-{
-	struct iio_dev *indio_dev = platform_get_drvdata(pdev);
-	struct m2k_la *m2k_la = iio_priv(indio_dev);
-
-	if (!m2k_la->powerdown)
-		clk_disable_unprepare(m2k_la->clk);
-
-	return 0;
-}
-
 static const struct of_device_id m2k_la_of_match[] = {
 	{ .compatible = "adi,m2k-logic-analyzer" },
 	{},
@@ -905,7 +906,6 @@ static struct platform_driver m2k_la_driver = {
 		.of_match_table = m2k_la_of_match,
 	},
 	.probe = m2k_la_probe,
-	.remove = m2k_la_remove,
 };
 module_platform_driver(m2k_la_driver);
 


### PR DESCRIPTION
While taking a look at the driver's usage of buffers, I found that the iio_device_unregister() could cause a double-free error.

In the meantime, I cleaned up some more bits in the driver.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>