### PR TITLE
arch: arm: rpi-cn0504: add dt overlay for the board

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -151,6 +151,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	rpi-ad5791.dtbo \
 	rpi-backlight.dtbo \
 	rpi-cirrus-wm5102.dtbo \
+	rpi-cn0504.dtbo \
 	rpi-cn0508.dtbo \
 	rpi-cn0511.dtbo \
 	rpi-dac.dtbo \

--- a/arch/arm/boot/dts/overlays/rpi-cn0504-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-cn0504-overlay.dts
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709", "brcm,bcm2711";
+
+	fragment@0 {
+		target = <&ethernet>;
+		__overlay__ {
+			#address-cells = <2>;
+			#size-cells = <0>;
+
+			/* this works on RPi3 */
+			usb_eth_interface: usb_eth_interface@0 {
+				reg = <0 1>;
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&i2c1>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			ltc2945@6f{
+				compatible = "adi,ltc2945";
+				reg = <0x6f>;
+			};
+		};
+	};
+
+	fragment@2 {
+		target = <&spi0>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			ksz9477@0 {
+				compatible = "microchip,ksz9477";
+				reg = <0>;
+				spi-max-frequency = <500000>;
+
+				ports {
+					#address-cells = <1>;
+					#size-cells = <0>;
+					/**
+					 * LAN1 should be connected via an ethernet
+					 * cable to the RPi's ethernet jack
+					 */
+					port@0 {
+						reg = <0>;
+						label = "lan1";
+						ethernet = <&usb_eth_interface>;
+					};
+					port@1 {
+						reg = <1>;
+						label = "lan2";
+					};
+					port@2 {
+						reg = <2>;
+						label = "lan3";
+					};
+				};
+			};
+		};
+	};
+
+	fragment@3 {
+		target = <&spidev0>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@4 {
+		target = <&spidev1>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+};


### PR DESCRIPTION
This adds support for the CN0504 ethernet hat board for Raspberry Pi.
For the overlay, this needs to setup the Microchip KSZ9477 switch, and
LTC2945 power monitor drivers to be available.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>