### PR TITLE
jesd204: separate register from FSM start 

### DIFF
--- a/drivers/jesd204/jesd204-core.c
+++ b/drivers/jesd204/jesd204-core.c
@@ -182,7 +182,7 @@ void *jesd204_dev_priv(struct jesd204_dev *jdev)
 {
 	return jdev->priv;
 }
-EXPORT_SYMBOL(jesd204_dev_priv);
+EXPORT_SYMBOL_GPL(jesd204_dev_priv);
 
 struct jesd204_dev *jesd204_dev_from_device(struct device *dev)
 {
@@ -198,13 +198,13 @@ struct jesd204_dev *jesd204_dev_from_device(struct device *dev)
 
 	return NULL;
 }
-EXPORT_SYMBOL(jesd204_dev_from_device);
+EXPORT_SYMBOL_GPL(jesd204_dev_from_device);
 
 struct device *jesd204_dev_to_device(struct jesd204_dev *jdev)
 {
 	return jdev ? jdev->parent : NULL;
 }
-EXPORT_SYMBOL(jesd204_dev_to_device);
+EXPORT_SYMBOL_GPL(jesd204_dev_to_device);
 
 static int jesd204_dev_alloc_links(struct jesd204_dev_top *jdev_top)
 {

--- a/drivers/jesd204/jesd204-core.c
+++ b/drivers/jesd204/jesd204-core.c
@@ -641,10 +641,6 @@ static struct jesd204_dev *jesd204_dev_register(struct device *dev,
 	}
 	jdev->id = id;
 
-	ret = jesd204_fsm_probe(jdev);
-	if (ret)
-		goto err_device_del;
-
 	if (init->sizeof_priv) {
 		jdev->priv = devm_kzalloc(jdev->parent, init->sizeof_priv,
 					  GFP_KERNEL);

--- a/drivers/jesd204/jesd204-core.c
+++ b/drivers/jesd204/jesd204-core.c
@@ -741,7 +741,7 @@ static void jesd204_dev_unregister(struct jesd204_dev *jdev)
 		device_del(&jdev->dev);
 	}
 
-	jesd204_fsm_uninit_device(jdev);
+	jesd204_fsm_stop(jdev, JESD204_LINKS_ALL);
 	jesd204_dev_kref_put(jdev);
 }
 

--- a/drivers/jesd204/jesd204-fsm.c
+++ b/drivers/jesd204/jesd204-fsm.c
@@ -938,12 +938,13 @@ static int jesd204_fsm_table(struct jesd204_dev *jdev,
 			   handle_busy_flags);
 }
 
