### PR TITLE
jesd204: fsm: always start state transition from top-level device

### DIFF
--- a/drivers/jesd204/jesd204-fsm.c
+++ b/drivers/jesd204/jesd204-fsm.c
@@ -242,11 +242,6 @@ static int jesd204_fsm_propagate_cb_top_level(struct jesd204_dev *jdev_it,
 						 fsm_data->link_idx,
 						 fsm_data);
 
-	/*
-	 * FIXME: think of a better way to iterate the top-level device callback here.
-	 * for now this works; and is slightly cleaner than before
-	 */
-	jdev_it = &fsm_data->jdev_top->jdev;
 	for (i = 0; i < fsm_data->jdev_top->num_links; i++) {
 		ret = jesd204_fsm_handle_con_cb(jdev_it, NULL, i, fsm_data);
 		if (ret)
@@ -671,7 +666,13 @@ static int __jesd204_fsm(struct jesd204_dev *jdev,
 	if (ret)
 		goto out_clear_busy;
 
-	ret = jesd204_fsm_propagate_cb(jdev, &data);
+	/**
+	 * Always propagate from the top-level device, otherwise if
+	 * if we propagate from a device that is somewhere in a topology
+	 * and belongs to a certain JESD204 link, we may miss certain
+	 * devices when propagating changes for all JESD204 links
+	 */
+	ret = jesd204_fsm_propagate_cb(&jdev_top->jdev, &data);
 	if (ret)
 		goto out_clear_busy;
 


### PR DESCRIPTION
I assumed this was always true, but turns out it isn't. During probe, a
device will propagate only on it's own direct connections, which may be
only for a certain JESD204 link, and will ignore devices for all other
JESD204 links.

When propagating state changes for all JESD204 links, we should always
start from the top-level device.
That way, the propagations will happen for all JESD204 links (if they need
to), or only for a certain JESD204 link (if it needs to).
Though the latter hasn't been tested yet; it will be tested in future
cases.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>