### PR TITLE
one-bit-adc-dac: Add initial version of one bit ADC, DAC

### DIFF
--- a/Documentation/devicetree/bindings/iio/addac/one-bit-adc-dac.yaml
+++ b/Documentation/devicetree/bindings/iio/addac/one-bit-adc-dac.yaml
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: (GPL-2.0 OR BSD-2-Clause)
+# Copyright 2020 Analog Devices Inc.
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/bindings/iio/addac/adi,one-bit-adc-dac.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
+
+title: Analog Devices one bit ADC DAC driver
+
+maintainers:
+  - Cristian Pop <cristian.pop@analog.com>
+
+description: |
+  One bit ADC DAC driver
+
+properties:
+  compatible:
+    enum:
+      - adi,one-bit-adc-dac
+
+  '#address-cells':
+    const: 1
+
+  '#size-cells':
+    const: 0
+
+  in-gpios:
+    description:
+      - Input GPIO numbers
+
+  out-gpios:
+    description:
+      - Output GPIO numbers
+required:
+  - compatible
+  - in-gpios
+  - out-gpios
+
+patternProperties:
+  "^channel@([0-9]|1[0-5])$":
+    type: object
+    description: |
+      Represents the external channels which are connected to the ADDAC.
+
+    properties:
+      reg:
+        description: |
+          The channel number.
+
+      label:
+        description: |
+          Unique name to identify which channel this is.
+    required:
+      - reg
+
+examples:
+  - |
+    one-bit-adc-dac@0 {
+        compatible = "one-bit-adc-dac";
+
+        #address-cells = <1>;
+        #size-cells = <0>;
+
+        in-gpios = <&gpio 17 0>, <&gpio 27 0>;
+        out-gpios = <&gpio 23 0>, <&gpio 24 0>;
+
+        channel@0 {
+          reg = <0>;
+          label = "i_17";
+        };
+
+        channel@1 {
+          reg = <1>;
+          label = "i_27";
+        };
+
+        channel@2 {
+          reg = <2>;
+          label = "o_23";
+        };
+
+        channel@3 {
+          reg = <3>;
+          label = "o_24";
+        };
+			};
+		};

--- a/drivers/iio/Kconfig
+++ b/drivers/iio/Kconfig
@@ -73,6 +73,7 @@ config IIO_TRIGGERED_EVENT
 
 source "drivers/iio/accel/Kconfig"
 source "drivers/iio/adc/Kconfig"
+source "drivers/iio/addac/Kconfig"
 source "drivers/iio/afe/Kconfig"
 source "drivers/iio/amplifiers/Kconfig"
 source "drivers/iio/chemical/Kconfig"

--- a/drivers/iio/Kconfig.adi
+++ b/drivers/iio/Kconfig.adi
@@ -150,3 +150,4 @@ config IIO_ALL_ADI_DRIVERS
 	select AXI_JESD204_TX
 	select AXI_JESD204_RX
 	select AXI_ADXCVR
+	select ONE_BIT_ADC_DAC

--- a/drivers/iio/Makefile
+++ b/drivers/iio/Makefile
@@ -15,6 +15,7 @@ obj-$(CONFIG_IIO_TRIGGERED_EVENT) += industrialio-triggered-event.o
 
 obj-y += accel/
 obj-y += adc/
+obj-y += addac/
 obj-y += afe/
 obj-y += amplifiers/
 obj-y += buffer/

--- a/drivers/iio/addac/Kconfig
+++ b/drivers/iio/addac/Kconfig
@@ -1,0 +1,17 @@
+#
+# ADC DAC drivers
+#
+# When adding new entries keep the list in alphabetical order
+
+menu "Analog to digital and digital to analog converters"
+
+config ONE_BIT_ADC_DAC
+	tristate "Analog Devices ONE_BIT_ADC_DAC driver"
+	help
+	  Say yes here to build support for Analog Devices ONE_BIT_ADC_DAC
+	  driver.
+
+ 	  To compile this driver as a module, choose M here: the
+	  module will be called one-bit-adc-dac.
+
+endmenu

--- a/drivers/iio/addac/Makefile
+++ b/drivers/iio/addac/Makefile
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0
+#
+# Makefile for industrial I/O ADDAC drivers
+#
+
+# When adding new entries keep the list in alphabetical order
+obj-$(CONFIG_ONE_BIT_ADC_DAC) += one-bit-adc-dac.o

