### PR TITLE
iio: core: cleanups and minor syncs with upstream

### DIFF
--- a/drivers/iio/industrialio-buffer.c
+++ b/drivers/iio/industrialio-buffer.c
@@ -785,6 +785,13 @@ static int iio_verify_update(struct iio_dev *indio_dev,
 	bool scan_timestamp;
 	unsigned int modes;
 
+	if (insert_buffer &&
+	    bitmap_empty(insert_buffer->scan_mask, indio_dev->masklength)) {
+		dev_dbg(&indio_dev->dev,
+			"At least one scan element must be enabled first\n");
+		return -EINVAL;
+	}
+
 	memset(config, 0, sizeof(*config));
 	config->watermark = ~0;
 
@@ -1139,12 +1146,6 @@ static int __iio_update_buffers(struct iio_dev *indio_dev,
 		return ret;
 
 	if (insert_buffer) {
-		if (bitmap_empty(insert_buffer->scan_mask,
-			indio_dev->masklength)) {
-			ret = -EINVAL;
-			goto err_free_config;
-		}
-
 		ret = iio_buffer_request_update(indio_dev, insert_buffer);
 		if (ret)
 			goto err_free_config;

--- a/include/linux/iio/buffer_impl.h
+++ b/include/linux/iio/buffer_impl.h
@@ -178,12 +178,6 @@ struct iio_buffer {
 	struct kref ref;
 };
 
-static inline int iio_buffer_write(struct iio_buffer *buffer, size_t n,
-	const char __user *buf)
-{
-	return buffer->access->write(buffer, n, buf);
-}
-
 /**
  * iio_update_buffers() - add or remove buffer from active list
  * @indio_dev:		device to add buffer to

--- a/include/linux/iio/buffer_impl.h
+++ b/include/linux/iio/buffer_impl.h
@@ -162,9 +162,6 @@ struct iio_buffer {
 	 */
 	struct attribute_group scan_el_group;
 
-	/* @stufftoread: Flag to indicate new data. */
-	bool stufftoread;
-
 	/* @attrs: Standard attributes of the buffer. */
 	const struct attribute **attrs;
 


### PR DESCRIPTION
1 patch looks like a left-over from older internal/ADI work `iio: core: drop iio_buffer_write() function`
the other 2 were upstreamed

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>