### PR TITLE
clk: axi-clkgen: check axi clock before bus access

### DIFF
--- a/Documentation/devicetree/bindings/clock/axi-clkgen.txt
+++ b/Documentation/devicetree/bindings/clock/axi-clkgen.txt
@@ -8,10 +8,12 @@ Required properties:
 - compatible : shall be "adi,axi-clkgen-1.00.a" or "adi,axi-clkgen-2.00.a".
 - #clock-cells : from common clock binding; Should always be set to 0.
 - reg : Address and length of the axi-clkgen register set.
-- clocks : Phandle and clock specifier for the parent clock(s). This must
-	either reference one clock if only the first clock input is connected or two
-	if both clock inputs are connected. For the later case the clock connected
-	to the first input must be specified first.
+- clocks : Phandle and clock specifier for the axi control clock and MMCM input
+           clocks. The MMCM input clocks must either reference one clock if only the
+	   first clock input is connected or two if both inputs are connected.
+- clock-names: Should be "s_axi_aclk" for the axi control clock, and "clkin1"
+	       and "clkin2" for the MMCM input clocks (only one clkin is
+	       required).
 
 Optional properties:
 - clock-output-names : From common clock binding.
@@ -21,5 +23,6 @@ Example:
 		compatible = "adi,axi-clkgen";
 		#clock-cells = <0>;
 		reg = <0xff000000 0x1000>;
-		clocks = <&osc 1>;
+		clocks = <&clk 71>, <&osc 1>;
+		clock-names = "s_axi_acl", "clkin1";
 	};

--- a/arch/arm/boot/dts/zynq-adrv9361-z7035-fmc.dts
+++ b/arch/arm/boot/dts/zynq-adrv9361-z7035-fmc.dts
@@ -196,6 +196,7 @@
 			reg = <0x79000000 0x10000>;
 			#clock-cells = <0>;
 			clocks = <&clkc 16>;
+			clock-names = "clkin1";
 		};
 
 		axi_hdmi@70e00000 {

--- a/arch/arm/boot/dts/zynq-adrv9361-z7035-fmc.dts
+++ b/arch/arm/boot/dts/zynq-adrv9361-z7035-fmc.dts
@@ -195,8 +195,8 @@
 			compatible = "adi,axi-clkgen-2.00.a";
 			reg = <0x79000000 0x10000>;
 			#clock-cells = <0>;
-			clocks = <&clkc 16>;
-			clock-names = "clkin1";
+			clocks = <&clkc 15>, <&clkc 16>;
+			clock-names = "s_axi_aclk", "clkin1";
 		};
 
 		axi_hdmi@70e00000 {

--- a/arch/arm/boot/dts/zynq-zc702-adv7511.dtsi
+++ b/arch/arm/boot/dts/zynq-zc702-adv7511.dtsi
@@ -104,6 +104,7 @@
 			reg = <0x79000000 0x10000>;
 			#clock-cells = <0>;
 			clocks = <&clkc 16>;
+			clock-names = "clkin1";
 		};
 
 		axi_hdmi@70e00000 {

--- a/arch/arm/boot/dts/zynq-zc702-adv7511.dtsi
+++ b/arch/arm/boot/dts/zynq-zc702-adv7511.dtsi
@@ -103,8 +103,8 @@
 			compatible = "adi,axi-clkgen-2.00.a";
 			reg = <0x79000000 0x10000>;
 			#clock-cells = <0>;
-			clocks = <&clkc 16>;
-			clock-names = "clkin1";
+			clocks = <&clkc 15>, <&clkc 16>;
+			clock-names = "s_axi_aclk", "clkin1";
 		};
 
 		axi_hdmi@70e00000 {

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9008-1.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9008-1.dts
@@ -90,6 +90,7 @@
 		reg = <0x43c10000 0x10000>;
 		#clock-cells = <0>;
 		clocks = <&clk0_ad9528 1>;
+		clock-names = "clkin1";
 		clock-output-names = "axi_rx_clkgen";
 	};
 

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9008-1.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9008-1.dts
@@ -89,8 +89,8 @@
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x43c10000 0x10000>;
 		#clock-cells = <0>;
