### PR TITLE
iio: adc: ad7124: Fix typo in device name

### DIFF
--- a/drivers/iio/adc/ad7124.c
+++ b/drivers/iio/adc/ad7124.c
@@ -180,12 +180,12 @@ static const struct iio_chan_spec ad7124_channel_template = {
 
 static struct ad7124_chip_info ad7124_chip_info_tbl[] = {
 	[ID_AD7124_4] = {
-		.name = "ad7127-4",
+		.name = "ad7124-4",
 		.chip_id = CHIPID_AD7124_4,
 		.num_inputs = 8,
 	},
 	[ID_AD7124_8] = {
-		.name = "ad7127-8",
+		.name = "ad7124-8",
 		.chip_id = CHIPID_AD7124_8,
 		.num_inputs = 16,
 	},


### PR DESCRIPTION
This patch fixes the device name typo.

Fixes: f0bcebbf50dd ("iio: adc: ad7124: move chip ID & name on the chip_info table")
Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>