### PR TITLE
jesd204: add facility for keeping private info for a driver

### DIFF
--- a/drivers/jesd204/jesd204-core.c
+++ b/drivers/jesd204/jesd204-core.c
@@ -40,6 +40,12 @@ static inline bool dev_is_jesd204_dev(struct device *dev)
 	return device_property_read_bool(dev, "jesd204-device");
 }
 
+void *jesd204_dev_priv(struct jesd204_dev *jdev)
+{
+	return jdev->priv;
+}
+EXPORT_SYMBOL(jesd204_dev_priv);
+
 struct jesd204_dev *jesd204_dev_from_device(struct device *dev)
 {
 	struct jesd204_dev *jdev;
@@ -500,6 +506,15 @@ struct jesd204_dev *jesd204_dev_register(struct device *dev,
 	ret = jesd204_fsm_probe(jdev);
 	if (ret)
 		goto err_device_del;
+
+	if (init->sizeof_priv) {
+		jdev->priv = devm_kzalloc(jdev->parent, init->sizeof_priv,
+					  GFP_KERNEL);
+		if (!jdev->priv) {
+			ret = -ENOMEM;
+			goto err_device_del;
+		}
+	}
 
 	mutex_unlock(&jesd204_device_list_lock);
 

--- a/drivers/jesd204/jesd204-priv.h
+++ b/drivers/jesd204/jesd204-priv.h
@@ -85,6 +85,7 @@ struct jesd204_dev_con_out {
  * @dev			underlying device object
  * @id			unique device id
  * @entry		list entry for the framework to keep a list of devices
+ * @priv		private data to be returned to the driver
  * @is_top		true if this device is a top device in a topology of
  *			devices that make up a JESD204 link (typically the
  *			device that is the ADC, DAC, or transceiver)
@@ -103,6 +104,7 @@ struct jesd204_dev {
 	struct device			dev;
 	int				id;
 	struct list_head		entry;
+	void				*priv;
 
 	bool				is_top;
 

--- a/include/linux/jesd204/jesd204.h
+++ b/include/linux/jesd204/jesd204.h
@@ -122,11 +122,13 @@ enum jesd204_dev_op {
  * struct jesd204_dev_data - JESD204 device initialization data
  * @link_ops		JESD204 operations this device passes to the framework
  *			for JESD204 link management
+ * @sizeof_priv		amount of data to allocate for private information
  * @links		JESD204 initial link configuration
  * @num_links		number of JESD204 links
  */
 struct jesd204_dev_data {
 	const jesd204_link_cb			link_ops[__JESD204_MAX_OPS];
+	size_t					sizeof_priv;
 	const struct jesd204_link		*links;
 	unsigned int				num_links;
 };
@@ -143,6 +145,8 @@ void devm_jesd204_unregister(struct device *dev, struct jesd204_dev *jdev);
 
 struct device *jesd204_dev_to_device(struct jesd204_dev *jdev);
 struct jesd204_dev *jesd204_dev_from_device(struct device *dev);
+
+void *jesd204_dev_priv(struct jesd204_dev *jdev);
 
 #else /* !IS_ENABLED(CONFIG_JESD204) */
 
@@ -169,6 +173,11 @@ static inline struct device *jesd204_dev_to_device(struct jesd204_dev *jdev)
 }
 
 static inline struct jesd204_dev *jesd204_dev_from_device(struct device *dev)
+{
+	return NULL;
+}
+
+static inline void *jesd204_dev_priv(struct jesd204_dev *jdev)
 {
 	return NULL;
 }


### PR DESCRIPTION
Many kernel frameworks allow a 'get_drvdata()' or 'get_priv()' sort of
mechanism that a driver can use to associate information for a particular
driver state.

This one adds a similar facility for the JESD204 framework.
What's a bit different here, is that this is allocated separately from the
'struct jesd204_dev' struct, because we typically allocate these objects
from the DT when the framework loads.
So there is no simple way to allocate it in another fashion.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>