### PR TITLE
Revert "arch: arm: zynq-zed-adv7511: remove adi,channels for video"

### DIFF
--- a/arch/arm/boot/dts/zynq-zed-adv7511.dtsi
+++ b/arch/arm/boot/dts/zynq-zed-adv7511.dtsi
@@ -64,6 +64,19 @@
 			#dma-cells = <1>;
 			interrupts = <0 59 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&clkc 16>;
+
+			adi,channels {
+				#size-cells = <0>;
+				#address-cells = <1>;
+
+				dma-channel@0 {
+					reg = <0>;
+					adi,source-bus-width = <64>;
+					adi,source-bus-type = <0>;
+					adi,destination-bus-width = <64>;
+					adi,destination-bus-type = <1>;
+				};
+			};
 		};
 
 		hdmi_clock: axi-clkgen@79000000 {


### PR DESCRIPTION
This reverts commit 4678fddc9fb6df88767aa1ee0c136e345752030f.

Maybe we should wait 1-2 releases before doing these changes. Even
internally we will use some 2019_R1 HDL files with master, and with this
change, video (on ZedBoad) won't work on those.

So, to avoid any questions about this, this change reverts back the
adi,channels.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>