### PR TITLE
arch: arm: zynq-zed-adv7511: remove adi,channels for video

### DIFF
--- a/arch/arm/boot/dts/zynq-zed-adv7511.dtsi
+++ b/arch/arm/boot/dts/zynq-zed-adv7511.dtsi
@@ -64,19 +64,6 @@
 			#dma-cells = <1>;
 			interrupts = <0 59 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&clkc 16>;
-
-			adi,channels {
-				#size-cells = <0>;
-				#address-cells = <1>;
-
-				dma-channel@0 {
-					reg = <0>;
-					adi,source-bus-width = <64>;
-					adi,source-bus-type = <0>;
-					adi,destination-bus-width = <64>;
-					adi,destination-bus-type = <1>;
-				};
-			};
 		};
 
 		hdmi_clock: axi-clkgen@79000000 {


### PR DESCRIPTION
In a recent change, the DMA channels can be read from registers (vs reading
them from the DT).
We are too close to a release to do a full-cleanup.
This has been tested, so remove it.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>