### PR TITLE
jesd204: fsm: cleanups (1)

### DIFF
--- a/drivers/jesd204/jesd204-fsm.c
+++ b/drivers/jesd204/jesd204-fsm.c
@@ -282,6 +282,10 @@ static int __jesd204_link_fsm_update_state(struct jesd204_dev *jdev,
 {
 	ol->fsm_data = NULL;
 
+	/* clear error if current state is DONT_CARE */
+	if (fsm_data->cur_state == JESD204_STATE_DONT_CARE)
+		ol->error = 0;
+
 	if (ol->error) {
 		dev_err(&jdev->dev, "jesd got error from topology %d\n",
 			ol->error);

--- a/drivers/jesd204/jesd204-fsm.c
+++ b/drivers/jesd204/jesd204-fsm.c
@@ -947,10 +947,8 @@ static int jesd204_fsm_table_entry_done(struct jesd204_dev *jdev,
 	const struct jesd204_fsm_table_entry *table = it->table;
 	int cnt;
 
-	if (table[0].last) {
-		kfree(it->per_device_ran);
+	if (table[0].last)
 		return 0;
-	}
 
 	cnt = jesd204_device_count_get();
 	memset(it->per_device_ran, 0, sizeof(bool) * cnt);
@@ -966,7 +964,7 @@ static int jesd204_fsm_table(struct jesd204_dev *jdev,
 			     bool handle_busy_flags)
 {
 	struct jesd204_fsm_table_entry_iter it;
-	int cnt;
+	int cnt, ret;
 
 	it.table = table;
 
@@ -975,12 +973,16 @@ static int jesd204_fsm_table(struct jesd204_dev *jdev,
 	if (!it.per_device_ran)
 		return -ENOMEM;
 
-	return jesd204_fsm(jdev, link_idx,
+	ret = jesd204_fsm(jdev, link_idx,
 			  init_state, table[0].state,
 			  jesd204_fsm_table_entry_cb,
 			  &it,
 			  jesd204_fsm_table_entry_done,
 			  handle_busy_flags);
+
+	kfree(it.per_device_ran);
+
+	return ret;
 }
 
 void jesd204_fsm_stop(struct jesd204_dev *jdev, unsigned int link_idx)

--- a/drivers/jesd204/jesd204-fsm.c
+++ b/drivers/jesd204/jesd204-fsm.c
@@ -873,7 +873,6 @@ int jesd204_fsm_start(struct jesd204_dev *jdev, unsigned int link_idx)
 }
 EXPORT_SYMBOL_GPL(jesd204_fsm_start);
 
-
 static int jesd204_fsm_table_dev_op_cb(struct jesd204_dev *jdev,
 				       const struct jesd204_state_op *state_op,
 				       unsigned int link_idx,


### PR DESCRIPTION
* `jesd204: fsm: fix busy-flags handling and group init links with start links` - the busy flags were not handled properly
* `jesd204: fsm: handle memory free on each call of jesd204_fsm_table()` - fix potential leak on error path
* `jesd204: fsm: clear error current state is DONT_CARE` - so that we can restart the FSM if something goes wrong

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>