### PR TITLE
Adm1266 program firmware

### DIFF
--- a/Documentation/devicetree/bindings/hwmon/adi,adm1266.yaml
+++ b/Documentation/devicetree/bindings/hwmon/adi,adm1266.yaml
@@ -28,13 +28,12 @@ properties:
       maximum: 0x4F
 
   avcc-supply:
-    description:
+    description: |
       Phandle to the Avcc power supply.
 
-  adi,connected-adm1266:
+  adi,master-adm1266:
     description: |
-      Represents other ADM1266 devices cascaded through the IDB. Can be
-      cascaded with maximum 15 other adm1266s.
+      Represents phandle of a master ADM1266 device cascaded through the IDB.
     $ref: "/schemas/types.yaml#/definitions/phandle"
 
 required:

--- a/drivers/hwmon/pmbus/adm1266.c
+++ b/drivers/hwmon/pmbus/adm1266.c
@@ -8,6 +8,7 @@
 
 #include <linux/bitfield.h>
 #include <linux/debugfs.h>
+#include <linux/delay.h>
 #include <linux/gpio/driver.h>
 #include <linux/i2c.h>
 #include <linux/i2c-smbus.h>
@@ -16,19 +17,31 @@
 #include <linux/module.h>
 #include <linux/nvmem-consumer.h>
 #include <linux/nvmem-provider.h>
+#include <linux/property.h>
 #include <linux/slab.h>
 
 #include "pmbus.h"
 
+#define ADM1266_STORE_USER_ALL	0x15
+#define ADM1266_STATUS_MFR	0x80
+#define ADM1266_IC_DEVICE_REV	0xAE
 #define ADM1266_BLACKBOX_CONFIG	0xD3
 #define ADM1266_PDIO_CONFIG	0xD4
+#define ADM1266_SEQUENCE_CONFIG	0xD6
+#define ADM1266_SYSTEM_CONFIG	0xD7
 #define ADM1266_GO_COMMAND	0xD8
 #define ADM1266_READ_STATE	0xD9
 #define ADM1266_READ_BLACKBOX	0xDE
+#define ADM1266_LOGIC_CONFIG	0xE0
 #define ADM1266_GPIO_CONFIG	0xE1
+#define ADM1266_USER_DATA	0xE3
 #define ADM1266_BLACKBOX_INFO	0xE6
 #define ADM1266_PDIO_STATUS	0xE9
 #define ADM1266_GPIO_STATUS	0xEA
+#define ADM1266_MEMORY_CONFIG	0xF8
+#define ADM1266_SWITCH_MEMORY	0xFA
+#define ADM1266_UPDATE_FW	0xFC
+#define ADM1266_FW_PASSWORD	0xFD
 
 /* ADM1266 GPIO defines */
 #define ADM1266_GPIO_NR			9
@@ -43,8 +56,34 @@
 #define ADM1266_PDIO_GLITCH_FILT(x)	FIELD_GET(GENMASK(12, 9), x)
 #define ADM1266_PDIO_OUT_CFG(x)		FIELD_GET(GENMASK(2, 0), x)
 
+/* ADM1266 FW_PASSWORD defines*/
+#define ADM1266_PASSWD_CMD_LEN	17
+#define ADM1266_CHANGE_PASSWORD	1
+#define ADM1266_UNLOCK_DEV	2
+#define ADM1266_LOCK_DEV	3
+
+/* ADM1266 STATUS_MFR defines */
+#define ADM1266_STATUS_PART_LOCKED(x)	FIELD_GET(BIT(2), x)
+
+/* ADM1266 GO_COMMAND defines */
+#define ADM1266_GO_COMMAND_STOP		BIT(0)
+#define ADM1266_GO_COMMAND_SEQ_RES	BIT(1)
+#define ADM1266_GO_COMMAND_HARD_RES	BIT(2)
+
+#define ADM1266_FIRMWARE_OFFSET		0x00000
+#define ADM1266_FIRMWARE_SIZE		131072
 #define ADM1266_BLACKBOX_OFFSET		0x7F700
 #define ADM1266_BLACKBOX_SIZE		64
