### PR TITLE
arch: arm: zynq-zc706-adv7511: adrv9009: add jesd204-fsm variants

### DIFF
--- a/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9008-1-jesd204-fsm.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9008-1-jesd204-fsm.dts
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices ADRV9008-1 (via jesd204-fsm)
+ * https://wiki.analog.com/resources/eval/user-guides/adrv9009
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9009
+ * https://wiki.analog.com/resources/tools-software/linux-software/adrv9009_advanced_plugin
+ *
+ * hdl_project: <adrv9009/zc706>
+ * board_revision: <>
+ *
+ * Copyright (C) 2020 Analog Devices Inc.
+ */
+
+#include "zynq-zc706-adv7511-adrv9008-1.dts"
+
+#include <dt-bindings/iio/adc/adi,adrv9009.h>
+
+&trx0_adrv9009 {
+	jesd204-device;
+	#jesd204-cells = <2>;
+	jesd204-top-device = <0>; /* This is the TOP device */
+	jesd204-link-ids = <FRAMER_LINK_RX>;
+
+	jesd204-inputs =
+		<&axi_adrv9009_rx_jesd 0 FRAMER_LINK_RX>;
+
+	/delete-property/ interrupts;
+};
+
+&axi_adrv9009_rx_jesd {
+	jesd204-device;
+	#jesd204-cells = <2>;
+	jesd204-inputs = <&axi_adrv9009_adxcvr_rx 0 FRAMER_LINK_RX>;
+};
+
+&axi_adrv9009_adxcvr_rx {
+	jesd204-device;
+	#jesd204-cells = <2>;
+	jesd204-inputs =  <&clk0_ad9528 0 FRAMER_LINK_RX>;
+	clocks = <&clk0_ad9528 1>; /* div40 is controlled by axi_adrv9009_rx_jesd */
+	clock-names = "conv";
+};
+
+&clk0_ad9528 {
+	jesd204-device;
+	#jesd204-cells = <2>;
+	jesd204-sysref-provider;
+
+	adi,sysref-pattern-mode = <SYSREF_PATTERN_NSHOT>;
+	/delete-property/ adi,sysref-request-enable;
+	adi,sysref-nshot-mode = <SYSREF_NSHOT_8_PULSES>;
+};

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9008-2-jesd204-fsm.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9008-2-jesd204-fsm.dts
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices ADRV9008-2 (via jesd204-fsm)
+ * https://wiki.analog.com/resources/eval/user-guides/adrv9009
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9009
+ * https://wiki.analog.com/resources/tools-software/linux-software/adrv9009_advanced_plugin
+ *
+ * hdl_project: <adrv9009/zc706>
+ * board_revision: <>
+ *
+ * Copyright (C) 2020 Analog Devices Inc.
+ */
+#include "zynq-zc706-adv7511-adrv9008-2.dts"
+
+#include <dt-bindings/iio/adc/adi,adrv9009.h>
+
+&trx0_adrv9009 {
+	jesd204-device;
+	#jesd204-cells = <2>;
+	jesd204-top-device = <0>; /* This is the TOP device */
+	jesd204-link-ids = <DEFRAMER_LINK_TX FRAMER_LINK_ORX>;
+
+	jesd204-inputs =
+		<&axi_adrv9009_rx_os_jesd 0 FRAMER_LINK_ORX>,
+		<&axi_adrv9009_core_tx 0 DEFRAMER_LINK_TX>;
+
+	/delete-property/ interrupts;
+};
+
+&axi_adrv9009_core_tx {
+	jesd204-device;
+	#jesd204-cells = <2>;
+	jesd204-inputs = <&axi_adrv9009_tx_jesd 0 DEFRAMER_LINK_TX>;
+};
+
+&axi_adrv9009_rx_os_jesd {
+	jesd204-device;
+	#jesd204-cells = <2>;
+	jesd204-inputs = <&axi_adrv9009_adxcvr_rx_os 0 FRAMER_LINK_ORX>;
+};
+
+&axi_adrv9009_tx_jesd {
+	jesd204-device;
+	#jesd204-cells = <2>;
+	jesd204-inputs = <&axi_adrv9009_adxcvr_tx 0 DEFRAMER_LINK_TX>;
+};
+
+&axi_adrv9009_adxcvr_rx_os {
+	jesd204-device;
+	#jesd204-cells = <2>;
+	jesd204-inputs =  <&clk0_ad9528 0 FRAMER_LINK_ORX>;
+	clocks = <&clk0_ad9528 1>; /* div40 is controlled by axi_adrv9009_rx_os_jesd */
+	clock-names = "conv";
+};
+
+&axi_adrv9009_adxcvr_tx {
+	jesd204-device;
+	#jesd204-cells = <2>;
+	jesd204-inputs =  <&clk0_ad9528 0 DEFRAMER_LINK_TX>;
+	clocks = <&clk0_ad9528 1>; /* div40 is controlled by axi_adrv9009_tx_jesd */
+	clock-names = "conv";
+};
+
+&clk0_ad9528 {
+	jesd204-device;
+	#jesd204-cells = <2>;
+	jesd204-sysref-provider;
+
+	adi,sysref-pattern-mode = <SYSREF_PATTERN_NSHOT>;
+	/delete-property/ adi,sysref-request-enable;
+	adi,sysref-nshot-mode = <SYSREF_NSHOT_8_PULSES>;
+};

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9009-jesd204-fsm.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9009-jesd204-fsm.dts
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices ADRV9009 (via jesd204-fsm)
+ * https://wiki.analog.com/resources/eval/user-guides/adrv9009
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9009
+ * https://wiki.analog.com/resources/tools-software/linux-software/adrv9009_advanced_plugin
+ *
+ * hdl_project: <adrv9009/zc706>
+ * board_revision: <>
+ *
+ * Copyright (C) 2020 Analog Devices Inc.
+ */
+
+#include "zynq-zc706-adv7511-adrv9009.dts"
+
+#include <dt-bindings/iio/adc/adi,adrv9009.h>
+
+&trx0_adrv9009 {
+	jesd204-device;
+	#jesd204-cells = <2>;
+	jesd204-top-device = <0>; /* This is the TOP device */
+	jesd204-link-ids = <DEFRAMER_LINK_TX FRAMER_LINK_RX FRAMER_LINK_ORX>;
+
+	jesd204-inputs =
+		<&axi_adrv9009_rx_jesd 0 FRAMER_LINK_RX>,
+		<&axi_adrv9009_rx_os_jesd 0 FRAMER_LINK_ORX>,
+		<&axi_adrv9009_core_tx 0 DEFRAMER_LINK_TX>;
+
+	/delete-property/ interrupts;
+};
+
+&axi_adrv9009_core_tx {
+	jesd204-device;
+	#jesd204-cells = <2>;
+	jesd204-inputs = <&axi_adrv9009_tx_jesd 0 DEFRAMER_LINK_TX>;
+};
+
+&axi_adrv9009_rx_jesd {
+	jesd204-device;
+	#jesd204-cells = <2>;
+	jesd204-inputs = <&axi_adrv9009_adxcvr_rx 0 FRAMER_LINK_RX>;
+};
+
+&axi_adrv9009_rx_os_jesd {
+	jesd204-device;
+	#jesd204-cells = <2>;
+	jesd204-inputs = <&axi_adrv9009_adxcvr_rx_os 0 FRAMER_LINK_ORX>;
+};
+
+&axi_adrv9009_tx_jesd {
+	jesd204-device;
+	#jesd204-cells = <2>;
+	jesd204-inputs = <&axi_adrv9009_adxcvr_tx 0 DEFRAMER_LINK_TX>;
+};
+
+&axi_adrv9009_adxcvr_rx {
+    	jesd204-device;
+	#jesd204-cells = <2>;
+	jesd204-inputs =  <&clk0_ad9528 0 FRAMER_LINK_RX>;
+	clocks = <&clk0_ad9528 1>; /* div40 is controlled by axi_adrv9009_rx_jesd */
+	clock-names = "conv";
+};
+
+&axi_adrv9009_adxcvr_rx_os {
+    	jesd204-device;
+	#jesd204-cells = <2>;
+	jesd204-inputs =  <&clk0_ad9528 0 FRAMER_LINK_ORX>;
+	clocks = <&clk0_ad9528 1>; /* div40 is controlled by axi_adrv9009_rx_os_jesd */
+	clock-names = "conv";
+};
+
+&axi_adrv9009_adxcvr_tx {
+    	jesd204-device;
+	#jesd204-cells = <2>;
+	jesd204-inputs =  <&clk0_ad9528 0 DEFRAMER_LINK_TX>;
+	clocks = <&clk0_ad9528 1>; /* div40 is controlled by axi_adrv9009_tx_jesd */
+	clock-names = "conv";
+};
+
+&clk0_ad9528 {
+	jesd204-device;
+	#jesd204-cells = <2>;
+	jesd204-sysref-provider;
+
+	adi,sysref-pattern-mode = <SYSREF_PATTERN_NSHOT>;
+	/delete-property/ adi,sysref-request-enable;
+};

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9009.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9009.dts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 /*
- * Analog Devices ADRV9008-1
+ * Analog Devices ADRV9009
  * https://wiki.analog.com/resources/eval/user-guides/adrv9009
  * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9009
  * https://wiki.analog.com/resources/tools-software/linux-software/adrv9009_advanced_plugin


### PR DESCRIPTION
Adapted from ZCU102 variants.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>