### PR TITLE
jesd204: fsm: print once the SYSREF provider

### DIFF
--- a/drivers/jesd204/jesd204-fsm.c
+++ b/drivers/jesd204/jesd204-fsm.c
@@ -834,6 +834,9 @@ static int jesd204_init_sysref_cb(struct jesd204_dev *jdev,
 		return -EEXIST;
 	}
 
+	if (jdev_top->jdev_sysref)
+		return 0;
+
 	jesd204_info(jdev, "Using as SYSREF provider\n");
 	jdev_top->jdev_sysref = jdev;
 


### PR DESCRIPTION
Mostly reduces log spam.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>