### PR TITLE
arch: arm: dts: add license + project tags

### DIFF
--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcjesdadc1.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcjesdadc1.dts
@@ -1,4 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD-FMCOMMS11-EBZ
+ * https://wiki.analog.com/resources/eval/user-guides/ad-fmcjesdadc1-ebz
+ *
+ * hdl_project: <fmcjesdadc1/zc706>
+ * board_revision: <>
+ *
+ * Copyright (C) 2014-2020 Analog Devices Inc.
+*/
 /dts-v1/;
+
 
 #include "zynq-zc706.dtsi"
 #include "zynq-zc706-adv7511.dtsi"

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcomms11.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcomms11.dts
@@ -1,3 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD-FMCOMMS11-EBZ
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/ad9361
+ * https://wiki.analog.com/resources/eval/user-guides/ad-fmcomms11-ebz/hardware/functional_overview
+ *
+ * hdl_project: <fmcomms11/zc706>
+ * board_revision: <>
+ *
+ * Copyright (C) 2014-2020 Analog Devices Inc.
+*/
 /dts-v1/;
 
 #include "zynq-zc706.dtsi"

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad9364-fmcomms4.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad9364-fmcomms4.dts
@@ -1,3 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices EVAL-AD-FMCOMMS4-EBZ
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/ad9361
+ * https://wiki.analog.com/eval/user-guides/ad-fmcomms4-ebz
+ *
+ * hdl_project: <fmcomms2/zed>
+ * board_revision: <>
+ *
+ * Copyright (C) 2014-2020 Analog Devices Inc.
+ */
 /dts-v1/;
 
 #include "zynq-zed.dtsi"

--- a/arch/arm/boot/dts/zynq-zed-imageon.dts
+++ b/arch/arm/boot/dts/zynq-zed-imageon.dts
@@ -1,3 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices FMC-IMAGEON
+ * https://wiki.analog.com/resources/fpga/xilinx/fmc/fmc-imageon
+ *
+ * hdl_project: <imageon>
+ * board_revision: <>
+ *
+ * Copyright (C) 2016-2020 Analog Devices Inc.
+ */
 /dts-v1/;
 
 #include "zynq-zed.dtsi"


### PR DESCRIPTION
This change adds license and project tags to fmcjesdadc1, fmcomms11, fmcomms4 and imageon device tree files.