### PR TITLE
arch:arm:boot:dts:overlays:rpi-ad5791 fix SPI mode

### DIFF
--- a/arch/arm/boot/dts/overlays/rpi-ad5791-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ad5791-overlay.dts
@@ -41,6 +41,7 @@
 				compatible = "adi,ad5791";
 				reg = <1>;
 				spi-max-frequency = <5000000>;
+				spi-cpha;
 				vdd-supply = <&vdd>;
 				vss-supply = <&vss>;
 			};


### PR DESCRIPTION
AD5791 requires SPI mode 1 or 3 (data latched at falling clock edge.)

Signed-off-by: Mark Thoren <mark.thoren@analog.com>