### PR TITLE
jesd204: bug fixes

### DIFF
--- a/drivers/jesd204/jesd204-core.c
+++ b/drivers/jesd204/jesd204-core.c
@@ -758,13 +758,13 @@ static struct jesd204_dev *jesd204_dev_register(struct device *dev,
 
 	jdev = jesd204_dev_from_device(dev);
 	if (jdev) {
-		jesd204_err(jdev, "Device already registered with framework\n");
+		dev_err(dev, "Device already registered with framework\n");
 		return ERR_PTR(-EEXIST);
 	}
 
 	jdev = jesd204_dev_find_by_of_node(dev->of_node);
 	if (!jdev) {
-		jesd204_err(jdev, "Device has no configuration node\n");
+		dev_err(dev, "Device has no configuration node\n");
 		return ERR_PTR(-ENODEV);
 	}
 

--- a/drivers/jesd204/jesd204-core.c
+++ b/drivers/jesd204/jesd204-core.c
@@ -830,6 +830,7 @@ static void jesd204_of_unregister_devices(void)
 		jesd204_dev_unregister(jdev);
 		jesd204_dev_destroy_cons(jdev);
 		of_node_put(jdev->np);
+		list_del(&jdev->entry);
 		jesd204_device_count--;
 		if (!jdev->is_top) {
 			kfree(jdev);


### PR DESCRIPTION
Remove list entry for jdev object on framework unload, otherwise the list has a list of 
free'd elements, causing invalid memory access.

Also, up to a point, we should use dev_err(dev, ...) to print errors to identify
the device easier, because the jdev object isn't initialized yet.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>