--- a/drivers/iio/addac/one-bit-adc-dac.c
+++ b/drivers/iio/addac/one-bit-adc-dac.c
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * Analog Devices ONE_BIT_ADC_DAC
+ * Digital to Analog Converters driver
+ *
+ * Copyright 2020 Analog Devices Inc.
+ */
+
+#include <linux/device.h>
+#include <linux/module.h>
+#include <linux/iio/iio.h>
+#include <linux/platform_device.h>
+#include <linux/gpio/consumer.h>
+
+enum ch_direction {
+	CH_IN,
+	CH_OUT,
+};
+
+struct one_bit_adc_dac_state {
+	struct platform_device  *pdev;
+	struct gpio_descs       *in_gpio_descs;
+	struct gpio_descs       *out_gpio_descs;
+};
+
+static int one_bit_adc_dac_read_raw(struct iio_dev *indio_dev,
+	const struct iio_chan_spec *chan, int *val, int *val2, long info)
+{
+	struct one_bit_adc_dac_state *st = iio_priv(indio_dev);
+	struct gpio_descs *descs;
+
+	switch (info) {
+	case IIO_CHAN_INFO_RAW:
+		if (chan->output)
+			descs = st->out_gpio_descs;
+		else
+			descs = st->in_gpio_descs;
+		*val = gpiod_get_value_cansleep(descs->desc[chan->channel]);
+
+		return IIO_VAL_INT;
+	default:
+		return -EINVAL;
+	}
+}
+
+static int one_bit_adc_dac_write_raw(struct iio_dev *indio_dev,
+			    struct iio_chan_spec const *chan,
+			    int val,
+			    int val2,
+			    long info)
+{
+	struct one_bit_adc_dac_state *st = iio_priv(indio_dev);
+	int channel = chan->channel;
+
+	if (!chan->output)
+		return 0;
+
+	switch (info) {
+	case IIO_CHAN_INFO_RAW:
+		gpiod_set_value_cansleep(st->out_gpio_descs->desc[channel], val);
+
+		return 0;
+	default:
+		return -EINVAL;
+	}
+}
+
+static const struct iio_info one_bit_adc_dac_info = {
+	.read_raw = &one_bit_adc_dac_read_raw,
+	.write_raw = &one_bit_adc_dac_write_raw,
+};
+
+static int one_bit_adc_dac_set_ch(struct iio_chan_spec *channels,
+					int num_ch,
+					enum ch_direction direction)
+{
+	int i;
+
+	for (i = 0; i < num_ch; i++) {
+		channels[i].type = IIO_VOLTAGE;
+		channels[i].indexed = 1;
+		channels[i].channel = i;
+		channels[i].info_mask_separate = BIT(IIO_CHAN_INFO_RAW);
+		channels[i].output = direction;
+	}
+
+	return 0;
+}
+
+static void one_bit_adc_dac_set_channel_label(struct device *device,
+						struct iio_chan_spec *channels,
+						int num_channels)
+{
+	struct fwnode_handle *fwnode;
+	struct fwnode_handle *child;
+	struct iio_chan_spec *chan;
+	const char *label;
+	int crt_ch = 0;
+
+	fwnode = dev_fwnode(device);
+	fwnode_for_each_child_node(fwnode, child) {
+		if (fwnode_property_read_u32(child, "reg", &crt_ch))
+			continue;
+
+		if (crt_ch >= num_channels)
+			continue;
+
+		if (fwnode_property_read_string(child, "label", &label))
+			continue;
+
+		chan = &channels[crt_ch];
+		chan->info_mask_separate |= BIT(IIO_CHAN_INFO_LABEL);
+		chan->label_name = label;
+	}
+}
+
+static int one_bit_adc_dac_parse_dt(struct iio_dev *indio_dev)
+{
+	struct one_bit_adc_dac_state *st = iio_priv(indio_dev);
+	struct iio_chan_spec *channels;
+	int ret, in_num_ch = 0, out_num_ch = 0;
+
+	st->in_gpio_descs = devm_gpiod_get_array_optional(&st->pdev->dev, "in", GPIOD_IN);
+	if (IS_ERR(st->in_gpio_descs))
+		return PTR_ERR(st->in_gpio_descs);
+
+	if (st->in_gpio_descs)
+		in_num_ch = st->in_gpio_descs->ndescs;
+
+	st->out_gpio_descs = devm_gpiod_get_array_optional(&st->pdev->dev, "out", GPIOD_OUT_HIGH);
+	if (IS_ERR(st->out_gpio_descs))
+		return PTR_ERR(st->out_gpio_descs);
+
+	if (st->out_gpio_descs)
+		out_num_ch = st->out_gpio_descs->ndescs;
+
+	channels = devm_kcalloc(indio_dev->dev.parent, in_num_ch + out_num_ch,
+				sizeof(*channels), GFP_KERNEL);
+	if (!channels)
+		return -ENOMEM;
+
+	ret = one_bit_adc_dac_set_ch(&channels[0], in_num_ch, CH_IN);
+	if (ret)
+		return ret;
+
+	ret = one_bit_adc_dac_set_ch(&channels[in_num_ch], out_num_ch, CH_OUT);
+	if (ret)
+		return ret;
+
+	one_bit_adc_dac_set_channel_label(indio_dev->dev.parent, channels, in_num_ch + out_num_ch);
+	indio_dev->channels = channels;
+	indio_dev->num_channels = in_num_ch + out_num_ch;
+
+	return 0;
+}
+
+static int one_bit_adc_dac_probe(struct platform_device *pdev)
+{
+	struct iio_dev *indio_dev;
+	struct one_bit_adc_dac_state *st;
+	int ret;
+
+	indio_dev = devm_iio_device_alloc(&pdev->dev, sizeof(*st));
+	if (!indio_dev)
+		return -ENOMEM;
+
+	st = iio_priv(indio_dev);
+	st->pdev = pdev;
+	indio_dev->dev.parent = &pdev->dev;
+	indio_dev->name = "one-bit-adc-dac";
+	indio_dev->modes = INDIO_DIRECT_MODE;
+	indio_dev->info = &one_bit_adc_dac_info;
+
+	ret = one_bit_adc_dac_parse_dt(indio_dev);
+	if (ret)
+		return ret;
+
+	return devm_iio_device_register(indio_dev->dev.parent, indio_dev);
+}
+
+static const struct of_device_id one_bit_adc_dac_dt_match[] = {
+	{ .compatible = "one-bit-adc-dac" },
+	{}
+};
+MODULE_DEVICE_TABLE(of, one_bit_adc_dac_dt_match);
+
+static struct platform_driver one_bit_adc_dac_driver = {
+	.driver = {
+		.name = "one-bit-adc-dac",
+		.of_match_table = one_bit_adc_dac_dt_match,
+	},
+	.probe = one_bit_adc_dac_probe,
+};
+module_platform_driver(one_bit_adc_dac_driver);
+
+MODULE_AUTHOR("Cristian Pop <cristian.pop@analog.com>");
+MODULE_DESCRIPTION("Analog Devices ONE_BIT_ADC_DAC");
+MODULE_LICENSE("GPL v2");

