### PR TITLE
media/axi-hdmi-rx: Honor pclk-sample from devicetree

### DIFF
--- a/drivers/media/platform/axi-hdmi-rx.c
+++ b/drivers/media/platform/axi-hdmi-rx.c
@@ -73,6 +73,7 @@ struct axi_hdmi_rx {
 	struct v4l2_async_subdev *asds[1];
 
 	u8 bus_width;
+	u8 config_flags;
 
 	u8 edid_data[256];
 	u8 edid_blocks;
@@ -644,7 +645,7 @@ static int axi_hdmi_rx_s_fmt_vid_cap(struct file *file, void *priv_fh,
 	axi_hdmi_rx_write(hdmi_rx, AXI_HDMI_RX_REG_TIMING, 
 		(s->height << 16) | s->width);
 
-	config |= AXI_HDMI_RX_CONFIG_EDGE_SEL;
+	config |= hdmi_rx->config_flags;
 
 	axi_hdmi_rx_write(hdmi_rx, AXI_HDMI_RX_REG_CONFIG, config);
 
@@ -935,8 +936,11 @@ static int axi_hdmi_rx_probe(struct platform_device *pdev)
 		goto err_device_unregister;
 	}
 
+	if (!(bus_cfg.bus.parallel.flags & V4L2_MBUS_PCLK_SAMPLE_RISING))
+		hdmi_rx->config_flags = AXI_HDMI_RX_CONFIG_EDGE_SEL;
+
 	axi_hdmi_rx_write(hdmi_rx, AXI_HDMI_RX_REG_CONFIG,
-			AXI_HDMI_RX_CONFIG_EDGE_SEL);
+			hdmi_rx->config_flags);
 
 	return 0;
 


### PR DESCRIPTION
The driver defaults to sample on falling edge, but did not offer an interface
to change this. Implement the "pclk-sample" as specified in the devicetree
bindings (video-interfaces.txt) to work for this device.

This solves the artefacts caused by timing issues we've seen on all our boards.

Signed-off-by: Mike Looijmans <mike.looijmans@topic.nl>