### PR TITLE
jesd204: rework cleanup device unregister

### DIFF
--- a/drivers/jesd204/jesd204-core.c
+++ b/drivers/jesd204/jesd204-core.c
@@ -741,8 +741,10 @@ void jesd204_dev_unregister(struct jesd204_dev *jdev)
 	if (IS_ERR_OR_NULL(jdev))
 		return;
 
-	if (jdev->id > -1)
+	if (jdev->id > -1) {
+		jdev->id = -1;
 		device_del(&jdev->dev);
+	}
 
 	jesd204_fsm_uninit_device(jdev);
 	jesd204_dev_kref_put(jdev);

--- a/drivers/jesd204/jesd204-core.c
+++ b/drivers/jesd204/jesd204-core.c
@@ -627,8 +627,6 @@ struct jesd204_dev *jesd204_dev_register(struct device *dev,
 	if (ret)
 		goto err_put_device;
 
-	jdev->id = id;
-
 	jdev->dev.parent = dev;
 	jdev->dev.bus = &jesd204_bus_type;
 	device_initialize(&jdev->dev);


### PR DESCRIPTION
Don't free up topology when device unregisters. In case a driver needs to
re-probe, the topology is free'd up.
This was a mistake in the initial design.

All the jesd204_dev instances are statically initialized from DT, so they
should be free'd only when entire framework/module unloads.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>