### PR TITLE
iio: adc: adar1000: Fix adc conversion condition

### DIFF
--- a/drivers/iio/adc/adar1000.c
+++ b/drivers/iio/adc/adar1000.c
@@ -337,7 +337,7 @@ static int adar1000_read_adc(struct adar1000_state *st, u8 adc_ch, s32 *adc_data
 				  &adc_ctrl);
 		if (ret < 0)
 			return ret;
-	} while (adc_ctrl & ADAR1000_ADC_EOC);
+	} while (!(adc_ctrl & ADAR1000_ADC_EOC));
 
 	/* Read ADC sample */
 	return regmap_read(st->regmap, st->dev_addr | ADAR1000_ADC_OUTPUT,


### PR DESCRIPTION
This patch fixes the condition for end of conversion (EOC).

Fixes: b2316a2ae75e ("iio: adc: adar1000: Initial driver version")
Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>