### PR TITLE
arch: arm: boot: dts: Add ADAR1000 overlay

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -140,6 +140,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	rpi-ad738x.dtbo \
 	rpi-ad7768-1.dtbo \
 	rpi-ad9834.dtbo \
+	rpi-adar1000.dtbo \
 	rpi-adgs1408.dtbo \
 	rpi-adxl345.dtbo \
 	rpi-adxl372.dtbo \

--- a/arch/arm/boot/dts/overlays/rpi-adar1000-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-adar1000-overlay.dts
@@ -1,0 +1,56 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709";
+
+	fragment@0 {
+		target = <&spi0>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			adar1000@0 {
+				compatible = "adi,adar1000";
+				reg = <0>;
+				spi-max-frequency = <1000000>;
+
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				dev@0 {
+					reg = <0>;
+					label = "BEAM0";
+					adi,phasetable-name = "adar1000_std_phasetable";
+				};
+				dev@1 {
+					reg = <1>;
+					label = "BEAM1";
+				};
+				dev@2 {
+					reg = <2>;
+					label = "BEAM2";
+				};
+				dev@3 {
+					reg = <3>;
+					label = "BEAM3";
+				};
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&spidev0>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@2 {
+		target = <&spidev1>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+};


### PR DESCRIPTION
This patch adds an example device tree overlay for the ADAR1000 beamformer.

Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>