### PR TITLE
arch: dts: Remove the gpio hog on gpio52

### DIFF
--- a/arch/arm/boot/dts/zynq-zed-adrv9002-rx2tx2.dts
+++ b/arch/arm/boot/dts/zynq-zed-adrv9002-rx2tx2.dts
@@ -148,12 +148,3 @@ dgpio_0		32	86
 	ssi-sync-gpios = <&gpio0 108 GPIO_ACTIVE_HIGH>;
 };
 
-&gpio0 {
-	status = "okay";
-	output_enable {
-		gpio-hog;
-		gpios = <106 0>;
-		output-high;
-		line-name = "output_enable";
-	};
-};

--- a/arch/arm/boot/dts/zynq-zed-adrv9002.dts
+++ b/arch/arm/boot/dts/zynq-zed-adrv9002.dts
@@ -210,12 +210,3 @@ dgpio_0		32	86
 	reset-gpios = <&gpio0 100 GPIO_ACTIVE_LOW>;
 };
 
-&gpio0 {
-	status = "okay";
-	output_enable {
-		gpio-hog;
-		gpios = <106 0>;
-		output-high;
-		line-name = "output_enable";
-	};
-};

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9002-rx2tx2.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9002-rx2tx2.dts
@@ -145,12 +145,3 @@ dgpio_0		32	110
 	reset-gpios = <&gpio 124 GPIO_ACTIVE_LOW>;
 	ssi-sync-gpios = <&gpio 132 GPIO_ACTIVE_HIGH>;
 };
-
-&gpio {
-	output_enable {
-		gpio-hog;
-		gpios = <130 0>;
-		output-high;
-		line-name = "output_enable";
-	};
-};

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9002.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9002.dts
@@ -205,12 +205,3 @@ dgpio_0		32	110
 &adc0_adrv9002 {
 	reset-gpios = <&gpio 124 GPIO_ACTIVE_LOW>;
 };
-
-&gpio {
-	output_enable {
-		gpio-hog;
-		gpios = <130 0>;
-		output-high;
-		line-name = "output_enable";
-	};
-};


### PR DESCRIPTION
This is only needed for the zc706 platform as a prevention measure to VADJ
at 2.5V (needs to programmed to 1.8V). The gpio needs to be high in order
for the outputs in the FPGA to be enabled (alongside with a vadj check).
On both zed, and zcu102 this gpio is not used.

Signed-off-by: Nuno Sá <nuno.sa@analog.com>