### PR TITLE
arch: arm: dts: zynq-zed-imageon.dts: fix a typo in hdl tag

### DIFF
--- a/arch/arm/boot/dts/zynq-zed-imageon.dts
+++ b/arch/arm/boot/dts/zynq-zed-imageon.dts
@@ -3,7 +3,7 @@
  * Analog Devices FMC-IMAGEON
  * https://wiki.analog.com/resources/fpga/xilinx/fmc/fmc-imageon
  *
- * hdl_project: <imageon>
+ * hdl_project: <imageon/zed>
  * board_revision: <>
  *
  * Copyright (C) 2016-2020 Analog Devices Inc.


### PR DESCRIPTION
This commit is changing hdl tag in zynq-zed-imageon.dts, from 'imageon' to 'imageon/zed'.