### PR TITLE
media: axi-hdmi-rx: Provide device_caps in struct video_device

### DIFF
--- a/drivers/media/platform/axi-hdmi-rx.c
+++ b/drivers/media/platform/axi-hdmi-rx.c
@@ -748,6 +748,7 @@ static int axi_hdmi_rx_nodes_register(struct axi_hdmi_rx *hdmi_rx)
 		 "%s", hdmi_rx->v4l2_dev.name);
 	vdev->v4l2_dev = &hdmi_rx->v4l2_dev;
 	vdev->fops = &axi_hdmi_rx_fops;
+	vdev->device_caps = V4L2_CAP_VIDEO_CAPTURE | V4L2_CAP_STREAMING;
 	vdev->release = video_device_release_empty;
 	vdev->ctrl_handler = s->subdev->ctrl_handler;
 	vdev->lock = &s->lock;


### PR DESCRIPTION
The capture devices doesn't actually work yet after this change, it probes but hangs after capturing the first (garbled) frame. But at least the driver probes now.


Need to provide this info, otherwise video_register_device will trigger a WARN
and fail.

Fixes this kernel WARN message:

```
adv7611 4-004c: adv7611 found @ 0x98 (i2c-0-mux (chan_id 3))
unsupported bus type 0
------------[ cut here ]------------
WARNING: CPU: 1 PID: 320 at drivers/media/v4l2-core/v4l2-dev.c:863 __video_register_device+0x48/0x118
Modules linked in: axi_hdmi_rx(+) videobuf2_dma_contig videobuf2_v4l2 videobuf2_common videobuf2_mema
CPU: 1 PID: 320 Comm: modprobe Tainted: G        W         5.4.0-xilinx-v2020.1 #1
Hardware name: Xilinx Zynq Platform
[<c010d778>] (unwind_backtrace) from [<c0109aec>] (show_stack+0x10/0x14)
[<c0109aec>] (show_stack) from [<c063de88>] (dump_stack+0xb4/0xd0)
[<c063de88>] (dump_stack) from [<c0122edc>] (__warn+0xb8/0xd0)
[<c0122edc>] (__warn) from [<c0122f5c>] (warn_slowpath_fmt+0x68/0x7c)
[<c0122f5c>] (warn_slowpath_fmt) from [<c04c85f0>] (__video_register_device+0x48/0x1138)
[<c04c85f0>] (__video_register_device) from [<bf059d08>] (axi_hdmi_rx_async_complete+0x11c/0x140 [ax)
[<bf059d08>] (axi_hdmi_rx_async_complete [axi_hdmi_rx]) from [<c04dae2c>] (__v4l2_async_notifier_reg)
[<c04dae2c>] (__v4l2_async_notifier_register) from [<c04daf00>] (v4l2_async_notifier_register+0x44/0)
[<c04daf00>] (v4l2_async_notifier_register) from [<bf059f2c>] (axi_hdmi_rx_probe+0x200/0x288 [axi_hd)
[<bf059f2c>] (axi_hdmi_rx_probe [axi_hdmi_rx]) from [<c04151ac>] (platform_drv_probe+0x48/0x94)
[<c04151ac>] (platform_drv_probe) from [<c0413660>] (really_probe+0x1f8/0x318)
[<c0413660>] (really_probe) from [<c04139e4>] (driver_probe_device+0x13c/0x158)
[<c04139e4>] (driver_probe_device) from [<c0413b84>] (device_driver_attach+0x44/0x5c)
[<c0413b84>] (device_driver_attach) from [<c0413c48>] (__driver_attach+0xac/0xb4)
[<c0413c48>] (__driver_attach) from [<c0411cbc>] (bus_for_each_dev+0x54/0x78)
[<c0411cbc>] (bus_for_each_dev) from [<c0412b68>] (bus_add_driver+0x150/0x1b0)
[<c0412b68>] (bus_add_driver) from [<c041439c>] (driver_register+0xac/0xf0)
[<c041439c>] (driver_register) from [<c0102710>] (do_one_initcall+0x64/0x174)
[<c0102710>] (do_one_initcall) from [<c0187af0>] (do_init_module+0x54/0x1f0)
[<c0187af0>] (do_init_module) from [<c0189984>] (load_module+0x1c7c/0x1e88)
[<c0189984>] (load_module) from [<c0189d40>] (sys_finit_module+0x88/0x90)
[<c0189d40>] (sys_finit_module) from [<c0101000>] (ret_fast_syscall+0x0/0x54)
Exception stack(0xdb927fa8 to 0xdb927ff0)
7fa0:                   4f34cbf1 000a3190 00000003 000a41b0 00000000 000a4608
7fc0: 4f34cbf1 000a3190 000a3f38 0000017b 000a1c40 000a4652 000a4178 000a3d10
7fe0: bed3dad0 bed3dac0 0003dae1 4f388c42
---[ end trace cfc3614d3a39c0a0 ]---
axi-hdmi-rx 43c10000.axi-hdmi-rx: Error -22 registering device nodes
axi-hdmi-rx: probe of 43c10000.axi-hdmi-rx failed with error -22

```