### PR TITLE
jesd204: minor cleanups/polishes (3)

### DIFF
--- a/drivers/jesd204/jesd204-core.c
+++ b/drivers/jesd204/jesd204-core.c
@@ -29,6 +29,8 @@ static LIST_HEAD(jesd204_topologies);
 static unsigned int jesd204_device_count;
 static unsigned int jesd204_topologies_count;
 
+static unsigned int jesd204_con_id_counter;
+
 static void jesd204_dev_unregister(struct jesd204_dev *jdev);
 
 int jesd204_device_count_get()
@@ -385,6 +387,7 @@ static int jesd204_dev_create_con(struct jesd204_dev *jdev,
 			return -ENOMEM;
 		}
 
+		con->id = jesd204_con_id_counter++;
 		con->topo_id = args->args[0];
 		con->link_id = args->args[1];
 		con->link_idx = JESD204_LINKS_ALL;
@@ -395,6 +398,9 @@ static int jesd204_dev_create_con(struct jesd204_dev *jdev,
 		list_add(&con->entry, &jdev_in->outputs);
 		jdev_in->outputs_count++;
 	}
+
+	pr_info("created con: id=%u, topo=%u, link=%u, %pOF <-> %pOF\n",
+		con->id, con->topo_id, con->link_id, con->owner->np, jdev->np);
 
 	e->jdev = jdev;
 	list_add(&e->entry, &con->dests);

--- a/drivers/jesd204/jesd204-fsm.c
+++ b/drivers/jesd204/jesd204-fsm.c
@@ -30,7 +30,6 @@ typedef int (*jesd204_fsm_done_cb)(struct jesd204_dev *jdev,
  * @cb_data		callback data for @fsm_change_cb
  * @cur_state		current state from which this FSM is transitioning
  * @nxt_state		next state to which this FSM is transitioning
- * @inputs		true if this is running on the inputs
  */
 struct jesd204_fsm_data {
 	struct jesd204_dev_top		*jdev_top;
@@ -40,7 +39,6 @@ struct jesd204_fsm_data {
 	void				*cb_data;
 	enum jesd204_dev_state		cur_state;
 	enum jesd204_dev_state		nxt_state;
-	bool				inputs;
 };
 
 static int jesd204_fsm_handle_con_cb(struct jesd204_dev *jdev,
@@ -264,12 +262,10 @@ static int jesd204_fsm_propagate_cb(struct jesd204_dev *jdev,
 {
 	int ret;
 
-	data->inputs = true;
 	ret = jesd204_fsm_propagate_cb_inputs(jdev, data);
 	if (ret)
 		goto out;
 
-	data->inputs = false;
 	ret = jesd204_fsm_propagate_cb_outputs(jdev, data);
 	if (ret)
 		goto out;

--- a/drivers/jesd204/jesd204-fsm.c
+++ b/drivers/jesd204/jesd204-fsm.c
@@ -450,7 +450,7 @@ static int jesd204_fsm_handle_con_cb(struct jesd204_dev *jdev,
 		dev_err(&jdev->dev,
 			"JESD204 link[%u] got error from cb: %d\n",
 			link_idx, ret);
-		return ret;
+		return jesd204_dev_set_error(jdev, NULL, con, ret);
 	}
 
 	if (ret != JESD204_STATE_CHANGE_DONE)

--- a/drivers/jesd204/jesd204-fsm.c
+++ b/drivers/jesd204/jesd204-fsm.c
@@ -423,8 +423,9 @@ static int jesd204_con_validate_cur_state(struct jesd204_dev *jdev,
 	if (fsm_data->cur_state != c->state) {
 		ol = &fsm_data->jdev_top->active_links[c->link_idx];
 		dev_warn(&jdev->dev,
-			 "JESD204 link[%d] invalid connection state: %s, exp: %s, nxt: %s\n",
+			 "JESD204 link[%d] invalid con[%u] state: %s, exp: %s, nxt: %s\n",
 			 c->link_idx,
+			 c->id,
 			 jesd204_state_str(c->state),
 			 jesd204_state_str(fsm_data->cur_state),
 			 jesd204_state_str(fsm_data->nxt_state));

--- a/drivers/jesd204/jesd204-priv.h
+++ b/drivers/jesd204/jesd204-priv.h
@@ -47,6 +47,7 @@ struct jesd204_dev_list_entry {
 
 /**
  * struct jesd204_dev_con_out - Output connection of a JESD204 device
+ * @id			unique ID for this connection
  * @entry		list entry for a device to keep a list of connections
  * @owner		pointer to JESD204 device to which this connection
  *			belongs to
@@ -66,6 +67,7 @@ struct jesd204_dev_list_entry {
  * @state		current state of this connection
  */
 struct jesd204_dev_con_out {
+	unsigned int			id;
 	struct list_head		entry;
 	struct jesd204_dev		*owner;
 	struct jesd204_dev_top		*jdev_top;


### PR DESCRIPTION
* `jesd204: add connection simple unique IDs` - for debugging
* `jesd204: fsm: set error on the connection and jdev object if cb fails` - this error should be reported
* `jesd204: fsm: rename jdev -> jdev_it in propagation ` - this is cosmetic a bit, but mostly semantic; the name of this variable will be important later;
* `jesd204: fsm: remove inputs field` - just dead code

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>