### PR TITLE
jesd204,adrv9009: add support for stop states and resuming from them 

### DIFF
--- a/drivers/jesd204/jesd204-priv.h
+++ b/drivers/jesd204/jesd204-priv.h
@@ -18,8 +18,10 @@ struct jesd204_link_opaque;
 struct jesd204_dev_con_out;
 struct jesd204_fsm_data;
 
+#define JESD204_STATE_FSM_OFFSET	100
+
 #define JESD204_STATE_ENUM(x)	\
-	JESD204_STATE_##x = (JESD204_FSM_STATE_##x + 100)
+	JESD204_STATE_##x = (JESD204_FSM_STATE_##x + JESD204_STATE_FSM_OFFSET)
 
 enum jesd204_dev_state {
 	JESD204_STATE_UNINIT = 0,
@@ -104,6 +106,7 @@ struct jesd204_dev_con_out {
  *			devices that make up a JESD204 link (typically the
  *			device that is the ADC, DAC, or transceiver)
  * @is_sysref_provider	true if this device wants to be a SYSREF provider
+ * @stop_states		array of states on which to stop, after finishing transition
  * @sysfs_attr_group	attribute group for the sysfs files of this JESD204 device
  * @np			reference in the device-tree for this JESD204 device
  * @ref			ref count for this JESD204 device
@@ -125,6 +128,7 @@ struct jesd204_dev {
 	bool				is_top;
 
 	bool				is_sysref_provider;
+	bool				stop_states[JESD204_FSM_STATES_NUM + 1];
 
 	struct device_node		*np;
 
@@ -149,7 +153,8 @@ struct jesd204_dev {
  *			notification must be called by the device to decrement
  *			this and finally call the @fsm_complete_cbs
  *			callback (if provided)
- * @cur_state		current state of the JESD204 link
+ * @state		current state of the JESD204 link
+ * @fsm_paused		true if the FSM has paused during a transition (set)
  * @fsm_data		reference to state-transition information
  * @flags		internal flags set by the framework
  */
@@ -160,6 +165,7 @@ struct jesd204_link_opaque {
 
 	struct kref			cb_ref;
 	enum jesd204_dev_state		state;
+	bool				fsm_paused;
 	struct jesd204_fsm_data		*fsm_data;
 	unsigned long			flags;
 };

--- a/drivers/jesd204/jesd204-sysfs.c
+++ b/drivers/jesd204/jesd204-sysfs.c
@@ -46,6 +46,9 @@
 #define JESD204_LNK_ATTR_BOOL(_name)	\
 	JESD204_LNK_ATTR_TYPE(_name, JESD204_ATTR_TYPE_BOOL)
 
+#define JESD204_LNK_ATTR_BOOL_PRIV(_name)	\
+	JESD204_LNK_ATTR_TYPE_PRIV(_name, JESD204_ATTR_TYPE_BOOL)
+
 #define JESD204_LNK_ATTR_STR_PRIV(_name)	\
 	JESD204_LNK_ATTR_TYPE_PRIV(_name, JESD204_ATTR_TYPE_STR)
 
@@ -86,6 +89,7 @@ enum {
 	JESD204_LNK_ATTR_link_id,
 	JESD204_LNK_ATTR_error,
 	JESD204_LNK_ATTR_state,
+	JESD204_LNK_ATTR_fsm_paused,
 	JESD204_LNK_ATTR_sample_rate,
 	JESD204_LNK_ATTR_is_transmit,
 	JESD204_LNK_ATTR_num_lanes,
@@ -114,6 +118,7 @@ static const struct jesd204_attr jesd204_lnk_attrs[] = {
 	JESD204_LNK_ATTR_UINT(link_id),
 	JESD204_LNK_ATTR_INT(error),
 	JESD204_LNK_ATTR_STR_PRIV(state),
+	JESD204_LNK_ATTR_BOOL_PRIV(fsm_paused),
 	JESD204_LNK_ATTR_UINT(sample_rate),
 	JESD204_LNK_ATTR_BOOL(is_transmit),
 	JESD204_LNK_ATTR_UINT(num_lanes),

--- a/include/linux/jesd204/jesd204.h
+++ b/include/linux/jesd204/jesd204.h
@@ -251,6 +251,10 @@ struct jesd204_dev_data {
 struct jesd204_dev *devm_jesd204_dev_register(struct device *dev,
 					      const struct jesd204_dev_data *i);
 
+int jesd204_get_links_data(struct jesd204_dev *jdev,
+			   struct jesd204_link ** const links,
+			   const unsigned int num_links);
+
 int jesd204_fsm_start(struct jesd204_dev *jdev, unsigned int link_idx);
 void jesd204_fsm_stop(struct jesd204_dev *jdev, unsigned int link_idx);
 
@@ -275,12 +279,23 @@ int jesd204_sysref_async(struct jesd204_dev *jdev);
 
 bool jesd204_dev_is_top(struct jesd204_dev *jdev);
 
+bool jesd204_link_get_paused(const struct jesd204_link *lnk);
+
+const char *jesd204_link_get_state_str(const struct jesd204_link *lnk);
+
 #else /* !IS_ENABLED(CONFIG_JESD204) */
 
 static inline struct jesd204_dev *devm_jesd204_dev_register(
 		struct device *dev, const struct jesd204_dev_data *init)
 {
 	return NULL;
+}
+
+static inline int jesd204_get_links_data(struct jesd204_dev *jdev,
+					 struct jesd204_link * const *links,
+					 const unsigned int num_links)
+{
+	return -ENOTSUPP;
 }
 
 static inline int jesd204_fsm_start(struct jesd204_dev *jdev,
@@ -348,6 +363,16 @@ static inline int jesd204_sysref_async(struct jesd204_dev *jdev)
 static inline bool jesd204_dev_is_top(struct jesd204_dev *jdev)
 {
 	return false;
+}
+
+static inline bool jesd204_link_get_paused(const struct jesd204_link *lnk)
+{
+	return false;
+}
+
+static inline const char *jesd204_link_get_state_str(const struct jesd204_link *lnk)
+{
+	return NULL;
 }
 
 #endif /* #ifdef CONFIG_JESD204 */

--- a/include/linux/jesd204/jesd204.h
+++ b/include/linux/jesd204/jesd204.h
@@ -254,6 +254,8 @@ struct jesd204_dev *devm_jesd204_dev_register(struct device *dev,
 int jesd204_fsm_start(struct jesd204_dev *jdev, unsigned int link_idx);
 void jesd204_fsm_stop(struct jesd204_dev *jdev, unsigned int link_idx);
 
+int jesd204_fsm_resume(struct jesd204_dev *jdev, unsigned int link_idx);
+
 void jesd204_fsm_clear_errors(struct jesd204_dev *jdev, unsigned int link_idx);
 
 struct device *jesd204_dev_to_device(struct jesd204_dev *jdev);
@@ -289,6 +291,12 @@ static inline int jesd204_fsm_start(struct jesd204_dev *jdev,
 
 static inline void jesd204_fsm_stop(struct jesd204_dev *jdev,
 				    unsigned int link_idx) {}
+
+static inline int jesd204_fsm_resume(struct jesd204_dev *jdev,
+				     unsigned int link_idx)
+{
+	return 0;
+}
 
 static inline void jesd204_fsm_clear_errors(struct jesd204_dev *jdev,
 					    unsigned int link_idx) {}


### PR DESCRIPTION
This adds support for stop-states in the FSM.

For the 9009 we need to hack it a bit to re-use libiio to query when the FSM has paused into a
certain state and to resume from that state.

With this, in a device tree, any JESD204 device can define some states on
which it want to defer.

Example:
       jesd204-stop-states = <JESD204_FSM_STATE_LINK_PRE_SETUP
                              JESD204_FSM_STATE_LINK_ENABLE>;

The information can then be queried:

iio_attr -q -a -d adrv9009-phy jesd204_fsm_state
iio_attr -q -a -d adrv9009-phy jesd204_fsm_error
iio_attr -q -a -d adrv9009-phy jesd204_fsm_paused

And then a resume can be called:

iio_attr -q -a -d adrv9009-phy jesd204_fsm_resume 1

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>