### PR TITLE
arch: arm: zynq-zc706-adv7511.dtsi: fix i2c node address

### DIFF
--- a/arch/arm/boot/dts/zynq-zc706-adv7511.dtsi
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511.dtsi
@@ -98,7 +98,7 @@
 					#address-cells = <1>;
 					#size-cells = <0>;
 					reg = <4>;
-					rtc@54 {
+					rtc@51 {
 						compatible = "nxp,pcf8563";
 						reg = <0x51>;
 					};


### PR DESCRIPTION
The reg value is correct (0x51). The rtc@54 value is incorrect; should be
rtc@51.
Newer DT compilers complain about this:
arch/arm/boot/dts/zynq-zc706-adv7511.dts:77.11-80.6: Warning (i2c_bus_reg): /fpga-axi@0/i2c@41600000/i2c-mux@74/i2c@4/rtc@54: I2C bus unit address format error, expected "51"

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>