+
+#define ADM1266_MAX_DEVICES		16
+
+static LIST_HEAD(registered_masters);
+static DEFINE_MUTEX(registered_masters_lock);
+
+struct adm1266_data_ref {
+	struct adm1266_data *data;
+	struct list_head list;
+};
 
 struct adm1266_data {
 	struct pmbus_driver_info info;
@@ -53,6 +92,10 @@ struct adm1266_data {
 	struct dentry *debugfs_dir;
 	struct nvmem_config nvmem_config;
 	struct nvmem_device *nvmem;
+	bool master_dev;
+	struct list_head cascaded_devices_list;
+	struct mutex cascaded_devices_mutex; /* lock cascaded_devices_list */
+	u8 nr_devices;
 	u8 *dev_mem;
 };
 
@@ -61,6 +104,11 @@ static const struct nvmem_cell_info adm1266_nvmem_cells[] = {
 		.name           = "blackbox",
 		.offset         = ADM1266_BLACKBOX_OFFSET,
 		.bytes          = 2048,
+	},
+	{
+		.name           = "firmware",
+		.offset         = ADM1266_FIRMWARE_OFFSET,
+		.bytes          = ADM1266_FIRMWARE_SIZE,
 	},
 };
 
@@ -243,6 +291,36 @@ static inline int adm1266_config_gpio(struct adm1266_data *data)
 }
 #endif
 
