### PR TITLE
iio: gyro: adxrs290: sync with upstream version

### DIFF
--- a/Documentation/devicetree/bindings/iio/gyroscope/adi,adxrs290.yaml
+++ b/Documentation/devicetree/bindings/iio/gyroscope/adi,adxrs290.yaml
@@ -37,13 +37,11 @@ required:
   - spi-max-frequency
   - spi-cpol
   - spi-cpha
-  - interrupts
 
 additionalProperties: false
 
 examples:
   - |
-    #include <dt-bindings/gpio/gpio.h>
     #include <dt-bindings/interrupt-controller/irq.h>
     spi {
         #address-cells = <1>;


### PR DESCRIPTION
Update ADXRS290's driver and devicetree bindings in the ADI tree with the upstream version.

Signed-off-by: Nishant Malpani nish.malpani25@gmail.com