### PR TITLE
media/platform/axi-hdmi-rx: Announce GPLv2 module license

### DIFF
--- a/drivers/media/platform/axi-hdmi-rx.c
+++ b/drivers/media/platform/axi-hdmi-rx.c
@@ -982,3 +982,6 @@ static struct platform_driver axi_hdmi_rx_driver = {
 	.remove = axi_hdmi_rx_remove,
 };
 module_platform_driver(axi_hdmi_rx_driver);
+
+MODULE_LICENSE("GPL v2");
+MODULE_DESCRIPTION("ADI AXI HDMI RX driver");


### PR DESCRIPTION
Add missing MODULE_LICENSE directive, otherwise you'll get this when
you load the module:

axi_hdmi_rx: module license 'unspecified' taints kernel.
Disabling lock debugging due to kernel taint
axi_hdmi_rx: Unknown symbol vb2_queue_init (err -2)
axi_hdmi_rx: Unknown symbol vb2_streamoff (err -2)
axi_hdmi_rx: Unknown symbol devm_kmalloc (err -2)
...

Signed-off-by: Mike Looijmans <mike.looijmans@topic.nl>