### PR TITLE
ci: stop auto-sync-ing altera_4.14 & adi-iio branches

### DIFF
--- a/ci/travis/run-build.sh
+++ b/ci/travis/run-build.sh
@@ -380,8 +380,7 @@ __handle_sync_with_master() {
 build_sync_branches_with_master() {
 	GIT_FETCH_DEPTH=50
 	BRANCHES="xcomm_zynq:fast-forward adi-4.19.0:cherry-pick"
-	BRANCHES="$BRANCHES rpi-4.19.y:cherry-pick altera_4.14:cherry-pick"
-	BRANCHES="$BRANCHES adi-iio:cherry-pick"
+	BRANCHES="$BRANCHES rpi-4.19.y:cherry-pick"
 
 	for branch in $BRANCHES ; do
 		local dst_branch="$(echo $branch | cut -d: -f1)"


### PR DESCRIPTION
It seems that backporting to an older kernel version is a bit more
problematic sometimes, as master is on 4.19 and intel/altera on 4.14.

We should focus on moving support for intel/altera boards in master and not
carry extra branches around.
At some point we may also switch rpi-4.19.y to master, but first we should
start with altera branches.

If we need things in this branch, we should backport it manually.

The adi-iio branch is too far ahead of master and takes some effort to keep
it working as things change in the kernel (like GPIO APIs).

In the near future, kernel 5.4.0 will be the next version that will be
used. At that point version 4.14 will be more difficult to backport to.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>