### PR TITLE
iio: adc: adar1000: Fix SW_CTRL register write

### DIFF
--- a/drivers/iio/adc/adar1000.c
+++ b/drivers/iio/adc/adar1000.c
@@ -743,8 +743,7 @@ static int adar1000_setup(struct iio_dev *indio_dev)
 			   ADAR1000_SW_CTRL,
 			   ADAR1000_SW_DRV_EN_TR |
 			   ADAR1000_SW_DRV_EN_POL |
-			   ADAR1000_TR_SOURCE |
-			   ADAR1000_RX_CHX_RAM_BYPASS);
+			   ADAR1000_TR_SOURCE);
 	if (ret < 0)
 		return ret;
 


### PR DESCRIPTION
There was a copy/paste error at ADAR1000_SW_CTRL register write. This patch
removes the extra flag inserted in the write operation.

Fixes: b2316a2ae75e ("iio: adc: adar1000: Initial driver version")
Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>