### PR TITLE
arch: arm: zc706,daq3: add overclocked VCO limit for QPLL

### DIFF
--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcdaq3-revC.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcdaq3-revC.dts
@@ -112,6 +112,7 @@
 
 &axi_ad9152_adxcvr {
 	clocks = <&clk0_ad9528 4>, <&clk0_ad9528 6>;
+	adi,vco1-max-khz = <12333340>;
 };
 
 


### PR DESCRIPTION
This is a work-around for the TX QPLL, to bump to limit from 10
giga-samples to 12.3 giga-samples.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>