### PR TITLE
iio: gyro: adxrs290: sync with upstream version

### DIFF
--- a/Documentation/devicetree/bindings/iio/gyroscope/adi,adxrs290.yaml
+++ b/Documentation/devicetree/bindings/iio/gyroscope/adi,adxrs290.yaml
@@ -16,8 +16,7 @@ description: |
 
 properties:
   compatible:
-    enum:
-      - adi,adxrs290
+    const: adi,adxrs290
 
   reg:
     maxItems: 1
@@ -35,6 +34,8 @@ required:
   - spi-max-frequency
   - spi-cpol
   - spi-cpha
+
+additionalProperties: false
 
 examples:
   - |

--- a/drivers/iio/gyro/adxrs290.c
+++ b/drivers/iio/gyro/adxrs290.c
@@ -2,13 +2,13 @@
 /*
  * ADXRS290 SPI Gyroscope Driver
  *
+ * Copyright (C) 2020 Nishant Malpani <nish.malpani25@gmail.com>
  * Copyright (C) 2020 Analog Devices, Inc.
  */
 
-#include <asm/unaligned.h>
 #include <linux/bitfield.h>
-#include <linux/device.h>
 #include <linux/delay.h>
+#include <linux/device.h>
 #include <linux/kernel.h>
 #include <linux/module.h>
 #include <linux/spi/spi.h>
@@ -20,17 +20,17 @@
 #define ADXRS290_MEMS_ID	0x1D
 #define ADXRS290_DEV_ID		0x92
 
-#define ADXRS290_REG_ADI_ID	0x00 /* Analog Devices Identifier Register */
-#define ADXRS290_REG_MEMS_ID	0x01 /* MEMS Identifier Register */
-#define ADXRS290_REG_DEV_ID	0x02 /* Device Identifier Register */
-#define ADXRS290_REG_REV_ID	0x03 /* Silicon Revision Number Register */
+#define ADXRS290_REG_ADI_ID	0x00
+#define ADXRS290_REG_MEMS_ID	0x01
+#define ADXRS290_REG_DEV_ID	0x02
+#define ADXRS290_REG_REV_ID	0x03
 #define ADXRS290_REG_SN0	0x04 /* Serial Number Registers, 4 bytes */
 #define ADXRS290_REG_DATAX0	0x08 /* Roll Rate o/p Data Regs, 2 bytes */
 #define ADXRS290_REG_DATAY0	0x0A /* Pitch Rate o/p Data Regs, 2 bytes */
-#define ADXRS290_REG_TEMP0	0x0C /* Temperature Data Registers, 2 bytes */
-#define ADXRS290_REG_POWER_CTL	0x10 /* Power Control Register */
-#define ADXRS290_REG_FILTER	0x11 /* Band-pass Filter Register */
-#define ADXRS290_REG_DATA_RDY	0x12 /* Data Ready Register */
+#define ADXRS290_REG_TEMP0	0x0C
+#define ADXRS290_REG_POWER_CTL	0x10
+#define ADXRS290_REG_FILTER	0x11
+#define ADXRS290_REG_DATA_RDY	0x12
 
 #define ADXRS290_READ		BIT(7)
 #define ADXRS290_TSM		BIT(0)
@@ -46,35 +46,31 @@
 #define ADXRS290_MAX_TRANSITION_TIME_MS 100
 
 enum adxrs290_mode {
-	STANDBY,
-	MEASUREMENT,
+	ADXRS290_MODE_STANDBY,
+	ADXRS290_MODE_MEASUREMENT,
 };
 
 struct adxrs290_state {
 	struct spi_device	*spi;
-	/* To atomize successive reads for single measurement */
+	/* Serialize reads and their subsequent processing */
 	struct mutex		lock;
 	enum adxrs290_mode	mode;
 	unsigned int		lpf_3db_freq_idx;
 	unsigned int		hpf_3db_freq_idx;
-	union {
-		u8 tx;
-		u8 rx[2];
-	}			data ____cacheline_aligned;
 };
 
 /*
  * Available cut-off frequencies of the low pass filter in Hz.
  * The integer part and fractional part are represented separately.
  */
