### PR TITLE
Dev/cmos digital tuning

### DIFF
--- a/drivers/iio/adc/cf_axi_adc.h
+++ b/drivers/iio/adc/cf_axi_adc.h
@@ -138,7 +138,9 @@ enum adc_pn_sel {
 	ADC_PN23 = 6,
 	ADC_PN31 = 7,
 	ADC_PN_CUSTOM = 9,
-	ADC_PN_OFF = 10,
+	ADC_PN_RAMP_NIBBLE = 10,
+	ADC_PN_RAMP_16 = 11,
+	ADC_PN_OFF = 12,
 };
 
 enum adc_data_sel {

--- a/drivers/iio/adc/navassa/adrv9002.c
+++ b/drivers/iio/adc/navassa/adrv9002.c
@@ -2797,7 +2797,7 @@ static const char *const adrv9002_ssi_test_mode_data_avail[] = {
 #define ADRV9002_RX_SSI_TEST_DATA_LVDS_MASK	0x3b
 #define ADRV9002_RX_SSI_TEST_DATA_CMOS_MASK	GENMASK(2, 0)
 #define ADRV9002_TX_SSI_TEST_DATA_LVDS_MASK	0x33
-#define ADRV9002_TX_SSI_TEST_DATA_CMOS_MASK	GENMASK(1, 0)
+#define ADRV9002_TX_SSI_TEST_DATA_CMOS_MASK	GENMASK(2, 0)
 
 static unsigned long rx_ssi_avail_mask;
 static unsigned long tx_ssi_avail_mask;

--- a/drivers/iio/adc/navassa/adrv9002.c
+++ b/drivers/iio/adc/navassa/adrv9002.c
@@ -2325,10 +2325,6 @@ static int adrv9002_intf_tuning_unlocked(struct adrv9002_rf_phy *phy)
 	adi_adrv9001_SsiType_e ssi_type = adrv9002_axi_ssi_type_get(phy);
 	int i;
 
-	/* FIXME: do not tune for CMOS for now */
-	if (ssi_type == ADI_ADRV9001_SSI_TYPE_CMOS)
-		return 0;
-
 	for (i = 0; i < ARRAY_SIZE(phy->rx_channels); i++) {
 		chan = &phy->rx_channels[i].channel;
 

--- a/drivers/iio/adc/navassa/adrv9002_conv.c
+++ b/drivers/iio/adc/navassa/adrv9002_conv.c
@@ -412,6 +412,7 @@ static int adrv9002_axi_pn_check(const struct axiadc_converter *conv, const int 
 	struct axiadc_state *st = iio_priv(conv->indio_dev);
 	int n_chan = conv->chip_info->num_channels, chan;
 	struct adrv9002_rf_phy *phy = conv->phy;
+	u32 reg;
 
 	/* reset result */
 	for (chan = 0; chan < n_chan; chan++)
@@ -431,8 +432,9 @@ static int adrv9002_axi_pn_check(const struct axiadc_converter *conv, const int 
 			continue;
 		}
 
-		if (axiadc_read(st, AIM_AXI_REG(off, ADI_REG_CHAN_STATUS(chan)))) {
-			dev_dbg(&phy->spi->dev, "pn error in c:%d\n", chan);
+		reg = axiadc_read(st, AIM_AXI_REG(off, ADI_REG_CHAN_STATUS(chan)));
+		if (reg) {
+			dev_dbg(&phy->spi->dev, "pn error in c:%d, reg: %02X\n", chan, reg);
 			return 1;
 		}
 	}

--- a/drivers/iio/adc/navassa/adrv9002_conv.c
+++ b/drivers/iio/adc/navassa/adrv9002_conv.c
@@ -448,8 +448,8 @@ static void adrv9002_axi_tx_test_pattern_set(const struct axiadc_converter *conv
 	int c, sel;
 
 	if (ssi_type == ADI_ADRV9001_SSI_TYPE_CMOS)
-		/* FIXME: custom pattern - Need support for RAMP */
-		sel = 9;
+		/* RAMP nibble */
+		sel = 10;
 	else
 		/* pn15 */
 		sel = 7;
@@ -482,8 +482,7 @@ static void adrv9002_axi_rx_test_pattern_pn_sel(const struct axiadc_converter *c
 	enum adc_pn_sel sel;
 
 	if (ssi_type == ADI_ADRV9001_SSI_TYPE_CMOS)
-		/* FIXME: custom pattern - Need support for RAMP */
-		sel = ADC_PN_OFF;
+		sel = ADC_PN_RAMP_NIBBLE;
 	else
 		sel = ADC_PN15;
 

--- a/drivers/iio/adc/navassa/adrv9002_init_data.c
+++ b/drivers/iio/adc/navassa/adrv9002_init_data.c
@@ -3204,15 +3204,5 @@ void adrv9002_cmos_default_set(void)
 	 * use the cmos default profile
 	 */
 	adrv9002_init = &adrv9002_init_cmos;
-	/*
-	 * FIXME: This is necessary for a proper spectrum. However, this
-	 * might be different for different profiles, so that we need to
-	 * dynamically compute the best parameters for the interface at runtime.
-	 * For that we need to make use of the test mode API and we need support
-	 * for ramp test patterns in cmos (the axi core only supports
-	 * prbs for now)
-	 */
-	adrv9001_radio_ctrl_init.ssiConfig.txClkDelay[0] = 0x7;
-	adrv9001_radio_ctrl_init.ssiConfig.txClkDelay[1] = 0x7;
 }
 EXPORT_SYMBOL(adrv9002_cmos_default_set);

--- a/drivers/iio/adc/navassa/devices/adrv9001/public/src/adi_adrv9001_ssi.c
+++ b/drivers/iio/adc/navassa/devices/adrv9001/public/src/adi_adrv9001_ssi.c
@@ -205,29 +205,34 @@ int32_t adi_adrv9001_Ssi_Tx_TestMode_Configure(adi_adrv9001_Device_t *device,
         baseAddress = ADRV9001_BF_TX2_CORE;
     }
 
-    /* FIXME: Add support to disable the debug test block for CMOS */
     if (ADI_ADRV9001_SSI_TYPE_CMOS == ssiType)
     {
-        ADI_EXPECT(adrv9001_NvsRegmapTx_CssiTxDebugMode_Set, device, baseAddress, 0x1);
-        /* Nothing to be configured for fixed pattern */
-        if (ADI_ADRV9001_SSI_TESTMODE_DATA_RAMP_NIBBLE == ssiTestModeConfig->testData)
+        ADI_EXPECT(adrv9001_NvsRegmapTx_CssiTxDebugStartRamp_Set, device, baseAddress, 0x0);
+        if (ADI_ADRV9001_SSI_TESTMODE_DATA_NORMAL == ssiTestModeConfig->testData)
         {
-            ADI_EXPECT(adrv9001_NvsRegmapTx_CssiTxDebugStartRamp_Set, device, baseAddress, 0x0);
-
-            ADI_EXPECT(adrv9001_NvsRegmapTx_CssiTxClearRampShiftError_Set, device, baseAddress, 0x0);
-            ADI_EXPECT(adrv9001_NvsRegmapTx_CssiTxClearRampShiftError_Set, device, baseAddress, 0x1);
-            ADI_EXPECT(adrv9001_NvsRegmapTx_CssiTxClearRampShiftError_Set, device, baseAddress, 0x0);
-
-            ADI_EXPECT(adrv9001_NvsRegmapTx_CssiTxFifoClear_Set, device, baseAddress, 0x0);
-            ADI_EXPECT(adrv9001_NvsRegmapTx_CssiTxFifoClear_Set, device, baseAddress, 0x1);
-            ADI_EXPECT(adrv9001_NvsRegmapTx_CssiTxFifoClear_Set, device, baseAddress, 0x0);
-
-            ADI_EXPECT(adrv9001_NvsRegmapTx_CssiTxClearStrobeAlignError_Set, device, baseAddress, 0x0);
-            ADI_EXPECT(adrv9001_NvsRegmapTx_CssiTxClearStrobeAlignError_Set, device, baseAddress, 0x1);
-            ADI_EXPECT(adrv9001_NvsRegmapTx_CssiTxClearStrobeAlignError_Set, device, baseAddress, 0x0);
-
-            ADI_EXPECT(adrv9001_NvsRegmapTx_CssiTxDebugStartRamp_Set, device, baseAddress, 0x1);
+            ADI_EXPECT(adrv9001_NvsRegmapTx_CssiTxDebugMode_Set, device, baseAddress, 0x0);
         }
+        else
+        {
+            ADI_EXPECT(adrv9001_NvsRegmapTx_CssiTxDebugMode_Set, device, baseAddress, 0x1);
+            /* Nothing to be configured for fixed pattern */
+            if (ADI_ADRV9001_SSI_TESTMODE_DATA_RAMP_NIBBLE == ssiTestModeConfig->testData)
+            {
+                ADI_EXPECT(adrv9001_NvsRegmapTx_CssiTxClearRampShiftError_Set, device, baseAddress, 0x0);
+                ADI_EXPECT(adrv9001_NvsRegmapTx_CssiTxClearRampShiftError_Set, device, baseAddress, 0x1);
+                ADI_EXPECT(adrv9001_NvsRegmapTx_CssiTxClearRampShiftError_Set, device, baseAddress, 0x0);
+
+                ADI_EXPECT(adrv9001_NvsRegmapTx_CssiTxFifoClear_Set, device, baseAddress, 0x0);
+                ADI_EXPECT(adrv9001_NvsRegmapTx_CssiTxFifoClear_Set, device, baseAddress, 0x1);
+                ADI_EXPECT(adrv9001_NvsRegmapTx_CssiTxFifoClear_Set, device, baseAddress, 0x0);
+
+                ADI_EXPECT(adrv9001_NvsRegmapTx_CssiTxClearStrobeAlignError_Set, device, baseAddress, 0x0);
+                ADI_EXPECT(adrv9001_NvsRegmapTx_CssiTxClearStrobeAlignError_Set, device, baseAddress, 0x1);
+                ADI_EXPECT(adrv9001_NvsRegmapTx_CssiTxClearStrobeAlignError_Set, device, baseAddress, 0x0);
+
+                ADI_EXPECT(adrv9001_NvsRegmapTx_CssiTxDebugStartRamp_Set, device, baseAddress, 0x1);
+            }
+	}
     }
     else /* LVDS */
     {

--- a/drivers/iio/frequency/cf_axi_dds.h
+++ b/drivers/iio/frequency/cf_axi_dds.h
@@ -55,6 +55,8 @@ enum dds_data_select {
 	DATA_SEL_PN15,
 	DATA_SEL_LB,	/* loopback data (ADC) */
 	DATA_SEL_PNXX,	/* (Device specific) */
+	DATA_SEL_RAMP_NIBBLE,
+	DATA_SEL_RAMP_16,
 };
 
 


### PR DESCRIPTION
Support CMOS digital tuning.  The series include some more minor improvements and supports TX nibble ramp in the debugs fs interface since it's now supported in the hdl side.