### PR TITLE
arch: arm: boot: dts: Add support for ad7768-1EVB with Zedboard

### DIFF
--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad7768-1EVB.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad7768-1EVB.dts
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD7768-1
+ * https://wiki.analog.com/resources/eval/user-guides/ad7768-1
+ *
+ * hdl_project: <ad77681evb/zed>
+ * board_revision: <B>
+ *
+ * Copyright (C) 2020 Analog Devices Inc.
+*/
+/dts-v1/;
+
+#include "zynq-zed.dtsi"
+#include "zynq-zed-adv7511.dtsi"
+#include <dt-bindings/interrupt-controller/irq.h>
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	vref: regulator-vref {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-supply";
+		regulator-min-microvolt = <4096000>;
+		regulator-max-microvolt = <4096000>;
+		regulator-always-on;
+	};
+
+	clocks {
+		ad7768_1_mclk: clock@0 {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <16384000>;
+		};
+	};
+};
+
+&fpga_axi {
+	rx_dma: rx-dmac@0x44a30000 {
+		compatible = "adi,axi-dmac-1.00.a";
+		reg = <0x44a30000 0x10000>;
+		#dma-cells = <1>;
+		interrupt-parent = <&intc>;
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&clkc 16>;
+
+		adi,channels {
+			#size-cells = <0>;
+			#address-cells = <1>;
+
+			dma-channel@0 {
+				reg = <0>;
+				adi,source-bus-width = <32>;
+				adi,source-bus-type = <1>;
+				adi,destination-bus-width = <64>;
+				adi,destination-bus-type = <0>;
+			};
+		};
+	};
+
+	axi_spi_engine_0: axi-spi-engine@0x44a00000 {
+		compatible = "adi,axi-spi-engine-1.00.a";
+		reg = <0x44a00000 0x1000>;
+		interrupt-parent = <&intc>;
+		interrupts = <0 55 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&clkc 15 &clkc 15>;
+		clock-names = "s_axi_aclk", "spi_clk";
+		num-cs = <1>;
+
+		#address-cells = <0x1>;
+		#size-cells = <0x0>;
+
+		ad7768_1: adc@0 {
+			compatible = "adi,ad7768-1";
+			reg = <0>;
+			spi-max-frequency = <20000000>;
+			spi-cpol;
+			spi-cpha;
+			vref-supply = <&vref>;
+			adi,sync-in-gpios = <&gpio0 88 GPIO_ACTIVE_LOW>;
+			reset-gpios = <&gpio0 86 GPIO_ACTIVE_LOW>;
+			clocks = <&ad7768_1_mclk>;
+			clock-names = "mclk";
+			dmas = <&rx_dma 0>;
+			dma-names = "rx";
+			#io-channel-cells = <1>;
+		};
+	};
+};


### PR DESCRIPTION
Add support for the EV-AD7768-1FMC kit. The EV-AD7768-1FMCZ evaluation kit
features the AD7768-1 24-bit, 256 kSPS analog-to-digital converter (ADC).
The EVAD7768-1FMCZ board connects to the USB port of the PC via the
EVAL-SDP-CH1Z motherboard. By default, power is supplied from the
EVAL-SDP-CH1Z supply, which is regulated to 5 V and 3.3 V to supply the
AD7768-1 and support components.