### PR TITLE
iio: frequency: ad916x: Fix NCO Frequency setting behavior.

### DIFF
--- a/drivers/iio/frequency/ad916x/ad916x_nco_api.c
+++ b/drivers/iio/frequency/ad916x/ad916x_nco_api.c
@@ -15,6 +15,10 @@ static int ad916x_nco_set_configure_main(ad916x_handle_t *h,
 	int err;
 	/* check if the desired frequency power of 2 */
 	uint8_t is_pow2 = 0;
+
+	if (carrier_freq_hz == 0)
+		return API_ERROR_INVALID_PARAM;
+
 	tmp_freq = carrier_freq_hz;
 	while (tmp_freq <= h->dac_freq_hz) {
 		if ((tmp_freq) == h->dac_freq_hz) {
@@ -29,8 +33,8 @@ static int ad916x_nco_set_configure_main(ad916x_handle_t *h,
 		/* Integer NCO mode */
 		/* As we are in Integer NCO mode it guranteed the
 		   value is integer power of 2 */
-		tmp_freq = DIV_U64(h->dac_freq_hz, carrier_freq_hz);
-		tmp_freq = DIV_U64(ADI_POW2_48, tmp_freq);
+		tmp_freq = DIV64_U64(h->dac_freq_hz, carrier_freq_hz);
+		tmp_freq = DIV64_U64(ADI_POW2_48, tmp_freq);
 		/* Disable modulus */
 		err = ad916x_nco_set_enable(h, 0, 1);
 		if (err != API_ERROR_OK) {
@@ -70,8 +74,8 @@ static int ad916x_nco_set_configure_main(ad916x_handle_t *h,
 		/* Modulus NCO mode */
 
 		gcd = adi_api_utils_gcd(carrier_freq_hz, h->dac_freq_hz);
-		M = DIV_U64(carrier_freq_hz, gcd);
-		N = DIV_U64(h->dac_freq_hz, gcd);
+		M = DIV64_U64(carrier_freq_hz, gcd);
+		N = DIV64_U64(h->dac_freq_hz, gcd);
 
 		if (M > INT16_MAX) {
 			uint64_t mask = U64MSB;
@@ -80,10 +84,10 @@ static int ad916x_nco_set_configure_main(ad916x_handle_t *h,
 				mask >>= 1;
 				i++;
 			}
-			int_part = DIV_U64(M*((uint64_t)1u << i), N);
+			int_part = DIV64_U64(M*((uint64_t)1u << i), N);
 			int_part *= ((uint64_t)1u << (48 - i));
 		} else {
-			int_part = DIV_U64(M*(ADI_POW2_48), N);
+			int_part = DIV64_U64(M*(ADI_POW2_48), N);
 		}
 
 		adi_api_utils_mult_128(M, ADI_POW2_48, &tmp_ah, &tmp_al);
@@ -93,8 +97,8 @@ static int ad916x_nco_set_configure_main(ad916x_handle_t *h,
 		frac_part_b = N;
 
 		gcd = adi_api_utils_gcd(frac_part_a, frac_part_b);
-		frac_part_a = DIV_U64(frac_part_a, gcd);
-		frac_part_b = DIV_U64(frac_part_b, gcd);
+		frac_part_a = DIV64_U64(frac_part_a, gcd);
+		frac_part_b = DIV64_U64(frac_part_b, gcd);
 
 		if ((frac_part_a > ADI_MAXUINT48) || (frac_part_b > ADI_MAXUINT48)) {
 			/* TODO: a better error */

--- a/drivers/iio/frequency/ad916x/api_def.h
+++ b/drivers/iio/frequency/ad916x/api_def.h
@@ -18,7 +18,8 @@
 #define ADI_MAXUINT32 (ADI_POW2_32 - 1)
 #define ADI_MAXUINT24 (0xFFFFFF)
 #define ADI_GET_BYTE(w, p) (uint8_t)(((w) >> (p)) & 0xFF)
-#define DIV_U64(x,y) div_u64(x, y)
+#define DIV_U64(x, y) div_u64(x, y)
+#define DIV64_U64(x, y) div64_u64(x, y)
 
 #define INT16_MAX S16_MAX
 

--- a/drivers/iio/frequency/ad916x/utils.c
+++ b/drivers/iio/frequency/ad916x/utils.c
@@ -1,16 +1,18 @@
+#include <linux/math64.h>
+
 #include "utils.h"
 
 #define LOWER_16(A) ((A) & 0xFFFF)
 #define UPPER_16(A) (((A) >> 16) & 0xFFFF)
 #define LOWER_32(A) ((A) & (uint32_t) 0xFFFFFFFF)
 
-int adi_api_utils_gcd(int u, int v)
+int64_t adi_api_utils_gcd(int64_t u, int64_t v)
 {
-	int t;
+	int64_t t;
 	while (v != 0) {
-		t = u; 
-		u = v; 
-		v = t % v;
+		t = u;
+		u = v;
+		div64_u64_rem(t, v, &v);
 	}
 	return u < 0 ? -u : u; /* abs(u) */
 }

--- a/drivers/iio/frequency/ad916x/utils.h
+++ b/drivers/iio/frequency/ad916x/utils.h
@@ -9,7 +9,7 @@
 
 #define U64MSB 0x8000000000000000ull
 
-int adi_api_utils_gcd(int u, int v);
+int64_t adi_api_utils_gcd(int64_t u, int64_t v);
 void adi_api_utils_mult_64(uint32_t a, uint32_t b, uint32_t *hi, uint32_t *lo);
 void adi_api_utils_lshift_128(uint64_t *hi, uint64_t *lo);
 void adi_api_utils_rshift_128(uint64_t *hi, uint64_t *lo);


### PR DESCRIPTION
Incorrect behaviours in NCO frequency setting for the ad916x can be due to:
1. Divisors getting truncated in 32-bit-divisor routines.
2. Truncation in computation of GCD. 
3. Setting NCO frequency=0. This causes the driver to hang.

This patch addresses the above causes to fix the problem.

Signed-off-by: kister-jimenez <kister.jimenez@analog.com>