### PR TITLE
jesd204: add pre/post transition hooks

### DIFF
--- a/drivers/jesd204/jesd204-core.c
+++ b/drivers/jesd204/jesd204-core.c
@@ -561,7 +561,9 @@ static int jesd204_dev_init_links_data(struct jesd204_dev *jdev,
 	 * Framework users should provide at least initial JESD204 link data,
 	 * or a link init op/callback which should do JESD204 link init.
 	 */
-	if (!init->links && !init->link_ops[JESD204_OP_LINK_INIT]) {
+	if (!init->links &&
+	    !init->state_ops &&
+	    !init->state_ops[JESD204_OP_LINK_INIT].per_link) {
 		dev_err(dev,
 			"num_links is non-zero, but no links data provided\n");
 		return -EINVAL;
@@ -618,7 +620,7 @@ struct jesd204_dev *jesd204_dev_register(struct device *dev,
 		goto err_free_id;
 	}
 
-	jdev->link_ops = init->link_ops;
+	jdev->state_ops = init->state_ops;
 	jdev->parent = get_device(dev);
 
 	ret = jesd204_dev_init_links_data(jdev, init);

--- a/drivers/jesd204/jesd204-priv.h
+++ b/drivers/jesd204/jesd204-priv.h
@@ -10,7 +10,6 @@
 
 #include <linux/jesd204/jesd204.h>
 
-#define JESD204_LINKS_ALL		((unsigned int)(-1))
 #define JESD204_MAX_LINKS		16
 
 struct jesd204_dev;
@@ -89,8 +88,9 @@ struct jesd204_dev_con_out {
  * @is_top		true if this device is a top device in a topology of
  *			devices that make up a JESD204 link (typically the
  *			device that is the ADC, DAC, or transceiver)
+ * @error		error code for this device if something happened
  * @parent		parent device that registers itself as a JESD204 device
- * @link_ops		JESD204 operations for JESD204 link management
+ * @state_ops		ops for each state transition of type @struct jesd204_state_ops
  * @np			reference in the device-tree for this JESD204 device
  * @ref			ref count for this JESD204 device
  * @inputs		array of pointers to output connections from other
@@ -108,8 +108,9 @@ struct jesd204_dev {
 
 	bool				is_top;
 
+	int				error;
 	struct device			*parent;
-	const jesd204_link_cb		*link_ops;
+	const struct jesd204_state_ops	*state_ops;
 	struct device_node		*np;
 	struct kref			ref;
 
@@ -162,8 +163,6 @@ struct jesd204_link_opaque {
  *			(connections should match against this)
  * @link_ids		JESD204 link IDs for this top-level device
  *			(connections should match against this)
- * @error		error code for this topology after a state has failed
- *			to transition
  * @init_links		initial settings passed from the driver
  * @active_links	active JESD204 link settings
  * @staged_links	JESD204 link settings staged to be committed as active
@@ -180,7 +179,6 @@ struct jesd204_dev_top {
 	int				topo_id;
 	unsigned int			link_ids[JESD204_MAX_LINKS];
 	unsigned int			num_links;
-	int				error;
 
 	const struct jesd204_link	*init_links;
 	struct jesd204_link_opaque	*active_links;


### PR DESCRIPTION
These are useful for multi-link devices, when a user may want to call a
hook for all JESD204 links before or after all links are called
individually to transition.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>