### PR TITLE
arm64: dts: add device-tree variants for ADRV9009 & ADRV9008-1 with JESD204 FSM

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9008-1-jesd204-fsm.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9008-1-jesd204-fsm.dts
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices ADRV9008-1 (via jesd204-fsm)
+ * https://wiki.analog.com/resources/eval/user-guides/adrv9009
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9009
+ * https://wiki.analog.com/resources/tools-software/linux-software/adrv9009_advanced_plugin
+ *
+ * hdl_project: <adrv9009/zcu102>
+ * board_revision: <>
+ *
+ * Copyright (C) 2019 Analog Devices Inc.
+ */
+
+#include "zynqmp-zcu102-rev10-adrv9008-1.dts"
+
+#include <dt-bindings/iio/adc/adi,adrv9009.h>
+
+&trx0_adrv9009 {
+	jesd204-device;
+	#jesd204-cells = <2>;
+	jesd204-top-device = <0>; /* This is the TOP device */
+	jesd204-link-ids = <FRAMER_LINK_RX>;
+
+	jesd204-inputs =
+		<&axi_adrv9009_rx_jesd 0 FRAMER_LINK_RX>;
+
+	/delete-property/ interrupts;
+};
+
+&axi_adrv9009_rx_jesd {
+	jesd204-device;
+	#jesd204-cells = <2>;
+	jesd204-inputs = <&axi_adrv9009_adxcvr_rx 0 FRAMER_LINK_RX>;
+};
+
+&axi_adrv9009_adxcvr_rx {
+	jesd204-device;
+	#jesd204-cells = <2>;
+	jesd204-inputs =  <&clk0_ad9528 0 FRAMER_LINK_RX>;
+	clocks = <&clk0_ad9528 1>; /* div40 is controlled by axi_adrv9009_rx_jesd */
+	clock-names = "conv";
+};
+
+&clk0_ad9528 {
+	jesd204-device;
+	#jesd204-cells = <2>;
+	jesd204-sysref-provider;
+
+	adi,sysref-pattern-mode = <SYSREF_PATTERN_NSHOT>;
+	/delete-property/ adi,sysref-request-enable;
+	adi,sysref-nshot-mode = <SYSREF_NSHOT_8_PULSES>;
+};

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9009-jesd204-fsm.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9009-jesd204-fsm.dts
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices ADRV9009
+ * https://wiki.analog.com/resources/eval/user-guides/adrv9009
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9009
+ * https://wiki.analog.com/resources/tools-software/linux-software/adrv9009_advanced_plugin
+ *
+ * hdl_project: <adrv9009/zcu102>
+ * board_revision: <>
+ *
+ * Copyright (C) 2019 Analog Devices Inc.
+ */
+
+#include "zynqmp-zcu102-rev10-adrv9009.dts"
+
+#include <dt-bindings/iio/adc/adi,adrv9009.h>
+
+&trx0_adrv9009 {
+	jesd204-device;
+	#jesd204-cells = <2>;
+	jesd204-top-device = <0>; /* This is the TOP device */
+	jesd204-link-ids = <DEFRAMER_LINK_TX FRAMER_LINK_RX FRAMER_LINK_ORX>;
+
+	jesd204-inputs =
+		<&axi_adrv9009_rx_jesd 0 FRAMER_LINK_RX>,
+		<&axi_adrv9009_rx_os_jesd 0 FRAMER_LINK_ORX>,
+		<&axi_adrv9009_core_tx 0 DEFRAMER_LINK_TX>;
+
+	/delete-property/ interrupts;
+};
+
+&axi_adrv9009_core_tx {
+	jesd204-device;
+	#jesd204-cells = <2>;
+	jesd204-inputs = <&axi_adrv9009_tx_jesd 0 DEFRAMER_LINK_TX>;
+};
+
+&axi_adrv9009_rx_jesd {
+	jesd204-device;
+	#jesd204-cells = <2>;
+	jesd204-inputs = <&axi_adrv9009_adxcvr_rx 0 FRAMER_LINK_RX>;
+};
+
+&axi_adrv9009_rx_os_jesd {
+	jesd204-device;
+	#jesd204-cells = <2>;
+	jesd204-inputs = <&axi_adrv9009_adxcvr_rx_os 0 FRAMER_LINK_ORX>;
+};
+
+&axi_adrv9009_tx_jesd {
+	jesd204-device;
+	#jesd204-cells = <2>;
+	jesd204-inputs = <&axi_adrv9009_adxcvr_tx 0 DEFRAMER_LINK_TX>;
+};
+
+&axi_adrv9009_adxcvr_rx {
+    	jesd204-device;
+	#jesd204-cells = <2>;
+	jesd204-inputs =  <&clk0_ad9528 0 FRAMER_LINK_RX>;
+	clocks = <&clk0_ad9528 1>; /* div40 is controlled by axi_adrv9009_rx_jesd */
+	clock-names = "conv";
+};
+
+&axi_adrv9009_adxcvr_rx_os {
+    	jesd204-device;
+	#jesd204-cells = <2>;
+	jesd204-inputs =  <&clk0_ad9528 0 FRAMER_LINK_ORX>;
+	clocks = <&clk0_ad9528 1>; /* div40 is controlled by axi_adrv9009_rx_os_jesd */
+	clock-names = "conv";
+};
+
+&axi_adrv9009_adxcvr_tx {
+    	jesd204-device;
+	#jesd204-cells = <2>;
+	jesd204-inputs =  <&clk0_ad9528 0 DEFRAMER_LINK_TX>;
+	clocks = <&clk0_ad9528 1>; /* div40 is controlled by axi_adrv9009_tx_jesd */
+	clock-names = "conv";
+};
+
+&clk0_ad9528 {
+	jesd204-device;
+	#jesd204-cells = <2>;
+	jesd204-sysref-provider;
+
+	adi,sysref-pattern-mode = <SYSREF_PATTERN_NSHOT>;
+	/delete-property/ adi,sysref-request-enable;
+};

--- a/include/dt-bindings/iio/adc/adi,adrv9009.h
+++ b/include/dt-bindings/iio/adc/adi,adrv9009.h
@@ -1,0 +1,12 @@
+/*
+ * This header provides constants for ADRV9009
+ */
+
+#ifndef _DT_BINDINGS_IIO_ADC_ADRV9009_H
+#define _DT_BINDINGS_IIO_ADC_ADRV9009_H
+
+#define DEFRAMER_LINK_TX	0
+#define FRAMER_LINK_RX		1
+#define FRAMER_LINK_ORX		2
+
+#endif

--- a/include/dt-bindings/iio/frequency/hmc7044.h
+++ b/include/dt-bindings/iio/frequency/hmc7044.h
@@ -43,4 +43,13 @@
 #define HMC7044_OUTPUT_MUX_GROUP_PAIR		3
 #define HMC7044_OUTPUT_MUX_VCO_CLOCK		4
 
+/*
+ * adi,sync-pin-mode
+ */
+
+#define HMC7044_SYNC_PIN_DISABLED		        0
+#define HMC7044_SYNC_PIN_SYNC   		        1
+#define HMC7044_SYNC_PIN_PULSE_GEN_REQ	        2
+#define HMC7044_SYNC_PIN_SYNC_THEN_PULSE_GEN	3
+
 #endif /* _DT_BINDINGS_IIO_FREQUENCY_HMC7044_H_ */


### PR DESCRIPTION
Add first batch of device-trees with the JESD204 framework.
Some framework bits still need to be merged, for this to work.
Particularly the adrv9009 driver integration with the framework.

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>
Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>