### PR TITLE
jesd204: core: tweaks/cleanups; move error field on the public jesd204_link type

### DIFF
--- a/drivers/jesd204/jesd204-core.c
+++ b/drivers/jesd204/jesd204-core.c
@@ -258,6 +258,7 @@ struct jesd204_dev_top *jesd204_dev_get_topology_top_dev(struct jesd204_dev *jde
 int jesd204_sysref_async(struct jesd204_dev *jdev)
 {
 	struct jesd204_dev_top *jdev_top = jesd204_dev_get_topology_top_dev(jdev);
+	const struct jesd204_dev_data *dev_data;
 
 	if (!jdev_top)
 		return -EFAULT;
@@ -266,8 +267,13 @@ int jesd204_sysref_async(struct jesd204_dev *jdev)
 	if (!jdev_top->jdev_sysref)
 		return 0;
 
+	if (!jdev_top->jdev_sysref->dev_data)
+		return -EFAULT;
+
+	dev_data = jdev_top->jdev_sysref->dev_data;
+
 	/* By now, this should have been validated to have sysref_cb() */
-	return jdev_top->jdev_sysref->sysref_cb(jdev_top->jdev_sysref);
+	return dev_data->sysref_cb(jdev_top->jdev_sysref);
 }
 EXPORT_SYMBOL(jesd204_sysref_async);
 
@@ -784,8 +790,7 @@ static struct jesd204_dev *jesd204_dev_register(struct device *dev,
 	jesd204_dev_init_top_data(jdev, init);
 
 	jdev->dev.parent = dev;
-	jdev->sysref_cb = init->sysref_cb;
-	jdev->state_ops = init->state_ops;
+	jdev->dev_data = init;
 	jdev->dev.bus = &jesd204_bus_type;
 	device_initialize(&jdev->dev);
 	dev_set_name(&jdev->dev, "jesd204:%d", jdev->id);

--- a/drivers/jesd204/jesd204-fsm.c
+++ b/drivers/jesd204/jesd204-fsm.c
@@ -213,8 +213,6 @@ static int jesd204_dev_set_error(struct jesd204_dev *jdev,
 	if (err == 0)
 		return 0;
 
-	jdev->error = err;
-
 	if (con)
 		con->error = err;
 

--- a/drivers/jesd204/jesd204-fsm.c
+++ b/drivers/jesd204/jesd204-fsm.c
@@ -217,7 +217,7 @@ static int jesd204_dev_set_error(struct jesd204_dev *jdev,
 		con->error = err;
 
 	if (ol)
-		ol->error = err;
+		ol->link.error = err;
 
 	return err;
 }
@@ -330,9 +330,10 @@ static int __jesd204_link_fsm_update_state(struct jesd204_dev *jdev,
 	if (fsm_data->rollback)
 		exit_on_error = false;
 
-	if (exit_on_error && ol->error) {
-		jesd204_err(jdev, "jesd got error from topology %d\n", ol->error);
-		return ol->error;
+	if (exit_on_error && ol->link.error) {
+		jesd204_err(jdev, "jesd got error from topology %d\n",
+			    ol->link.error);
+		return ol->link.error;
 	}
 
 	jesd204_info(jdev, "JESD204 link[%u] transition %s -> %s\n",
@@ -1110,7 +1111,7 @@ static int jesd204_fsm_clr_errors_cb(struct jesd204_dev *jdev,
 	}
 
 	ol = &fsm_data->jdev_top->active_links[link_idx];
-	ol->error = 0;
+	ol->link.error = 0;
 
 	return JESD204_STATE_CHANGE_DONE;
 }

--- a/drivers/jesd204/jesd204-fsm.c
+++ b/drivers/jesd204/jesd204-fsm.c
@@ -830,7 +830,7 @@ static int jesd204_init_sysref_cb(struct jesd204_dev *jdev,
 	if (!jdev->is_sysref_provider)
 		return 0;
 
-	if (!jdev->sysref_cb) {
+	if (!jdev->dev_data->sysref_cb) {
 		jesd204_err(jdev, "Configured as SYSREF, but no SYSREF cb\n");
 		return -EINVAL;
 	}
@@ -928,10 +928,10 @@ static int jesd204_fsm_table_entry_cb(struct jesd204_dev *jdev,
 	enum jesd204_state_op_reason reason;
 	struct jesd204_link_opaque *ol;
 
-	if (!jdev->state_ops)
+	if (!jdev->dev_data->state_ops)
 		return JESD204_STATE_CHANGE_DONE;
 
-	state_op = &jdev->state_ops[it->table[0].op];
+	state_op = &jdev->dev_data->state_ops[it->table[0].op];
 
 	if (fsm_data->rollback)
 		reason = JESD204_STATE_OP_REASON_UNINIT;
@@ -969,7 +969,7 @@ static int jesd204_fsm_table_entry_done(struct jesd204_dev *jdev,
 	}
 
 	if (!fsm_data->rollback) {
-		state_op = &jdev->state_ops[it->table[0].op];
+		state_op = &jdev->dev_data->state_ops[it->table[0].op];
 		if (state_op->post_state_sysref && jesd204_dev_is_top(jdev))
 			jesd204_sysref_async(jdev);
 	}
@@ -1010,7 +1010,7 @@ static int jesd204_fsm_table_single(struct jesd204_dev *jdev,
 	while (!jesd204_fsm_table_end(&it->table[0], rollback)) {
 		it->table = table;
 
-		state_op = &jdev->state_ops[table[0].op];
+		state_op = &jdev->dev_data->state_ops[table[0].op];
 
 		data->completed = false;
 		data->cur_state = init_state;

--- a/drivers/jesd204/jesd204-priv.h
+++ b/drivers/jesd204/jesd204-priv.h
@@ -101,7 +101,6 @@ struct jesd204_dev_con_out {
  *			devices that make up a JESD204 link (typically the
  *			device that is the ADC, DAC, or transceiver)
  * @is_sysref_provider	true if this device wants to be a SYSREF provider
- * @error		error code for this device if something happened
  * @sysfs_attr_group	attribute group for the sysfs files of this JESD204 device
  * @np			reference in the device-tree for this JESD204 device
  * @ref			ref count for this JESD204 device
@@ -124,7 +123,6 @@ struct jesd204_dev {
 
 	bool				is_sysref_provider;
 
-	int				error;
 	struct device_node		*np;
 
 	struct attribute_group		sysfs_attr_group;

--- a/drivers/jesd204/jesd204-priv.h
+++ b/drivers/jesd204/jesd204-priv.h
@@ -92,6 +92,7 @@ struct jesd204_dev_con_out {
 /**
  * struct jesd204_dev - JESD204 device
  * @dev			underlying device object
+ * @dev_data		ref to data provided by the driver registering with the framework
  * @id			unique device id
  * @entry		list entry for the framework to keep a list of devices
  * @priv		private data to be returned to the driver
@@ -99,10 +100,8 @@ struct jesd204_dev_con_out {
  * @is_top		true if this device is a top device in a topology of
  *			devices that make up a JESD204 link (typically the
  *			device that is the ADC, DAC, or transceiver)
- * @sysref_cb		callback to the SYSREF logic provided by this device
  * @is_sysref_provider	true if this device wants to be a SYSREF provider
  * @error		error code for this device if something happened
- * @state_ops		ops for each state transition of type @struct jesd204_state_ops
  * @sysfs_attr_group	attribute group for the sysfs files of this JESD204 device
  * @np			reference in the device-tree for this JESD204 device
  * @ref			ref count for this JESD204 device
@@ -115,6 +114,7 @@ struct jesd204_dev_con_out {
  */
 struct jesd204_dev {
 	struct device			dev;
+	const struct jesd204_dev_data	*dev_data;
 	int				id;
 	struct list_head		entry;
 	void				*priv;
@@ -122,11 +122,9 @@ struct jesd204_dev {
 	bool				fsm_inited;
 	bool				is_top;
 
-	jesd204_sysref_cb		sysref_cb;
 	bool				is_sysref_provider;
 
 	int				error;
-	const struct jesd204_state_op	*state_ops;
 	struct device_node		*np;
 
 	struct attribute_group		sysfs_attr_group;

--- a/drivers/jesd204/jesd204-priv.h
+++ b/drivers/jesd204/jesd204-priv.h
@@ -149,7 +149,6 @@ struct jesd204_dev {
  * @cur_state		current state of the JESD204 link
  * @fsm_data		reference to state-transition information
  * @flags		internal flags set by the framework
- * @error		error codes for the JESD204 link
  */
 struct jesd204_link_opaque {
 	struct jesd204_link		link;
@@ -160,7 +159,6 @@ struct jesd204_link_opaque {
 	enum jesd204_dev_state		state;
 	struct jesd204_fsm_data		*fsm_data;
 	unsigned long			flags;
-	int				error;
 };
 
 /**

--- a/include/linux/jesd204/jesd204.h
+++ b/include/linux/jesd204/jesd204.h
@@ -65,6 +65,7 @@ struct jesd204_sysref {
 /**
  * struct jesd204_link - JESD204 link configuration settings
  * @link_id			JESD204 link ID provided via DT configuration
+ * @error			error code for this JESD204 link
  * @is_transmit			true if this link is transmit (digital to analog)
  * @sample_rate			sample rate for the link
  * @num_lanes			number of JESD204 lanes (L)
@@ -98,6 +99,7 @@ struct jesd204_sysref {
  */
 struct jesd204_link {
 	u32 link_id;
+	int error;
 
 	u64 sample_rate;
 


### PR DESCRIPTION
Some bits of cleanups done while adding more stuff to the framework.
The more important one [here] is the move error field on the public jesd204_link type; with this we can pass the error information to the state callbacks/ops and to the completion callback.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>