-		clocks = <&clk0_ad9528 1>;
-		clock-names = "clkin1";
+		clocks = <&clkc 15>, <&clk0_ad9528 1>;
+		clock-names = "s_axi_aclk", "clkin1";
 		clock-output-names = "axi_rx_clkgen";
 	};
 

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9008-2.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9008-2.dts
@@ -143,6 +143,7 @@
 		reg = <0x43c00000 0x10000>;
 		#clock-cells = <0>;
 		clocks = <&clk0_ad9528 1>;
+		clock-names = "clkin1";
 		clock-output-names = "axi_tx_clkgen";
 	};
 
@@ -151,6 +152,7 @@
 		reg = <0x43c20000 0x10000>;
 		#clock-cells = <0>;
 		clocks = <&clk0_ad9528 1>;
+		clock-names = "clkin1";
 		clock-output-names = "axi_rx_os_clkgen";
 	};
 

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9008-2.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9008-2.dts
@@ -142,8 +142,8 @@
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x43c00000 0x10000>;
 		#clock-cells = <0>;
-		clocks = <&clk0_ad9528 1>;
-		clock-names = "clkin1";
+		clocks = <&clkc 15>, <&clk0_ad9528 1>;
+		clock-names = "s_axi_aclk", "clkin1";
 		clock-output-names = "axi_tx_clkgen";
 	};
 
@@ -151,8 +151,8 @@
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x43c20000 0x10000>;
 		#clock-cells = <0>;
-		clocks = <&clk0_ad9528 1>;
-		clock-names = "clkin1";
+		clocks = <&clkc 15>, <&clk0_ad9528 1>;
+		clock-names = "s_axi_aclk", "clkin1";
 		clock-output-names = "axi_rx_os_clkgen";
 	};
 

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9009.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9009.dts
@@ -192,6 +192,7 @@
 		reg = <0x43c00000 0x10000>;
 		#clock-cells = <0>;
 		clocks = <&clk0_ad9528 1>;
+		clock-names = "clkin1";
 		clock-output-names = "axi_tx_clkgen";
 	};
 
@@ -200,6 +201,7 @@
 		reg = <0x43c10000 0x10000>;
 		#clock-cells = <0>;
 		clocks = <&clk0_ad9528 1>;
+		clock-names = "clkin1";
 		clock-output-names = "axi_rx_clkgen";
 	};
 
@@ -208,6 +210,7 @@
 		reg = <0x43c20000 0x10000>;
 		#clock-cells = <0>;
 		clocks = <&clk0_ad9528 1>;
+		clock-names = "clkin1";
 		clock-output-names = "axi_rx_os_clkgen";
 	};
 

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9009.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9009.dts
@@ -191,8 +191,8 @@
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x43c00000 0x10000>;
 		#clock-cells = <0>;
-		clocks = <&clk0_ad9528 1>;
-		clock-names = "clkin1";
+		clocks = <&clkc 15>, <&clk0_ad9528 1>;
+		clock-names = "s_axi_aclk", "clkin1";
 		clock-output-names = "axi_tx_clkgen";
 	};
 
@@ -200,8 +200,8 @@
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x43c10000 0x10000>;
 		#clock-cells = <0>;
-		clocks = <&clk0_ad9528 1>;
-		clock-names = "clkin1";
+		clocks = <&clkc 15>, <&clk0_ad9528 1>;
+		clock-names = "s_axi_aclk", "clkin1";
 		clock-output-names = "axi_rx_clkgen";
 	};
 
@@ -209,8 +209,8 @@
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x43c20000 0x10000>;
 		#clock-cells = <0>;
