### PR TITLE
FIX: IIO_ALL_ADI_DRIVERS option for Intel FPGAs.

### DIFF
--- a/drivers/iio/Kconfig.adi
+++ b/drivers/iio/Kconfig.adi
@@ -47,7 +47,7 @@ config IIO_ALL_ADI_DRIVERS
 	select CF_AXI_TDD
 	select AXI_PULSE_CAPTURE
 	select AXI_FMCADC5_SYNC
-	select XILINX_XADC
+	select XILINX_XADC if (ARCH_ZYNQ || ARCH_ZYNQMP || MICROBLAZE)
 	select LTC2497
 	select AD8366
 	select HMC425


### PR DESCRIPTION
Per some suggestions, changed this to a (ARCH_ZYNQ || ARCH_ZYNQMP || MICROBLAZE) from my original ARCH_SOCFPGA. Tested and works with the Arria 10 dev boards. Separate pull request due to some issues on my end with branches. 