### PR TITLE
iio: adc: ad9467: convert to full dt probe support 

### DIFF
--- a/drivers/iio/adc/cf_axi_adc.h
+++ b/drivers/iio/adc/cf_axi_adc.h
@@ -192,6 +192,7 @@ enum adc_data_sel {
 struct axiadc_state;
 
 struct axiadc_chip_info {
+	unsigned int			id;
 	char				*name;
 	unsigned			num_channels;
 	unsigned 		num_shadow_slave_channels;


### PR DESCRIPTION
This removes the SPI device ID table. Upstream this isn't present.
And re-uses the current chip_info to be matched via OF.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>