### PR TITLE
build: fix some code compilation issues

### DIFF
--- a/drivers/media/platform/axi-hdmi-rx.c
+++ b/drivers/media/platform/axi-hdmi-rx.c
@@ -90,12 +90,6 @@ static void axi_hdmi_rx_write(struct axi_hdmi_rx *axi_hdmi_rx,
 	writel(val, axi_hdmi_rx->base + reg);
 }
 
-static unsigned int axi_hdmi_rx_read(struct axi_hdmi_rx *axi_hdmi_rx,
-	unsigned int reg)
-{
-	return readl(axi_hdmi_rx->base + reg);
-}
-
 static struct axi_hdmi_rx *to_axi_hdmi_rx(struct v4l2_device *v4l2_dev)
 {
 	return container_of(v4l2_dev, struct axi_hdmi_rx, v4l2_dev);
@@ -293,6 +287,12 @@ static const struct vb2_ops axi_hdmi_rx_qops = {
 };
 
 #ifdef CONFIG_VIDEO_ADV_DEBUG
+
+static unsigned int axi_hdmi_rx_read(struct axi_hdmi_rx *axi_hdmi_rx,
+	unsigned int reg)
+{
+	return readl(axi_hdmi_rx->base + reg);
+}
 
 static int axi_hdmi_rx_g_register(struct file *file, void *priv_fh,
 	struct v4l2_dbg_register *reg)

--- a/kernel/trace/trace.c
+++ b/kernel/trace/trace.c
@@ -8341,12 +8341,8 @@ void ftrace_dump(enum ftrace_dump_mode oops_dump_mode)
 
 		cnt++;
 
-		/* reset all but tr, trace, and overruns */
-		memset(&iter.seq, 0,
-		       sizeof(struct trace_iterator) -
-		       offsetof(struct trace_iterator, seq));
+		trace_iterator_reset(&iter);
 		iter.iter_flags |= TRACE_FILE_LAT_FMT;
-		iter.pos = -1;
 
 		if (trace_find_next_entry_inc(&iter) != NULL) {
 			int ret;

--- a/kernel/trace/trace.h
+++ b/kernel/trace/trace.h
@@ -1844,4 +1844,22 @@ static inline void tracer_hardirqs_off(unsigned long a0, unsigned long a1) { }
 
 extern struct trace_iterator *tracepoint_print_iter;
 
+/*
+ * Reset the state of the trace_iterator so that it can read consumed data.
+ * Normally, the trace_iterator is used for reading the data when it is not
+ * consumed, and must retain state.
+ */
+static __always_inline void trace_iterator_reset(struct trace_iterator *iter)
+{
+	const size_t offset = offsetof(struct trace_iterator, seq);
+
+	/*
+	 * Keep gcc from complaining about overwriting more than just one
+	 * member in the structure.
+	 */
+	memset((char *)iter + offset, 0, sizeof(struct trace_iterator) - offset);
+
+	iter->pos = -1;
+}
+
 #endif /* _LINUX_KERNEL_TRACE_H */

--- a/kernel/trace/trace_kdb.c
+++ b/kernel/trace/trace_kdb.c
@@ -41,12 +41,8 @@ static void ftrace_dump_buf(int skip_lines, long cpu_file)
 
 	kdb_printf("Dumping ftrace buffer:\n");
 
-	/* reset all but tr, trace, and overruns */
-	memset(&iter.seq, 0,
-		   sizeof(struct trace_iterator) -
-		   offsetof(struct trace_iterator, seq));
+	trace_iterator_reset(&iter);
 	iter.iter_flags |= TRACE_FILE_LAT_FMT;
-	iter.pos = -1;
 
 	if (cpu_file == RING_BUFFER_ALL_CPUS) {
 		for_each_tracing_cpu(cpu) {


### PR DESCRIPTION
One is a backport.
The other one is for the AXI HDMI RX driver when CONFIG_VIDEO_ADV_DEBUG is un-defined.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>