### PR TITLE
iio: jesd204: axi_jesd204_rx: Frame alignment error interrupt support

### DIFF
--- a/drivers/iio/jesd204/axi_jesd204_rx.c
+++ b/drivers/iio/jesd204/axi_jesd204_rx.c
@@ -354,7 +354,7 @@ static ssize_t axi_jesd204_rx_laneinfo_read(struct device *dev,
 	lane_status = readl_relaxed(jesd->base +
 				    JESD204_RX_REG_LANE_STATUS(lane));
 
-	if (ADI_AXI_PCORE_VER_MINOR(jesd->version) >= 2) {
+	if (jesd->version >= ADI_AXI_PCORE_VER(1, 2, 'a')) {
 		errors = axi_jesd204_rx_get_lane_errors(jesd, lane);
 		ret += scnprintf(buf + ret, PAGE_SIZE - ret, "Errors: %u\n",
 				 errors);
@@ -587,7 +587,7 @@ static bool axi_jesd204_rx_check_lane_status(struct axi_jesd204_rx *jesd,
 			return false;
 	}
 
-	if (ADI_AXI_PCORE_VER_MINOR(jesd->version) >= 2) {
+	if (jesd->version >= ADI_AXI_PCORE_VER(1, 2, 'a')) {
 		errors = axi_jesd204_rx_get_lane_errors(jesd, lane);
 		scnprintf(error_str, sizeof(error_str), " (%u errors)", errors);
 	} else {


### PR DESCRIPTION
This patch adds Interrupt support for HDL Core Version >=1.04a

 * 0  Frame Alignment Error (204B only)
	- At least one of the lanes frame alignment monitor error counter
	  met a threshold defined by register 0x248
 * 1  Unexpected Lane State Error (204B and 204C)
	- At least one of the enabled lanes entered in an unexpected state
	  while the link is up (in DATA phase).
	- For 204B this happens when the lane state machine falls back to
	  INIT phase while the link is up in response to at least four or
	  more consecutive invalid characters received from the phy.
	  From this state the lane state machine can recover only with a
	  CGS sequence.
	- For 204C this happens when one of the lanes loses sync header
	  alignment or multi-block alignment.

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>