### PR TITLE
arch: arm,microblaze: prefix with adi, all compat strings related to ad9467 driver

### DIFF
--- a/arch/microblaze/boot/dts/adi-ad9467-fmc-250ebz.dtsi
+++ b/arch/microblaze/boot/dts/adi-ad9467-fmc-250ebz.dtsi
@@ -13,7 +13,7 @@
 	adc_ad9467: ad9467@0 {
 		#address-cells = <1>;
 		#size-cells = <0>;
-		compatible = "ad9467";
+		compatible = "adi,ad9467";
 		reg = <0>;
 		spi-max-frequency = <10000000>;
 		clocks = <&clk_ad9517 3>;

--- a/arch/microblaze/boot/dts/adi-fmcjesdadc1.dtsi
+++ b/arch/microblaze/boot/dts/adi-fmcjesdadc1.dtsi
@@ -19,7 +19,7 @@
 	spi_fmcjesdadc1: spi-fmcjesdadc1@0 {
 		#address-cells = <1>;
 		#size-cells = <0>;
-		compatible = "spi-ad9250";
+		compatible = "adi,spi-ad9250";
 		reg = <0>;
 		spi-max-frequency = <10000000>;
 

--- a/arch/microblaze/boot/dts/adi-fmcomms1.dtsi
+++ b/arch/microblaze/boot/dts/adi-fmcomms1.dtsi
@@ -107,7 +107,7 @@
 		adc0_ad9467: ad9467@1 {
 			#address-cells = <1>;
 			#size-cells = <0>;
-			compatible = "ad9643";
+			compatible = "adi,ad9643";
 			reg = <1>;
 			spi-max-frequency = <10000000>;
 			spi-3wire;


### PR DESCRIPTION
Since moving to OF probing, the match-string is 'adi,adxxxx'. This change
updates all places with devices related to the ad9467 driver, to have this
prefix, to account for this (and future) OF changes.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>