### PR TITLE
jesd204: cleanups/fixes (2)

### DIFF
--- a/drivers/jesd204/jesd204-fsm.c
+++ b/drivers/jesd204/jesd204-fsm.c
@@ -411,6 +411,13 @@ static int jesd204_con_validate_cur_state(struct jesd204_dev *jdev,
 	if (c->state == fsm_data->nxt_state)
 		return 0;
 
+	if (c->link_idx == JESD204_LINKS_ALL) {
+		if (!fsm_data->jdev_top->initialized)
+			return 0;
+		dev_err(&jdev->dev, "Uninitialized connection in topology\n");
+		return -EINVAL;
+	}
+
 	if (fsm_data->cur_state != c->state) {
 		ol = &fsm_data->jdev_top->active_links[c->link_idx];
 		dev_warn(&jdev->dev,
@@ -467,17 +474,9 @@ static int jesd204_fsm_handle_con(struct jesd204_dev *jdev,
 	/* if this transitioned already, we're done */
 	if (con->state == fsm_data->nxt_state)
 		return 0;
-
 	ret = jesd204_con_validate_cur_state(jdev, con, fsm_data);
 	if (ret)
 		return ret;
-
-	jdev_top = fsm_data->jdev_top;
-
-	if (jdev_top->initialized && con->link_idx == JESD204_LINKS_ALL) {
-		dev_err(&jdev->dev, "Uninitialized connection in topology\n");
-		return -EINVAL;
-	}
 
 	if (fsm_data->link_idx != JESD204_LINKS_ALL &&
 	    fsm_data->link_idx != con->link_idx)
@@ -486,6 +485,8 @@ static int jesd204_fsm_handle_con(struct jesd204_dev *jdev,
 	if (con->link_idx != JESD204_LINKS_ALL)
 		return jesd204_fsm_handle_con_cb(jdev, con, con->link_idx,
 						 fsm_data);
+
+	jdev_top = fsm_data->jdev_top;
 
 	if (jdev_top->initialized)
 		return 0;

--- a/drivers/jesd204/jesd204-fsm.c
+++ b/drivers/jesd204/jesd204-fsm.c
@@ -375,16 +375,11 @@ static void __jesd204_fsm_kref_link_put_get(struct jesd204_dev_top *jdev_top,
 		return;
 	}
 
-	for (link_idx = 0; link_idx < jdev_top->num_links; link_idx++) {
-		kref = &jdev_top->cb_ref;
-		for (link_idx = 0; link_idx < jdev_top->num_links; link_idx++) {
-			if (put)
-				kref_put(kref,
-					 __jesd204_all_links_fsm_done_cb);
-			else
-				kref_get(kref);
-		}
-	}
+	kref = &jdev_top->cb_ref;
+	if (put)
+		kref_put(kref, __jesd204_all_links_fsm_done_cb);
+	else
+		kref_get(kref);
 }
 
 static void jesd204_fsm_kref_link_get(struct jesd204_dev_top *jdev_top,
@@ -519,12 +514,8 @@ static int jesd204_fsm_link_init(struct jesd204_dev_top *jdev_top,
 		return 0;
 	}
 
-	for (link_idx = 0; link_idx < jdev_top->num_links; link_idx++) {
-		kref_init(&jdev_top->cb_ref);
-		for (link_idx = 1; link_idx < jdev_top->num_links; link_idx++)
-			kref_get(&jdev_top->cb_ref);
-		jdev_top->fsm_data = fsm_data;
-	}
+	kref_init(&jdev_top->cb_ref);
+	jdev_top->fsm_data = fsm_data;
 
 	return 0;
 }

--- a/drivers/jesd204/jesd204-fsm.c
+++ b/drivers/jesd204/jesd204-fsm.c
@@ -676,6 +676,8 @@ static int __jesd204_fsm(struct jesd204_dev *jdev,
 		goto out_clear_busy;
 
 	ret = jesd204_fsm_propagate_cb(jdev, &data);
+	if (ret)
+		goto out_clear_busy;
 
 	jesd204_fsm_kref_link_put(jdev_top, link_idx);
 

--- a/drivers/jesd204/jesd204-fsm.c
+++ b/drivers/jesd204/jesd204-fsm.c
@@ -757,10 +757,11 @@ static int jesd204_dev_initialize_cb(struct jesd204_dev *jdev,
 		return JESD204_STATE_CHANGE_DONE;
 
 	ret = jesd204_con_link_idx_in_jdev_top(con, fsm_data->jdev_top);
-	if (ret >= 0) {
-		con->jdev_top = fsm_data->jdev_top;
-		con->link_idx = ret;
-	}
+	if (ret < 0)
+		return JESD204_STATE_CHANGE_DEFER;
+
+	con->jdev_top = fsm_data->jdev_top;
+	con->link_idx = ret;
 
 	return JESD204_STATE_CHANGE_DONE;
 }


### PR DESCRIPTION
* `jesd204: fsm: don't get/put kref too many times` - no bugs noticed yet for this,but it looks like it could occur
* `jesd204: fsm: don't decrease refcounts on error in __jesd204_fsm()` - hasn't happened yet; but a done_cb could trigger on error [even if it shouldn't]
* `jesd204: fsm: return DEFER in initialize_cb if no link_idx found ` - this would still stop at some other state-transition; but better to stop it early
* `jesd204: fsm: fix validation of connection link_idx ` - this would cause a crash if the topology ID is not correct

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>