### PR TITLE
jesd204: fsm: implement fsm completion/finished callback

### DIFF
--- a/drivers/jesd204/jesd204-fsm.c
+++ b/drivers/jesd204/jesd204-fsm.c
@@ -216,8 +216,7 @@ static int jesd204_dev_set_error(struct jesd204_dev *jdev,
 	if (con)
 		con->error = err;
 
-	if (ol)
-		ol->link.error = err;
+	ol->link.error = err;
 
 	return err;
 }
@@ -495,6 +494,7 @@ static int jesd204_fsm_handle_con_cb(struct jesd204_dev *jdev_it,
 				     struct jesd204_fsm_data *fsm_data)
 {
 	struct jesd204_dev_top *jdev_top = fsm_data->jdev_top;
+	struct jesd204_link_opaque *ol;
 	int ret;
 
 	jesd204_fsm_kref_link_get(jdev_top, fsm_data->link_idx);
@@ -515,11 +515,11 @@ static int jesd204_fsm_handle_con_cb(struct jesd204_dev *jdev_it,
 		goto out;
 
 	if (ret < 0) {
+		ol = &jdev_top->active_links[link_idx];
 		jesd204_err(jdev_it,
 			    "JESD204 link[%u] got error from cb: %d\n",
-			    jdev_top->active_links[link_idx].link.link_id,
-			    ret);
-		return jesd204_dev_set_error(jdev_it, NULL, con, ret);
+			    ol->link.link_id, ret);
+		return jesd204_dev_set_error(jdev_it, ol, con, ret);
 	}
 
 	if (ret != JESD204_STATE_CHANGE_DONE)

--- a/drivers/jesd204/jesd204-fsm.c
+++ b/drivers/jesd204/jesd204-fsm.c
@@ -335,12 +335,16 @@ static int __jesd204_link_fsm_update_state(struct jesd204_dev *jdev,
 		return ol->link.error;
 	}
 
-	jesd204_info(jdev, "JESD204 link[%u] transition %s -> %s\n",
-		 ol->link.link_id,
-		 jesd204_state_str(fsm_data->cur_state),
-		 jesd204_state_str(fsm_data->nxt_state));
+	if (fsm_data->cur_state != JESD204_STATE_DONT_CARE &&
+	    fsm_data->nxt_state != JESD204_STATE_DONT_CARE)
+		jesd204_info(jdev, "JESD204 link[%u] transition %s -> %s\n",
+			     ol->link.link_id,
+			     jesd204_state_str(fsm_data->cur_state),
+			     jesd204_state_str(fsm_data->nxt_state));
+
 	if (fsm_data->nxt_state != JESD204_STATE_DONT_CARE)
 		ol->state = fsm_data->nxt_state;
+
 	fsm_data->completed = true;
 
 	return 0;
@@ -364,11 +368,6 @@ static void __jesd204_link_fsm_done_cb(struct kref *ref)
 	ret = fsm_data->fsm_complete_cb(jdev, fsm_data);
 	if (ret == 0)
 		goto out;
-
-	jesd204_err(jdev,
-		    "error from completion cb %d, state %s\n",
-		    ret,
-		    jesd204_state_str(ol->state));
 
 	if (fsm_data->rollback)
 		goto out;
@@ -405,9 +404,6 @@ static void __jesd204_all_links_fsm_done_cb(struct kref *ref)
 
 	if (fsm_data->rollback)
 		goto out;
-
-	jesd204_err(jdev, "error from completion cb %d, state %s\n",
-		    ret, jesd204_state_str(fsm_data->cur_state));
 
 	for (link_idx = 0; link_idx < jdev_top->num_links; link_idx++) {
 		ol = &jdev_top->active_links[link_idx];
@@ -1126,6 +1122,9 @@ static int jesd204_fsm_table(struct jesd204_dev *jdev,
 						   handle_busy_flags);
 		}
 	} while (ret && num_retries--);
+
+	if (ret)
+		jesd204_err(jdev, "FSM completed with error %d\n", ret);
 
 	jesd204_fsm_run_finished_cb(jdev, jdev_top, link_idx, handle_busy_flags);
 

