### PR TITLE
iio: frequency: hmc7044: Fix MAX SYSREF frequency computation 

### DIFF
--- a/drivers/iio/frequency/hmc7044.c
+++ b/drivers/iio/frequency/hmc7044.c
@@ -318,6 +318,7 @@ struct hmc7044 {
 	struct jesd204_dev 		*jdev;
 	u32				jdev_lmfc_lemc_rate;
 	u32				jdev_lmfc_lemc_gcd;
+	u32				jdev_max_sysref_freq;
 	bool				is_sysref_provider;
 	bool				hmc_two_level_tree_sync_en;
 };
@@ -1292,6 +1293,10 @@ static int hmc7044_parse_dt(struct device *dev,
 
 	hmc->hmc_two_level_tree_sync_en = of_property_read_bool(np, "adi,hmc-two-level-tree-sync-en");
 
+	hmc->jdev_max_sysref_freq = INT_MAX;
+	of_property_read_u32(np, "adi,jesd204-max-sysref-frequency-hz",
+			     &hmc->jdev_max_sysref_freq);
+
 	hmc->rf_reseeder_en =
 		!of_property_read_bool(np, "adi,rf-reseeder-disable");
 
@@ -1664,6 +1669,9 @@ static int hmc7044_jesd204_link_pre_setup(struct jesd204_dev *jdev,
 		return JESD204_STATE_CHANGE_DONE;
 
 	dev_dbg(dev, "%s:%d link_num %u\n", __func__, __LINE__, lnk->link_id);
+
+	while (hmc->jdev_lmfc_lemc_gcd > hmc->jdev_max_sysref_freq)
+		hmc->jdev_lmfc_lemc_gcd >>= 1;
 
 	/* Program the output channels */
 	for (i = 0; i < hmc->num_channels; i++) {

--- a/drivers/iio/frequency/hmc7044.c
+++ b/drivers/iio/frequency/hmc7044.c
@@ -1670,15 +1670,25 @@ static int hmc7044_jesd204_link_pre_setup(struct jesd204_dev *jdev,
 
 	dev_dbg(dev, "%s:%d link_num %u\n", __func__, __LINE__, lnk->link_id);
 
-	while (hmc->jdev_lmfc_lemc_gcd > hmc->jdev_max_sysref_freq)
+	while ((hmc->jdev_lmfc_lemc_gcd > hmc->jdev_max_sysref_freq) &&
+		(hmc->jdev_lmfc_lemc_gcd % (hmc->jdev_lmfc_lemc_gcd >> 1) == 0))
 		hmc->jdev_lmfc_lemc_gcd >>= 1;
 
 	/* Program the output channels */
 	for (i = 0; i < hmc->num_channels; i++) {
 		if (hmc->channels[i].start_up_mode_dynamic_enable || hmc->channels[i].is_sysref) {
+			long rate;
+
 			dev_dbg(dev, "%s:%d Found SYSREF channel%u setting f=%u Hz\n",
 				__func__, __LINE__, hmc->channels[i].num, hmc->jdev_lmfc_lemc_gcd);
-			ret = clk_set_rate(hmc->clks[hmc->channels[i].num], hmc->jdev_lmfc_lemc_gcd);
+
+			rate = clk_round_rate(hmc->clks[hmc->channels[i].num], hmc->jdev_lmfc_lemc_gcd);
+
+			if (rate == (long)hmc->jdev_lmfc_lemc_gcd)
+				ret = clk_set_rate(hmc->clks[hmc->channels[i].num], hmc->jdev_lmfc_lemc_gcd);
+			else
+				ret = -EINVAL;
+
 			if (ret < 0)
 				dev_err(dev, "%s: Link%u setting SYSREF rate %u failed (%d)\n",
 					__func__, lnk->link_id, hmc->jdev_lmfc_lemc_gcd, ret);


### PR DESCRIPTION
Using non power of two reference frequencies such as 125.00MHz instead
of 122.88MHz, dividing by 2 can cause a residual.
This case must be avoided. Therefore check and stop before this happens.

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>