### PR TITLE
jesd204: adrv9009,ad9081: change semantic num_links -> max_num_links

### DIFF
--- a/drivers/iio/adc/ad9081.c
+++ b/drivers/iio/adc/ad9081.c
@@ -3251,7 +3251,7 @@ static const struct jesd204_dev_data jesd204_ad9081_init = {
 		},
 	},
 
-	.num_links = 2,
+	.max_num_links = 2,
 	.num_retries = 3,
 	.sizeof_priv = sizeof(struct ad9081_jesd204_priv),
 };

--- a/drivers/iio/adc/adrv9009.c
+++ b/drivers/iio/adc/adrv9009.c
@@ -5976,7 +5976,7 @@ static const struct jesd204_dev_data jesd204_adrv9009_init = {
 		},
 	},
 
-	.num_links = 3,
+	.max_num_links = 3,
 	.sizeof_priv = sizeof(struct adrv9009_jesd204_priv),
 };
 
@@ -6032,7 +6032,7 @@ static const struct jesd204_dev_data jesd204_adrv90081_init = {
 		},
 	},
 
-	.num_links = 1,
+	.max_num_links = 1,
 	.sizeof_priv = sizeof(struct adrv9009_jesd204_priv),
 };
 
@@ -6088,7 +6088,7 @@ static const struct jesd204_dev_data jesd204_adrv90082_init = {
 		},
 	},
 
-	.num_links = 2,
+	.max_num_links = 2,
 	.sizeof_priv = sizeof(struct adrv9009_jesd204_priv),
 };
 

--- a/drivers/jesd204/jesd204-core.c
+++ b/drivers/jesd204/jesd204-core.c
@@ -817,16 +817,15 @@ static int jesd204_dev_init_links_data(struct device *parent,
 	if (!jdev_top)
 		return 0;
 
-	if (!init->num_links) {
-		jesd204_err(jdev, "num_links shouldn't be zero\n");
+	if (!init->max_num_links) {
+		jesd204_err(jdev, "max_num_links shouldn't be zero\n");
 		return -EINVAL;
 	}
 
-	/* FIXME: should we just do a minimum? for now we error out if these mismatch */
-	if (init->num_links != jdev_top->num_links) {
+	if (init->max_num_links < jdev_top->num_links) {
 		jesd204_err(jdev,
-			"Driver and DT mismatch for number of links %u vs %u\n",
-			init->num_links, jdev_top->num_links);
+			"Driver supports %u number of links, DT specified %u\n",
+			init->max_num_links, jdev_top->num_links);
 		return -EINVAL;
 	}
 

--- a/include/linux/jesd204/jesd204.h
+++ b/include/linux/jesd204/jesd204.h
@@ -232,7 +232,7 @@ enum jesd204_dev_op {
  * @fsm_finished_cb	callback for when the FSM finishes a series of transitions
  * @sizeof_priv		amount of data to allocate for private information
  * @links		JESD204 initial link configuration
- * @num_links		number of JESD204 links
+ * @max_num_links	maximum number of JESD204 links this device can support
  * @num_retries		number of retries in case of error (only for top-level device)
  * @state_ops		ops for each state transition of type @struct jesd204_state_op
  */
@@ -241,7 +241,7 @@ struct jesd204_dev_data {
 	jesd204_fsm_finished_cb			fsm_finished_cb;
 	size_t					sizeof_priv;
 	const struct jesd204_link		*links;
-	unsigned int				num_links;
+	unsigned int				max_num_links;
 	unsigned int				num_retries;
 	struct jesd204_state_op			state_ops[__JESD204_MAX_OPS];
 };


### PR DESCRIPTION
In the initial phase of the JESD204 framework work, it wasn't all that
clear where the number of JESD204 links would be specified, so the init
data passed to the framework contained the exact number of JESD204 links
that a topology should contain.

However, with the latest code, the number of "active" links is specified in
the device-tree. So, for this 'num_links' on the init-data we can
re-purpose it to be 'max_num_links' to make sure the DT doesn't go above
the number of JESD204 links that a device can support.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>