### PR TITLE
jesd204: fsm: implement retry mechanism 

### DIFF
--- a/drivers/jesd204/jesd204-core.c
+++ b/drivers/jesd204/jesd204-core.c
@@ -742,6 +742,18 @@ static int jesd204_dev_init_links_data(struct device *parent,
 	return 0;
 }
 
+static void jesd204_dev_init_top_data(struct jesd204_dev *jdev,
+				      const struct jesd204_dev_data *init)
+{
+	struct jesd204_dev_top *jdev_top;
+
+	jdev_top = jesd204_dev_top_dev(jdev);
+	if (!jdev_top)
+		return;
+
+	jdev_top->num_retries = init->num_retries;
+}
+
 static struct jesd204_dev *jesd204_dev_register(struct device *dev,
 						const struct jesd204_dev_data *init)
 {
@@ -768,6 +780,8 @@ static struct jesd204_dev *jesd204_dev_register(struct device *dev,
 	ret = jesd204_dev_init_links_data(dev, jdev, init);
 	if (ret)
 		return ERR_PTR(ret);
+
+	jesd204_dev_init_top_data(jdev, init);
 
 	jdev->dev.parent = dev;
 	jdev->sysref_cb = init->sysref_cb;

--- a/drivers/jesd204/jesd204-fsm.c
+++ b/drivers/jesd204/jesd204-fsm.c
@@ -721,23 +721,12 @@ static int jesd204_fsm(struct jesd204_dev *jdev,
 		       struct jesd204_fsm_data *data,
 		       bool handle_busy_flags)
 {
-	struct list_head *jesd204_topologies = jesd204_topologies_get();
-	struct jesd204_dev_top *jdev_top = jesd204_dev_top_dev(jdev);
-	int ret;
+	struct jesd204_dev_top *jdev_top = jesd204_dev_get_topology_top_dev(jdev);
 
-	if (jdev_top)
-		return __jesd204_fsm(jdev, jdev_top, data, handle_busy_flags);
+	if (!jdev_top)
+		return -EFAULT;
 
-	list_for_each_entry(jdev_top, jesd204_topologies, entry) {
-		if (!jesd204_dev_has_con_in_topology(jdev, jdev_top))
-			continue;
-
-		ret = __jesd204_fsm(jdev, jdev_top, data, handle_busy_flags);
-		if (ret)
-			return ret;
-	}
-
-	return 0;
+	return __jesd204_fsm(jdev, jdev_top, data, handle_busy_flags);
 }
 
 static int jesd204_dev_initialize_cb(struct jesd204_dev *jdev,

--- a/drivers/jesd204/jesd204-priv.h
+++ b/drivers/jesd204/jesd204-priv.h
@@ -167,6 +167,7 @@ struct jesd204_link_opaque {
  * @entry		list entry for the framework to keep a list of top
  *			devices (and implicitly topologies)
  * @initialized		true the topoology connections have been initialized
+ * @num_retries		number of retries if an error occurs
  * @jdev_sysref		reference to the object that is the SYSREF provider for this topology
  * @fsm_data		ref to JESD204 FSM data for JESD204_LNK_FSM_PARALLEL
  * @cb_ref		kref which for each JESD204 link will increment when it
@@ -178,15 +179,16 @@ struct jesd204_link_opaque {
  *			(connections should match against this)
  * @link_ids		JESD204 link IDs for this top-level device
  *			(connections should match against this)
+ * @num_links		number of links
  * @init_links		initial settings passed from the driver
  * @active_links	active JESD204 link settings
  * @staged_links	JESD204 link settings staged to be committed as active
- * @num_links		number of links
  */
 struct jesd204_dev_top {
 	struct jesd204_dev		jdev;
 	struct list_head		entry;
 	bool				initialized;
+	unsigned int			num_retries;
 
 	struct jesd204_dev		*jdev_sysref;
 

--- a/drivers/jesd204/jesd204-priv.h
+++ b/drivers/jesd204/jesd204-priv.h
@@ -204,10 +204,7 @@ struct jesd204_dev_top {
 
 int jesd204_device_count_get(void);
 
-bool jesd204_dev_has_con_in_topology(struct jesd204_dev *jdev,
-				     struct jesd204_dev_top *jdev_top);
-
-struct list_head *jesd204_topologies_get(void);
+struct jesd204_dev_top *jesd204_dev_get_topology_top_dev(struct jesd204_dev *jdev);
 
 static inline struct jesd204_dev_top *jesd204_dev_top_dev(
 		struct jesd204_dev *jdev)

--- a/include/linux/jesd204/jesd204.h
+++ b/include/linux/jesd204/jesd204.h
@@ -221,18 +221,18 @@ enum jesd204_dev_op {
 
 /**
  * struct jesd204_dev_data - JESD204 device initialization data
- * @state_ops		ops for each state transition of type @struct jesd204_state_op
  * @sysref_cb		SYSREF callback, if this device/driver supports it
  * @sizeof_priv		amount of data to allocate for private information
  * @links		JESD204 initial link configuration
  * @num_links		number of JESD204 links
+ * @state_ops		ops for each state transition of type @struct jesd204_state_op
  */
 struct jesd204_dev_data {
-	struct jesd204_state_op			state_ops[__JESD204_MAX_OPS];
 	jesd204_sysref_cb			sysref_cb;
 	size_t					sizeof_priv;
 	const struct jesd204_link		*links;
 	unsigned int				num_links;
+	struct jesd204_state_op			state_ops[__JESD204_MAX_OPS];
 };
 
 #ifdef CONFIG_JESD204

--- a/include/linux/jesd204/jesd204.h
+++ b/include/linux/jesd204/jesd204.h
@@ -225,6 +225,7 @@ enum jesd204_dev_op {
  * @sizeof_priv		amount of data to allocate for private information
  * @links		JESD204 initial link configuration
  * @num_links		number of JESD204 links
+ * @num_retries		number of retries in case of error (only for top-level device)
  * @state_ops		ops for each state transition of type @struct jesd204_state_op
  */
 struct jesd204_dev_data {
@@ -232,6 +233,7 @@ struct jesd204_dev_data {
 	size_t					sizeof_priv;
 	const struct jesd204_link		*links;
 	unsigned int				num_links;
+	unsigned int				num_retries;
 	struct jesd204_state_op			state_ops[__JESD204_MAX_OPS];
 };
 


### PR DESCRIPTION
This change splits the jesd204_fsm_table() function into a
jesd204_fsm_table_single() function that gets re-called a number of
retries.

This allows for a number of retries to be called to transition to the final
state in the table.
The jesd204_fsm_table_single() also performs a rollback, so on a single
try:
- FSM will try to go to the final state
- on an error it will rollback to IDLE

Currently the num_retries need to be specified by the driver, but later we
may add an option to configure this from DT.

The num_retries field will only be taken into consideration for the
 top-level device (in a topology).

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>