### PR TITLE
arch: arm: boot: dts: cn0540: cora: Change spi_clk parent

### DIFF
--- a/arch/arm/boot/dts/zynq-coraz7s-cn0540.dts
+++ b/arch/arm/boot/dts/zynq-coraz7s-cn0540.dts
@@ -135,7 +135,7 @@
 		reg = <0x44a00000 0x10000>;
 		interrupt-parent = <&intc>;
 		interrupts = <0 55 IRQ_TYPE_LEVEL_HIGH>;
-		clocks = <&clkc 15 &clkc 16>;
+		clocks = <&clkc 15 &spi_clk>;
 		clock-names = "s_axi_aclk", "spi_clk";
 		num-cs = <1>;
 
@@ -176,5 +176,14 @@
 			reg = <0x10>;
 			vref-supply = <&vref>;
 		};
+	};
+
+	spi_clk: axi-clkgen@0x44a70000 {
+		compatible = "adi,axi-clkgen-2.00.a";
+		reg = <0x44a70000 0x10000>;
+		#clock-cells = <0>;
+		clocks = <&clkc 15>, <&clkc 15>;
+		clock-names = "s_axi_aclk", "clkin1";
+		clock-output-names = "spi_clk";
 	};
 };


### PR DESCRIPTION
In order to get a more stable spi clock, an axi_clkgen IP has been
added. This change updates the devicetree according to the hardware
changes.

Signed-off-by: Sergiu Cuciurean <sergiu.cuciurean@analog.com>