### PR TITLE
arch: arm64: adrv9009-zu11eg: Update framer-lmfc-offset

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-reva.dtsi
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-reva.dtsi
@@ -541,7 +541,7 @@
 		adi,jesd204-framer-a-external-sysref = <1>;
 		adi,jesd204-framer-a-serializer-lanes-enabled = <0x03>;
 		adi,jesd204-framer-a-serializer-lane-crossbar = <0xE4>;
-		adi,jesd204-framer-a-lmfc-offset = <5>;
+		adi,jesd204-framer-a-lmfc-offset = <15>;
 		adi,jesd204-framer-a-new-sysref-on-relink = <0>;
 		adi,jesd204-framer-a-syncb-in-select = <0>;
 		adi,jesd204-framer-a-over-sample = <0>;
@@ -561,7 +561,7 @@
 		adi,jesd204-framer-b-external-sysref = <1>;
 		adi,jesd204-framer-b-serializer-lanes-enabled = <0x0C>;
 		adi,jesd204-framer-b-serializer-lane-crossbar = <0xE4>;
-		adi,jesd204-framer-b-lmfc-offset = <5>;
+		adi,jesd204-framer-b-lmfc-offset = <15>;
 		adi,jesd204-framer-b-new-sysref-on-relink = <0>;
 		adi,jesd204-framer-b-syncb-in-select = <1>;
 		adi,jesd204-framer-b-over-sample = <0>;


### PR DESCRIPTION
Adjust lmfc-offset for trx1_adrv9009 so release point in FPGA moves
away of the LMFC edge. Similar to trx0_adrv9009.

Signed-off-by: Mihai Bancisor <mihai.bancisor@analog.com>
Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>