-		clocks = <&clk0_ad9528 1>;
-		clock-names = "clkin1";
+		clocks = <&clkc 15>, <&clk0_ad9528 1>;
+		clock-names = "s_axi_aclk", "clkin1";
 		clock-output-names = "axi_rx_os_clkgen";
 	};
 

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9371.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9371.dts
@@ -191,6 +191,7 @@
 		reg = <0x43c00000 0x10000>;
 		#clock-cells = <0>;
 		clocks = <&clk0_ad9528 1>;
+		clock-names = "clkin1";
 		clock-output-names = "axi_tx_clkgen";
 	};
 
@@ -199,6 +200,7 @@
 		reg = <0x43c10000 0x10000>;
 		#clock-cells = <0>;
 		clocks = <&clk0_ad9528 1>;
+		clock-names = "clkin1";
 		clock-output-names = "axi_rx_clkgen";
 
 	};
@@ -208,6 +210,7 @@
 		reg = <0x43c20000 0x10000>;
 		#clock-cells = <0>;
 		clocks = <&clk0_ad9528 1>;
+		clock-names = "clkin1";
 		clock-output-names = "axi_rx_os_clkgen";
 
 	};

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9371.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9371.dts
@@ -209,8 +209,8 @@
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x43c20000 0x10000>;
 		#clock-cells = <0>;
-		clocks = <&clk0_ad9528 1>;
-		clock-names = "clkin1";
+		clocks = <&clkc 15>, <&clk0_ad9528 1>;
+		clock-names = "s_axi_aclk", "clkin1";
 		clock-output-names = "axi_rx_os_clkgen";
 
 	};

--- a/arch/arm/boot/dts/zynq-zc706-adv7511.dtsi
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511.dtsi
@@ -132,6 +132,7 @@
 			reg = <0x79000000 0x10000>;
 			#clock-cells = <0>;
 			clocks = <&clkc 16>;
+			clock-names = "clkin1";
 		};
 
 		axi_hdmi@70e00000 {

--- a/arch/arm/boot/dts/zynq-zc706-adv7511.dtsi
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511.dtsi
@@ -131,8 +131,8 @@
 			compatible = "adi,axi-clkgen-2.00.a";
 			reg = <0x79000000 0x10000>;
 			#clock-cells = <0>;
-			clocks = <&clkc 16>;
-			clock-names = "clkin1";
+			clocks = <&clkc 15>, <&clkc 16>;
+			clock-names = "s_axi_aclk", "clkin1";
 		};
 
 		axi_hdmi@70e00000 {

--- a/arch/arm/boot/dts/zynq-zed-adv7511-m2k-revb.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-m2k-revb.dts
@@ -214,6 +214,7 @@
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x70000000 0x10000>;
 		clocks = <&clkc 16>;
+		clock-names = "clkin1";
 
 		#clock-cells = <0>;
 	};

--- a/arch/arm/boot/dts/zynq-zed-adv7511-m2k-revb.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-m2k-revb.dts
@@ -213,8 +213,8 @@
 	logic_analyzer_clkgen: clock@7000000 {
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x70000000 0x10000>;
-		clocks = <&clkc 16>;
-		clock-names = "clkin1";
+		clocks = <&clkc 15>, <&clkc 16>;
+		clock-names = "s_axi_aclk", "clkin1";
 
 		#clock-cells = <0>;
 	};

--- a/arch/arm/boot/dts/zynq-zed-adv7511.dtsi
+++ b/arch/arm/boot/dts/zynq-zed-adv7511.dtsi
@@ -84,6 +84,7 @@
 			reg = <0x79000000 0x10000>;
 			#clock-cells = <0>;
 			clocks = <&clkc 16>;
