### PR TITLE
jesd204: minor tweaks: convert link_idx to unsigned & handle static lane IDs

### DIFF
--- a/drivers/jesd204/jesd204-core.c
+++ b/drivers/jesd204/jesd204-core.c
@@ -465,7 +465,7 @@ unlock:
 }
 
 static int jesd204_dev_init_link_lane_ids(struct jesd204_dev_top *jdev_top,
-					  int link_idx,
+					  unsigned int link_idx,
 					  struct jesd204_link *jlink)
 {
 	struct jesd204_dev *jdev = &jdev_top->jdev;
@@ -479,7 +479,11 @@ static int jesd204_dev_init_link_lane_ids(struct jesd204_dev_top *jdev_top,
 		return -EINVAL;
 	}
 
-	/* FIXME: see about the case where lane IDs are provided via init */
+	/* We have some lane IDs provided statically for this link ID; exit */
+	if (jdev_top->init_links &&
+	    jdev_top->init_links[link_idx].lane_ids)
+		return 0;
+
 	if (jlink->lane_ids)
 		devm_kfree(dev, jlink->lane_ids);
 
@@ -502,7 +506,6 @@ static int __jesd204_dev_init_link_data(struct jesd204_dev_top *jdev_top,
 	struct jesd204_link_opaque *ol;
 	int ret;
 
-	/* FIXME: fix the case where the driver provides static lane IDs */
 	ol = &jdev_top->active_links[link_idx];
 	ol->link.link_id = jdev_top->link_ids[link_idx];
 	ol->jdev_top = jdev_top;
@@ -517,6 +520,7 @@ static int __jesd204_dev_init_link_data(struct jesd204_dev_top *jdev_top,
 	return 0;
 }
 
+/* FIXME: see about maybe handling lane IDs assigned via the link_op for init links */
 int jesd204_dev_init_link_data(struct jesd204_dev_top *jdev_top,
 			       unsigned int link_idx)
 {

--- a/drivers/jesd204/jesd204-fsm.c
+++ b/drivers/jesd204/jesd204-fsm.c
@@ -511,7 +511,7 @@ static int jesd204_fsm_link_init(struct jesd204_dev_top *jdev_top,
 
 static int jesd204_fsm_test_and_set_busy(struct jesd204_dev_top *jdev_top,
 					 enum jesd204_dev_state cur_state,
-					 int link_idx)
+					 unsigned int link_idx)
 {
 	struct jesd204_dev *jdev = &jdev_top->jdev;
 	struct jesd204_link_opaque *ol;
@@ -542,7 +542,7 @@ static int jesd204_fsm_test_and_set_busy(struct jesd204_dev_top *jdev_top,
 	return 0;
 
 err_unwind_busy:
-	for (; link_idx > 0; link_idx--) {
+	for (; link_idx != JESD204_LINKS_ALL; link_idx--) {
 		ol = &jdev_top->active_links[link_idx];
 		clear_bit(JESD204_FSM_BUSY, &ol->flags);
 	}


### PR DESCRIPTION
Handling the `link_idx` as unsigned everywhere is a little more consistent.
And this also adds the option to specify lane IDs statically from the driver. It does fix a potential bug with some use-case with the framework. But it's still not yet complete; will be done later as things evolve.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>