-void jesd204_fsm_uninit_device(struct jesd204_dev *jdev)
+void jesd204_fsm_stop(struct jesd204_dev *jdev, unsigned int link_idx)
 {
 	if (!jdev->fsm_started)
 		return;
 
-	jesd204_fsm_table(jdev, JESD204_LINKS_ALL,
+	jesd204_fsm_table(jdev, link_idx,
 			  JESD204_STATE_DONT_CARE, jesd204_uninit_dev_states,
 			  false);
 }
+EXPORT_SYMBOL_GPL(jesd204_fsm_stop);

--- a/drivers/jesd204/jesd204-priv.h
+++ b/drivers/jesd204/jesd204-priv.h
@@ -206,6 +206,4 @@ int jesd204_init_topology(struct jesd204_dev_top *jdev_top);
 
 int jesd204_fsm_probe(struct jesd204_dev *jdev);
 
-void jesd204_fsm_uninit_device(struct jesd204_dev *jdev);
-
 #endif /* _JESD204_PRIV_H_ */

--- a/drivers/jesd204/jesd204-priv.h
+++ b/drivers/jesd204/jesd204-priv.h
@@ -85,6 +85,7 @@ struct jesd204_dev_con_out {
  * @id			unique device id
  * @entry		list entry for the framework to keep a list of devices
  * @priv		private data to be returned to the driver
+ * @fsm_started		true if the FSM has been started for this device
  * @is_top		true if this device is a top device in a topology of
  *			devices that make up a JESD204 link (typically the
  *			device that is the ADC, DAC, or transceiver)
@@ -106,6 +107,7 @@ struct jesd204_dev {
 	struct list_head		entry;
 	void				*priv;
 
+	bool				fsm_started;
 	bool				is_top;
 
 	int				error;

--- a/include/linux/jesd204/jesd204.h
+++ b/include/linux/jesd204/jesd204.h
@@ -175,13 +175,10 @@ struct jesd204_dev_data {
 
 #if IS_ENABLED(CONFIG_JESD204)
 
-struct jesd204_dev *jesd204_dev_register(struct device *dev,
-					 const struct jesd204_dev_data *init);
 struct jesd204_dev *devm_jesd204_dev_register(struct device *dev,
 					      const struct jesd204_dev_data *i);
 
-void jesd204_dev_unregister(struct jesd204_dev *jdev);
-void devm_jesd204_unregister(struct device *dev, struct jesd204_dev *jdev);
+int jesd204_start_fsm_from_probe(struct jesd204_dev *jdev);
 
 struct device *jesd204_dev_to_device(struct jesd204_dev *jdev);
 struct jesd204_dev *jesd204_dev_from_device(struct device *dev);
@@ -198,22 +195,16 @@ int jesd204_link_get_device_clock(struct jesd204_link *lnk,
 
 #else /* !IS_ENABLED(CONFIG_JESD204) */
 
-static inline struct jesd204_dev *jesd204_dev_register(
-		struct device *dev, const struct jesd204_dev_data *init)
-{
-	return NULL;
-}
-
-static inline void jesd204_dev_unregister(struct jesd204_dev *jdev) {}
-
 static inline struct jesd204_dev *devm_jesd204_dev_register(
 		struct device *dev, const struct jesd204_dev_data *init)
 {
 	return NULL;
 }
 
-static inline void devm_jesd204_unregister(struct device *dev,
-	       struct jesd204_dev *jdev) {}
+static inline int jesd204_start_fsm_from_probe(struct jesd204_dev *jdev)
+{
+	return 0;
+}
 
 static inline struct device *jesd204_dev_to_device(struct jesd204_dev *jdev)
 {

--- a/include/linux/jesd204/jesd204.h
+++ b/include/linux/jesd204/jesd204.h
@@ -178,7 +178,7 @@ struct jesd204_dev_data {
 struct jesd204_dev *devm_jesd204_dev_register(struct device *dev,
 					      const struct jesd204_dev_data *i);
 
-int jesd204_start_fsm_from_probe(struct jesd204_dev *jdev);
+int jesd204_fsm_start(struct jesd204_dev *jdev, unsigned int link_idx);
 
 struct device *jesd204_dev_to_device(struct jesd204_dev *jdev);
 struct jesd204_dev *jesd204_dev_from_device(struct device *dev);
@@ -201,7 +201,8 @@ static inline struct jesd204_dev *devm_jesd204_dev_register(
 	return NULL;
 }
 
-static inline int jesd204_start_fsm_from_probe(struct jesd204_dev *jdev)
+static inline int jesd204_fsm_start(struct jesd204_dev *jdev,
+				    unsigned int link_idx)
 {
 	return 0;
 }

--- a/include/linux/jesd204/jesd204.h
+++ b/include/linux/jesd204/jesd204.h
@@ -179,6 +179,7 @@ struct jesd204_dev *devm_jesd204_dev_register(struct device *dev,
 					      const struct jesd204_dev_data *i);
 
 int jesd204_fsm_start(struct jesd204_dev *jdev, unsigned int link_idx);
+void jesd204_fsm_stop(struct jesd204_dev *jdev, unsigned int link_idx);
 
 struct device *jesd204_dev_to_device(struct jesd204_dev *jdev);
 struct jesd204_dev *jesd204_dev_from_device(struct device *dev);
@@ -206,6 +207,9 @@ static inline int jesd204_fsm_start(struct jesd204_dev *jdev,
 {
 	return 0;
 }
+
+static inline void jesd204_fsm_stop(struct jesd204_dev *jdev,
+				    unsigned int link_idx) {}
 
 static inline struct device *jesd204_dev_to_device(struct jesd204_dev *jdev)
 {


### PR DESCRIPTION
With this change a driver should first call jesd204_dev_register() really
early.
If a non-error/non-zero pointer is returned, the driver operates with the
JESD204 framework.

Now, what's needed, is that the jesd204_start_fsm_from_probe() be called to
actually run through the FSM and do some framework... work.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>