### PR TITLE
iio: adc: adar1000: Set channel extended name

### DIFF
--- a/drivers/iio/adc/adar1000.c
+++ b/drivers/iio/adc/adar1000.c
@@ -232,6 +232,7 @@ static int adar1000_reg_access(struct iio_dev *indio_dev,
 	.channel = (_num),					\
 	.info_mask_separate = BIT(IIO_CHAN_INFO_HARDWAREGAIN) | \
 		BIT(IIO_CHAN_INFO_PHASE),			\
+	.extend_name = "RX",					\
 }
 
 #define ADAR1000_TX_CHANNEL(_num)				\
@@ -242,6 +243,7 @@ static int adar1000_reg_access(struct iio_dev *indio_dev,
 	.channel = (_num),					\
 	.info_mask_separate = BIT(IIO_CHAN_INFO_HARDWAREGAIN) | \
 		BIT(IIO_CHAN_INFO_PHASE),			\
+	.extend_name = "TX",					\
 }
 
 #define ADAR1000_TEMP_CHANNEL(_num)				\


### PR DESCRIPTION
This patch adds an extended name to RX and TX channels to improve
readability.

Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>