### PR TITLE
jesd204: fsm: don't handle stop-states during rollback

### DIFF
--- a/drivers/jesd204/jesd204-fsm.c
+++ b/drivers/jesd204/jesd204-fsm.c
@@ -974,6 +974,9 @@ static void jesd204_fsm_handle_stop_state(struct jesd204_dev *jdev,
 	struct jesd204_fsm_table_entry_iter *it = fsm_data->cb_data;
 	int state_idx;
 
+	if (fsm_data->rollback)
+		return;
+
 	/* FSM states from DT start at offset 100 */
 	state_idx = it->table[0].state - JESD204_STATE_FSM_OFFSET;
 	if (state_idx < 0 || state_idx >= JESD204_FSM_STATES_NUM)


### PR DESCRIPTION
For now, stop-states are only needed during init for sync-ing SOMs. Later
we may [probably] need some stop-states for rollback, but for now, ignore
the stop-states during rollback.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>