### PR TITLE
iio: dac: ad5770r: fix off-by-one check on maximum number of channels

### DIFF
--- a/drivers/iio/dac/ad5770r.c
+++ b/drivers/iio/dac/ad5770r.c
@@ -525,7 +525,7 @@ static int ad5770r_channel_config(struct ad5770r_state *st)
 		ret = fwnode_property_read_u32(child, "num", &num);
 		if (ret)
 			return ret;
-		if (num > AD5770R_MAX_CHANNELS)
+		if (num >= AD5770R_MAX_CHANNELS)
 			return -EINVAL;
 
 		ret = fwnode_property_read_u32_array(child,


### PR DESCRIPTION
Currently there is an off-by-one check on the number of channels that
will cause an arry overrun in array st->output_mode when calling the
function d5770r_store_output_range. Fix this by using >= rather than >
to check for maximum number of channels.

Addresses-Coverity: ("Out-of-bounds access")
Fixes: cbbb819837f6 ("iio: dac: ad5770r: Add AD5770R support")
Signed-off-by: Colin Ian King <colin.king@canonical.com>
Reviewed-by: Alexandru Ardelean <alexandru.ardelean@analog.com>
Signed-off-by: Jonathan Cameron <Jonathan.Cameron@huawei.com>