+			clock-names = "clkin1";
 		};
 
 		axi_hdmi@70e00000 {

--- a/arch/arm/boot/dts/zynq-zed-adv7511.dtsi
+++ b/arch/arm/boot/dts/zynq-zed-adv7511.dtsi
@@ -83,8 +83,8 @@
 			compatible = "adi,axi-clkgen-2.00.a";
 			reg = <0x79000000 0x10000>;
 			#clock-cells = <0>;
-			clocks = <&clkc 16>;
-			clock-names = "clkin1";
+			clocks = <&clkc 15>, <&clkc 16>;
+			clock-names = "s_axi_aclk", "clkin1";
 		};
 
 		axi_hdmi@70e00000 {

--- a/arch/arm/boot/dts/zynq-zed-imageon.dts
+++ b/arch/arm/boot/dts/zynq-zed-imageon.dts
@@ -136,6 +136,7 @@
 			reg = <0x79000000 0x10000>;
 			#clock-cells = <0>;
 			clocks = <&clkc 16>;
+			clock-names = "clkin1";
 		};
 
 		axi_hdmi_core: axi-hdmi-tx@70e00000 {

--- a/arch/arm/boot/dts/zynq-zed-imageon.dts
+++ b/arch/arm/boot/dts/zynq-zed-imageon.dts
@@ -135,8 +135,8 @@
 			compatible = "adi,axi-clkgen-2.00.a";
 			reg = <0x79000000 0x10000>;
 			#clock-cells = <0>;
-			clocks = <&clkc 16>;
-			clock-names = "clkin1";
+			clocks = <&clkc 15>, <&clkc 16>;
+			clock-names = "s_axi_aclk", "clkin1";
 		};
 
 		axi_hdmi_core: axi-hdmi-tx@70e00000 {

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9008-1.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9008-1.dts
@@ -94,6 +94,7 @@
 			reg = <0x83c10000 0x10000>;
 			#clock-cells = <0>;
 			clocks = <&clk0_ad9528 1>;
+			clock-names = "clkin1";
 			clock-output-names = "axi_rx_clkgen";
 		};
 

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9008-1.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9008-1.dts
@@ -93,8 +93,8 @@
 			compatible = "adi,axi-clkgen-2.00.a";
 			reg = <0x83c10000 0x10000>;
 			#clock-cells = <0>;
-			clocks = <&clk0_ad9528 1>;
-			clock-names = "clkin1";
+			clocks = <&zynqmp_clk 71>, <&clk0_ad9528 1>;
+			clock-names = "s_axi_aclk", "clkin1";
 			clock-output-names = "axi_rx_clkgen";
 		};
 

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9008-2.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9008-2.dts
@@ -149,6 +149,7 @@
 			reg = <0x83c00000 0x10000>;
 			#clock-cells = <0>;
 			clocks = <&clk0_ad9528 1>;
+			clock-names = "clkin1";
 			clock-output-names = "axi_tx_clkgen";
 		};
 
@@ -157,6 +158,7 @@
 			reg = <0x83c20000 0x10000>;
 			#clock-cells = <0>;
 			clocks = <&clk0_ad9528 1>;
+			clock-names = "clkin1";
 			clock-output-names = "axi_rx_os_clkgen";
 		};
 

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9008-2.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9008-2.dts
@@ -148,8 +148,8 @@
 			compatible = "adi,axi-clkgen-2.00.a";
 			reg = <0x83c00000 0x10000>;
 			#clock-cells = <0>;
-			clocks = <&clk0_ad9528 1>;
-			clock-names = "clkin1";
+			clocks = <&zynqmp_clk 71>, <&clk0_ad9528 1>;
+			clock-names = "s_axi_aclk", "clkin1";
 			clock-output-names = "axi_tx_clkgen";
 		};
 
@@ -157,8 +157,8 @@
 			compatible = "adi,axi-clkgen-2.00.a";
 			reg = <0x83c20000 0x10000>;
 			#clock-cells = <0>;