+static int adm1266_group_cmd(struct adm1266_data *data, u8 cmd, u8 *write_data,
+			     u8 w_len, bool to_slaves)
+{
+	struct adm1266_data_ref *slave_ref;
+	struct i2c_client *clients[ADM1266_MAX_DEVICES];
+	u8 *data_w[ADM1266_MAX_DEVICES];
+	u8 w_lens[ADM1266_MAX_DEVICES];
+	u8 cmds[ADM1266_MAX_DEVICES];
+	int i = 0;
+
+	clients[i] = data->client;
+	data_w[i] = write_data;
+	i++;
+
+	memset(w_lens, w_len, ADM1266_MAX_DEVICES);
+	memset(cmds, cmd, ADM1266_MAX_DEVICES);
+
+	if (!to_slaves)
+		return pmbus_group_command(clients, cmds, w_lens, data_w, i);
+
+	list_for_each_entry(slave_ref, &data->cascaded_devices_list,
+			    list) {
+		clients[i] = slave_ref->data->client;
+		data_w[i] = write_data;
+		i++;
+	}
+
+	return pmbus_group_command(clients, cmds, w_lens, data_w, i);
+}
+
 static int adm1266_get_state_op(void *pdata, u64 *state)
 {
 	struct adm1266_data *data = pdata;
@@ -364,6 +442,9 @@ static int adm1266_read_mem_cell(struct adm1266_data *data,
 		if (ret)
 			dev_err(&data->client->dev, "Could not read blackbox!");
 		return ret;
+	case ADM1266_FIRMWARE_OFFSET:
+		/* firmware is write-only */
+		return 0;
 	default:
 		return -EINVAL;
 	}
@@ -392,14 +473,361 @@ static int adm1266_nvmem_read(void *priv, unsigned int offset, void *val,
 	return 0;
 }
 
+static int adm1266_unlock_device(struct adm1266_data *data)
+{
+	struct i2c_client *client = data->client;
+	u8 passwd_cmd[PMBUS_BLOCK_MAX];
+	int reg_val;
+	int ret;
+	int i;
+
+	memset(passwd_cmd, 0xFF, PMBUS_BLOCK_MAX);
+	passwd_cmd[ADM1266_PASSWD_CMD_LEN - 1] = ADM1266_UNLOCK_DEV;
+
+	/* password needs to be written twice correctly*/
+	for (i = 0; i < 2; i++) {
+		ret = pmbus_block_write(client, ADM1266_FW_PASSWORD,
+					ADM1266_PASSWD_CMD_LEN, passwd_cmd);
+		if (ret < 0) {
+			dev_err(&client->dev, "Could not write password.");
+			return ret;
+		}
+
+		/* 50 ms delay between subsequent password writes are needed*/
+		mdelay(50);
+	}
+
+	/* check if device is unlocked */
+	reg_val = pmbus_read_byte_data(client, 0, ADM1266_STATUS_MFR);
+	if (reg_val < 0) {
+		dev_err(&client->dev, "Could not read status.");
+		return reg_val;
+	}
+	if (ADM1266_STATUS_PART_LOCKED(reg_val)) {
+		dev_err(&client->dev, "Device locked.");
+		return -EBUSY;
+	}
+
+	return 0;
+}
+
+static int adm1266_unlock_all_dev(struct adm1266_data *data)
+{
+	struct adm1266_data_ref *slave_ref;
+	int ret;
+
+	ret = adm1266_unlock_device(data);
+	if (ret < 0) {
+		dev_err(&data->client->dev, "Could not unlock master.");
+		return ret;
+	}
+
+	list_for_each_entry(slave_ref, &data->cascaded_devices_list, list) {
+		ret = adm1266_unlock_device(slave_ref->data);
+		if (ret < 0) {
+			dev_err(&data->client->dev,
+				"Could not unlock slave addr: %d.",
+				slave_ref->data->client->addr);
+			return ret;
+		}
+	}
+
+	return 0;
+}
+
+static const int write_delays[][3] = {
+	{ADM1266_SYSTEM_CONFIG, 400, 1},
+	{ADM1266_USER_DATA, 100, 1},
+	{ADM1266_LOGIC_CONFIG, 200, 1},
+	{ADM1266_SEQUENCE_CONFIG, 2500, 1},
+	{ADM1266_UPDATE_FW, 2000, 1},
+	{ADM1266_MEMORY_CONFIG, 100, 0},
+	{ADM1266_STORE_USER_ALL, 300, 0},
+};
+
+static int adm1266_write_hex(struct adm1266_data *data,
+			     unsigned int offset, unsigned int size)
+{
+	const u8 *ending_str = ":00000001FF";
+	u8 *hex_cmd = data->dev_mem + offset;
+	u8 *fw_end = data->dev_mem + offset + size;
+	unsigned int write_delay;
+	u8 write_buf[PMBUS_BLOCK_MAX + 1];
+	u8 first_writes[7];
+	u8 byte_count;
+	u8 reg_address;
+	int ret;
+	int i;
+
+	memset(first_writes, 1, 7);
+
+	while (hex_cmd < fw_end) {
+		hex_cmd = strnchr(hex_cmd, size, ':');
+
+		if (!hex_cmd || hex_cmd >= fw_end) {
+			dev_err(&data->client->dev, "Firmware ending missing.");
+			return -EINVAL;
+		}
+
+		if (!strncmp(hex_cmd, ending_str, strlen(ending_str)))
+			break;
+
+		hex_cmd++;
+
+		ret = hex2bin(&byte_count, hex_cmd, 1);
+		if (ret < 0)
+			return ret;
+
+		ret = hex2bin(&reg_address, hex_cmd + 4, 1);
+		if (ret < 0)
+			return ret;
+
+		ret = hex2bin(write_buf, hex_cmd + 8, byte_count);
+		if (ret < 0)
+			return ret;
+
+		ret = adm1266_group_cmd(data, reg_address, write_buf,
+					byte_count, true);
+		if (ret < 0) {
+			dev_err(&data->client->dev, "Firmware write error: %d.",
+				ret);
+			return ret;
+		}
+
+		/* write to eeprom with specified delays */
+		write_delay = 40;
+		for (i = 0; i < 7; i++) {
+			if (reg_address == write_delays[i][0]) {
+				if (write_delays[i][2] && first_writes[i]) {
+					first_writes[i] = 0;
+					write_delay = write_delays[i][1];
+				}
+
+				if (!write_delays[i][2])
+					write_delay = write_delays[i][1];
+			}
+		}
+		mdelay(write_delay);
+	}
+
+	return 0;
+}
+
+static int adm1266_program_firmware(struct adm1266_data *data)
+{
+	u8 write_data[3];
+	int ret;
+
+	write_data[0] = ADM1266_GO_COMMAND_STOP | ADM1266_GO_COMMAND_SEQ_RES;
+	write_data[1] = 0x0;
+	ret = adm1266_group_cmd(data, ADM1266_GO_COMMAND, write_data, 2, true);
+	if (ret < 0) {
+		dev_err(&data->client->dev, "Could not stop all devs.");
+		return ret;
+	}
+
+	/* after issuing a stop command, wait 100 ms */
+	mdelay(100);
+
+	ret = adm1266_unlock_all_dev(data);
+	if (ret < 0)
+		return ret;
+
+	write_data[0] = 0x2;
+	write_data[1] = 0x0;
+	write_data[2] = 0x0;
+	ret = adm1266_group_cmd(data, ADM1266_UPDATE_FW, write_data, 3, true);
+	if (ret < 0) {
+		dev_err(&data->client->dev, "Could not set bootloader mode.");
+		return ret;
+	}
+
+	/* wait for adm1266 to enter bootloader mode */
+	mdelay(2000);
+
+	ret = adm1266_write_hex(data, ADM1266_FIRMWARE_OFFSET,
+				ADM1266_FIRMWARE_SIZE);
+	if (ret < 0) {
+		dev_err(&data->client->dev, "Could not write hex.");
+		return ret;
+	}
+
+	write_data[0] = ADM1266_GO_COMMAND_HARD_RES;
+	ret = adm1266_group_cmd(data, ADM1266_GO_COMMAND, write_data, 2, true);
+	if (ret < 0) {
+		dev_err(&data->client->dev, "Could not reset all devs.");
+		return ret;
+	}
+
+	return 0;
+}
+
+/* check if firmware/config write has ended */
+static bool adm1266_check_ending(struct adm1266_data *data, unsigned int offset,
+				 unsigned int size)
+{
+	const u8 *ending_str = ":00000001FF";
+	u8 *hex_cmd = data->dev_mem + offset;
+	u8 *fw_end = data->dev_mem + offset + size;
+
+	hex_cmd = strnchr(hex_cmd, size, ':');
+	for (; hex_cmd && hex_cmd < fw_end;
+	     hex_cmd = strnchr(hex_cmd, size, ':')) {
+		if (!strncmp(hex_cmd, ending_str, strlen(ending_str)))
+			return true;
+
+		hex_cmd++;
+	}
+
+	return false;
+}
+
+static int adm1266_write_mem_cell(struct adm1266_data *data,
+				  const struct nvmem_cell_info *mem_cell,
+				  unsigned int offset,
+				  u8 *val,
+				  size_t bytes)
+{
+	unsigned int cell_end = mem_cell->offset + mem_cell->bytes;
+	unsigned int cell_start = mem_cell->offset;
+	bool fw_writen;
+
+	switch (mem_cell->offset) {
+	case ADM1266_FIRMWARE_OFFSET:
+		if (!data->master_dev) {
+			dev_err(&data->client->dev,
+				"Only master programs the firmware.");
+			return -EINVAL;
+		}
+
+		if (offset < cell_start || offset + bytes >= cell_end)
+			return -EINVAL;
+
+		if (offset == ADM1266_FIRMWARE_OFFSET)
+			memset(data->dev_mem, 0, ADM1266_FIRMWARE_SIZE);
+
+		memcpy(data->dev_mem + offset, val, bytes);
+
+		fw_writen = adm1266_check_ending(data, ADM1266_FIRMWARE_OFFSET,
+						 ADM1266_FIRMWARE_SIZE);
+
+		if (fw_writen)
+			return adm1266_program_firmware(data);
+
+		return 0;
+	default:
+		return -EINVAL;
+	}
+}
+
+static int adm1266_nvmem_write(void *priv, unsigned int offset, void *val,
+			       size_t bytes)
+{
+	const struct nvmem_cell_info *mem_cell;
+	struct adm1266_data *data = priv;
+	int ret;
+	int i;
+
+	for (i = 0; i < data->nvmem_config.ncells; i++) {
+		mem_cell = &adm1266_nvmem_cells[i];
+
+		if (!adm1266_cell_is_accessed(mem_cell, offset, bytes))
+			continue;
+
+		ret = adm1266_write_mem_cell(data, mem_cell, offset,
+					     val, bytes);
+		if (ret < 0)
+			return ret;
+	}
+
+	return 0;
+}
+
+static int adm1266_register_slave(struct adm1266_data *slave,
+				  struct adm1266_data *master)
+{
+	struct adm1266_data_ref *slave_ref;
+
+	slave_ref = devm_kzalloc(&slave->client->dev,
+				 sizeof(*slave_ref), GFP_KERNEL);
+	if (!slave_ref)
+		return -ENOMEM;
+
+	slave_ref->data = slave;
+	INIT_LIST_HEAD(&slave_ref->list);
+
+	mutex_lock(&master->cascaded_devices_mutex);
+	list_add_tail(&slave_ref->list, &master->cascaded_devices_list);
+	mutex_unlock(&master->cascaded_devices_mutex);
+
+	return 0;
+}
+
+static int adm1266_register(struct adm1266_data *data)
+{
+	struct fwnode_reference_args master_fwnode_ref;
+	const struct fwnode_handle *fw;
+	const struct fwnode_handle *master_fw;
+	struct adm1266_data_ref *master_ref;
+	int ret;
+
+	fw = dev_fwnode(&data->client->dev);
+	INIT_LIST_HEAD(&data->cascaded_devices_list);
+
+	/* master devices do not have this property */
+	if (!fwnode_property_present(fw, "adi,master-adm1266")) {
+		data->master_dev = true;
+
+		master_ref = devm_kzalloc(&data->client->dev,
+					  sizeof(*master_ref), GFP_KERNEL);
+		if (!master_ref)
+			return -ENOMEM;
+
+		master_ref->data = data;
+		INIT_LIST_HEAD(&master_ref->list);
+
+		mutex_lock(&registered_masters_lock);
+		list_add(&master_ref->list, &registered_masters);
+		mutex_unlock(&registered_masters_lock);
+	}
+
+	if (data->master_dev)
+		return 0;
+
+	ret = fwnode_property_get_reference_args(fw, "adi,master-adm1266",
+						 NULL, 0, 0,
+						 &master_fwnode_ref);
+	if (ret < 0) {
+		dev_err(&data->client->dev,
+			"Could not read adi,master-adm1266 property");
+		return ret;
+	}
+
+	mutex_lock(&registered_masters_lock);
+
+	/* search for the corresponding master of this slave */
+	list_for_each_entry(master_ref, &registered_masters, list) {
+		master_fw = dev_fwnode(&master_ref->data->client->dev);
+
+		if (master_fw == master_fwnode_ref.fwnode) {
+			mutex_unlock(&registered_masters_lock);
+			return adm1266_register_slave(data, master_ref->data);
+		}
+	}
+
+	mutex_unlock(&registered_masters_lock);
+
+	return -EPROBE_DEFER;
+}
+
 static int adm1266_config_nvmem(struct adm1266_data *data)
 {
 	data->nvmem_config.name = dev_name(&data->client->dev);
 	data->nvmem_config.dev = &data->client->dev;
 	data->nvmem_config.root_only = true;
-	data->nvmem_config.read_only = true;
 	data->nvmem_config.owner = THIS_MODULE;
 	data->nvmem_config.reg_read = adm1266_nvmem_read;
+	data->nvmem_config.reg_write = adm1266_nvmem_write;
 	data->nvmem_config.cells = adm1266_nvmem_cells;
 	data->nvmem_config.ncells = ARRAY_SIZE(adm1266_nvmem_cells);
 	data->nvmem_config.priv = data;
@@ -422,6 +850,21 @@ static int adm1266_config_nvmem(struct adm1266_data *data)
 	return 0;
 }
 
+static int adm1266_firmware_present(struct i2c_client *client)
+{
+	u8 read_buf[I2C_SMBUS_BLOCK_MAX];
+	int ret;
+
+	ret = i2c_smbus_read_i2c_block_data(client, ADM1266_IC_DEVICE_REV,
+					    8, read_buf);
+	if (ret < 0) {
+		dev_err(&client->dev, "Could not read firmware revision.");
+		return ret;
+	}
+
+	return !!(read_buf[0] | read_buf[1] | read_buf[2]);
+}
+
 static int adm1266_probe(struct i2c_client *client,
 			 const struct i2c_device_id *id)
 {
@@ -437,6 +880,22 @@ static int adm1266_probe(struct i2c_client *client,
 		return -ENOMEM;
 
 	data->client = client;
+	mutex_init(&data->cascaded_devices_mutex);
+
+	ret = adm1266_register(data);
+	if (ret < 0)
+		return ret;
+
+	adm1266_debug_init(data);
+
+	ret = adm1266_firmware_present(client);
+	if (ret < 0)
+		return ret;
+
+	if (!ret) {
+		dev_notice(&client->dev, "Chip firmware not written.");
+		return adm1266_config_nvmem(data);
+	}
 
 	ret = adm1266_config_gpio(data);
 	if (ret < 0)
@@ -445,8 +904,6 @@ static int adm1266_probe(struct i2c_client *client,
 	ret = adm1266_config_nvmem(data);
 	if (ret < 0)
 		return ret;
-
-	adm1266_debug_init(data);
 
 	info = &data->info;
 	info->pages = 17;

--- a/drivers/hwmon/pmbus/pmbus.h
+++ b/drivers/hwmon/pmbus/pmbus.h
@@ -444,6 +444,8 @@ int pmbus_set_page(struct i2c_client *client, int page);
 int pmbus_block_write(struct i2c_client *client, u8 cmd, u8 w_len, u8 *data_w);
 int pmbus_block_wr(struct i2c_client *client, u8 cmd, u8 w_len, u8 *data_w,
 		   u8 *data_r);
+int pmbus_group_command(struct i2c_client **clients, u8 *cmds, u8 *w_lens,
+			u8 **data_w, u8 nr_cmds);
 int pmbus_read_word_data(struct i2c_client *client, int page, u8 reg);
 int pmbus_write_word_data(struct i2c_client *client, int page, u8 reg, u16 word);
 int pmbus_read_byte_data(struct i2c_client *client, int page, u8 reg);

--- a/drivers/hwmon/pmbus/pmbus.h
+++ b/drivers/hwmon/pmbus/pmbus.h
@@ -441,6 +441,7 @@ extern const struct regulator_ops pmbus_regulator_ops;
 
 void pmbus_clear_cache(struct i2c_client *client);
 int pmbus_set_page(struct i2c_client *client, int page);
+int pmbus_block_write(struct i2c_client *client, u8 cmd, u8 w_len, u8 *data_w);
 int pmbus_block_wr(struct i2c_client *client, u8 cmd, u8 w_len, u8 *data_w,
 		   u8 *data_r);
 int pmbus_read_word_data(struct i2c_client *client, int page, u8 reg);

--- a/drivers/hwmon/pmbus/pmbus_core.c
+++ b/drivers/hwmon/pmbus/pmbus_core.c
@@ -318,6 +318,68 @@ int pmbus_block_write(struct i2c_client *client, u8 cmd, u8 w_len, u8 *data_w)
 }
 EXPORT_SYMBOL_GPL(pmbus_block_write);
 
+/* Group command.
+ * @clients: Array of handles to slave devices
+ * @cmds: Array of bytes interpreted by slave
+ * @w_len: Array of sizes of write data block; PMBus allows at most 255 bytes
+ * @data_w: Array of byte arrays which will be written.
+ * @nr_cmds: Number of commands.
+ *
+ * Returns 0 or negative errno.
+ */
+int pmbus_group_command(struct i2c_client **clients, u8 *cmds, u8 *w_lens,
+			u8 **data_w, u8 nr_cmds)
+{
+	u8 write_buf[PMBUS_BLOCK_MAX + 1];
+	struct i2c_msg *msgs;
+	u8 addr;
+	int ret;
+	int i;
+
+	msgs = kcalloc(nr_cmds, sizeof(struct i2c_msg), GFP_KERNEL);
+	if (!msgs)
+		return -ENOMEM;
+
+	for (i = 0; i < nr_cmds; i++) {
+		msgs[i].addr = clients[i]->addr,
+		msgs[i].flags = 0,
+		msgs[i].buf = write_buf,
+		msgs[i].len = w_lens[i] + 1,
+
+		msgs[i].buf[0] = cmds[i];
+		memcpy(&msgs[i].buf[1], data_w[i], w_lens[i]);
+
+		msgs[i].buf = i2c_get_dma_safe_msg_buf(&msgs[i], 1);
+		if (!msgs[i].buf) {
+			ret = -ENOMEM;
+			goto cleanup;
+		}
+
+		if (clients[i]->flags & I2C_CLIENT_PEC) {
+			u8 crc = 0;
+
+			addr = i2c_8bit_addr_from_msg(&msgs[i]);
+			crc = crc8(pmbus_crc_table, &addr, 1, crc);
+			crc = crc8(pmbus_crc_table, msgs[i].buf, msgs[i].len,
+				   crc);
+
+			msgs[i].buf[msgs[i].len] = crc;
+			msgs[i].len++;
+		}
+	};
+
+	ret = i2c_transfer(clients[0]->adapter, msgs, nr_cmds);
+
+cleanup:
+	for (i = i - 1; i >= 0; i--)
+		i2c_put_dma_safe_msg_buf(msgs[i].buf, &msgs[i], true);
+
+	kfree(msgs);
+
+	return ret;
+}
+EXPORT_SYMBOL_GPL(pmbus_group_command);
+
 int pmbus_write_byte(struct i2c_client *client, int page, u8 value)
 {
 	int rv;

--- a/drivers/hwmon/pmbus/pmbus_core.c
+++ b/drivers/hwmon/pmbus/pmbus_core.c
@@ -272,6 +272,52 @@ cleanup:
 }
 EXPORT_SYMBOL_GPL(pmbus_block_wr);
 
+/* Block Write command.
+ * @client: Handle to slave device
+ * @cmd: Byte interpreted by slave
+ * @w_len: Size of write data block; PMBus allows at most 255 bytes
+ * @data_w: byte array which will be written.
+ *
+ * Returns 0 or negative errno.
+ */
+int pmbus_block_write(struct i2c_client *client, u8 cmd, u8 w_len, u8 *data_w)
+{
+	u8 write_buf[PMBUS_BLOCK_MAX + 1];
+	struct i2c_msg msg = {
+		.addr = client->addr,
+		.flags = 0,
+		.buf = write_buf,
+		.len = w_len + 2,
+	};
+	u8 addr = 0;
+	u8 crc = 0;
+	int ret;
+
+	msg.buf[0] = cmd;
+	msg.buf[1] = w_len;
+	memcpy(&msg.buf[2], data_w, w_len);
+
+	msg.buf = i2c_get_dma_safe_msg_buf(&msg, 1);
+	if (!msg.buf)
+		return -ENOMEM;
+
+	if (client->flags & I2C_CLIENT_PEC) {
+		addr = i2c_8bit_addr_from_msg(&msg);
+		crc = crc8(pmbus_crc_table, &addr, 1, crc);
+		crc = crc8(pmbus_crc_table, msg.buf,  msg.len, crc);
+
+		msg.buf[msg.len] = crc;
+		msg.len++;
+	}
+
+	ret = i2c_transfer(client->adapter, &msg, 1);
+
+	i2c_put_dma_safe_msg_buf(msg.buf, &msg, true);
+
+	return ret;
+}
+EXPORT_SYMBOL_GPL(pmbus_block_write);
+
 int pmbus_write_byte(struct i2c_client *client, int page, u8 value)
 {
 	int rv;


### PR DESCRIPTION
This series adds the ability to write the firmware through PMBus by writing the Intel Hex file at the start of Nvmem file created by adm1266 driver:
- dt-bindings: hwmon: Add ref node for ADM1266 slaves: slaves now have a phandle to their master
- hwmon: (pmbus/core) Add Block W: used for writing the password as specified in AN-1453
- hwmon: (pmbus/core) Add group command support: send commands to all cascaded devices but execute them only when stop bit is sent
- hwmon: pmbus: adm1266: program firmware: writing to address 0 of nvmem file will now trigger a firmware update of all cascaded devices.