### PR TITLE
jesd204: core: add async sysref helper

### DIFF
--- a/drivers/jesd204/jesd204-core.c
+++ b/drivers/jesd204/jesd204-core.c
@@ -38,6 +38,26 @@ int jesd204_device_count_get()
 	return jesd204_device_count;
 }
 
+bool jesd204_dev_has_con_in_topology(struct jesd204_dev *jdev,
+				     struct jesd204_dev_top *jdev_top)
+{
+	struct jesd204_dev_con_out *c;
+	int i;
+
+	list_for_each_entry(c, &jdev->outputs, entry) {
+		if (c->jdev_top == jdev_top)
+			return true;
+	}
+
+	for (i = 0; i < jdev->inputs_count; i++) {
+		c = jdev->inputs[i];
+		if (c->jdev_top == jdev_top)
+			return true;
+	}
+
+	return false;
+}
+
 static int jesd204_link_validate_params(const struct jesd204_link *lnk)
 {
 	if (!lnk->num_lanes) {

--- a/drivers/jesd204/jesd204-fsm.c
+++ b/drivers/jesd204/jesd204-fsm.c
@@ -687,26 +687,6 @@ out_clear_busy:
 	return ret;
 }
 
-static bool jesd204_dev_has_con_in_topology(struct jesd204_dev *jdev,
-					    struct jesd204_dev_top *jdev_top)
-{
-	struct jesd204_dev_con_out *c;
-	int i;
-
-	list_for_each_entry(c, &jdev->outputs, entry) {
-		if (c->jdev_top == jdev_top)
-			return true;
-	}
-
-	for (i = 0; i < jdev->inputs_count; i++) {
-		c = jdev->inputs[i];
-		if (c->jdev_top == jdev_top)
-			return true;
-	}
-
-	return false;
-}
-
 static int jesd204_fsm(struct jesd204_dev *jdev,
 		       struct jesd204_fsm_data *data,
 		       bool handle_busy_flags)

--- a/drivers/jesd204/jesd204-priv.h
+++ b/drivers/jesd204/jesd204-priv.h
@@ -89,6 +89,8 @@ struct jesd204_dev_con_out {
  * @is_top		true if this device is a top device in a topology of
  *			devices that make up a JESD204 link (typically the
  *			device that is the ADC, DAC, or transceiver)
+ * @sysref_cb		callback to the SYSREF logic provided by this device
+ * @is_sysref_provider	true if this device wants to be a SYSREF provider
  * @error		error code for this device if something happened
  * @state_ops		ops for each state transition of type @struct jesd204_state_ops
  * @np			reference in the device-tree for this JESD204 device
@@ -108,6 +110,9 @@ struct jesd204_dev {
 
 	bool				fsm_inited;
 	bool				is_top;
+
+	jesd204_sysref_cb		sysref_cb;
+	bool				is_sysref_provider;
 
 	int				error;
 	const struct jesd204_state_op	*state_ops;
@@ -152,6 +157,7 @@ struct jesd204_link_opaque {
  * @entry		list entry for the framework to keep a list of top
  *			devices (and implicitly topologies)
  * @initialized		true the topoology connections have been initialized
+ * @jdev_sysref		reference to the object that is the SYSREF provider for this topology
  * @fsm_data		ref to JESD204 FSM data for JESD204_LNK_FSM_PARALLEL
  * @cb_ref		kref which for each JESD204 link will increment when it
  *			needs to defer a state transition; this is similar to the
@@ -171,6 +177,8 @@ struct jesd204_dev_top {
 	struct jesd204_dev		jdev;
 	struct list_head		entry;
 	bool				initialized;
+
+	struct jesd204_dev		*jdev_sysref;
 
 	struct jesd204_fsm_data		*fsm_data;
 	struct kref			cb_ref;

--- a/drivers/jesd204/jesd204-priv.h
+++ b/drivers/jesd204/jesd204-priv.h
@@ -186,6 +186,9 @@ struct jesd204_dev_top {
 
 int jesd204_device_count_get(void);
 
+bool jesd204_dev_has_con_in_topology(struct jesd204_dev *jdev,
+				     struct jesd204_dev_top *jdev_top);
+
 struct list_head *jesd204_topologies_get(void);
 
 static inline struct jesd204_dev_top *jesd204_dev_top_dev(

--- a/include/linux/jesd204/jesd204.h
+++ b/include/linux/jesd204/jesd204.h
@@ -146,8 +146,10 @@ static inline const char *jesd204_state_op_reason_str(enum jesd204_state_op_reas
 	}
 }
 
+typedef int (*jesd204_sysref_cb)(struct jesd204_dev *jdev);
+
 typedef int (*jesd204_dev_cb)(struct jesd204_dev *jdev,
-			     enum jesd204_state_op_reason reason);
+			      enum jesd204_state_op_reason reason);
 
 typedef int (*jesd204_link_cb)(struct jesd204_dev *jdev,
 			       enum jesd204_state_op_reason,
@@ -185,12 +187,14 @@ enum jesd204_dev_op {
 /**
  * struct jesd204_dev_data - JESD204 device initialization data
  * @state_ops		ops for each state transition of type @struct jesd204_state_op
+ * @sysref_cb		SYSREF callback, if this device/driver supports it
  * @sizeof_priv		amount of data to allocate for private information
  * @links		JESD204 initial link configuration
  * @num_links		number of JESD204 links
  */
 struct jesd204_dev_data {
 	struct jesd204_state_op			state_ops[__JESD204_MAX_OPS];
+	jesd204_sysref_cb			sysref_cb;
 	size_t					sizeof_priv;
 	const struct jesd204_link		*links;
 	unsigned int				num_links;
@@ -218,6 +222,8 @@ int jesd204_link_get_rate_khz(struct jesd204_link *lnk,
 int jesd204_link_get_rate(struct jesd204_link *lnk, u64 *lane_rate_hz);
 int jesd204_link_get_device_clock(struct jesd204_link *lnk,
 				  unsigned long *device_clock);
+
+int jesd204_sysref_async(struct jesd204_dev *jdev);
 
 bool jesd204_dev_is_top(struct jesd204_dev *jdev);
 
@@ -276,6 +282,11 @@ static inline int jesd204_link_get_rate(struct jesd204_link *lnk,
 
 static inline int jesd204_link_get_device_clock(struct jesd204_link *lnk,
 						unsigned long *device_clock)
+{
+	return -ENOTSUPP;
+}
+
+static inline int jesd204_sysref_async(struct jesd204_dev *jdev)
 {
 	return -ENOTSUPP;
 }


### PR DESCRIPTION
Adapted from Michael's work.
This adds the jesd204_sysref_async(), but with a bit more integration into
the topology of the framework.

There can be only one SYSREF provider in a topology. But more devices in a
topology could issue a SYSREF, but only the device configured in the DT
should be used.

This validates that the device configured as a SYSREF provider actually has
callback for issuing a SYSREF. It also validates that no second device
tries to configure itself as a SYSREF provider during probe.

At the moment the jesd204_sysref_async() takes only a single parameter (as
jdev object). Maybe later some other parameters may make sense.

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>
Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>