--- a/drivers/jesd204/jesd204-fsm.c
+++ b/drivers/jesd204/jesd204-fsm.c
@@ -1043,6 +1043,51 @@ static int jesd204_fsm_table_single(struct jesd204_dev *jdev,
 	return ret1;
 }
 
+static int jesd204_fsm_run_finished_cb_cb(struct jesd204_dev *jdev,
+					  struct jesd204_dev_con_out *con,
+					  unsigned int link_idx,
+					  struct jesd204_fsm_data *fsm_data)
+{
+	const struct jesd204_link * const *links = fsm_data->cb_data;
+
+	if (!jdev->dev_data->fsm_finished_cb)
+		return JESD204_STATE_CHANGE_DONE;
+
+	jdev->dev_data->fsm_finished_cb(jdev, links,
+					fsm_data->jdev_top->num_links);
+
+	return JESD204_STATE_CHANGE_DONE;
+}
+
+static void jesd204_fsm_run_finished_cb(struct jesd204_dev *jdev,
+					struct jesd204_dev_top *jdev_top,
+					unsigned int link_idx,
+					bool handle_busy_flags)
+{
+	struct jesd204_fsm_data data;
+	struct jesd204_link **links;
+	unsigned int i;
+
+	links = kcalloc(jdev_top->num_links, sizeof(*links), GFP_KERNEL);
+	if (!links)
+		return;
+
+	for (i = 0; i < jdev_top->num_links; i++)
+		links[i] = &jdev_top->active_links[i].link;
+
+	memset(&data, 0, sizeof(data));
+	data.fsm_change_cb = jesd204_fsm_run_finished_cb_cb;
+	data.cur_state = JESD204_STATE_DONT_CARE;
+	data.nxt_state = JESD204_STATE_DONT_CARE;
+	data.link_idx = link_idx;
+	data.mode = JESD204_STATE_OP_MODE_PER_DEVICE;
+	data.cb_data = links;
+
+	jesd204_fsm(jdev, &data, handle_busy_flags);
+
+	kfree(links);
+}
+
 static int jesd204_fsm_table(struct jesd204_dev *jdev,
 			     unsigned int link_idx,
 			     enum jesd204_dev_state init_state,
@@ -1081,6 +1126,8 @@ static int jesd204_fsm_table(struct jesd204_dev *jdev,
 						   handle_busy_flags);
 		}
 	} while (ret && num_retries--);
+
+	jesd204_fsm_run_finished_cb(jdev, jdev_top, link_idx, handle_busy_flags);
 
 	return ret;
 }

--- a/include/linux/jesd204/jesd204.h
+++ b/include/linux/jesd204/jesd204.h
@@ -178,6 +178,10 @@ typedef int (*jesd204_link_cb)(struct jesd204_dev *jdev,
 			       enum jesd204_state_op_reason,
 			       struct jesd204_link *lnk);
 
+typedef void (*jesd204_fsm_finished_cb)(struct jesd204_dev *jdev,
+					const struct jesd204_link * const *links,
+					unsigned int num_links);
+
 enum jesd204_state_op_mode {
 	JESD204_STATE_OP_MODE_PER_LINK,
 	JESD204_STATE_OP_MODE_PER_DEVICE,
@@ -224,6 +228,7 @@ enum jesd204_dev_op {
 /**
  * struct jesd204_dev_data - JESD204 device initialization data
  * @sysref_cb		SYSREF callback, if this device/driver supports it
+ * @fsm_finished_cb	callback for when the FSM finishes a series of transitions
  * @sizeof_priv		amount of data to allocate for private information
  * @links		JESD204 initial link configuration
  * @num_links		number of JESD204 links
@@ -232,6 +237,7 @@ enum jesd204_dev_op {
  */
 struct jesd204_dev_data {
 	jesd204_sysref_cb			sysref_cb;
+	jesd204_fsm_finished_cb			fsm_finished_cb;
 	size_t					sizeof_priv;
 	const struct jesd204_link		*links;
 	unsigned int				num_links;


### PR DESCRIPTION
When the FSM finishes transitioning [through all states], it can be useful
for some drivers to get a callback to get notified of this.
This is useful even when an error happened.
    
This change implements this callback, and provides the error callback. This
is called once per each device, regardless of the number of links it
initialized for.
   
Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>
