### PR TITLE
arch: microblaze: boot: dts: Add CPLL VCO

### DIFF
--- a/arch/microblaze/boot/dts/kc705_fmcdaq2.dts
+++ b/arch/microblaze/boot/dts/kc705_fmcdaq2.dts
@@ -98,6 +98,7 @@
 		adi,out-clk-select = <4>;
 		adi,use-lpm-enable;
 		adi,use-cpll-enable;
+		adi,vco-max-khz = <5000000>;
 
 		#clock-cells = <1>;
 		clock-output-names = "adc_gt_clk", "rx_out_clk";


### PR DESCRIPTION
DAQ2 CPLL on microblaze KC705 was used out of spec. In order for the device
to be probed correctly VCO max frequency was defined in the device tree
since it was above the 3.3 GHz limit for GTX2.

Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>