### PR TITLE
dts: arm: overlays: Add ADAU1472 overlay

### DIFF
--- a/arch/arm/boot/dts/overlays/rpi-adau1472-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-adau1472-overlay.dts
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: GPL-2.0
+
+/dts-v1/;
+/plugin/;
+
+/*
+ * Device Tree Overlay for generic I2S audio input and output on RaspberryPi
+ * with ADAU1472 master
+ */
+
+/ {
+	compatible = "brcm,bcm2835", "brcm,bcm2711";
+
+	fragment@0 {
+		target = <&sound>;
+		__overlay__ {
+			compatible = "simple-audio-card";
+			simple-audio-card,name = "ADAU1472";
+
+			status="okay";
+
+			capture_link: simple-audio-card,dai-link@0 {
+				format = "i2s";
+
+				bitclock-master = <&r_codec_dai>;
+				frame-master = <&r_codec_dai>;
+
+				r_cpu_dai: cpu {
+					sound-dai = <&i2s>;
+					/*
+					 * TDM slot configuration
+					 * BCLK ratio: 64 x Fs (2 x 32 bit)
+					 */
+					dai-tdm-slot-num = <2>;
+					dai-tdm-slot-width = <32>;
+				};
+
+				r_codec_dai: codec {
+					sound-dai = <&codec_in>;
+				};
+			};
+
+			playback_link: simple-audio-card,dai-link@1 {
+				format = "i2s";
+
+				bitclock-master = <&p_codec_dai>;
+				frame-master = <&p_codec_dai>;
+
+				p_cpu_dai: cpu {
+					sound-dai = <&i2s>;
+					/*
+					 * TDM slot configuration
+					 * BCLK ratio: 64 x Fs (2 x 32 bit)
+					 */
+					dai-tdm-slot-num = <2>;
+					dai-tdm-slot-width = <32>;
+				};
+
+				p_codec_dai: codec {
+					sound-dai = <&codec_out>;
+				};
+			};
+		};
+	};
+
+	fragment@1 {
+		target-path = "/";
+		__overlay__ {
+			codec_in: spdif_receiver {
+				#address-cells = <0>;
+				#size-cells = <0>;
+				#sound-dai-cells = <0>;
+				compatible = "linux,spdif-dir";
+				status = "okay";
+			};
+
+			codec_out: spdif-transmitter {
+				#address-cells = <0>;
+				#size-cells = <0>;
+				#sound-dai-cells = <0>;
+				compatible = "linux,spdif-dit";
+				status = "okay";
+			};
+		};
+	};
+
+	fragment@2 {
+		target = <&i2s>;
+		__overlay__ {
+			#sound-dai-cells = <0>;
+			status = "okay";
+		};
+	};
+};


### PR DESCRIPTION
Add devicetree overlay for ADAU1472 SigmaDSP.

Signed-off-by: Jason Wagar <Jason.Wagar@analog.com>
Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>