### PR TITLE
iio: adrv9002: Fix digital tuning false negative

### DIFF
--- a/drivers/iio/adc/navassa/adrv9002_conv.c
+++ b/drivers/iio/adc/navassa/adrv9002_conv.c
@@ -581,7 +581,7 @@ int adrv9002_axi_intf_tune(struct adrv9002_rf_phy *phy, const bool tx, const int
 		}
 	}
 
-	return cnt < 0 ? cnt : 0;
+	return max_cnt ? 0 : -EIO;
 }
 EXPORT_SYMBOL(adrv9002_axi_intf_tune);
 


### PR DESCRIPTION
The last condition to check for errors in the tuning function is wrong.
As it was, if all points of the last raw were invalid, the function
would return error even though there were valid points in another
rows...

Fixes: 17a27f3675b35 ("iio: Add ADRV9002 support")
Signed-off-by: Nuno Sá <nuno.sa@analog.com>