### PR TITLE
arm: boot: dts: overlays: Add AD7173 device tree

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -136,6 +136,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	rpi-ad5766.dtbo \
 	rpi-ad7124.dtbo \
 	rpi-ad7124-8-all-diff-cs0-int25.dtbo \
+	rpi-ad7173.dtbo \
 	rpi-ad7190.dtbo \
 	rpi-ad738x.dtbo \
 	rpi-ad7768-1.dtbo \

--- a/arch/arm/boot/dts/overlays/rpi-ad7173-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ad7173-overlay.dts
@@ -1,0 +1,78 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709", "brcm,bcm2711";
+
+	fragment@0 {
+		target = <&spi0>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			ad7173@0 {
+				compatible = "adi,ad7173-8";
+				reg = <0>;
+				interrupts = <25 2>;
+				interrupt-parent = <&gpio>;
+				spi-max-frequency = <100000>;
+				spi-cpol;
+				spi-cpha;
+
+				adi,channels {
+					#address-cells = <2>;
+					#size-cells = <0>;
+
+					channel@0,1 {
+						reg = <0 1>;
+						adi,bipolar;
+					};
+
+					channel@2,3 {
+						reg = <2 3>;
+						adi,bipolar;
+					};
+					channel@4,5 {
+						reg = <4 5>;
+						adi,bipolar;
+					};
+					channel@6,7 {
+						reg = <6 7>;
+						adi,bipolar;
+					};
+					channel@8,9 {
+						reg = <8 9>;
+						adi,bipolar;
+					};
+					channel@10,11 {
+						reg = <10 11>;
+						adi,bipolar;
+					};
+					channel@12,13 {
+						reg = <12 13>;
+						adi,bipolar;
+					};
+					channel@14,15 {
+						reg = <14 15>;
+						adi,bipolar;
+					};
+				};
+			};
+		};
+	};
+
+	fragment@3 {
+		target = <&spidev0>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@4 {
+		target = <&spidev1>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+};


### PR DESCRIPTION
This patch adds an example device tree for the AD7173 ADC.

Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>