### PR TITLE
jesd204: core: minor cleanups

### DIFF
--- a/drivers/jesd204/jesd204-core.c
+++ b/drivers/jesd204/jesd204-core.c
@@ -79,8 +79,6 @@ static struct jesd204_dev *jesd204_dev_alloc(struct device_node *np)
 			return ERR_PTR(-ENOMEM);
 	}
 
-	kref_get(&jdev->ref);
-
 	jdev->is_top = is_top;
 	jdev->np = of_node_get(np);
 	kref_init(&jdev->ref);

--- a/drivers/jesd204/jesd204-core.c
+++ b/drivers/jesd204/jesd204-core.c
@@ -532,35 +532,6 @@ struct jesd204_dev *devm_jesd204_dev_register(struct device *dev,
 }
 EXPORT_SYMBOL_GPL(devm_jesd204_dev_register);
 
-static int devm_jesd204_dev_match(struct device *dev, void *res, void *data)
-{
-	struct jesd204_dev **r = res;
-
-	if (!r || !*r) {
-		WARN_ON(!r || !*r);
-		return 0;
-	}
-
-	return *r == data;
-}
-
-/**
- * devm_jesd204_dev_unregister - Resource-managed jesd204_dev_unregister()
- * @dev:	Device this jesd204_dev belongs to
- * @jdev:	the jesd204_dev associated with the device
- *
- * Unregister jesd204_dev registered with devm_jesd204_dev_register().
- */
-void devm_jesd204_dev_unregister(struct device *dev, struct jesd204_dev *jdev)
-{
-	int rc;
-
-	rc = devres_release(dev, devm_jesd204_dev_unreg,
-			    devm_jesd204_dev_match, jdev);
-	WARN_ON(rc);
-}
-EXPORT_SYMBOL_GPL(devm_jesd204_dev_unregister);
-
 static int __init jesd204_init(void)
 {
 	int ret;


### PR DESCRIPTION
Remove `devm_jesd204_dev_unregister() ` & un-needed `kref_get()`

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>