### PR TITLE
arch: arm: dts: cn0540 devicetree updates and rename

### DIFF
--- a/arch/arm/boot/dts/zynq-coraz7s-ad7768-1ARDZ.dts
+++ b/arch/arm/boot/dts/zynq-coraz7s-ad7768-1ARDZ.dts
@@ -27,7 +27,7 @@
 		ad7768_1_mclk: clock@0 {
 			#clock-cells = <0>;
 			compatible = "fixed-clock";
-			clock-frequency = <100000000>;
+			clock-frequency = <16384000>;
 		};
 	};
 };

--- a/arch/arm/boot/dts/zynq-coraz7s-ad7768-1ARDZ.dts
+++ b/arch/arm/boot/dts/zynq-coraz7s-ad7768-1ARDZ.dts
@@ -30,6 +30,52 @@
 			clock-frequency = <16384000>;
 		};
 	};
+
+	one-bit-adc-dac@0 {
+		compatible = "one-bit-adc-dac";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		in-gpios =  <&gpio0 91 GPIO_ACTIVE_HIGH>;
+		out-gpios = <&gpio0 88 GPIO_ACTIVE_HIGH>,
+			    <&gpio0 89 GPIO_ACTIVE_HIGH>,
+			    <&gpio0 94 GPIO_ACTIVE_HIGH>,
+			    <&ad7768_1 0 GPIO_ACTIVE_HIGH>,
+			    <&ad7768_1 1 GPIO_ACTIVE_HIGH>,
+			    <&ad7768_1 2 GPIO_ACTIVE_HIGH>,
+			    <&ad7768_1 3 GPIO_ACTIVE_HIGH>;
+		channel@0 {
+			reg = <0>;
+			label = "cn0540_sw_ff_gpio";
+		};
+		channel@1 {
+			reg = <1>;
+			label = "cn0540_red_led";
+		};
+		channel@2 {
+			reg = <2>;
+			label = "cn0540_blue_led";
+		};
+		channel@3 {
+			reg = <3>;
+			label = "cn0540_shutdown_gpio";
+		};
+		channel@4 {
+			reg = <4>;
+			label = "cn0540_ad7768-1-gpio0";
+		};
+		channel@5 {
+			reg = <5>;
+			label = "cn0540_ad7768-1-gpio1";
+		};
+		channel@6 {
+			reg = <6>;
+			label = "cn0540_FDA_DIS";
+		};
+		channel@7 {
+			reg = <7>;
+			label = "cn0540_FDA_MODE";
+		};
+	};
 };
 
 &adc {

--- a/arch/arm/boot/dts/zynq-coraz7s-ad7768-1ARDZ.dts
+++ b/arch/arm/boot/dts/zynq-coraz7s-ad7768-1ARDZ.dts
@@ -32,6 +32,34 @@
 	};
 };
 
+&adc {
+	xlnx,channels {
+		#address-cells = <0x1>;
+		#size-cells = <0x0>;
+		channel@0 {
+			reg = <0>;
+		};
+		channel@2 {
+			reg = <2>;
+		};
+		channel@6 {
+			reg = <6>;
+		};
+		channel@7 {
+			reg = <7>;
+		};
+		channel@10 {
+			reg = <10>;
+		};
+		channel@14 {
+			reg = <14>;
+		};
+		channel@16 {
+			reg = <16>;
+		};
+	};
+};
+
 &fpga_axi {
 	rx_dma: rx-dmac@44a30000 {
 		compatible = "adi,axi-dmac-1.00.a";

--- a/arch/arm/boot/dts/zynq-coraz7s-ad7768-1ARDZ.dts
+++ b/arch/arm/boot/dts/zynq-coraz7s-ad7768-1ARDZ.dts
@@ -74,6 +74,8 @@
 			spi-cpol;
 			spi-cpha;
 			vref-supply = <&vref>;
+			#gpio-cells = <2>;
+			gpio-controller;
 			adi,sync-in-gpios = <&gpio0 87 GPIO_ACTIVE_LOW>;
 			reset-gpios = <&gpio0 93 GPIO_ACTIVE_LOW>;
 			clocks = <&ad7768_1_mclk>;

--- a/arch/arm/boot/dts/zynq-coraz7s-ad7768-1ARDZ.dts
+++ b/arch/arm/boot/dts/zynq-coraz7s-ad7768-1ARDZ.dts
@@ -85,4 +85,21 @@
 			#io-channel-cells = <1>;
 		};
 	};
