### PR TITLE
mmc: host: sdhci-of-arasan: fix timings allocation code 

### DIFF
--- a/drivers/mmc/host/sdhci-of-arasan.c
+++ b/drivers/mmc/host/sdhci-of-arasan.c
@@ -932,13 +932,16 @@ static void arasan_dt_read_tap_delay(struct device *dev, u32 *tapdly,
 				     u8 mode, const char *prop)
 {
 	struct device_node *np = dev->of_node;
+	u32 tmp;
 	/*
 	 * Read Tap Delay values from DT, if the DT does not contain the
 	 * Tap Values then use the pre-defined values
 	 */
-	if (of_property_read_u32(np, prop, &tapdly[mode])) {
+	if (of_property_read_u32(np, prop, &tmp)) {
 		dev_dbg(dev, "Using predefined tapdly for %s = %d\n",
 			prop, tapdly[mode]);
+	} else {
+		tapdly[mode] = tmp;
 	}
 }
 

--- a/drivers/mmc/host/sdhci-of-arasan.c
+++ b/drivers/mmc/host/sdhci-of-arasan.c
@@ -955,20 +955,26 @@ static void arasan_dt_parse_tap_delays(struct device *dev)
 	struct sdhci_host *host = platform_get_drvdata(pdev);
 	struct sdhci_pltfm_host *pltfm_host = sdhci_priv(host);
 	struct sdhci_arasan_data *sdhci_arasan = sdhci_pltfm_priv(pltfm_host);
-	u32 *itapdly;
-	u32 *otapdly;
+	u32 itapdly[MMC_TIMING_MMC_HS400 + 1];
+	u32 otapdly[MMC_TIMING_MMC_HS400 + 1];
 	int i;
 
 	if (of_device_is_compatible(pdev->dev.of_node, "xlnx,zynqmp-8.9a")) {
-		itapdly = (u32 [MMC_TIMING_MMC_HS400 + 1]) ZYNQMP_ITAP_DELAYS;
-		otapdly = (u32 [MMC_TIMING_MMC_HS400 + 1]) ZYNQMP_OTAP_DELAYS;
+		u32 zynqmp_itapdly[MMC_TIMING_MMC_HS400 + 1] = ZYNQMP_ITAP_DELAYS;
+		u32 zynqmp_otapdly[MMC_TIMING_MMC_HS400 + 1] = ZYNQMP_OTAP_DELAYS;
+
+		memcpy(itapdly, zynqmp_itapdly, sizeof(itapdly));
+		memcpy(otapdly, zynqmp_otapdly, sizeof(otapdly));
 		if (sdhci_arasan->mio_bank == MMC_BANK2) {
 			otapdly[MMC_TIMING_UHS_SDR104] = 0x2;
 			otapdly[MMC_TIMING_MMC_HS200] = 0x2;
 		}
 	} else {
-		itapdly = (u32 [MMC_TIMING_MMC_HS400 + 1]) VERSAL_ITAP_DELAYS;
-		otapdly = (u32 [MMC_TIMING_MMC_HS400 + 1]) VERSAL_OTAP_DELAYS;
+		u32 versal_itapdly[MMC_TIMING_MMC_HS400 + 1] = VERSAL_ITAP_DELAYS;
+		u32 versal_otapdly[MMC_TIMING_MMC_HS400 + 1] = VERSAL_OTAP_DELAYS;
+
+		memcpy(itapdly, versal_itapdly, sizeof(itapdly));
+		memcpy(otapdly, versal_otapdly, sizeof(otapdly));
 	}
 
 	arasan_dt_read_tap_delay(dev, itapdly, MMC_TIMING_SD_HS,


### PR DESCRIPTION
The initial code that was adding delays was doing a cast over undefined
memory. This meant that the delays would be all gibberish.

This change, allocates all delays on the stack, and assigns them from the
ZynqMP & Vesal macros/delay-list. And then finally copies them over the
common itapdly & otapdly variables.

It seems that without this change the UHS SD cards don't work well on ZCU102.

Fixes: c0c8d73 ("sdhci: arasan: Add support for Versal Tap Delays")
Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>