### PR TITLE
jesd204: fsm: cleanup/improve error handling in the state-machine

### DIFF
--- a/drivers/jesd204/jesd204-fsm.c
+++ b/drivers/jesd204/jesd204-fsm.c
@@ -304,17 +304,19 @@ static int __jesd204_link_fsm_update_state(struct jesd204_dev *jdev,
 					   struct jesd204_link_opaque *ol,
 					   struct jesd204_fsm_data *fsm_data)
 {
+	bool exit_on_error = true;
+
 	ol->fsm_data = NULL;
 
 	/* clear error if current state is DONT_CARE */
 	if (fsm_data->cur_state == JESD204_STATE_DONT_CARE)
-		ol->error = 0;
+		exit_on_error = false;
 
 	/* clear error if rolling back */
 	if (fsm_data->rollback)
-		ol->error = 0;
+		exit_on_error = false;
 
-	if (ol->error) {
+	if (exit_on_error && ol->error) {
 		jesd204_err(jdev, "jesd got error from topology %d\n", ol->error);
 		return ol->error;
 	}

--- a/drivers/jesd204/jesd204-fsm.c
+++ b/drivers/jesd204/jesd204-fsm.c
@@ -108,6 +108,10 @@ static int jesd204_fsm_table(struct jesd204_dev *jdev,
 static int jesd204_fsm_init_link(struct jesd204_dev *jdev,
 				 struct jesd204_fsm_data *fsm_data);
 
+static void __jesd204_fsm_clear_errors(struct jesd204_dev *jdev,
+				       unsigned int link_idx,
+				       bool handle_busy_flags);
+
 /* States to transition to start a JESD204 link */
 static const struct jesd204_fsm_table_entry jesd204_start_links_states[] = {
 	JESD204_STATE_NOP(IDLE),
@@ -1091,10 +1095,13 @@ static int jesd204_fsm_table(struct jesd204_dev *jdev,
 					       handle_busy_flags);
 		/**
 		 * If we got an error, we rolled-back, we should be in IDLE
-		 * for the next retry
+		 * for the next retry, and clear errors on JESD204 link objects
 		 */
-		if (ret)
+		if (ret && num_retries) {
 			init_state = JESD204_STATE_IDLE;
+			__jesd204_fsm_clear_errors(jdev, link_idx,
+						   handle_busy_flags);
+		}
 	} while (ret && num_retries--);
 
 	kfree(it.per_device_ran);
@@ -1133,7 +1140,9 @@ static int jesd204_fsm_clr_errors_cb(struct jesd204_dev *jdev,
 	return JESD204_STATE_CHANGE_DONE;
 }
 
-void jesd204_fsm_clear_errors(struct jesd204_dev *jdev, unsigned int link_idx)
+static void __jesd204_fsm_clear_errors(struct jesd204_dev *jdev,
+				       unsigned int link_idx,
+				       bool handle_busy_flags)
 {
 	struct jesd204_fsm_data data;
 
@@ -1143,6 +1152,11 @@ void jesd204_fsm_clear_errors(struct jesd204_dev *jdev, unsigned int link_idx)
 	data.nxt_state = JESD204_STATE_DONT_CARE;
 	data.link_idx = link_idx;
 
-	jesd204_fsm(jdev, &data, true);
+	jesd204_fsm(jdev, &data, handle_busy_flags);
+}
+
+void jesd204_fsm_clear_errors(struct jesd204_dev *jdev, unsigned int link_idx)
+{
+	__jesd204_fsm_clear_errors(jdev, link_idx, true);
 }
 EXPORT_SYMBOL_GPL(jesd204_fsm_clear_errors);


### PR DESCRIPTION
When running during these cases, we should not clear the errors. There's
now an API call that does that (i.e. jesd204_fsm_clear_errors()).

These cases were added, when this API call did not exist.
Drivers that want to retry, usually call this function.

Also, if we won't clear error: rollback will work fine, but now the JESD204 link objects contain errors,
so they need to be explicitly cleared before retrying.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>