### PR TITLE
Revert "mtd: spi-nor: Fix SPI-NOR-UniqueID prints"

### DIFF
--- a/drivers/mtd/spi-nor/spi-nor.c
+++ b/drivers/mtd/spi-nor/spi-nor.c
@@ -1656,8 +1656,7 @@ static const struct flash_info *spi_nor_read_id(struct spi_nor *nor)
 		info = &spi_nor_ids[tmp];
 		if (info->id_len) {
 			if (!memcmp(info->id, id, info->id_len)) {
-				/* ST and MICRON seem to use the same manufacturer ID */
-				if (id[0] == SNOR_MFR_MICRON || id[0] == SNOR_MFR_ST)
+				if (id[0] == SNOR_MFR_MICRON)
 					dev_info(nor->dev, "SPI-NOR-UniqueID %*phN\n",
 						 SPI_NOR_MAX_EDID_LEN - info->id_len, &id[info->id_len]);
 				return &spi_nor_ids[tmp];


### PR DESCRIPTION
This reverts commit 96f15b80459b451e092d867d8bb02d26c288a514.

Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>