### PR TITLE
iio: core: Fix handling of 'dB'

### DIFF
--- a/drivers/iio/industrialio-core.c
+++ b/drivers/iio/industrialio-core.c
@@ -916,14 +916,11 @@ static ssize_t iio_write_channel_info(struct device *dev,
 			return -EINVAL;
 		integer = ch;
 	} else {
-		ret = iio_str_to_fixpoint(buf, fract_mult, &integer, &fract);
+		ret = __iio_str_to_fixpoint(buf, fract_mult, &integer, &fract,
+					    scale_db);
 		if (ret)
 			return ret;
 	}
-	ret = __iio_str_to_fixpoint(buf, fract_mult, &integer, &fract,
-				    scale_db);
-	if (ret)
-		return ret;
 
 	ret = indio_dev->info->write_raw(indio_dev, this_attr->c,
 					 integer, fract, this_attr->address);


### PR DESCRIPTION
This patch fixes the call to iio_str_to_fixpoint when using 'dB' sufix.
Before this the scale_db was not used when parsing the string written to
the attribute and it failed with invalid value.

Fixes: c8d44e142d5f ("iio: core: Handle 'dB' suffix in core")
Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>