### PR TITLE
media: axi-hdmi-rx: Initialize bus_type

### DIFF
--- a/drivers/media/platform/axi-hdmi-rx.c
+++ b/drivers/media/platform/axi-hdmi-rx.c
@@ -869,7 +869,7 @@ static int axi_hdmi_rx_probe(struct platform_device *pdev)
 	struct device_node *ep_node;
 	struct axi_hdmi_rx *hdmi_rx;
 	struct resource *res;
-	struct v4l2_fwnode_endpoint bus_cfg;
+	struct v4l2_fwnode_endpoint bus_cfg = { .bus_type = V4L2_MBUS_UNKNOWN };
 	int ret;
 
 	hdmi_rx = devm_kzalloc(&pdev->dev, sizeof(*hdmi_rx), GFP_KERNEL);


### PR DESCRIPTION
The v4l2-fwnode expects the bus_type member passed to v4l2_fwnode_endpoint_parse
to have an actual value. Set it to V4L2_MBUS_UNKNOWN (0) to request the bus type
to be obtained from the devicetree.

This fixes the color coding and sync signals were not being read from the devicetree.

Signed-off-by: Mike Looijmans <mike.looijmans@topic.nl>