### PR TITLE
arch: arm: zynq-zed-adv7511: remove bitclock & frame-master props

### DIFF
--- a/arch/arm/boot/dts/zynq-zed-adv7511.dtsi
+++ b/arch/arm/boot/dts/zynq-zed-adv7511.dtsi
@@ -134,8 +134,6 @@
 			format = "spdif";
 			cpu {
 				sound-dai = <&axi_spdif_tx_0>;
-				frame-master;
-				bitclock-master;
 			};
 			codec {
 				sound-dai = <&adv7511>;
@@ -166,8 +164,6 @@
 			format = "i2s";
 			cpu {
 				sound-dai = <&axi_i2s_0>;
-				frame-master;
-				bitclock-master;
 			};
 			codec {
 				sound-dai = <&adau1761>;


### PR DESCRIPTION
These properties don't seem to be parsed in this current form, so they
aren't really used.

The form has changed, and 'frame-master' & 'bitclock-master' are now
phandles and not boolean properties.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>