### PR TITLE
dts: arm: overlays: Add support for Chicony ToF camera module

### DIFF
--- a/arch/arm/boot/dts/overlays/rpi-addi9036-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-addi9036-overlay.dts
@@ -103,8 +103,23 @@
 		};
 	};
 
+/* Fragment valid only for Chicony */
+	fragment@8 {
+		target = <&i2c_vc>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			tmp102_i2c_vc: temp@48 {
+				compatible = "ti,tmp102";
+				reg = <0x48>;
+			};
+		};
+	};
+
 	__overrides__ {
-		revb = <0>,"+4+5-6+7";
-		revc = <0>,"-4-5+6-7";
+		revb = <0>,"+4+5-6+7-8";
+		revc = <0>,"-4-5+6-7-8";
+		chicony = <0>,"-4-5+6-7+8";
 	};
 };


### PR DESCRIPTION
The Chicony ToF camera module has a different termperature
sensor model compared to ADI ToF module. Add a devicetree
fragment to probe the temp sensor with corresponding driver
at correct I2C address.

Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>