### PR TITLE
iio: jesd204: Support for optional (slaved) GT REFCLK

### DIFF
--- a/drivers/iio/jesd204/axi_adxcvr.h
+++ b/drivers/iio/jesd204/axi_adxcvr.h
@@ -52,6 +52,7 @@ struct adxcvr_state {
 	struct device		*dev;
 	void __iomem		*regs;
 	struct clk		*conv_clk;
+	struct clk		*conv2_clk;
 	struct clk		*lane_rate_div40_clk;
 	struct clk_hw		lane_clk_hw;
 	struct work_struct	work;

--- a/drivers/iio/jesd204/axi_jesd204_rx.c
+++ b/drivers/iio/jesd204/axi_jesd204_rx.c
@@ -90,6 +90,7 @@ struct axi_jesd204_rx {
 
 	struct clk *axi_clk;
 	struct clk *device_clk;
+	struct clk *conv2_clk;
 
 	int irq;
 
@@ -755,9 +756,28 @@ static int axi_jesd204_rx_probe(struct platform_device *pdev)
 	if (IS_ERR(jesd->lane_clk))
 		return PTR_ERR(jesd->lane_clk);
 
+	/*
+	 * Optional CPLL/QPLL REFCLK from a difference source
+	 * which rate and state must be in sync with the main conv clk
+	 * This is used in axi_jesd204_rx_jesd204_link_setup() where the
+	 * main REFCLK is the parent of jesd->lane_clk.
+	 */
+	jesd->conv2_clk = devm_clk_get(&pdev->dev, "conv2");
+	if (IS_ERR(jesd->conv2_clk)) {
+		if (PTR_ERR(jesd->conv2_clk) != -ENOENT)
+			return PTR_ERR(jesd->conv2_clk);
+		jesd->conv2_clk = NULL;
+	}
+
 	ret = clk_prepare_enable(jesd->axi_clk);
 	if (ret)
 		return ret;
+
+	if (jesd->conv2_clk) {
+		ret = clk_prepare_enable(jesd->conv2_clk);
+		if (ret)
+			goto err_axi_clk_disable;
+	}
 
 	jesd->num_lanes = readl_relaxed(jesd->base + JESD204_RX_REG_SYNTH_NUM_LANES);
 	jesd->data_path_width = readl_relaxed(jesd->base + JESD204_RX_REG_SYNTH_DATA_PATH_WIDTH);
@@ -769,11 +789,11 @@ static int axi_jesd204_rx_probe(struct platform_device *pdev)
 	if (jesd->encoder == JESD204_ENCODER_UNKNOWN)
 		jesd->encoder = JESD204_ENCODER_8B10B;
 	else if (jesd->encoder >= JESD204_ENCODER_MAX)
-		goto err_axi_clk_disable;
+		goto err_conv2_clk_disable;
 
 	ret = axi_jesd204_rx_apply_config(jesd, &config);
 	if (ret)
-		goto err_axi_clk_disable;
+		goto err_conv2_clk_disable;
 
 	writel_relaxed(0xff, jesd->base + JESD204_RX_REG_IRQ_PENDING);
 	writel_relaxed(0x00, jesd->base + JESD204_RX_REG_IRQ_ENABLE);
@@ -783,7 +803,7 @@ static int axi_jesd204_rx_probe(struct platform_device *pdev)
 	ret = request_irq(irq, axi_jesd204_rx_irq, 0, dev_name(&pdev->dev),
 		jesd);
 	if (ret)
-		goto err_axi_clk_disable;
+		goto err_conv2_clk_disable;
 
 /* FIXME: Enabling the clock here and keeping it enabled will prevent
  * reconfiguration of the the clock when the lane rate changes. We need to find
@@ -843,6 +863,8 @@ err_disable_device_clk:
 err_free_irq:
 */
 	free_irq(irq, jesd);
+err_conv2_clk_disable:
+	clk_disable_unprepare(jesd->conv2_clk);
 err_axi_clk_disable:
 	clk_disable_unprepare(jesd->axi_clk);
 
@@ -864,6 +886,7 @@ static int axi_jesd204_rx_remove(struct platform_device *pdev)
 	writel_relaxed(0x1, jesd->base + JESD204_RX_REG_LINK_DISABLE);
 
 /*	clk_disable_unprepare(jesd->device_clk);*/
+	clk_disable_unprepare(jesd->conv2_clk);
 	clk_disable_unprepare(jesd->axi_clk);
 
 	return 0;


### PR DESCRIPTION
This patch adds support for an optional CPLL/QPLL REFCLK from a
difference source, which rate and state must be in sync with the main
conv clk (GT REFCLK). This feature is used on the ADRV9009-ZU11EG SoM
in combination with the external FMCOMMS8 FMC card, where each HMC7044
clock chip provides it's own GT REFCLK connected to different QUADs in
an identical configuration.

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>