### PR TITLE
arm: boot: dts: overlays: Add AD5791 device tree

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -146,6 +146,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	rpi-adxl372.dtbo \
 	rpi-adxl375.dtbo \
 	rpi-ad5770r.dtbo \
+	rpi-ad5791.dtbo \
 	rpi-backlight.dtbo \
 	rpi-cirrus-wm5102.dtbo \
 	rpi-cn0508.dtbo \

--- a/arch/arm/boot/dts/overlays/rpi-ad5791-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ad5791-overlay.dts
@@ -1,0 +1,63 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709", "brcm,bcm2711";
+
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			vdd: fixedregulator@0 {
+				compatible = "regulator-fixed";
+				regulator-name = "fixed-supply";
+				regulator-min-microvolt = <2500000>;
+				regulator-max-microvolt = <2500000>;
+				regulator-boot-on;
+			};
+		};
+	};
+
+	fragment@1 {
+		target-path = "/";
+		__overlay__ {
+			vss: fixedregulator@1 {
+				compatible = "regulator-fixed";
+				regulator-name = "fixed-supply";
+				regulator-min-microvolt = <2500000>;
+				regulator-max-microvolt = <2500000>;
+				regulator-boot-on;
+			};
+		};
+	};
+
+	fragment@2 {
+		target = <&spi0>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			ad5791@1 {
+				compatible = "adi,ad5791";
+				reg = <1>;
+				spi-max-frequency = <5000000>;
+				vdd-supply = <&vdd>;
+				vss-supply = <&vss>;
+			};
+		};
+	};
+
+	fragment@3 {
+		target = <&spidev0>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@4 {
+		target = <&spidev1>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+};


### PR DESCRIPTION
This patch adds an example device tree for the AD5791 DAC.

Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>