### PR TITLE
iio: axi-dds: register with JESD204 framework and add support for ADRV9009-X4

### DIFF
--- a/drivers/iio/frequency/cf_axi_dds.c
+++ b/drivers/iio/frequency/cf_axi_dds.c
@@ -988,6 +988,21 @@ static const unsigned long ad9361_2x2_available_scan_masks[] = {
 	0x00,
 };
 
+static const unsigned long ad9009_4x2_available_scan_masks[] = {
+	0x0001, 0x0002, 0x0004, 0x0008, 0x0003, 0x000C, /* 1 & 2 chan */
+	0x0010, 0x0020, 0x0040, 0x0080, 0x0030, 0x00C0, /* 1 & 2 chan */
+	0x0100, 0x0200, 0x0400, 0x0800, 0x0300, 0x0C00, /* 1 & 2 chan */
+	0x1000, 0x2000, 0x4000, 0x8000, 0x3000, 0xC000, /* 1 & 2 chan */
+	0x0033, 0x00CC, 0x00C3, 0x003C, 0x000F, 0x00F0, /* 4 chan */
+	0x3300, 0xCC00, 0xC300, 0x3C00, 0x0F00, 0xF000, /* 4 chan */
+	0x0330, 0x0CC0, 0x0C30, 0x03C0, 0x00F0, 0x0F00, /* 4 chan */
+	0x3300, 0xCC00, 0xC300, 0x3C00, 0x0F00, 0xF000, /* 4 chan */
+	0x00FF, 0xFF00, 0x0FF0,	0x3333, 0xCCCC, 0xF0F0, /* 8 chan */
+	0x0F0F,						/* 8 chan */
+	0xFFFF,						/* 16 chan */
+	0x00,
+};
+
 static const unsigned long ad9361_available_scan_masks[] = {
 	0x01, 0x02, 0x04, 0x08, 0x03, 0x0C, 0x0F,
 	0x00,
@@ -1312,6 +1327,64 @@ static struct cf_axi_dds_chip_info cf_axi_dds_chip_info_adrv9009_x2 = {
 	.num_dds_channels = 16,
 	.num_buf_channels = 8,
 	.scan_masks = ad9361_2x2_available_scan_masks,
+};
+
+static struct cf_axi_dds_chip_info cf_axi_dds_chip_info_adrv9009_x4 = {
+	.name = "ADRV9009-X4",
+	.channel = {
+		CF_AXI_DDS_CHAN_BUF(0),
+		CF_AXI_DDS_CHAN_BUF(1),
+		CF_AXI_DDS_CHAN_BUF(2),
+		CF_AXI_DDS_CHAN_BUF(3),
+		CF_AXI_DDS_CHAN_BUF(4),
+		CF_AXI_DDS_CHAN_BUF(5),
+		CF_AXI_DDS_CHAN_BUF(6),
+		CF_AXI_DDS_CHAN_BUF(7),
+		CF_AXI_DDS_CHAN_BUF(8),
+		CF_AXI_DDS_CHAN_BUF(9),
+		CF_AXI_DDS_CHAN_BUF(10),
+		CF_AXI_DDS_CHAN_BUF(11),
+		CF_AXI_DDS_CHAN_BUF(12),
+		CF_AXI_DDS_CHAN_BUF(13),
+		CF_AXI_DDS_CHAN_BUF(14),
+		CF_AXI_DDS_CHAN_BUF(15),
+		CF_AXI_DDS_CHAN(0, 0, "TX1_I_F1"),
+		CF_AXI_DDS_CHAN(1, 0, "TX1_I_F2"),
+		CF_AXI_DDS_CHAN(2, 0, "TX1_Q_F1"),
+		CF_AXI_DDS_CHAN(3, 0, "TX1_Q_F2"),
+		CF_AXI_DDS_CHAN(4, 0, "TX2_I_F1"),
+		CF_AXI_DDS_CHAN(5, 0, "TX2_I_F2"),
+		CF_AXI_DDS_CHAN(6, 0, "TX2_Q_F1"),
+		CF_AXI_DDS_CHAN(7, 0, "TX2_Q_F2"),
+		CF_AXI_DDS_CHAN(8, 0, "TX3_I_F1"),
+		CF_AXI_DDS_CHAN(9, 0, "TX3_I_F2"),
+		CF_AXI_DDS_CHAN(10, 0, "TX3_Q_F1"),
+		CF_AXI_DDS_CHAN(11, 0, "TX3_Q_F2"),
+		CF_AXI_DDS_CHAN(12, 0, "TX4_I_F1"),
+		CF_AXI_DDS_CHAN(13, 0, "TX4_I_F2"),
+		CF_AXI_DDS_CHAN(14, 0, "TX4_Q_F1"),
+		CF_AXI_DDS_CHAN(15, 0, "TX4_Q_F2"),
+		CF_AXI_DDS_CHAN(16, 0, "TX5_I_F1"),
+		CF_AXI_DDS_CHAN(17, 0, "TX5_I_F2"),
+		CF_AXI_DDS_CHAN(18, 0, "TX5_Q_F1"),
+		CF_AXI_DDS_CHAN(19, 0, "TX5_Q_F2"),
+		CF_AXI_DDS_CHAN(20, 0, "TX6_I_F1"),
+		CF_AXI_DDS_CHAN(21, 0, "TX6_I_F2"),
+		CF_AXI_DDS_CHAN(22, 0, "TX6_Q_F1"),
+		CF_AXI_DDS_CHAN(23, 0, "TX6_Q_F2"),
+		CF_AXI_DDS_CHAN(24, 0, "TX7_I_F1"),
+		CF_AXI_DDS_CHAN(25, 0, "TX7_I_F2"),
+		CF_AXI_DDS_CHAN(26, 0, "TX7_Q_F1"),
+		CF_AXI_DDS_CHAN(27, 0, "TX7_Q_F2"),
+		CF_AXI_DDS_CHAN(28, 0, "TX8_I_F1"),
+		CF_AXI_DDS_CHAN(29, 0, "TX8_I_F2"),
+		CF_AXI_DDS_CHAN(30, 0, "TX8_Q_F1"),
+		CF_AXI_DDS_CHAN(31, 0, "TX8_Q_F2"),
+	},
+	.num_channels = 48,
+	.num_dds_channels = 32,
+	.num_buf_channels = 16,
+	.scan_masks = ad9009_4x2_available_scan_masks,
 };
 
 static struct cf_axi_dds_chip_info cf_axi_dds_chip_info_ad9364 = {
@@ -1807,6 +1880,13 @@ static const struct axidds_core_info adrv9009_x2_9_00_a_info = {
 	.chip_info = &cf_axi_dds_chip_info_adrv9009_x2,
 };
 
+static const struct axidds_core_info adrv9009_x4_9_00_a_info = {
+	.version = ADI_AXI_PCORE_VER(9, 0, 'a'),
+	.standalone = true,
+	.rate = 3,
+	.chip_info = &cf_axi_dds_chip_info_adrv9009_x4,
+};
+
 static const struct axidds_core_info ad9162_1_00_a_info = {
 	.version = ADI_AXI_PCORE_VER(9, 0, 'a'),
 	.rate = 1,
@@ -1866,6 +1946,9 @@ static const struct of_device_id cf_axi_dds_of_match[] = {
 	    .compatible = "adi,axi-adrv9009-x2-tx-1.0",
 	    .data = &adrv9009_x2_9_00_a_info,
 	}, {
+            .compatible = "adi,axi-adrv9009-x4-tx-1.0",
+            .data = &adrv9009_x4_9_00_a_info,
+        }, {
 	    .compatible = "adi,axi-ad9162-1.0",
 	    .data = &ad9162_1_00_a_info,
 	}, {

--- a/drivers/iio/frequency/cf_axi_dds.h
+++ b/drivers/iio/frequency/cf_axi_dds.h
@@ -119,6 +119,9 @@ enum dds_data_select {
 #define ADI_TO_JESD_N(x)		(((x) >> 0) & 0xFF)
 #define ADI_TO_JESD_NP(x)		(((x) >> 8) & 0xFF)
 
+#define ADI_TO_PROFILE_NUM(x)	(((x) >> 0) & 0xF)
+#define ADI_PROFILE_SEL(x)		((x) & 0xF)
+
 /* DAC CHANNEL */
 
 #define ADI_REG_CHAN_CNTRL_1_IIOCHAN(x)	(0x0400 + ((x) >> 1) * 0x40 + ((x) & 1) * 0x8)


### PR DESCRIPTION
Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>
Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>
Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>
