### PR TITLE
iio: adc: adar1000: Fix regmap read flag

### DIFF
--- a/drivers/iio/adc/adar1000.c
+++ b/drivers/iio/adc/adar1000.c
@@ -161,7 +161,7 @@ struct adar1000_state {
 static const struct regmap_config adar1000_regmap_config = {
 	.reg_bits = 16,
 	.val_bits = 8,
-	.read_flag_mask = BIT(15),
+	.read_flag_mask = BIT(7),
 };
 
 /* Phase values Table 13, 14, 15, 16 page 34 of the datasheet - these values


### PR DESCRIPTION
This patch fixes the read flag mask. Before this modification the mask wast
set to BIT(15) and the read flag was set on the second transfer byte on bit
7.

Fixes: b2316a2ae75e ("iio: adc: adar1000: Initial driver version")
Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>