### PR TITLE
iio: jesd204: adxcvr: register with the JESD204 framework 

### DIFF
--- a/drivers/iio/jesd204/axi_adxcvr.c
+++ b/drivers/iio/jesd204/axi_adxcvr.c
@@ -237,14 +237,16 @@ static int adxcvr_clk_enable(struct clk_hw *hw)
 {
 	struct adxcvr_state *st =
 		container_of(hw, struct adxcvr_state, lane_clk_hw);
-	int ret;
+	int ret, retry = 1;
 
 	dev_dbg(st->dev, "%s: %s", __func__, st->tx_enable ? "TX" : "RX");
 
-
-	adxcvr_write(st, ADXCVR_REG_RESETN, ADXCVR_RESETN);
-
-	ret = adxcvr_status_error(st->dev);
+	do {
+		adxcvr_write(st, ADXCVR_REG_RESETN, 0);
+		udelay(2);
+		adxcvr_write(st, ADXCVR_REG_RESETN, ADXCVR_RESETN);
+		ret = adxcvr_status_error(st->dev);
+	} while (ret < 0 && retry--);
 
 	return ret;
 }
@@ -253,6 +255,8 @@ static void adxcvr_clk_disable(struct clk_hw *hw)
 {
 	struct adxcvr_state *st =
 		container_of(hw, struct adxcvr_state, lane_clk_hw);
+
+	dev_dbg(st->dev, "%s: %s", __func__, st->tx_enable ? "TX" : "RX");
 
 	adxcvr_write(st, ADXCVR_REG_RESETN, 0);
 }

--- a/drivers/iio/jesd204/axi_adxcvr.c
+++ b/drivers/iio/jesd204/axi_adxcvr.c
@@ -524,7 +524,7 @@ static void adxcvr_parse_dt_vco_ranges(struct adxcvr_state *st,
 		st->xcvr.vco1_max = 0;
 }
 
-static int adxcvr_parse_dt(struct adxcvr_state *st, struct device_node *np)
+static void adxcvr_parse_dt(struct adxcvr_state *st, struct device_node *np)
 {
 	of_property_read_u32(np, "adi,sys-clk-select", &st->sys_clk_sel);
 	of_property_read_u32(np, "adi,out-clk-select", &st->out_clk_sel);
@@ -533,10 +533,6 @@ static int adxcvr_parse_dt(struct adxcvr_state *st, struct device_node *np)
 	st->lpm_enable = of_property_read_bool(np, "adi,use-lpm-enable");
 
 	adxcvr_parse_dt_vco_ranges(st, np);
-
-	INIT_WORK(&st->work, adxcvr_work_func);
-
-	return 0;
 }
 
 /* Match table for of_platform binding */
@@ -654,10 +650,9 @@ static int adxcvr_probe(struct platform_device *pdev)
 
 	st->xcvr.dev = &pdev->dev;
 	st->xcvr.drp_ops = &adxcvr_drp_ops;
+	INIT_WORK(&st->work, adxcvr_work_func);
 
-	ret = adxcvr_parse_dt(st, np);
-	if (ret < 0)
-		goto disable_unprepare_conv_clk2;
+	adxcvr_parse_dt(st, np);
 
 	mem = platform_get_resource(pdev, IORESOURCE_MEM, 0);
 	st->regs = devm_ioremap_resource(&pdev->dev, mem);

--- a/drivers/iio/jesd204/axi_adxcvr.h
+++ b/drivers/iio/jesd204/axi_adxcvr.h
@@ -14,6 +14,7 @@
 #include <linux/clk.h>
 #include <linux/clk-provider.h>
 #include <linux/fpga/adi-axi-common.h>
+#include <linux/jesd204/jesd204.h>
 
 #include "xilinx_transceiver.h"
 
@@ -51,6 +52,7 @@
 struct adxcvr_state {
 	struct device		*dev;
 	void __iomem		*regs;
+	struct jesd204_dev	*jdev;
 	struct clk		*conv_clk;
 	struct clk		*conv2_clk;
 	struct clk		*lane_rate_div40_clk;


### PR DESCRIPTION
Currently just register some blank init data. Will be populated later as it
evolves.

Also, squeezed in some cleanups.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>