### PR TITLE
jesd204,adrv9009: tweak the FSM paused hooks

### DIFF
--- a/drivers/iio/adc/adrv9009.c
+++ b/drivers/iio/adc/adrv9009.c
@@ -1515,7 +1515,7 @@ static ssize_t adrv9009_phy_show(struct device *dev,
 	struct jesd204_dev *jdev = phy->jdev;
 	struct jesd204_link *links[3];
 	int ret = 0;
-	int i, err;
+	int i, err, num_links;
 	u32 val;
 
 	mutex_lock(&indio_dev->mlock);
@@ -1535,11 +1535,15 @@ static ssize_t adrv9009_phy_show(struct device *dev,
 			ret = sprintf(buf, "%d\n", !!(phy->cal_mask & val));
 		break;
 	case ADRV9009_JESD204_FSM_ERROR:
-		ret = jesd204_get_links_data(jdev, links, 3);
+		num_links = jesd204_get_active_links_num(jdev);
+		if (num_links < 0)
+			return num_links;
+
+		ret = jesd204_get_links_data(jdev, links, num_links);
 		if (ret)
 			return ret;
 		err = 0;
-		for (i = 0; i < 3; i++) {
+		for (i = 0; i < num_links; i++) {
 			if (links[i]->error) {
 				err = links[i]->error;
 				break;
@@ -1548,14 +1552,22 @@ static ssize_t adrv9009_phy_show(struct device *dev,
 		ret = sprintf(buf, "%d\n", err);
 		break;
 	case ADRV9009_JESD204_FSM_PAUSED:
-		ret = jesd204_get_links_data(jdev, links, 3);
+		num_links = jesd204_get_active_links_num(jdev);
+		if (num_links < 0)
+			return num_links;
+
+		ret = jesd204_get_links_data(jdev, links, num_links);
 		if (ret)
 			return ret;
 		/* just get the first link state; we're assuming that all 3 are in sync  */
 		ret = sprintf(buf, "%d\n", jesd204_link_get_paused(links[0]));
 		break;
 	case ADRV9009_JESD204_FSM_STATE:
-		ret = jesd204_get_links_data(jdev, links, 3);
+		num_links = jesd204_get_active_links_num(jdev);
+		if (num_links < 0)
+			return num_links;
+
+		ret = jesd204_get_links_data(jdev, links, num_links);
 		if (ret)
 			return ret;
 		/* just get the first link state; we're assuming that all 3 are in sync  */

--- a/drivers/jesd204/jesd204-core.c
+++ b/drivers/jesd204/jesd204-core.c
@@ -33,6 +33,22 @@ static unsigned int jesd204_con_id_counter;
 
 static void jesd204_dev_unregister(struct jesd204_dev *jdev);
 
+int jesd204_get_active_links_num(struct jesd204_dev *jdev)
+{
+	struct jesd204_dev_top *jdev_top;
+
+	if (!jdev)
+		return -EINVAL;
+
+	jdev_top = jesd204_dev_get_topology_top_dev(jdev);
+	if (!jdev_top) {
+		jesd204_err(jdev, "Could not find top-level device\n");
+		return -EFAULT;
+	}
+
+	return jdev_top->num_links;
+}
+
 int jesd204_get_links_data(struct jesd204_dev *jdev,
 			   struct jesd204_link ** const links,
 			   const unsigned int num_links)

--- a/include/linux/jesd204/jesd204.h
+++ b/include/linux/jesd204/jesd204.h
@@ -251,6 +251,8 @@ struct jesd204_dev_data {
 struct jesd204_dev *devm_jesd204_dev_register(struct device *dev,
 					      const struct jesd204_dev_data *i);
 
+int jesd204_get_active_links_num(struct jesd204_dev *jdev);
+
 int jesd204_get_links_data(struct jesd204_dev *jdev,
 			   struct jesd204_link ** const links,
 			   const unsigned int num_links);
@@ -291,6 +293,11 @@ static inline struct jesd204_dev *devm_jesd204_dev_register(
 		struct device *dev, const struct jesd204_dev_data *init)
 {
 	return NULL;
+}
+
+static inline int jesd204_get_active_links_num(struct jesd204_dev *jdev)
+{
+	return -ENOTSUPP;
 }
 
 static inline int jesd204_get_links_data(struct jesd204_dev *jdev,


### PR DESCRIPTION
Changeset adds a helper to retrieve active number of links.

For ADR9009, we need to apply the hooks for the FSM paused stuff, based on the number of active links, not the max number of links.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>