### PR TITLE
dts: vcu118_quad_ad9081_204*.dts: Always use continuous SYSREF 

### DIFF
--- a/arch/arm64/boot/dts/xilinx/adi-ad9081-fmc-ebz.dtsi
+++ b/arch/arm64/boot/dts/xilinx/adi-ad9081-fmc-ebz.dtsi
@@ -64,6 +64,7 @@
 			adi,extended-name = "DEV_SYSREF";
 			adi,divider = <256>;	// 12.109375
 			adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;	// LVDS
+			adi,jesd204-sysref-chan;
 		};
 
 		hmc7044_c6: channel@6 {
@@ -96,6 +97,7 @@
 			adi,extended-name = "FPGA_SYSREF";
 			adi,divider = <256>;	// 12.109375
 			adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;	// LVDS
+			adi,jesd204-sysref-chan;
 		};
 	};
 };

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9081-m8-l4.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9081-m8-l4.dts
@@ -100,6 +100,7 @@
 			adi,extended-name = "DEV_SYSREF";
 			adi,divider = <1536>;
 			adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
+			adi,jesd204-sysref-chan;
 		};
 
 		hmc7044_c6: channel@6 {
@@ -133,6 +134,7 @@
 			adi,extended-name = "FPGA_SYSREF";
 			adi,divider = <1536>;
 			adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
+			adi,jesd204-sysref-chan;
 		};
 	};
 };

--- a/arch/microblaze/boot/dts/adi-ad9081-fmc-ebz.dtsi
+++ b/arch/microblaze/boot/dts/adi-ad9081-fmc-ebz.dtsi
@@ -62,6 +62,7 @@
 			adi,extended-name = "DEV_SYSREF";
 			adi,divider = <256>;	// 12.109375
 			adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;	// LVDS
+			adi,jesd204-sysref-chan;
 		};
 
 		hmc7044_c6: channel@6 {
@@ -94,6 +95,7 @@
 			adi,extended-name = "FPGA_SYSREF";
 			adi,divider = <256>;	// 12.109375
 			adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;	// LVDS
+			adi,jesd204-sysref-chan;
 		};
 	};
 	trx0_ad9081: ad9081@0 {

--- a/arch/microblaze/boot/dts/vcu118_quad_ad9081_204b_txmode_9_rxmode_10.dts
+++ b/arch/microblaze/boot/dts/vcu118_quad_ad9081_204b_txmode_9_rxmode_10.dts
@@ -264,8 +264,6 @@
 			adi,extended-name = "SYSREF_MXFE0";
 			adi,divider = <HMC7043_SYSREF_CLKDIV>;
 			adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
-			adi,startup-mode-dynamic-enable;
-			adi,high-performance-mode-disable;
 
 			adi,coarse-digital-delay = <0>;
 			adi,fine-analog-delay = <24>; /* max analog */
@@ -278,8 +276,6 @@
 			adi,extended-name = "SYSREF_MXFE1";
 			adi,divider = <HMC7043_SYSREF_CLKDIV>;
 			adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
-			adi,startup-mode-dynamic-enable;
-			adi,high-performance-mode-disable;
 
 			adi,coarse-digital-delay = <1>; /* 1 ns */
 			adi,fine-analog-delay = <0>;
@@ -292,8 +288,6 @@
 			adi,extended-name = "SYSREF_MXFE2";
 			adi,divider = <HMC7043_SYSREF_CLKDIV>;
 			adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
-			adi,startup-mode-dynamic-enable;
-			adi,high-performance-mode-disable;
 
 			adi,coarse-digital-delay = <0>;
 			adi,fine-analog-delay = <16>;
@@ -306,8 +300,6 @@
 			adi,extended-name = "SYSREF_MXFE3";
 			adi,divider = <HMC7043_SYSREF_CLKDIV>;
 			adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
-			adi,startup-mode-dynamic-enable;
-			adi,high-performance-mode-disable;
 
 			adi,coarse-digital-delay = <0>;
 			adi,fine-analog-delay = <0>;
@@ -320,8 +312,6 @@
 			adi,extended-name = "SYSREF_FPGA";
 			adi,divider = <HMC7043_SYSREF_CLKDIV>;
 			adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
-			adi,startup-mode-dynamic-enable;
-			adi,high-performance-mode-disable;
 			adi,jesd204-sysref-chan;
 		};
 	};

