### PR TITLE
Fix: Allow Intel FPGA targets to use the new all Analog Device Drivers option.

### DIFF
--- a/drivers/iio/Kconfig.adi
+++ b/drivers/iio/Kconfig.adi
@@ -39,7 +39,6 @@ config IIO_ALL_ADI_DRIVERS
 	select AD9361
 	select AD9361_EXT_BAND_CONTROL
 	select AD9371
-	select ADAR1000
 	select ADRV9009
 	select AD9467
 	select AD9680
@@ -47,7 +46,7 @@ config IIO_ALL_ADI_DRIVERS
 	select CF_AXI_TDD
 	select AXI_PULSE_CAPTURE
 	select AXI_FMCADC5_SYNC
-	select XILINX_XADC
+	select XILINX_XADC if !ARCH_SOCFPGA
 	select LTC2497
 	select AD8366
 	select HMC425


### PR DESCRIPTION
This fix adds a check so that the Xilinx XADC driver is not included for Intel configs when the all 'analog devices drivers' option is enabled.