### PR TITLE
staging: ad2s1210: remove 2nd cs_change in transfer

### DIFF
--- a/drivers/staging/iio/resolver/ad2s1210.c
+++ b/drivers/staging/iio/resolver/ad2s1210.c
@@ -135,7 +135,6 @@ static int ad2s1210_config_read(struct ad2s1210_state *st,
 			.len = 1,
 			.rx_buf = &st->rx[1],
 			.tx_buf = &st->tx[1],
-			.cs_change = 1,
 		},
 	};
 	int ret = 0;


### PR DESCRIPTION
When doing a transfer, cs_change is mostly useful in-between transfers.
When applying it to the last transfer, this may have a weird effect of
keeping the CS line up.

Whenever a SPI transfer finishes, the CS line is de-asserted anyway, so no
need to apply 'cs_change' to the last transfer.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>