--- a/arch/microblaze/boot/dts/vcu118_quad_ad9081_204b_txmode_9_rxmode_10.dts
+++ b/arch/microblaze/boot/dts/vcu118_quad_ad9081_204b_txmode_9_rxmode_10.dts
@@ -270,6 +270,7 @@
 			adi,coarse-digital-delay = <0>;
 			adi,fine-analog-delay = <24>; /* max analog */
 			adi,output-mux-mode = <1>;
+			adi,jesd204-sysref-chan;
 		};
 
 		hmc7043_c3: channel@3 {
@@ -283,6 +284,7 @@
 			adi,coarse-digital-delay = <1>; /* 1 ns */
 			adi,fine-analog-delay = <0>;
 			adi,output-mux-mode = <0>;
+			adi,jesd204-sysref-chan;
 		};
 
 		hmc7043_c5: channel@5 {
@@ -296,6 +298,7 @@
 			adi,coarse-digital-delay = <0>;
 			adi,fine-analog-delay = <16>;
 			adi,output-mux-mode = <1>;
+			adi,jesd204-sysref-chan;
 		};
 
 		hmc7043_c7: channel@7 {
@@ -309,6 +312,7 @@
 			adi,coarse-digital-delay = <0>;
 			adi,fine-analog-delay = <0>;
 			adi,output-mux-mode = <0>;
+			adi,jesd204-sysref-chan;
 		};
 
 		hmc7043_c9: channel@9 {
@@ -318,6 +322,7 @@
 			adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
 			adi,startup-mode-dynamic-enable;
 			adi,high-performance-mode-disable;
+			adi,jesd204-sysref-chan;
 		};
 	};
 };

--- a/arch/microblaze/boot/dts/vcu118_quad_ad9081_204c_txmode_10_rxmode_11.dts
+++ b/arch/microblaze/boot/dts/vcu118_quad_ad9081_204c_txmode_10_rxmode_11.dts
@@ -300,6 +300,7 @@
 			adi,coarse-digital-delay = <0>;
 			adi,fine-analog-delay = <24>; /* max analog */
 			adi,output-mux-mode = <1>;
+			adi,jesd204-sysref-chan;
 		};
 
 		hmc7043_c3: channel@3 {
@@ -313,6 +314,7 @@
 			adi,coarse-digital-delay = <1>; /* 1 ns */
 			adi,fine-analog-delay = <0>;
 			adi,output-mux-mode = <0>;
+			adi,jesd204-sysref-chan;
 		};
 
 		hmc7043_c5: channel@5 {
@@ -326,6 +328,7 @@
 			adi,coarse-digital-delay = <0>;
 			adi,fine-analog-delay = <16>;
 			adi,output-mux-mode = <1>;
+			adi,jesd204-sysref-chan;
 		};
 
 		hmc7043_c7: channel@7 {
@@ -339,6 +342,7 @@
 			adi,coarse-digital-delay = <0>;
 			adi,fine-analog-delay = <0>;
 			adi,output-mux-mode = <0>;
+			adi,jesd204-sysref-chan;
 		};
 
 		hmc7043_c9: channel@9 {
@@ -348,6 +352,7 @@
 			adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
 			adi,startup-mode-dynamic-enable;
 			adi,high-performance-mode-disable;
+			adi,jesd204-sysref-chan;
 		};
 	};
 };

--- a/arch/microblaze/boot/dts/vcu118_quad_ad9081_204c_txmode_10_rxmode_11.dts
+++ b/arch/microblaze/boot/dts/vcu118_quad_ad9081_204c_txmode_10_rxmode_11.dts
@@ -294,8 +294,6 @@
 			adi,extended-name = "SYSREF_MXFE0";
 			adi,divider = <HMC7043_SYSREF_CLKDIV>;
 			adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
-			adi,startup-mode-dynamic-enable;
-			adi,high-performance-mode-disable;
 
 			adi,coarse-digital-delay = <0>;
 			adi,fine-analog-delay = <24>; /* max analog */
@@ -308,8 +306,6 @@
 			adi,extended-name = "SYSREF_MXFE1";
 			adi,divider = <HMC7043_SYSREF_CLKDIV>;
 			adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
-			adi,startup-mode-dynamic-enable;
-			adi,high-performance-mode-disable;
 
 			adi,coarse-digital-delay = <1>; /* 1 ns */
 			adi,fine-analog-delay = <0>;
@@ -322,8 +318,6 @@
 			adi,extended-name = "SYSREF_MXFE2";
 			adi,divider = <HMC7043_SYSREF_CLKDIV>;
 			adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
-			adi,startup-mode-dynamic-enable;
-			adi,high-performance-mode-disable;
 
 			adi,coarse-digital-delay = <0>;
 			adi,fine-analog-delay = <16>;
