### PR TITLE
iio: adc: adm1177: Make a distinction between the hwmon and iio versions 

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-reva.dtsi
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-reva.dtsi
@@ -78,7 +78,7 @@
 	sda-gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
 
 	current_limiter@58 { /* U12 */
-		compatible = "adi,adm1177";
+		compatible = "adi,adm1177-iio";
 		reg = <0x58>;
 		adi,r-sense-mohm = <10>; /* 10 mOhm */
 		adi,shutdown-threshold-ma = <10000>; /* 10 A */

--- a/drivers/iio/adc/adm1177.c
+++ b/drivers/iio/adc/adm1177.c
@@ -219,13 +219,13 @@ static int adm1177_remove(struct i2c_client *client)
 }
 
 static const struct i2c_device_id adm1177_ids[] = {
-	{ "adm1177", 0 },
+	{ "adm1177-iio", 0 },
 	{}
 };
 MODULE_DEVICE_TABLE(i2c, adm1177_ids);
 
 static const struct of_device_id adm1177_dt_ids[] = {
-	{ .compatible = "adi,adm1177" },
+	{ .compatible = "adi,adm1177-iio" },
 	{},
 };
 MODULE_DEVICE_TABLE(of, nau7802_dt_ids);


### PR DESCRIPTION
https://github.com/analogdevicesinc/linux/commit/3a901a778f83f4c12106bef6670db85c49f9d5be has started to do it, but the i2c_device_id and of_device_id were not updated, so the change had no effect.