### PR TITLE
iio: minor build updates that show up only kernel 5.4

### DIFF
--- a/drivers/iio/adc/ad7124.c
+++ b/drivers/iio/adc/ad7124.c
@@ -9,6 +9,7 @@
 #include <linux/delay.h>
 #include <linux/device.h>
 #include <linux/err.h>
+#include <linux/interrupt.h>
 #include <linux/kernel.h>
 #include <linux/module.h>
 #include <linux/regulator/consumer.h>

--- a/drivers/iio/jesd204/axi_adxcvr.c
+++ b/drivers/iio/jesd204/axi_adxcvr.c
@@ -7,6 +7,8 @@
  *
  * https://wiki.analog.com/resources/fpga/docs/axi_adxcvr
  */
+
+#include <asm/io.h>
 #include <linux/module.h>
 #include <linux/delay.h>
 #include <linux/of_device.h>


### PR DESCRIPTION
These 2 are some small fixes that show up on kernel 5.4, but can be fixed now.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>