### PR TITLE
mtd: spi-nor: Fix SPI-NOR-UniqueID prints

### DIFF
--- a/drivers/mtd/spi-nor/spi-nor.c
+++ b/drivers/mtd/spi-nor/spi-nor.c
@@ -1703,7 +1703,8 @@ static const struct flash_info *spi_nor_read_id(struct spi_nor *nor)
 		info = &spi_nor_ids[tmp];
 		if (info->id_len) {
 			if (!memcmp(info->id, id, info->id_len)) {
-				if (id[0] == SNOR_MFR_MICRON)
+				/* ST and MICRON seem to use the same manufacturer ID */
+				if (id[0] == SNOR_MFR_MICRON || id[0] == SNOR_MFR_ST)
 					dev_info(nor->dev, "SPI-NOR-UniqueID %*phN\n",
 						 SPI_NOR_MAX_EDID_LEN - info->id_len, &id[info->id_len]);
 				return &spi_nor_ids[tmp];


### PR DESCRIPTION
Commit 3a70b0ddf changed Micron JEDEC manufacturer ID from 0x20 to 0x2C.
Almost all Micron flashes I know use 0x20. Example: MT25QU256ABA

Fixes: 3a70b0ddf ("mtd: spi-nor: add macros related to MICRON flash")
Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>