### PR TITLE
iio: jesd204: axi_jesd204_rx: register & integrate with the JESD204 framework 

### DIFF
--- a/drivers/jesd204/jesd204-core.c
+++ b/drivers/jesd204/jesd204-core.c
@@ -649,6 +649,7 @@ static int __jesd204_dev_init_link_data(struct jesd204_dev_top *jdev_top,
 	ol->link.link_id = jdev_top->link_ids[link_idx];
 	ol->jdev_top = jdev_top;
 	ol->link_idx = link_idx;
+	ol->link.sysref.lmfc_offset = JESD204_LMFC_OFFSET_UNINITIALIZED;
 	ret = jesd204_dev_init_link_lane_ids(jdev_top, link_idx, &ol->link);
 	if (ret)
 		return ret;

--- a/include/linux/jesd204/jesd204.h
+++ b/include/linux/jesd204/jesd204.h
@@ -70,8 +70,8 @@ struct jesd204_sysref {
  * @jesd_version		JESD204 version (A, B or C) (JESDV)
  * @jesd_encoder		JESD204C encoder (8B10B, 64B66B, 64B80B)
  * @subclass			JESD204 subclass (0,1 or 2) (SUBCLASSV)
- * @did				device ID (DID)
- * @bid				bank ID (BID)
+ * @device_id			device ID (DID)
+ * @bank_id			bank ID (BID)
  * @scrambling			true if scrambling enabled (SCR)
  * @high_density		true if high-density format is used (HD)
  * @ctrl_words_per_frame_clk	number of control words per frame clock
@@ -109,8 +109,8 @@ struct jesd204_link {
 	u8 jesd_encoder;
 	u8 subclass;
 
-	u8 did;
-	u8 bid;
+	u8 device_id;
+	u8 bank_id;
 
 	u8 scrambling;
 	u8 high_density;

--- a/include/linux/jesd204/jesd204.h
+++ b/include/linux/jesd204/jesd204.h
@@ -44,15 +44,19 @@ enum jesd204_state_change_result {
 
 #define JESD204_LINKS_ALL		((unsigned int)(-1))
 
-/** struct jesd204_sysref - JESD204 configuration for SYSREF
+#define JESD204_LMFC_OFFSET_UNINITIALIZED	((u16)-1)
+
+/** struct jesd204_sysref - JESD204 parameters for SYSREF
  * @mode			SYSREF mode (see @jesd204_sysref_mode)
  * @capture_falling_edge	true if it should capture falling edge
  * @valid_falling_edge		true if falling edge should be valid
+ * @lmfc_offset			offset for LMFC
  */
 struct jesd204_sysref {
 	enum jesd204_sysref_mode	mode;
 	u8				capture_falling_edge;
 	u8				valid_falling_edge;
+	u16				lmfc_offset;
 };
 
 /**


### PR DESCRIPTION
This changeset integrates the `axi_jesd204_rx` driver into the JESD204 framework.
The driver should be able to also operate without the framework.

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>
Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>