-			clocks = <&clk0_ad9528 1>;
-			clock-names = "clkin1";
+			clocks = <&zynqmp_clk 71>, <&clk0_ad9528 1>;
+			clock-names = "s_axi_aclk", "clkin1";
 			clock-output-names = "axi_rx_os_clkgen";
 		};
 

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9009.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9009.dts
@@ -214,6 +214,7 @@
 			reg = <0x83c00000 0x10000>;
 			#clock-cells = <0>;
 			clocks = <&clk0_ad9528 1>;
+			clock-names = "clkin1";
 			clock-output-names = "axi_tx_clkgen";
 		};
 
@@ -222,6 +223,7 @@
 			reg = <0x83c10000 0x10000>;
 			#clock-cells = <0>;
 			clocks = <&clk0_ad9528 1>;
+			clock-names = "clkin1";
 			clock-output-names = "axi_rx_clkgen";
 		};
 
@@ -230,6 +232,7 @@
 			reg = <0x83c20000 0x10000>;
 			#clock-cells = <0>;
 			clocks = <&clk0_ad9528 1>;
+			clock-names = "clkin1";
 			clock-output-names = "axi_rx_os_clkgen";
 		};
 

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9009.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9009.dts
@@ -213,8 +213,8 @@
 			compatible = "adi,axi-clkgen-2.00.a";
 			reg = <0x83c00000 0x10000>;
 			#clock-cells = <0>;
-			clocks = <&clk0_ad9528 1>;
-			clock-names = "clkin1";
+			clocks = <&zynqmp_clk 71>, <&clk0_ad9528 1>;
+			clock-names = "s_axi_aclk", "clkin1";
 			clock-output-names = "axi_tx_clkgen";
 		};
 
@@ -222,8 +222,8 @@
 			compatible = "adi,axi-clkgen-2.00.a";
 			reg = <0x83c10000 0x10000>;
 			#clock-cells = <0>;
-			clocks = <&clk0_ad9528 1>;
-			clock-names = "clkin1";
+			clocks = <&zynqmp_clk 71>, <&clk0_ad9528 1>;
+			clock-names = "s_axi_aclk", "clkin1";
 			clock-output-names = "axi_rx_clkgen";
 		};
 
@@ -231,8 +231,8 @@
 			compatible = "adi,axi-clkgen-2.00.a";
 			reg = <0x83c20000 0x10000>;
 			#clock-cells = <0>;
-			clocks = <&clk0_ad9528 1>;
-			clock-names = "clkin1";
+			clocks = <&zynqmp_clk 71>, <&clk0_ad9528 1>;
+			clock-names = "s_axi_aclk", "clkin1";
 			clock-output-names = "axi_rx_os_clkgen";
 		};
 

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9371.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9371.dts
@@ -195,6 +195,7 @@
 			reg = <0x83c00000 0x10000>;
 			#clock-cells = <0>;
 			clocks = <&clk0_ad9528 1>;
+			clock-names = "clkin1";
 			clock-output-names = "axi_tx_clkgen";
 		};
 
@@ -203,6 +204,7 @@
 			reg = <0x83c10000 0x10000>;
 			#clock-cells = <0>;
 			clocks = <&clk0_ad9528 1>;
+			clock-names = "clkin1";
 			clock-output-names = "axi_rx_clkgen";
 		};
 
@@ -211,6 +213,7 @@
 			reg = <0x83c20000 0x10000>;
 			#clock-cells = <0>;
 			clocks = <&clk0_ad9528 1>;
+			clock-names = "clkin1";
 			clock-output-names = "axi_rx_os_clkgen";
 		};
 

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9371.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9371.dts
@@ -194,8 +194,8 @@
 			compatible = "adi,axi-clkgen-2.00.a";
 			reg = <0x83c00000 0x10000>;
 			#clock-cells = <0>;
-			clocks = <&clk0_ad9528 1>;
-			clock-names = "clkin1";
+			clocks = <&zynqmp_clk 71>, <&clk0_ad9528 1>;
+			clock-names = "s_axi_aclk", "clkin1";
 			clock-output-names = "axi_tx_clkgen";
 		};
 
