### PR TITLE
net: macb: disable gigabit for MII & RMII modes

### DIFF
--- a/drivers/net/ethernet/cadence/macb_main.c
+++ b/drivers/net/ethernet/cadence/macb_main.c
@@ -626,6 +626,11 @@ static int macb_mii_probe(struct net_device *dev)
 	else
 		phydev->supported &= PHY_BASIC_FEATURES;
 
+	/* FIXME: Drop this in newer kernels */
+	if (bp->phy_interface == PHY_INTERFACE_MODE_RMII ||
+	    bp->phy_interface == PHY_INTERFACE_MODE_MII)
+		phydev->supported &= PHY_BASIC_FEATURES;
+
 	if (bp->caps & MACB_CAPS_NO_GIGABIT_HALF)
 		phydev->supported &= ~SUPPORTED_1000baseT_Half;
 


### PR DESCRIPTION
This is a special case: both MAC & PHY support gigabit. But the interface
is MII or RMII.
For those cases we need to disable gigabit in 'phydev->supported'.

This patch is temporary for 4.19 and the ADI kernel.

What happens is that in MII/RMII mode the phy negotiates 1000Mbps. Since
the interface between MAC & PHY can't do more than 100Mbps [in MII/RMII],
this doesn't work.

If you give it a 100 Mbps link-partner, all is fine.

The problem appeared sometime after 4.19, which this commit f22dab12b0dec
("net: macb: Sync macb_config usage with mainline").
Or mainline commit 83a77e9ec4150 ("net: macb: Added PCI wrapper for
Platform Driver.").
It's not clear whether this code is still broken in usptream (yet).

But even if it is, a different commit will be needed there as the context
changed.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>