--- a/include/linux/iio/iio.h
+++ b/include/linux/iio/iio.h
@@ -243,6 +243,7 @@ struct iio_event_spec {
  *			correspond to the first name that the channel is referred
  *			to by in the datasheet (e.g. IND), or the nearest
  *			possible compound name (e.g. IND-INC).
+ * @label_name:		Unique name to identify which channel this is.
  * @modified:		Does a modifier apply to this channel. What these are
  *			depends on the channel type.  Modifier is set in
  *			channel2. Examples are IIO_MOD_X for axial sensors about
@@ -280,6 +281,7 @@ struct iio_chan_spec {
 	const struct iio_chan_spec_ext_info *ext_info;
 	const char		*extend_name;
 	const char		*datasheet_name;
+	const char		*label_name;
 	unsigned		modified:1;
 	unsigned		indexed:1;
 	unsigned		output:1;

--- a/include/linux/iio/types.h
+++ b/include/linux/iio/types.h
@@ -37,6 +37,7 @@ enum iio_available_type {
 
 enum iio_chan_info_enum {
 	IIO_CHAN_INFO_RAW = 0,
+	IIO_CHAN_INFO_LABEL,
 	IIO_CHAN_INFO_PROCESSED,
 	IIO_CHAN_INFO_SCALE,
 	IIO_CHAN_INFO_OFFSET,


### PR DESCRIPTION
This allows remote GPIO read and write, trough libiio.

Signed-off-by: Cristian Pop <cristian.pop@analog.com>