### PR TITLE
jesd204: axi-jesd204-rx/tx: move encoder enums to framework 

### DIFF
--- a/drivers/iio/jesd204/axi_jesd204.h
+++ b/drivers/iio/jesd204/axi_jesd204.h
@@ -8,18 +8,4 @@
 #define JESD204_ENCODER_MASK		GENMASK(9, 8)
 #define JESD204_ENCODER_GET(x)		FIELD_GET(JESD204_ENCODER_MASK, x)
 
-/* JESD204C Supported encoding scheme */
-enum jesd204_encoder {
-	JESD204_ENCODER_UNKNOWN,
-	JESD204_ENCODER_8B10B,
-	JESD204_ENCODER_64B66B,
-	JESD204_ENCODER_MAX,
-};
-
-static const char *axi_jesd204_encoder_label[JESD204_ENCODER_MAX] = {
-	"unknown",
-	"8b10b",
-	"64b66b"
-};
-
 #endif

--- a/drivers/iio/jesd204/axi_jesd204_rx.c
+++ b/drivers/iio/jesd204/axi_jesd204_rx.c
@@ -209,7 +209,7 @@ static ssize_t encoder_show(struct device *dev, struct device_attribute *attr,
 {
 	struct axi_jesd204_rx *jesd = dev_get_drvdata(dev);
 
-	return sprintf(buf, "%s", axi_jesd204_encoder_label[jesd->encoder]);
+	return sprintf(buf, "%s", jesd204_encoder_str(jesd->encoder));
 }
 
 static DEVICE_ATTR_RO(encoder);
@@ -968,10 +968,13 @@ static int axi_jesd204_rx_probe(struct platform_device *pdev)
 	jesd->encoder = JESD204_ENCODER_GET(synth_1);
 
 	/* backward compatibility with older HDL cores */
-	if (jesd->encoder == JESD204_ENCODER_UNKNOWN)
+	if (jesd->encoder == JESD204_ENCODER_UNKNOWN) {
 		jesd->encoder = JESD204_ENCODER_8B10B;
-	else if (jesd->encoder >= JESD204_ENCODER_MAX)
+	} else if (jesd->encoder >= JESD204_ENCODER_MAX) {
+		dev_err(&pdev->dev, "Invalid encoder value from HDL core %u\n",
+			jesd->encoder);
 		goto err_conv2_clk_disable;
+	}
 
 	ret = axi_jesd204_rx_apply_config(jesd, &config);
 	if (ret)

--- a/drivers/iio/jesd204/axi_jesd204_tx.c
+++ b/drivers/iio/jesd204/axi_jesd204_tx.c
@@ -181,7 +181,7 @@ static ssize_t encoder_show(struct device *dev, struct device_attribute *attr,
 {
 	struct axi_jesd204_tx *jesd = dev_get_drvdata(dev);
 
-	return sprintf(buf, "%s", axi_jesd204_encoder_label[jesd->encoder]);
+	return sprintf(buf, "%s", jesd204_encoder_str(jesd->encoder));
 }
 
 static DEVICE_ATTR_RO(encoder);
@@ -764,10 +764,13 @@ static int axi_jesd204_tx_probe(struct platform_device *pdev)
 	jesd->encoder = JESD204_ENCODER_GET(synth_1);
 
 	/* backward compatibility with older HDL cores */
-	if (jesd->encoder == JESD204_ENCODER_UNKNOWN)
+	if (jesd->encoder == JESD204_ENCODER_UNKNOWN) {
 		jesd->encoder = JESD204_ENCODER_8B10B;
-	else if (jesd->encoder >= JESD204_ENCODER_MAX)
+	} else if (jesd->encoder >= JESD204_ENCODER_MAX) {
+		dev_err(&pdev->dev, "Invalid encoder value from HDL core %u\n",
+			jesd->encoder);
 		goto err_conv2_clk_disable;
+	}
 
 	/* Allocate lane IDs if not running with the framework */
 	if (!jdev) {

--- a/drivers/jesd204/jesd204-core.c
+++ b/drivers/jesd204/jesd204-core.c
@@ -95,15 +95,15 @@ int jesd204_link_get_rate(struct jesd204_link *lnk, u64 *lane_rate_hz)
 	switch (lnk->jesd_version) {
 	case JESD204_VERSION_C:
 		switch (lnk->jesd_encoder) {
-		case JESD204_ENC_64B66B:
+		case JESD204_ENCODER_64B66B:
 			encoding_n = 66; /* JESD 204C */
 			encoding_d = 64;
 			break;
-		case JESD204_ENC_8B10B:
+		case JESD204_ENCODER_8B10B:
 			encoding_n = 10; /* JESD 204C */
 			encoding_d = 8;
 			break;
-		case JESD204_ENC_64B80B:
+		case JESD204_ENCODER_64B80B:
 			encoding_n = 80; /* JESD 204C */
 			encoding_d = 64;
 			break;
@@ -157,13 +157,13 @@ int jesd204_link_get_device_clock(struct jesd204_link *lnk,
 		return ret;
 
 	switch (lnk->jesd_encoder) {
-	case JESD204_ENC_64B66B:
+	case JESD204_ENCODER_64B66B:
 		encoding_n = 66; /* JESD 204C */
 		break;
-	case JESD204_ENC_8B10B:
+	case JESD204_ENCODER_8B10B:
 		encoding_n = 40; /* JESD 204ABC */
 		break;
-	case JESD204_ENC_64B80B:
+	case JESD204_ENCODER_64B80B:
 		encoding_n = 80; /* JESD 204C */
 		break;
 	default:
@@ -190,11 +190,11 @@ int jesd204_link_get_lmfc_lemc_rate(struct jesd204_link *lnk,
 		return ret;
 
 	switch (lnk->jesd_encoder) {
-	case JESD204_ENC_64B66B:
+	case JESD204_ENCODER_64B66B:
 		bkw = 66; /* JESD 204C */
 		/* fall-through */
-	case JESD204_ENC_64B80B:
-		if (lnk->jesd_encoder == JESD204_ENC_64B80B)
+	case JESD204_ENCODER_64B80B:
+		if (lnk->jesd_encoder == JESD204_ENCODER_64B80B)
 			bkw = 80; /* JESD 204C */
 
 		if (lnk->num_of_multiblocks_in_emb) {

--- a/include/linux/jesd204/jesd204.h
+++ b/include/linux/jesd204/jesd204.h
@@ -24,10 +24,13 @@ enum jesd204_version {
 };
 
 /* JESD204C Supported encoding scheme */
-enum jesd204_enc { /* FIXME: unify with link layer defines */
-	JESD204_ENC_8B10B,
-	JESD204_ENC_64B66B,
-	JESD204_ENC_64B80B,
+enum jesd204_encoder {
+	JESD204_ENCODER_UNKNOWN,
+	JESD204_ENCODER_8B10B,
+	JESD204_ENCODER_64B66B,
+	JESD204_ENCODER_64B80B,
+
+	JESD204_ENCODER_MAX
 };
 
 enum jesd204_sysref_mode {
@@ -137,6 +140,20 @@ enum jesd204_state_op_reason {
 	JESD204_STATE_OP_REASON_INIT,
 	JESD204_STATE_OP_REASON_UNINIT,
 };
+
+static inline const char *jesd204_encoder_str(enum jesd204_encoder enc)
+{
+	switch (enc) {
+	case JESD204_ENCODER_8B10B:
+		return "8b10b";
+	case JESD204_ENCODER_64B66B:
+		return "64b66b";
+	case JESD204_ENCODER_64B80B:
+		return "64b80b";
+	default:
+		return "unknown";
+	}
+}
 
 static inline const char *jesd204_state_op_reason_str(enum jesd204_state_op_reason reason)
 {


### PR DESCRIPTION
This change renames the JESD204 framework's enums from JESD204_ENC_xxx to
JESD204_ENCODER_xxx. This is also to make sure we catch some that collide.

Added a helper jesd204_encoder_str() that replaces the
axi_jesd204_encoder_label table.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>