-static const unsigned int adxrs290_lpf_3db_freq_tbl[][2] = {
+static const int adxrs290_lpf_3db_freq_hz_table[][2] = {
 	[0] = {480, 0},
 	[1] = {320, 0},
 	[2] = {160, 0},
 	[3] = {80, 0},
-	[4] = {56, 600},
+	[4] = {56, 600000},
 	[5] = {40, 0},
-	[6] = {28, 300},
+	[6] = {28, 300000},
 	[7] = {20, 0},
 };
 
@@ -82,102 +78,82 @@ static const unsigned int adxrs290_lpf_3db_freq_tbl[][2] = {
  * Available cut-off frequencies of the high pass filter in Hz.
  * The integer part and fractional part are represented separately.
  */
-static const unsigned int adxrs290_hpf_3db_freq_tbl[][2] = {
+static const int adxrs290_hpf_3db_freq_hz_table[][2] = {
 	[0] = {0, 0},
-	[1] = {0, 11},
-	[2] = {0, 22},
-	[3] = {0, 44},
-	[4] = {0, 87},
-	[5] = {0, 175},
-	[6] = {0, 350},
-	[7] = {0, 700},
-	[8] = {1, 400},
-	[9] = {2, 800},
-	[10] = {11, 300},
+	[1] = {0, 11000},
+	[2] = {0, 22000},
+	[3] = {0, 44000},
+	[4] = {0, 87000},
+	[5] = {0, 175000},
+	[6] = {0, 350000},
+	[7] = {0, 700000},
+	[8] = {1, 400000},
+	[9] = {2, 800000},
+	[10] = {11, 300000},
 };
 
-static int adxrs290_spi_read16b(struct iio_dev *indio_dev, const u8 cmd,
-				u16 *val)
+static int adxrs290_get_rate_data(struct iio_dev *indio_dev, const u8 cmd, int *val)
 {
 	struct adxrs290_state *st = iio_priv(indio_dev);
 	int ret = 0;
-
-	struct spi_transfer t[] = {
-		{
-			.tx_buf = &st->data.tx,
-			.bits_per_word = 8,
-			.len = sizeof(st->data.tx),
-			.cs_change = 0,
-		}, {
-			.rx_buf = &st->data.rx,
-			.bits_per_word = 8,
-			.len = sizeof(st->data.rx),
-		},
-	};
+	int temp;
 
 	mutex_lock(&st->lock);
-
-	st->data.tx = cmd;
-	ret = spi_sync_transfer(st->spi, t, ARRAY_SIZE(t));
-
-	if (ret < 0) {
-		dev_err(&st->spi->dev, "error reading 16b from reg 0x%02x\n",
-			cmd);
+	temp = spi_w8r16(st->spi, cmd);
+	if (temp < 0) {
+		ret = temp;
 		goto err_unlock;
 	}
 
-	*val = get_unaligned_le16(st->data.rx);
+	*val = temp;
 
 err_unlock:
 	mutex_unlock(&st->lock);
 	return ret;
 }
 
-static int adxrs290_get_rate_data(struct iio_dev *indio_dev, const u8 cmd,
-				  unsigned int *val)
+static int adxrs290_get_temp_data(struct iio_dev *indio_dev, int *val)
 {
-	int ret;
-	u16 temp;
-
-	ret = adxrs290_spi_read16b(indio_dev, cmd, &temp);
-	if (ret < 0)
-		return ret;
-
-	*val = temp;
-
-	return 0;
-}
-
-static int adxrs290_get_temp_data(struct iio_dev *indio_dev, unsigned int *val)
-{
-	int ret;
-	u16 temp;
 	const u8 cmd = ADXRS290_READ_REG(ADXRS290_REG_TEMP0);
+	struct adxrs290_state *st = iio_priv(indio_dev);
+	int ret = 0;
+	int temp;
 
-	ret = adxrs290_spi_read16b(indio_dev, cmd, &temp);
-	if (ret < 0)
-		return ret;
+	mutex_lock(&st->lock);
+	temp = spi_w8r16(st->spi, cmd);
+	if (temp < 0) {
+		ret = temp;
+		goto err_unlock;
+	}
 
 	/* extract lower 12 bits temperature reading */
 	*val = temp & 0x0FFF;
 
-	return 0;
+err_unlock:
+	mutex_unlock(&st->lock);
+	return ret;
 }
 
 static int adxrs290_get_3db_freq(struct iio_dev *indio_dev, u8 *val, u8 *val2)
 {
-	struct adxrs290_state *st = iio_priv(indio_dev);
 	const u8 cmd = ADXRS290_READ_REG(ADXRS290_REG_FILTER);
-	int temp;
+	struct adxrs290_state *st = iio_priv(indio_dev);
+	int ret = 0;
+	short temp;
 
+	mutex_lock(&st->lock);
 	temp = spi_w8r8(st->spi, cmd);
-	if (temp < 0)
-		return temp;
+	if (temp < 0) {
+		ret = temp;
+		goto err_unlock;
+	}
 
 	*val = FIELD_GET(ADXRS290_LPF_MASK, temp);
 	*val2 = FIELD_GET(ADXRS290_HPF_MASK, temp);
 
-	return 0;
+err_unlock:
+	mutex_unlock(&st->lock);
+	return ret;
 }
 
 static int adxrs290_spi_write_reg(struct spi_device *spi, const u8 reg,
@@ -188,30 +164,25 @@ static int adxrs290_spi_write_reg(struct spi_device *spi, const u8 reg,
 	buf[0] = reg;
 	buf[1] = val;
 
-	return spi_write(spi, buf, ARRAY_SIZE(buf));
+	return spi_write_then_read(spi, buf, ARRAY_SIZE(buf), NULL, 0);
 }
 
-static unsigned int adxrs290_find_best_match(const unsigned int (*freq_tbl)[2],
-					     unsigned int n, unsigned int freq)
+static int adxrs290_find_match(const int (*freq_tbl)[2], const int n,
+			       const int val, const int val2)
 {
-	unsigned int i, best_freq_idx;
-	unsigned int diff, best_diff;
+	int i;
 
-	best_freq_idx = 0;
-	best_diff = UINT_MAX;
 	for (i = 0; i < n; i++) {
-		diff = abs(freq_tbl[i][0] - freq);
-		if (diff < best_diff) {
-			best_diff = diff;
-			best_freq_idx = i;
-		}
+		if (freq_tbl[i][0] == val && freq_tbl[i][1] == val2)
+			return i;
 	}
 
-	return best_freq_idx;
+	return -EINVAL;
 }
 
 static int adxrs290_set_filter_freq(struct iio_dev *indio_dev,
-				    unsigned int lpf_idx, unsigned int hpf_idx)
+				    const unsigned int lpf_idx,
+				    const unsigned int hpf_idx)
 {
 	struct adxrs290_state *st = iio_priv(indio_dev);
 	u8 val;
@@ -221,60 +192,11 @@ static int adxrs290_set_filter_freq(struct iio_dev *indio_dev,
 	return adxrs290_spi_write_reg(st->spi, ADXRS290_REG_FILTER, val);
 }
 
-static ssize_t adxrs290_show_avail(const unsigned int (*freq_tbl)[2], size_t n,
-				   char *buf)
-{
-	ssize_t len = 0;
-	int i;
-
-	for (i = 0; i < n; i++) {
-		len += scnprintf(buf + len, PAGE_SIZE - len,
-				 "%u.%03u ", freq_tbl[i][0], freq_tbl[i][1]);
-	}
-	buf[len - 1] = '\n';
-
-	return len;
-}
-
-static ssize_t adxrs290_show_lpf_freq_avail(struct device *dev,
-					    struct device_attribute *attr,
-					    char *buf)
-{
-	return adxrs290_show_avail(adxrs290_lpf_3db_freq_tbl,
-				   ARRAY_SIZE(adxrs290_lpf_3db_freq_tbl), buf);
-}
-
-static ssize_t adxrs290_show_hpf_freq_avail(struct device *dev,
-					    struct device_attribute *attr,
-					    char *buf)
-{
-	return adxrs290_show_avail(adxrs290_hpf_3db_freq_tbl,
-				   ARRAY_SIZE(adxrs290_hpf_3db_freq_tbl), buf);
-}
-
-/* attribute to display available 3db frequencies for the low-pass filter */
-static IIO_DEVICE_ATTR(in_anglvel_filter_low_pass_3db_frequency_available,
-		       0444, adxrs290_show_lpf_freq_avail, NULL, 0);
-
-/* attribute to display available 3db frequencies for the high-pass filter */
-static IIO_DEVICE_ATTR(in_anglvel_filter_high_pass_3db_frequency_available,
-		       0444, adxrs290_show_hpf_freq_avail, NULL, 0);
-
-static struct attribute *adxrs290_attributes[] = {
-	&iio_dev_attr_in_anglvel_filter_low_pass_3db_frequency_available.dev_attr.attr,
-	&iio_dev_attr_in_anglvel_filter_high_pass_3db_frequency_available.dev_attr.attr,
-	NULL,
-};
-
-static const struct attribute_group adxrs290_attrs_group = {
-	.attrs = adxrs290_attributes,
-};
-
 static int adxrs290_initial_setup(struct iio_dev *indio_dev)
 {
 	struct adxrs290_state *st = iio_priv(indio_dev);
 
-	st->mode = MEASUREMENT;
+	st->mode = ADXRS290_MODE_MEASUREMENT;
 
 	return adxrs290_spi_write_reg(st->spi,
 				      ADXRS290_REG_POWER_CTL,
@@ -288,8 +210,8 @@ static int adxrs290_read_raw(struct iio_dev *indio_dev,
 			     long mask)
 {
 	struct adxrs290_state *st = iio_priv(indio_dev);
-	int ret;
 	unsigned int t;
+	int ret;
 
 	switch (mask) {
 	case IIO_CHAN_INFO_RAW:
@@ -297,16 +219,16 @@ static int adxrs290_read_raw(struct iio_dev *indio_dev,
 		case IIO_ANGL_VEL:
 			ret = adxrs290_get_rate_data(indio_dev,
 						     ADXRS290_READ_REG(chan->address),
-						     &t);
+						     val);
 			if (ret < 0)
 				return ret;
-			*val = t;
+
 			return IIO_VAL_INT;
 		case IIO_TEMP:
-			ret = adxrs290_get_temp_data(indio_dev, &t);
+			ret = adxrs290_get_temp_data(indio_dev, val);
 			if (ret < 0)
 				return ret;
-			*val = t;
+
 			return IIO_VAL_INT;
 		default:
 			return -EINVAL;
@@ -314,10 +236,12 @@ static int adxrs290_read_raw(struct iio_dev *indio_dev,
 	case IIO_CHAN_INFO_SCALE:
 		switch (chan->type) {
 		case IIO_ANGL_VEL:
+			/* 1 LSB = 0.005 degrees/sec */
 			*val = 0;
 			*val2 = 87266;
 			return IIO_VAL_INT_PLUS_NANO;
 		case IIO_TEMP:
+			/* 1 LSB = 0.1 degrees Celsius */
 			*val = 100;
 			return IIO_VAL_INT;
 		default:
@@ -327,8 +251,8 @@ static int adxrs290_read_raw(struct iio_dev *indio_dev,
 		switch (chan->type) {
 		case IIO_ANGL_VEL:
 			t = st->lpf_3db_freq_idx;
-			*val = adxrs290_lpf_3db_freq_tbl[t][0];
-			*val2 = adxrs290_lpf_3db_freq_tbl[t][1] * 1000;
+			*val = adxrs290_lpf_3db_freq_hz_table[t][0];
+			*val2 = adxrs290_lpf_3db_freq_hz_table[t][1];
 			return IIO_VAL_INT_PLUS_MICRO;
 		default:
 			return -EINVAL;
@@ -337,8 +261,8 @@ static int adxrs290_read_raw(struct iio_dev *indio_dev,
 		switch (chan->type) {
 		case IIO_ANGL_VEL:
 			t = st->hpf_3db_freq_idx;
-			*val = adxrs290_hpf_3db_freq_tbl[t][0];
-			*val2 = adxrs290_hpf_3db_freq_tbl[t][1] * 1000;
+			*val = adxrs290_hpf_3db_freq_hz_table[t][0];
+			*val2 = adxrs290_hpf_3db_freq_hz_table[t][1];
 			return IIO_VAL_INT_PLUS_MICRO;
 		default:
 			return -EINVAL;
@@ -355,22 +279,26 @@ static int adxrs290_write_raw(struct iio_dev *indio_dev,
 			      long mask)
 {
 	struct adxrs290_state *st = iio_priv(indio_dev);
-	unsigned int lpf_idx, hpf_idx;
+	int lpf_idx, hpf_idx;
 
 	switch (mask) {
 	case IIO_CHAN_INFO_LOW_PASS_FILTER_3DB_FREQUENCY:
-		lpf_idx = adxrs290_find_best_match(adxrs290_lpf_3db_freq_tbl,
-						   ARRAY_SIZE(adxrs290_lpf_3db_freq_tbl),
-						   val);
+		lpf_idx = adxrs290_find_match(adxrs290_lpf_3db_freq_hz_table,
+					      ARRAY_SIZE(adxrs290_lpf_3db_freq_hz_table),
+					      val, val2);
+		if (lpf_idx < 0)
+			return -EINVAL;
 		/* caching the updated state of the low-pass filter */
 		st->lpf_3db_freq_idx = lpf_idx;
 		/* retrieving the current state of the high-pass filter */
 		hpf_idx = st->hpf_3db_freq_idx;
 		return adxrs290_set_filter_freq(indio_dev, lpf_idx, hpf_idx);
 	case IIO_CHAN_INFO_HIGH_PASS_FILTER_3DB_FREQUENCY:
-		hpf_idx = adxrs290_find_best_match(adxrs290_hpf_3db_freq_tbl,
-						   ARRAY_SIZE(adxrs290_hpf_3db_freq_tbl),
-						   val);
+		hpf_idx = adxrs290_find_match(adxrs290_hpf_3db_freq_hz_table,
+					      ARRAY_SIZE(adxrs290_hpf_3db_freq_hz_table),
+					      val, val2);
+		if (hpf_idx < 0)
+			return -EINVAL;
 		/* caching the updated state of the high-pass filter */
 		st->hpf_3db_freq_idx = hpf_idx;
 		/* retrieving the current state of the low-pass filter */
@@ -381,6 +309,31 @@ static int adxrs290_write_raw(struct iio_dev *indio_dev,
 	return -EINVAL;
 }
 
+static int adxrs290_read_avail(struct iio_dev *indio_dev,
+			       struct iio_chan_spec const *chan,
+			       const int **vals, int *type, int *length,
+			       long mask)
+{
+	switch (mask) {
+	case IIO_CHAN_INFO_LOW_PASS_FILTER_3DB_FREQUENCY:
+		*vals = (const int *)adxrs290_lpf_3db_freq_hz_table;
+		*type = IIO_VAL_INT_PLUS_MICRO;
+		/* Values are stored in a 2D matrix */
+		*length = ARRAY_SIZE(adxrs290_lpf_3db_freq_hz_table) * 2;
+
+		return IIO_AVAIL_LIST;
+	case IIO_CHAN_INFO_HIGH_PASS_FILTER_3DB_FREQUENCY:
+		*vals = (const int *)adxrs290_hpf_3db_freq_hz_table;
+		*type = IIO_VAL_INT_PLUS_MICRO;
+		/* Values are stored in a 2D matrix */
+		*length = ARRAY_SIZE(adxrs290_hpf_3db_freq_hz_table) * 2;
+
+		return IIO_AVAIL_LIST;
+	default:
+		return -EINVAL;
+	}
+}
+
 #define ADXRS290_ANGL_VEL_CHANNEL(reg, axis) {				\
 	.type = IIO_ANGL_VEL,						\
 	.address = reg,							\
@@ -388,6 +341,9 @@ static int adxrs290_write_raw(struct iio_dev *indio_dev,
 	.channel2 = IIO_MOD_##axis,					\
 	.info_mask_separate = BIT(IIO_CHAN_INFO_RAW),			\
 	.info_mask_shared_by_type = BIT(IIO_CHAN_INFO_SCALE) |		\
+	BIT(IIO_CHAN_INFO_LOW_PASS_FILTER_3DB_FREQUENCY) |		\
+	BIT(IIO_CHAN_INFO_HIGH_PASS_FILTER_3DB_FREQUENCY),		\
+	.info_mask_shared_by_type_available =				\
 	BIT(IIO_CHAN_INFO_LOW_PASS_FILTER_3DB_FREQUENCY) |		\
 	BIT(IIO_CHAN_INFO_HIGH_PASS_FILTER_3DB_FREQUENCY),		\
 }
@@ -404,17 +360,17 @@ static const struct iio_chan_spec adxrs290_channels[] = {
 };
 
 static const struct iio_info adxrs290_info = {
-	.attrs = &adxrs290_attrs_group,
 	.read_raw = &adxrs290_read_raw,
 	.write_raw = &adxrs290_write_raw,
+	.read_avail = &adxrs290_read_avail,
 };
 
 static int adxrs290_probe(struct spi_device *spi)
 {
 	struct iio_dev *indio_dev;
 	struct adxrs290_state *st;
-	int ret;
 	u8 val, val2;
+	int ret;
 
 	indio_dev = devm_iio_device_alloc(&spi->dev, sizeof(*st));
 	if (!indio_dev)
@@ -422,9 +378,7 @@ static int adxrs290_probe(struct spi_device *spi)
 
 	st = iio_priv(indio_dev);
 	st->spi = spi;
-	spi_set_drvdata(spi, indio_dev);
 
-	indio_dev->dev.parent = &spi->dev;
 	indio_dev->name = "adxrs290";
 	indio_dev->modes = INDIO_DIRECT_MODE;
 	indio_dev->channels = adxrs290_channels;
@@ -450,7 +404,7 @@ static int adxrs290_probe(struct spi_device *spi)
 	}
 
 	/* default mode the gyroscope starts in */
-	st->mode = STANDBY;
+	st->mode = ADXRS290_MODE_STANDBY;
 
 	/* switch to measurement mode and switch on the temperature sensor */
 	ret = adxrs290_initial_setup(indio_dev);
@@ -458,7 +412,7 @@ static int adxrs290_probe(struct spi_device *spi)
 		return ret;
 
 	/* max transition time to measurement mode */
-	msleep_interruptible(ADXRS290_MAX_TRANSITION_TIME_MS);
+	msleep(ADXRS290_MAX_TRANSITION_TIME_MS);
 
 	ret = adxrs290_get_3db_freq(indio_dev, &val, &val2);
 	if (ret < 0)
@@ -472,7 +426,7 @@ static int adxrs290_probe(struct spi_device *spi)
 
 static const struct of_device_id adxrs290_of_match[] = {
 	{ .compatible = "adi,adxrs290" },
-	{ },
+	{ }
 };
 MODULE_DEVICE_TABLE(of, adxrs290_of_match);
 


### PR DESCRIPTION
Update ADXRS290's driver and dt-bindings in the ADI tree with the upstream version [1] [2].

[1] https://patchwork.kernel.org/patch/11685711/
[2] https://patchwork.kernel.org/patch/11685713/

Signed-off-by: Nishant Malpani <nish.malpani25@gmail.com>