### PR TITLE
iio: ad9528: minor cleanups of the driver

### DIFF
--- a/drivers/iio/frequency/ad9528.c
+++ b/drivers/iio/frequency/ad9528.c
@@ -1525,7 +1525,6 @@ MODULE_DEVICE_TABLE(spi, ad9528_id);
 static struct spi_driver ad9528_driver = {
 	.driver = {
 		.name	= "ad9528",
-		.owner	= THIS_MODULE,
 	},
 	.probe		= ad9528_probe,
 	.remove		= ad9528_remove,


### PR DESCRIPTION
Remove owner assignment to the driver object.
Convert the rest of the probe to device-managed functions.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>