### PR TITLE
iio: addac: one-bit-adc-dac: Set output to Low

### DIFF
--- a/drivers/iio/addac/one-bit-adc-dac.c
+++ b/drivers/iio/addac/one-bit-adc-dac.c
@@ -127,7 +127,7 @@ static int one_bit_adc_dac_parse_dt(struct iio_dev *indio_dev)
 	if (st->in_gpio_descs)
 		in_num_ch = st->in_gpio_descs->ndescs;
 
-	st->out_gpio_descs = devm_gpiod_get_array_optional(&st->pdev->dev, "out", GPIOD_OUT_HIGH);
+	st->out_gpio_descs = devm_gpiod_get_array_optional(&st->pdev->dev, "out", GPIOD_OUT_LOW);
 	if (IS_ERR(st->out_gpio_descs))
 		return PTR_ERR(st->out_gpio_descs);
 


### PR DESCRIPTION
There are cases where these GPIOs are used to enable some auxiliary things
and setting them to default HIGH would have unintended behavior triggered in
the hardware. This patch changes the default to LOW.

Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>

I am not saying this is the best fix to this problem, but i wanted to start a discussion around it. Maybe a device tree default state would be more appropriate and would cover the case of inverse logic for enables.