### PR TITLE
iio: ad9081: fix potential invalid error code

### DIFF
--- a/drivers/iio/adc/ad9081.c
+++ b/drivers/iio/adc/ad9081.c
@@ -871,14 +871,16 @@ static ssize_t ad9081_ext_info_read(struct iio_dev *indio_dev,
 				    BIT(chan->channel)) {
 					val = phy->tx_main_ffh_select[i];
 					ret = 0;
-					break;
+					goto out_unlock;
 				}
 			}
 		}
+		/* fall-through */
 	default:
 		ret = -EINVAL;
 	}
 
+out_unlock:
 	mutex_unlock(&indio_dev->mlock);
 
 	if (ret == 0)


### PR DESCRIPTION
Compiler complains about a potential fall-through. But in reality this can
also be a bug, where -EINVAL is returned by a potential invalid
fall-through.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>