### PR TITLE
iio: frequency: ad9528: Fix usage of adi,output-dis dt channel property

### DIFF
--- a/drivers/iio/frequency/ad9528.c
+++ b/drivers/iio/frequency/ad9528.c
@@ -880,7 +880,7 @@ static int ad9528_clks_register(struct iio_dev *indio_dev)
 		struct clk *clk;
 
 		chan = &pdata->channels[i];
-		if (chan->channel_num >= AD9528_NUM_CHAN || chan->output_dis)
+		if (chan->channel_num >= AD9528_NUM_CHAN)
 			continue;
 
 		clk = ad9528_clk_register(indio_dev, chan->channel_num,
@@ -1093,10 +1093,9 @@ pll2_bypassed:
 		chan = &pdata->channels[i];
 		if (chan->channel_num >= AD9528_NUM_CHAN)
 			continue;
-		if (chan->output_dis)
-			continue;
+		if (!chan->output_dis)
+			__set_bit(chan->channel_num, &active_mask);
 
-		__set_bit(chan->channel_num, &active_mask);
 		if (chan->sync_ignore_en)
 			__set_bit(chan->channel_num, &ignoresync_mask);
 		ret = ad9528_write(indio_dev,


### PR DESCRIPTION
The kernel CCF assumes ownership and that clocks are disabled
by default. That's not the case for this driver. This property
makes sure that the clock output starts up disabled.
If you want to disable the channel entirely simply remove it's channel
dt node from the device.
This patch also syncs the implementation with the ad9523 driver,
where we initially introduced this.

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>