### PR TITLE
Dev/adrv9002 misc enhancements

### DIFF
--- a/arch/arm/boot/dts/adi-adrv9002.dtsi
+++ b/arch/arm/boot/dts/adi-adrv9002.dtsi
@@ -24,7 +24,7 @@
 		/* Clocks */
 		clocks = <&adrv9002_clkin 0>;
 		clock-names = "adrv9002_ext_refclk";
-		clock-output-names = "rx1_sampl_clk", "rx2_sampl_clk", "tx1_sampl_clk", "tx2_sampl_clk";
+		clock-output-names = "rx1_sampl_clk", "tx1_sampl_clk", "rx2_sampl_clk", "tx2_sampl_clk";
 		#clock-cells = <1>;
 
 		agc0: agc@0 {

--- a/arch/arm/boot/dts/zynq-zed-adrv9002-rx2tx2.dts
+++ b/arch/arm/boot/dts/zynq-zed-adrv9002-rx2tx2.dts
@@ -85,7 +85,7 @@
 		axi_adrv9002_core_tx: axi-adrv9002-tx-lpc@44A0A000 {
 			compatible = "adi,axi-adrv9002-rx2tx2-1.0";
 			reg = <0x44A0A000 0x2000>;
-			clocks = <&adc0_adrv9002 2>;
+			clocks = <&adc0_adrv9002 1>;
 			clock-names = "sampl_clk";
 			dmas = <&tx_dma 0>;
 			dma-names = "tx";
@@ -146,5 +146,7 @@ dgpio_0		32	86
 	compatible = "adi,adrv9002-rx2tx2";
 	reset-gpios = <&gpio0 100 GPIO_ACTIVE_LOW>;
 	ssi-sync-gpios = <&gpio0 108 GPIO_ACTIVE_HIGH>;
+
+	clock-output-names = "rx1_sampl_clk", "tx1_sampl_clk";
 };
 

--- a/arch/arm/boot/dts/zynq-zed-adrv9002.dts
+++ b/arch/arm/boot/dts/zynq-zed-adrv9002.dts
@@ -129,7 +129,7 @@
 		axi_adrv9002_core_tx1: axi-adrv9002-tx-lpc@44A04000 {
 			compatible = "adi,axi-adrv9002-tx-1.0";
 			reg = <0x44A0A000 0x2000>;
-			clocks = <&adc0_adrv9002 2>;
+			clocks = <&adc0_adrv9002 1>;
 			clock-names = "sampl_clk";
 			dmas = <&tx1_dma 0>;
 			dma-names = "tx";
@@ -140,7 +140,7 @@
 		axi_adrv9002_core_rx2: axi-adrv9002-rx2-lpc@44A02000 {
 			compatible = "adi,axi-adrv9002-rx2-1.0";
 			reg = <0x44A09000 0x1000>;
-			clocks = <&adc0_adrv9002 1>;
+			clocks = <&adc0_adrv9002 2>;
 			clock-names = "sampl_clk";
 			dmas = <&rx2_dma 0>;
 			dma-names = "rx";

--- a/arch/arm64/boot/dts/xilinx/adi-adrv9002.dtsi
+++ b/arch/arm64/boot/dts/xilinx/adi-adrv9002.dtsi
@@ -24,7 +24,7 @@
 		/* Clocks */
 		clocks = <&adrv9002_clkin 0>;
 		clock-names = "adrv9002_ext_refclk";
-		clock-output-names = "rx1_sampl_clk", "rx2_sampl_clk", "tx1_sampl_clk", "tx2_sampl_clk";
+		clock-output-names = "rx1_sampl_clk", "tx1_sampl_clk", "rx2_sampl_clk", "tx2_sampl_clk";
 		#clock-cells = <1>;
 
 		agc0: agc@0 {

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9002-rx2tx2.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9002-rx2tx2.dts
@@ -89,7 +89,7 @@
 		axi_adrv9002_core_tx: axi-adrv9002-tx-lpc@84A04000 {
 			compatible = "adi,axi-adrv9002-rx2tx2-1.0";
 			reg = <0x84A02000 0x2000>;
-			clocks = <&adc0_adrv9002 2>;
+			clocks = <&adc0_adrv9002 1>;
 			clock-names = "sampl_clk";
 			dmas = <&tx_dma 0>;
 			dma-names = "tx";
@@ -144,4 +144,5 @@ dgpio_0		32	110
 	compatible = "adi,adrv9002-rx2tx2";
 	reset-gpios = <&gpio 124 GPIO_ACTIVE_LOW>;
 	ssi-sync-gpios = <&gpio 132 GPIO_ACTIVE_HIGH>;
+	clock-output-names = "rx1_sampl_clk", "tx1_sampl_clk";
 };

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9002.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9002.dts
@@ -131,7 +131,7 @@
 		axi_adrv9002_core_tx1: axi-adrv9002-tx-lpc@84A04000 {
 			compatible = "adi,axi-adrv9002-tx-1.0";
 			reg = <0x84A0A000 0x2000>;
-			clocks = <&adc0_adrv9002 2>;
+			clocks = <&adc0_adrv9002 1>;
 			clock-names = "sampl_clk";
 			dmas = <&tx1_dma 0>;
 			dma-names = "tx";
@@ -142,7 +142,7 @@
 		axi_adrv9002_core_rx2: axi-adrv9002-rx2-lpc@84A02000 {
 			compatible = "adi,axi-adrv9002-rx2-1.0";
 			reg = <0x84A09000 0x1000>;
-			clocks = <&adc0_adrv9002 1>;
+			clocks = <&adc0_adrv9002 2>;
 			clock-names = "sampl_clk";
 			dmas = <&rx2_dma 0>;
 			dma-names = "rx";

--- a/drivers/iio/adc/navassa/adrv9002.h
+++ b/drivers/iio/adc/navassa/adrv9002.h
@@ -98,6 +98,7 @@ struct adrv9002_clock {
 };
 
 struct adrv9002_chan {
+	struct clk *clk;
 	adi_adrv9001_ChannelState_e cached_state;
 	adi_common_ChannelNumber_e number;
 	u32 power;
@@ -152,6 +153,7 @@ struct adrv9002_rf_phy {
 	struct adi_adrv9001_Init	*curr_profile;
 	struct adi_adrv9001_Init	profile;
 	struct adi_adrv9001_InitCals	init_cals;
+	u32				n_clks;
 	int				spi_device_id;
 	int				ngpios;
 	u8				rx2tx2;

--- a/drivers/iio/adc/navassa/adrv9002_conv.c
+++ b/drivers/iio/adc/navassa/adrv9002_conv.c
@@ -340,15 +340,15 @@ void adrv9002_axi_digital_tune_verbose(struct adrv9002_rf_phy *phy, u8 field[][8
 {
 	int i, j;
 	char c;
-	u8 clk;
+	struct adrv9002_chan *ch;
 
 	if (tx)
-		clk = channel ? TX2_SAMPL_CLK : TX1_SAMPL_CLK;
+		ch = &phy->tx_channels[channel].channel;
 	else
-		clk = channel ? RX2_SAMPL_CLK : RX1_SAMPL_CLK;
+		ch = &phy->tx_channels[channel].channel;
 
 	pr_info("SAMPL CLK: %lu tuning: %s%d\n",
-	        clk_get_rate(phy->clks[clk]), tx ? "TX" : "RX",
+	        clk_get_rate(ch->clk), tx ? "TX" : "RX",
 		channel ? 2 : 1);
 	pr_info("  ");
 	for (i = 0; i < 8; i++)


### PR DESCRIPTION
This patch series does some improvements on how the clocks are registered to be consumed by the DAC/ADC drivers. For instance, in rx2tx2 mode, we just need to register RX1/TX1 clocks...

It also adds some improvements on cleaning up before loading a new profile...