@@ -336,8 +330,6 @@
 			adi,extended-name = "SYSREF_MXFE3";
 			adi,divider = <HMC7043_SYSREF_CLKDIV>;
 			adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
-			adi,startup-mode-dynamic-enable;
-			adi,high-performance-mode-disable;
 
 			adi,coarse-digital-delay = <0>;
 			adi,fine-analog-delay = <0>;
@@ -350,8 +342,6 @@
 			adi,extended-name = "SYSREF_FPGA";
 			adi,divider = <HMC7043_SYSREF_CLKDIV>;
 			adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
-			adi,startup-mode-dynamic-enable;
-			adi,high-performance-mode-disable;
 			adi,jesd204-sysref-chan;
 		};
 	};

--- a/arch/microblaze/boot/dts/vcu118_quad_ad9081_204c_txmode_11_rxmode_4.dts
+++ b/arch/microblaze/boot/dts/vcu118_quad_ad9081_204c_txmode_11_rxmode_4.dts
@@ -300,6 +300,7 @@
 			adi,coarse-digital-delay = <0>;
 			adi,fine-analog-delay = <24>; /* max analog */
 			adi,output-mux-mode = <1>;
+			adi,jesd204-sysref-chan;
 		};
 
 		hmc7043_c3: channel@3 {
@@ -313,6 +314,7 @@
 			adi,coarse-digital-delay = <1>; /* 1 ns */
 			adi,fine-analog-delay = <0>;
 			adi,output-mux-mode = <0>;
+			adi,jesd204-sysref-chan;
 		};
 
 		hmc7043_c5: channel@5 {
@@ -326,6 +328,7 @@
 			adi,coarse-digital-delay = <0>;
 			adi,fine-analog-delay = <16>;
 			adi,output-mux-mode = <1>;
+			adi,jesd204-sysref-chan;
 		};
 
 		hmc7043_c7: channel@7 {
@@ -339,6 +342,7 @@
 			adi,coarse-digital-delay = <0>;
 			adi,fine-analog-delay = <0>;
 			adi,output-mux-mode = <0>;
+			adi,jesd204-sysref-chan;
 		};
 
 		hmc7043_c9: channel@9 {
@@ -348,6 +352,7 @@
 			adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
 			adi,startup-mode-dynamic-enable;
 			adi,high-performance-mode-disable;
+			adi,jesd204-sysref-chan;
 		};
 	};
 };

--- a/arch/microblaze/boot/dts/vcu118_quad_ad9081_204c_txmode_11_rxmode_4.dts
+++ b/arch/microblaze/boot/dts/vcu118_quad_ad9081_204c_txmode_11_rxmode_4.dts
@@ -294,8 +294,6 @@
 			adi,extended-name = "SYSREF_MXFE0";
 			adi,divider = <HMC7043_SYSREF_CLKDIV>;
 			adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
-			adi,startup-mode-dynamic-enable;
-			adi,high-performance-mode-disable;
 
 			adi,coarse-digital-delay = <0>;
 			adi,fine-analog-delay = <24>; /* max analog */
@@ -308,8 +306,6 @@
 			adi,extended-name = "SYSREF_MXFE1";
 			adi,divider = <HMC7043_SYSREF_CLKDIV>;
 			adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
-			adi,startup-mode-dynamic-enable;
-			adi,high-performance-mode-disable;
 
 			adi,coarse-digital-delay = <1>; /* 1 ns */
 			adi,fine-analog-delay = <0>;
@@ -322,8 +318,6 @@
 			adi,extended-name = "SYSREF_MXFE2";
 			adi,divider = <HMC7043_SYSREF_CLKDIV>;
 			adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
-			adi,startup-mode-dynamic-enable;
-			adi,high-performance-mode-disable;
 
 			adi,coarse-digital-delay = <0>;
 			adi,fine-analog-delay = <16>;
@@ -336,8 +330,6 @@
 			adi,extended-name = "SYSREF_MXFE3";
 			adi,divider = <HMC7043_SYSREF_CLKDIV>;
 			adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
-			adi,startup-mode-dynamic-enable;
-			adi,high-performance-mode-disable;
 
 			adi,coarse-digital-delay = <0>;
 			adi,fine-analog-delay = <0>;
@@ -350,8 +342,6 @@
 			adi,extended-name = "SYSREF_FPGA";
 			adi,divider = <HMC7043_SYSREF_CLKDIV>;
 			adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
-			adi,startup-mode-dynamic-enable;
-			adi,high-performance-mode-disable;
 			adi,jesd204-sysref-chan;
 		};
 	};

