### PR TITLE
iio: axi-adc/axi-dds: common-alize the TPL reg definitions into a single header

### DIFF
--- a/drivers/iio/adc/cf_axi_adc.h
+++ b/drivers/iio/adc/cf_axi_adc.h
@@ -95,21 +95,6 @@
 #define ADI_REG_CLOCKS_PER_PPS_STATUS	0x00C4
 #define ADI_CLOCKS_PER_PPS_STAT_INVAL	(1 << 0)
 
-/* JESD TPL */
-
-#define ADI_REG_TPL_CNTRL		0x0200
-#define ADI_REG_TPL_STATUS		0x0204
-#define ADI_REG_TPL_DESCRIPTOR_1	0x0240
-#define ADI_REG_TPL_DESCRIPTOR_2	0x0244
-
-#define ADI_TO_JESD_M(x)		(((x) >> 0) & 0xFF)
-#define ADI_TO_JESD_L(x)		(((x) >> 8) & 0xFF)
-#define ADI_TO_JESD_S(x)		(((x) >> 16) & 0xFF)
-#define ADI_TO_JESD_F(x)		(((x) >> 24) & 0xFF)
-
-#define ADI_TO_JESD_N(x)		(((x) >> 0) & 0xFF)
-#define ADI_TO_JESD_NP(x)		(((x) >> 8) & 0xFF)
-
 /* ADC CHANNEL */
 
 #define ADI_REG_CHAN_CNTRL(c)		(0x0400 + (c) * 0x40)

--- a/drivers/iio/frequency/cf_axi_dds.h
+++ b/drivers/iio/frequency/cf_axi_dds.h
@@ -104,24 +104,6 @@ enum dds_data_select {
 
 #define ADI_REG_DAC_GP_CONTROL	0x00BC
 
-/* JESD TPL */
-
-#define ADI_REG_TPL_CNTRL		0x0200
-#define ADI_REG_TPL_STATUS		0x0204
-#define ADI_REG_TPL_DESCRIPTOR_1	0x0240
-#define ADI_REG_TPL_DESCRIPTOR_2	0x0244
-
-#define ADI_TO_JESD_M(x)		(((x) >> 0) & 0xFF)
-#define ADI_TO_JESD_L(x)		(((x) >> 8) & 0xFF)
-#define ADI_TO_JESD_S(x)		(((x) >> 16) & 0xFF)
-#define ADI_TO_JESD_F(x)		(((x) >> 24) & 0xFF)
-
-#define ADI_TO_JESD_N(x)		(((x) >> 0) & 0xFF)
-#define ADI_TO_JESD_NP(x)		(((x) >> 8) & 0xFF)
-
-#define ADI_TO_PROFILE_NUM(x)	(((x) >> 0) & 0xF)
-#define ADI_PROFILE_SEL(x)		((x) & 0xF)
-
 /* DAC CHANNEL */
 
 #define ADI_REG_CHAN_CNTRL_1_IIOCHAN(x)	(0x0400 + ((x) >> 1) * 0x40 + ((x) & 1) * 0x8)

--- a/include/linux/jesd204/adi-common.h
+++ b/include/linux/jesd204/adi-common.h
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Analog Devices common definitions for JESD204 IP cores
+ *
+ * Copyright 2020 Analog Devices Inc.
+ *
+ * https://wiki.analog.com/resources/fpga/docs/axi_ip
+ * https://wiki.analog.com/resources/fpga/docs/hdl/regmap
+ * https://wiki.analog.com/resources/fpga/peripherals/jesd204/jesd204_tpl_adc
+ * https://wiki.analog.com/resources/fpga/peripherals/jesd204/jesd204_tpl_dac
+ */
+#ifndef _ADI_JESD204_H_
+#define _ADI_JESD204_H_
+
+/* JESD TPL COMMON */
+
+#define ADI_JESD204_REG_TPL_CNTRL		0x0200
+#define ADI_JESD204_REG_TPL_STATUS		0x0204
+#define ADI_JESD204_REG_TPL_DESCRIPTOR_1	0x0240
+#define ADI_JESD204_REG_TPL_DESCRIPTOR_2	0x0244
+
+#define ADI_JESD204_TPL_TO_M(x)			(((x) >> 0) & 0xFF)
+#define ADI_JESD204_TPL_TO_L(x)			(((x) >> 8) & 0xFF)
+#define ADI_JESD204_TPL_TO_S(x)			(((x) >> 16) & 0xFF)
+#define ADI_JESD204_TPL_TO_F(x)			(((x) >> 24) & 0xFF)
+
+#define ADI_JESD204_TPL_TO_N(x)			(((x) >> 0) & 0xFF)
+#define ADI_JESD204_TPL_TO_NP(x)		(((x) >> 8) & 0xFF)
+
+#define ADI_JESD204_TPL_TO_PROFILE_NUM(x)	(((x) >> 0) & 0xF)
+#define ADI_JESD204_PROFILE_SEL(x)		((x) & 0xF)
+
+#endif


### PR DESCRIPTION
This changeset moves the common TPL regs into a common header file.

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>
Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>