@@ -203,8 +203,8 @@
 			compatible = "adi,axi-clkgen-2.00.a";
 			reg = <0x83c10000 0x10000>;
 			#clock-cells = <0>;
-			clocks = <&clk0_ad9528 1>;
-			clock-names = "clkin1";
+			clocks = <&zynqmp_clk 71>, <&clk0_ad9528 1>;
+			clock-names = "s_axi_aclk", "clkin1";
 			clock-output-names = "axi_rx_clkgen";
 		};
 
@@ -212,8 +212,8 @@
 			compatible = "adi,axi-clkgen-2.00.a";
 			reg = <0x83c20000 0x10000>;
 			#clock-cells = <0>;
-			clocks = <&clk0_ad9528 1>;
-			clock-names = "clkin1";
+			clocks = <&zynqmp_clk 71>, <&clk0_ad9528 1>;
+			clock-names = "s_axi_aclk", "clkin1";
 			clock-output-names = "axi_rx_os_clkgen";
 		};
 

--- a/arch/microblaze/boot/dts/kcu105_adrv9371x.dts
+++ b/arch/microblaze/boot/dts/kcu105_adrv9371x.dts
@@ -112,6 +112,7 @@
 		reg = <0x43c10000 0x10000>;
 		#clock-cells = <0>;
 		clocks = <&clk0_ad9528 1>;