--- a/arch/microblaze/boot/dts/vcu118_quad_ad9081_204c_txmode_11_rxmode_4_direct_6g.dts
+++ b/arch/microblaze/boot/dts/vcu118_quad_ad9081_204c_txmode_11_rxmode_4_direct_6g.dts
@@ -230,6 +230,7 @@
 			adi,coarse-digital-delay = <1>;
 			adi,fine-analog-delay = <5>; /* max analog */
 			adi,output-mux-mode = <1>;
+			adi,jesd204-sysref-chan;
 		};
 
 		hmc7043_c3: channel@3 {
@@ -243,6 +244,7 @@
 			adi,coarse-digital-delay = <1>; /* 1 ns */
 			adi,fine-analog-delay = <15>;
 			adi,output-mux-mode = <1>;
+			adi,jesd204-sysref-chan;
 		};
 
 		hmc7043_c5: channel@5 {
@@ -256,6 +258,7 @@
 			adi,coarse-digital-delay = <0>;
 			adi,fine-analog-delay = <12>;
 			adi,output-mux-mode = <1>;
+			adi,jesd204-sysref-chan;
 		};
 
 		hmc7043_c7: channel@7 {
@@ -269,6 +272,7 @@
 			adi,coarse-digital-delay = <0>;
 			adi,fine-analog-delay = <0>;
 			adi,output-mux-mode = <0>;
+			adi,jesd204-sysref-chan;
 		};
 
 		hmc7043_c9: channel@9 {
@@ -278,6 +282,7 @@
 			adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
 			adi,startup-mode-dynamic-enable;
 			adi,high-performance-mode-disable;
+			adi,jesd204-sysref-chan;
 		};
 	};
 };

--- a/arch/microblaze/boot/dts/vcu118_quad_ad9081_204c_txmode_11_rxmode_4_direct_6g.dts
+++ b/arch/microblaze/boot/dts/vcu118_quad_ad9081_204c_txmode_11_rxmode_4_direct_6g.dts
@@ -224,11 +224,9 @@
 			adi,extended-name = "SYSREF_MXFE0";
 			adi,divider = <HMC7043_SYSREF_CLKDIV>;
 			adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
-			adi,startup-mode-dynamic-enable;
-			adi,high-performance-mode-disable;
 
-			adi,coarse-digital-delay = <1>;
-			adi,fine-analog-delay = <5>; /* max analog */
+			adi,coarse-digital-delay = <0>;
+			adi,fine-analog-delay = <24>; /* max analog */
 			adi,output-mux-mode = <1>;
 			adi,jesd204-sysref-chan;
 		};
@@ -238,12 +236,10 @@
 			adi,extended-name = "SYSREF_MXFE1";
 			adi,divider = <HMC7043_SYSREF_CLKDIV>;
 			adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
-			adi,startup-mode-dynamic-enable;
-			adi,high-performance-mode-disable;
 
 			adi,coarse-digital-delay = <1>; /* 1 ns */
-			adi,fine-analog-delay = <15>;
-			adi,output-mux-mode = <1>;
+			adi,fine-analog-delay = <0>;
+			adi,output-mux-mode = <0>;
 			adi,jesd204-sysref-chan;
 		};
 
@@ -252,11 +248,9 @@
 			adi,extended-name = "SYSREF_MXFE2";
 			adi,divider = <HMC7043_SYSREF_CLKDIV>;
 			adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
-			adi,startup-mode-dynamic-enable;
-			adi,high-performance-mode-disable;
 
 			adi,coarse-digital-delay = <0>;
-			adi,fine-analog-delay = <12>;
+			adi,fine-analog-delay = <16>;
 			adi,output-mux-mode = <1>;
 			adi,jesd204-sysref-chan;
 		};
@@ -266,8 +260,6 @@
 			adi,extended-name = "SYSREF_MXFE3";
 			adi,divider = <HMC7043_SYSREF_CLKDIV>;
 			adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
-			adi,startup-mode-dynamic-enable;
-			adi,high-performance-mode-disable;
 
 			adi,coarse-digital-delay = <0>;
 			adi,fine-analog-delay = <0>;
@@ -280,8 +272,6 @@
 			adi,extended-name = "SYSREF_FPGA";
 			adi,divider = <HMC7043_SYSREF_CLKDIV>;
 			adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
-			adi,startup-mode-dynamic-enable;
-			adi,high-performance-mode-disable;
 			adi,jesd204-sysref-chan;
 		};
 	};


### PR DESCRIPTION
Therefore we can remove the startup-mode-dynamic-enable attributes.

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>