+
+	axi_i2c_0:axi-iic@0x44a40000{
+		compatible = "xlnx,axi-iic-1.02.a", "xlnx,xps-iic-2.00.a";
+		reg = <0x44a40000 0x1000>;
+		interrupt-parent = <&intc>;
+		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&clkc 15>;
+
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		ltc2606: ltc2606@0x10 {
+			compatible = "adi,ltc2606";
+			reg = <0x10>;
+			vref-supply = <&vref>;
+		};
+	};
 };

--- a/arch/arm/boot/dts/zynq-coraz7s-ad7768-1ARDZ.dts
+++ b/arch/arm/boot/dts/zynq-coraz7s-ad7768-1ARDZ.dts
@@ -60,7 +60,7 @@
 		reg = <0x44a00000 0x1000>;
 		interrupt-parent = <&intc>;
 		interrupts = <0 55 IRQ_TYPE_LEVEL_HIGH>;
-		clocks = <&clkc 15 &clkc 15>;
+		clocks = <&clkc 15 &clkc 16>;
 		clock-names = "s_axi_aclk", "spi_clk";
 		num-cs = <1>;
 

--- a/arch/arm/boot/dts/zynq-coraz7s-ad7768-1ARDZ.dts
+++ b/arch/arm/boot/dts/zynq-coraz7s-ad7768-1ARDZ.dts
@@ -70,16 +70,17 @@
 		ad7768_1: adc@0 {
 			compatible = "adi,ad7768-1";
 			reg = <0>;
-			spi-max-frequency = <2000000>;
+			spi-max-frequency = <20000000>;
 			spi-cpol;
 			spi-cpha;
 			vref-supply = <&vref>;
-			interrupts = <91 IRQ_TYPE_EDGE_RISING>;
-			interrupt-parent = <&gpio0>;
 			adi,sync-in-gpios = <&gpio0 87 GPIO_ACTIVE_LOW>;
-			reset-gpios = <&gpio0 86 GPIO_ACTIVE_LOW>;
+			reset-gpios = <&gpio0 93 GPIO_ACTIVE_LOW>;
 			clocks = <&ad7768_1_mclk>;
 			clock-names = "mclk";
+			dmas = <&rx_dma 0>;
+			dma-names = "rx";
+			#io-channel-cells = <1>;
 		};
 	};
 };

--- a/arch/arm/boot/dts/zynq-coraz7s-cn0540.dts
+++ b/arch/arm/boot/dts/zynq-coraz7s-cn0540.dts
@@ -132,7 +132,7 @@
 
 	axi_spi_engine_0: axi-spi-engine@44a00000 {
 		compatible = "adi,axi-spi-engine-1.00.a";
-		reg = <0x44a00000 0x1000>;
+		reg = <0x44a00000 0x10000>;
 		interrupt-parent = <&intc>;
 		interrupts = <0 55 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 15 &clkc 16>;

--- a/arch/arm/boot/dts/zynq-coraz7s-cn0540.dts
+++ b/arch/arm/boot/dts/zynq-coraz7s-cn0540.dts
@@ -2,9 +2,10 @@
 /*
  * Analog Devices AD7768-1
  * https://www.analog.com/en/products/ad7768-1.html
- * https://wiki.analog.com/resources/tools-software/linux-drivers/platforms/zynq
+ * https://wiki.analog.com/resources/eval/user-guides/circuits-from-the-lab/cn0540
+ * https://wiki.analog.com/resources/eval/user-guides/cn0540
  *
- * hdl_project: <ad77681evb/coraz7s>
+ * hdl_project: <cn0540/coraz7s>
  * board_revision: <A>
  *
  * Copyright (C) 2020 Analog Devices Inc.


### PR DESCRIPTION
Changes:
-Fix ad7768-1's mclk frequency
-Update spi parameters to use the spi engine at max frequency
- Add ltc2606 and one-bit-adc-dac