+		clock-names = "clkin1";
 		clock-output-names = "axi_rx_clkgen";
 	};
 	axi_rx_os_clkgen: axi-clkgen@43c20000  {
@@ -119,6 +120,7 @@
 		reg = <0x43c20000 0x10000>;
 		#clock-cells = <0>;
 		clocks = <&clk0_ad9528 1>;
+		clock-names = "clkin1";
 		clock-output-names = "axi_rx_os_clkgen";
 	};
 	axi_tx_clkgen: axi-clkgen@43c00000  {
@@ -126,6 +128,7 @@
 		reg = <0x43c00000 0x10000>;
 		#clock-cells = <0>;
 		clocks = <&clk0_ad9528 1>;
+		clock-names = "clkin1";
 		clock-output-names = "axi_tx_clkgen";
 	};
 	axi_ad9371_adxcvr_rx: axi-adxcvr-rx@44a60000 {

--- a/arch/microblaze/boot/dts/kcu105_adrv9371x.dts
+++ b/arch/microblaze/boot/dts/kcu105_adrv9371x.dts
@@ -111,24 +111,24 @@
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x43c10000 0x10000>;
 		#clock-cells = <0>;
-		clocks = <&clk0_ad9528 1>;
-		clock-names = "clkin1";
+		clocks = <&clk_bus_0>, <&clk0_ad9528 1>;
+		clock-names = "s_axi_aclk", "clkin1";
 		clock-output-names = "axi_rx_clkgen";
 	};
 	axi_rx_os_clkgen: axi-clkgen@43c20000  {
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x43c20000 0x10000>;
 		#clock-cells = <0>;
-		clocks = <&clk0_ad9528 1>;
-		clock-names = "clkin1";
+		clocks = <&clk_bus_0>, <&clk0_ad9528 1>;
+		clock-names = "s_axi_aclk", "clkin1";
 		clock-output-names = "axi_rx_os_clkgen";
 	};
 	axi_tx_clkgen: axi-clkgen@43c00000  {
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x43c00000 0x10000>;
 		#clock-cells = <0>;
-		clocks = <&clk0_ad9528 1>;
-		clock-names = "clkin1";
+		clocks = <&clk_bus_0>, <&clk0_ad9528 1>;
+		clock-names = "s_axi_aclk", "clkin1";
 		clock-output-names = "axi_tx_clkgen";
 	};
 	axi_ad9371_adxcvr_rx: axi-adxcvr-rx@44a60000 {

--- a/drivers/clk/clk-axi-clkgen.c
+++ b/drivers/clk/clk-axi-clkgen.c
@@ -55,6 +55,7 @@ struct axi_clkgen {
 	struct clk_hw clk_hw;
 	unsigned int pcore_version;
 	struct clk *parent_clocks[2];
+	struct clk *axi_clk;
 };
 
 static uint32_t axi_clkgen_lookup_filter(unsigned int m)
@@ -574,6 +575,16 @@ static int axi_clkgen_probe(struct platform_device *pdev)
 	if (IS_ERR(axi_clkgen->base))
 		return PTR_ERR(axi_clkgen->base);
 
+	axi_clkgen->axi_clk = devm_clk_get(&pdev->dev, "s_axi_aclk");
+	if (IS_ERR(axi_clkgen->axi_clk)) {
+		dev_err(&pdev->dev, "failed to get s_axi_aclk\n");
+		return PTR_ERR(axi_clkgen->axi_clk);
+	}
+
+	ret = clk_prepare_enable(axi_clkgen->axi_clk);
+	if (ret)
+		return ret;
+
 	axi_clkgen_read(axi_clkgen, ADI_AXI_REG_VERSION,
 			&axi_clkgen->pcore_version);
 
@@ -585,8 +596,10 @@ static int axi_clkgen_probe(struct platform_device *pdev)
 		axi_clkgen->parent_clocks[i] = devm_clk_get(&pdev->dev, clkin_name);
 		if (PTR_ERR(axi_clkgen->parent_clocks[i]) == -ENOENT)
 			continue;
-		if (IS_ERR(axi_clkgen->parent_clocks[i]))
-			return PTR_ERR(axi_clkgen->parent_clocks[i]);
+		if (IS_ERR(axi_clkgen->parent_clocks[i])) {
+			ret = PTR_ERR(axi_clkgen->parent_clocks[i]);
+			goto err_disable_axi_clk;
+		}
 
 		parent_names[i] = __clk_get_name(axi_clkgen->parent_clocks[i]);
 		init.num_parents++;
@@ -594,7 +607,8 @@ static int axi_clkgen_probe(struct platform_device *pdev)
 
 	if (init.num_parents < 1) {
 		dev_err(&pdev->dev, "Missing input clock, see 'clkin1' and 'clkin2'\n");
-		return -EINVAL;
+		ret = -EINVAL;
+		goto err_disable_axi_clk;
 	}
 
 	for (i = 0; i < init.num_parents; i++) {
@@ -602,7 +616,7 @@ static int axi_clkgen_probe(struct platform_device *pdev)
 		if (ret) {
 			while (--i >= 0)
 				clk_disable_unprepare(axi_clkgen->parent_clocks[i]);
-			return ret;
+			goto err_disable_axi_clk;
 		}
 	}
 
@@ -631,6 +645,9 @@ err_disable_parent_clocks:
 	for (i = 0; i < init.num_parents; i++)
 		clk_disable_unprepare(axi_clkgen->parent_clocks[i]);
 
+err_disable_axi_clk:
+	clk_disable_unprepare(axi_clkgen->axi_clk);
+
 	return ret;
 }
 
@@ -643,6 +660,8 @@ static int axi_clkgen_remove(struct platform_device *pdev)
 
 	for (i = 0; i < ARRAY_SIZE(axi_clkgen->parent_clocks); i++)
 		clk_disable_unprepare(axi_clkgen->parent_clocks[i]);
+
+	clk_disable_unprepare(axi_clkgen->axi_clk);
 
 	return 0;
 }

--- a/drivers/clk/clk-axi-clkgen.c
+++ b/drivers/clk/clk-axi-clkgen.c
@@ -8,6 +8,7 @@
  *
  */
 
+#include <linux/clk.h>
 #include <linux/platform_device.h>
 #include <linux/clk-provider.h>
 #include <linux/fpga/adi-axi-common.h>
