### PR TITLE
arch: arm: zc706,zed: cn0506: add RMII device-trees

### DIFF
--- a/arch/arm/boot/dts/adi-cn0506-rmii.dtsi
+++ b/arch/arm/boot/dts/adi-cn0506-rmii.dtsi
@@ -1,0 +1,45 @@
+#include <dt-bindings/gpio/gpio.h>
+
+&gem0 {
+	status = "okay";
+	phy-mode = "rmii";
+	phy-handle = <&ethernet_gem0_phy1>;
+	/* Override compatible string to configure a MAC that works
+	 * at 100 Mbit. Otherwise gigabit can be advertised by the
+	 * PHY after matching MAC link caps with PHY link caps,
+	 * even though, the design won't be able to actually support it
+	 */
+	compatible = "cdns,macb";
+
+	clocks = <&clkc 30>, <&fmc_mii_clk1>, <&clkc 13>;
+	clock-names = "pclk", "hclk", "tx_clk";
+
+	ethernet_gem0_phy1: ethernet-phy@1 {
+		reg = <1>;
+		reset-gpios = <&gpio0 91 GPIO_ACTIVE_HIGH>;
+		reset-assert-us = <20>; /* 10 us minimum */
+		reset-deassert-us = <10000>; /* 5 ms minimum */
+	};
+};
+
+&gem1 {
+	status = "okay";
+	phy-mode = "rmii";
+	phy-handle = <&ethernet_gem1_phy2>;
+	/* Override compatible string to configure a MAC that works
+	 * at 100 Mbit. Otherwise gigabit can be advertised by the
+	 * PHY after matching MAC link caps with PHY link caps,
+	 * even though, the design won't be able to actually support it
+	 */
+	compatible = "cdns,macb";
+
+	clocks = <&clkc 31>, <&fmc_mii_clk2>, <&clkc 14>;
+	clock-names = "pclk", "hclk", "tx_clk";
+
+	ethernet_gem1_phy2: ethernet-phy@2 {
+		reg = <2>;
+		reset-gpios = <&gpio0 90 GPIO_ACTIVE_HIGH>;
+		reset-assert-us = <20>; /* 10 us minimum */
+		reset-deassert-us = <10000>; /* 5 ms minimum */
+	};
+};

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-cn0506-rmii.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-cn0506-rmii.dts
@@ -1,0 +1,31 @@
+/dts-v1/;
+
+#include "zynq-zc706.dtsi"
+#include "zynq-zc706-adv7511.dtsi"
+#include "adi-cn0506-rmii.dtsi"
+
+&i2c_mux {
+	i2c@6 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <6>;
+
+		fmc_mii_clk1: clock-generator@32 {
+			#clock-cells = <0>;
+			compatible = "silabs,si514";
+			reg = <0x32>;
+			clock-output-names = "si514_fmc_mii_clk1";
+			assigned-clocks = <&fmc_mii_clk1>;
+			assigned-clock-rates = <50000000>;
+		};
+
+		fmc_mii_clk2: clock-generator@33 {
+			#clock-cells = <0>;
+			compatible = "silabs,si514";
+			reg = <0x33>;
+			clock-output-names = "si514_fmc_mii_clk2";
+			assigned-clocks = <&fmc_mii_clk2>;
+			assigned-clock-rates = <50000000>;
+		};
+	};
+};

--- a/arch/arm/boot/dts/zynq-zed-adv7511-cn0506-rmii.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-cn0506-rmii.dts
@@ -1,0 +1,37 @@
+/dts-v1/;
+
+#include "zynq-zed.dtsi"
+#include "zynq-zed-adv7511.dtsi"
+#include "adi-cn0506-rmii.dtsi"
+
+&fpga_axi {
+	fmc_i2c: i2c@41620000 {
+		compatible = "xlnx,axi-iic-1.01.b", "xlnx,xps-iic-2.00.a";
+		reg = <0x41620000 0x10000>;
+		interrupt-parent = <&intc>;
+		interrupts = <0 55 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&clkc 15>;
+		clock-names = "pclk";
+
+		#size-cells = <0>;
+		#address-cells = <1>;
+
+		fmc_mii_clk1: clock-generator@32 {
+			#clock-cells = <0>;
+			compatible = "silabs,si514";
+			reg = <0x32>;
+			clock-output-names = "si514_fmc_mii_clk1";
+			assigned-clocks = <&fmc_mii_clk1>;
+			assigned-clock-rates = <50000000>;
+		};
+
+		fmc_mii_clk2: clock-generator@33 {
+			#clock-cells = <0>;
+			compatible = "silabs,si514";
+			reg = <0x33>;
+			clock-output-names = "si514_fmc_mii_clk2";
+			assigned-clocks = <&fmc_mii_clk2>;
+			assigned-clock-rates = <50000000>;
+		};
+	};
+};

--- a/drivers/net/phy/adin.c
+++ b/drivers/net/phy/adin.c
@@ -631,7 +631,7 @@ static int adin_soft_reset(struct phy_device *phydev)
 	if (rc < 0)
 		return rc;
 
-	msleep(10);
+	msleep(20);
 
 	/* If we get a read error something may be wrong */
 	rc = phy_read_mmd(phydev, MDIO_MMD_VEND1,


### PR DESCRIPTION
This changeset adds device-trees for RMII mode on ZC706 & Zed.
On the CN0506 board RevB there is a Silabs Si514 clock-chip, which
initially boots-up at 25 Mhz, so for RGMII & MII modes, we don't need to
configure it in SW.

However, for RMII the clock is rev-ed up at 50 Mhz, then the reset-GPIO
pins are used to reset the PHY so that it can reconfigure for the new
frequency.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>