### PR TITLE
 hwmon: pmbus: fix CRC8 dep and move table init in module init

### DIFF
--- a/drivers/hwmon/pmbus/Kconfig
+++ b/drivers/hwmon/pmbus/Kconfig
@@ -4,7 +4,8 @@
 
 menuconfig PMBUS
 	tristate "PMBus support"
-	depends on I2C && CRC8
+	depends on I2C
+	select CRC8
 	default n
 	help
 	  Say yes here if you want to enable PMBus support.

--- a/drivers/hwmon/pmbus/pmbus_core.c
+++ b/drivers/hwmon/pmbus/pmbus_core.c
@@ -2402,8 +2402,6 @@ int pmbus_do_probe(struct i2c_client *client, const struct i2c_device_id *id,
 	if (!data)
 		return -ENOMEM;
 
-	crc8_populate_msb(pmbus_crc_table, 0x7);
-
 	i2c_set_clientdata(client, data);
 	mutex_init(&data->update_lock);
 	data->dev = dev;
@@ -2482,6 +2480,8 @@ static int __init pmbus_core_init(void)
 	pmbus_debugfs_dir = debugfs_create_dir("pmbus", NULL);
 	if (IS_ERR(pmbus_debugfs_dir))
 		pmbus_debugfs_dir = NULL;
+
+	crc8_populate_msb(pmbus_crc_table, 0x7);
 
 	return 0;
 }


### PR DESCRIPTION
CRC8 should be enforced. Otherwise this breaks places where PMBUS is
defined, and we need to explicitly select CRC8 just to have it.

Also, the CRC table should be initialized per module init.
It's not a problem to do it via probe, but that just initializes it on each driver probe.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>