@@ -53,6 +54,7 @@ struct axi_clkgen {
 	void __iomem *base;
 	struct clk_hw clk_hw;
 	unsigned int pcore_version;
+	struct clk *parent_clocks[2];
 };
 
 static uint32_t axi_clkgen_lookup_filter(unsigned int m)
@@ -549,6 +551,7 @@ static int axi_clkgen_probe(struct platform_device *pdev)
 	const struct of_device_id *id;
 	struct axi_clkgen *axi_clkgen;
 	struct clk_init_data init;
+	char clkin_name[7];
 	const char *parent_names[2];
 	const char *clk_name;
 	struct resource *mem;
@@ -577,14 +580,30 @@ static int axi_clkgen_probe(struct platform_device *pdev)
 	if (ADI_AXI_PCORE_VER_MAJOR(axi_clkgen->pcore_version) > 0x04)
 		axi_clkgen_setup_ranges(axi_clkgen);
 
-	init.num_parents = of_clk_get_parent_count(pdev->dev.of_node);
-	if (init.num_parents < 1 || init.num_parents > 2)
+	for (i = 0, init.num_parents = 0; i < ARRAY_SIZE(axi_clkgen->parent_clocks); i++) {
+		sprintf(clkin_name, "clkin%d", i + 1);
+		axi_clkgen->parent_clocks[i] = devm_clk_get(&pdev->dev, clkin_name);
+		if (PTR_ERR(axi_clkgen->parent_clocks[i]) == -ENOENT)
+			continue;
+		if (IS_ERR(axi_clkgen->parent_clocks[i]))
+			return PTR_ERR(axi_clkgen->parent_clocks[i]);
+
+		parent_names[i] = __clk_get_name(axi_clkgen->parent_clocks[i]);
+		init.num_parents++;
+	}
+
+	if (init.num_parents < 1) {
+		dev_err(&pdev->dev, "Missing input clock, see 'clkin1' and 'clkin2'\n");
 		return -EINVAL;
+	}
 
 	for (i = 0; i < init.num_parents; i++) {
-		parent_names[i] = of_clk_get_parent_name(pdev->dev.of_node, i);
-		if (!parent_names[i])
-			return -EINVAL;
+		ret = clk_prepare_enable(axi_clkgen->parent_clocks[i]);
+		if (ret) {
+			while (--i >= 0)
+				clk_disable_unprepare(axi_clkgen->parent_clocks[i]);
+			return ret;
+		}
 	}
 
 	clk_name = pdev->dev.of_node->name;
@@ -601,15 +620,29 @@ static int axi_clkgen_probe(struct platform_device *pdev)
 	axi_clkgen->clk_hw.init = &init;
 	ret = devm_clk_hw_register(&pdev->dev, &axi_clkgen->clk_hw);
 	if (ret)
-		return ret;
+		goto err_disable_parent_clocks;
+
+	platform_set_drvdata(pdev, axi_clkgen);
 
 	return of_clk_add_hw_provider(pdev->dev.of_node, of_clk_hw_simple_get,
 				      &axi_clkgen->clk_hw);
+
+err_disable_parent_clocks:
+	for (i = 0; i < init.num_parents; i++)
+		clk_disable_unprepare(axi_clkgen->parent_clocks[i]);
+
+	return ret;
 }
 
 static int axi_clkgen_remove(struct platform_device *pdev)
 {
+	struct axi_clkgen *axi_clkgen = platform_get_drvdata(pdev);
+	int i;
+
 	of_clk_del_provider(pdev->dev.of_node);
+
+	for (i = 0; i < ARRAY_SIZE(axi_clkgen->parent_clocks); i++)
+		clk_disable_unprepare(axi_clkgen->parent_clocks[i]);
 
 	return 0;
 }


### PR DESCRIPTION
If an axi read (or write) is performed before the clock is configured,
the driver hangs indefinitely. Make sure the axi clock is ready before
trying to access the bus.

This change forces the s_axi_aclk to be the first clock defined in the
devicetree.

Signed-off-by: Liam Beguin <lvb@xiphos.com>