### PR TITLE
Dev/tdd core refact

### DIFF
--- a/arch/arm/boot/dts/adi-adrv9002.dtsi
+++ b/arch/arm/boot/dts/adi-adrv9002.dtsi
@@ -24,7 +24,8 @@
 		/* Clocks */
 		clocks = <&adrv9002_clkin 0>;
 		clock-names = "adrv9002_ext_refclk";
-		clock-output-names = "rx1_sampl_clk", "tx1_sampl_clk", "rx2_sampl_clk", "tx2_sampl_clk";
+		clock-output-names = "rx1_sampl_clk", "tx1_sampl_clk", "tdd1_intf_clk",
+				"rx2_sampl_clk", "tx2_sampl_clk", "tdd2_intf_clk";
 		#clock-cells = <1>;
 
 		agc0: agc@0 {

--- a/arch/arm/boot/dts/zynq-zed-adrv9002-rx2tx2.dts
+++ b/arch/arm/boot/dts/zynq-zed-adrv9002-rx2tx2.dts
@@ -93,6 +93,13 @@
 			adi,axi-dds-default-frequency = <2000000>;
 		};
 
+		axi_adrv9002_core_tdd: axi-adrv9002-core-tdd-lpc@44A0C800 {
+			compatible = "adi,axi-tdd-1.00";
+			reg = <0x44A0C800 0x400>;
+			clocks = <&clkc 16>, <&adc0_adrv9002 2>;
+			clock-names = "s_axi_aclk", "intf_clk";
+		};
+
 		misc_clk_0: misc_clk_0 {
 			#clock-cells = <0>;
 			clock-frequency = <100000000>;
@@ -147,6 +154,6 @@ dgpio_0		32	86
 	reset-gpios = <&gpio0 100 GPIO_ACTIVE_LOW>;
 	ssi-sync-gpios = <&gpio0 108 GPIO_ACTIVE_HIGH>;
 
-	clock-output-names = "rx1_sampl_clk", "tx1_sampl_clk";
+	clock-output-names = "rx1_sampl_clk", "tx1_sampl_clk", "tdd1_intf_clk";
 };
 

--- a/arch/arm/boot/dts/zynq-zed-adrv9002.dts
+++ b/arch/arm/boot/dts/zynq-zed-adrv9002.dts
@@ -137,10 +137,17 @@
 			adi,axi-dds-default-frequency = <2000000>;
 		};
 
+		axi_adrv9002_core_tdd1: axi-adrv9002-core-tdd1-lpc@44A0C800 {
+			compatible = "adi,axi-tdd-1.00";
+			reg = <0x44A0C800 0x400>;
+			clocks = <&clkc 16>, <&adc0_adrv9002 2>;
+			clock-names = "s_axi_aclk", "intf_clk";
+		};
+
 		axi_adrv9002_core_rx2: axi-adrv9002-rx2-lpc@44A02000 {
 			compatible = "adi,axi-adrv9002-rx2-1.0";
 			reg = <0x44A09000 0x1000>;
-			clocks = <&adc0_adrv9002 2>;
+			clocks = <&adc0_adrv9002 3>;
 			clock-names = "sampl_clk";
 			dmas = <&rx2_dma 0>;
 			dma-names = "rx";
@@ -149,12 +156,19 @@
 		axi_adrv9002_core_tx2: axi-adrv9002-tx2-lpc@44A06000 {
 			compatible = "adi,axi-adrv9002-tx-1.0";
 			reg = <0x44A0C000 0x2000>;
-			clocks = <&adc0_adrv9002 3>;
+			clocks = <&adc0_adrv9002 4>;
 			clock-names = "sampl_clk";
 			dmas = <&tx2_dma 0>;
 			dma-names = "tx";
 			adi,axi-dds-default-scale = <0x800>;
 			adi,axi-dds-default-frequency = <2000000>;
+		};
+
+		axi_adrv9002_core_tdd2: axi-adrv9002-core-tdd2-lpc@44A0C800 {
+			compatible = "adi,axi-tdd-1.00";
+			reg = <0x44A0CC00 0x400>;
+			clocks = <&clkc 16>, <&adc0_adrv9002 5>;
+			clock-names = "s_axi_aclk", "intf_clk";
 		};
 
 		misc_clk_0: misc_clk_0 {

--- a/arch/arm64/boot/dts/xilinx/adi-adrv9002.dtsi
+++ b/arch/arm64/boot/dts/xilinx/adi-adrv9002.dtsi
@@ -24,7 +24,8 @@
 		/* Clocks */
 		clocks = <&adrv9002_clkin 0>;
 		clock-names = "adrv9002_ext_refclk";
-		clock-output-names = "rx1_sampl_clk", "tx1_sampl_clk", "rx2_sampl_clk", "tx2_sampl_clk";
+		clock-output-names = "rx1_sampl_clk", "tx1_sampl_clk", "tdd1_intf_clk",
+				"rx2_sampl_clk", "tx2_sampl_clk", "tdd2_intf_clk";
 		#clock-cells = <1>;
 
 		agc0: agc@0 {

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9002-rx2tx2.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9002-rx2tx2.dts
@@ -97,6 +97,13 @@
 			adi,axi-dds-default-frequency = <2000000>;
 		};
 
+		axi_adrv9002_core_tdd: axi-adrv9002-core-tdd-lpc@44A0C800 {
+			compatible = "adi,axi-tdd-1.00";
+			reg = <0x84A0C800 0x400>;
+			clocks = <&zynqmp_clk 71>, <&adc0_adrv9002 2>;
+			clock-names = "s_axi_aclk", "intf_clk";
+		};
+
 		axi_sysid_0: axi-sysid-0@85000000 {
 			compatible = "adi,axi-sysid-1.00.a";
 			reg = <0x85000000 0x10000>;
@@ -144,5 +151,5 @@ dgpio_0		32	110
 	compatible = "adi,adrv9002-rx2tx2";
 	reset-gpios = <&gpio 124 GPIO_ACTIVE_LOW>;
 	ssi-sync-gpios = <&gpio 132 GPIO_ACTIVE_HIGH>;
-	clock-output-names = "rx1_sampl_clk", "tx1_sampl_clk";
+	clock-output-names = "rx1_sampl_clk", "tx1_sampl_clk", "tdd1_intf_clk";
 };

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9002.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9002.dts
@@ -139,10 +139,17 @@
 			adi,axi-dds-default-frequency = <2000000>;
 		};
 
+		axi_adrv9002_core_tdd1: axi-adrv9002-core-tdd1-lpc@44A0C800 {
+			compatible = "adi,axi-tdd-1.00";
+			reg = <0x84A0C800 0x400>;
+			clocks = <&zynqmp_clk 71>, <&adc0_adrv9002 2>;
+			clock-names = "s_axi_aclk", "intf_clk";
+		};
+
 		axi_adrv9002_core_rx2: axi-adrv9002-rx2-lpc@84A02000 {
 			compatible = "adi,axi-adrv9002-rx2-1.0";
 			reg = <0x84A09000 0x1000>;
-			clocks = <&adc0_adrv9002 2>;
+			clocks = <&adc0_adrv9002 3>;
 			clock-names = "sampl_clk";
 			dmas = <&rx2_dma 0>;
 			dma-names = "rx";
@@ -151,12 +158,19 @@
 		axi_adrv9002_core_tx2: axi-adrv9002-tx2-lpc@84A06000 {
 			compatible = "adi,axi-adrv9002-tx-1.0";
 			reg = <0x84A0C000 0x2000>;
-			clocks = <&adc0_adrv9002 3>;
+			clocks = <&adc0_adrv9002 4>;
 			clock-names = "sampl_clk";
 			dmas = <&tx2_dma 0>;
 			dma-names = "tx";
 			adi,axi-dds-default-scale = <0x800>;
 			adi,axi-dds-default-frequency = <2000000>;
+		};
+
+		axi_adrv9002_core_tdd2: axi-adrv9002-core-tdd2-lpc@44A0C800 {
+			compatible = "adi,axi-tdd-1.00";
+			reg = <0x84A0CC00 0x400>;
+			clocks = <&zynqmp_clk 71>, <&adc0_adrv9002 5>;
+			clock-names = "s_axi_aclk", "intf_clk";
 		};
 
 		axi_sysid_0: axi-sysid-0@85000000 {

--- a/drivers/iio/adc/cf_axi_tdd.c
+++ b/drivers/iio/adc/cf_axi_tdd.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0
 /*
  * TDD HDL CORE driver
  *
@@ -6,6 +7,7 @@
  * Licensed under the GPL-2.
  */
 
+#include <linux/bits.h>
 #include <linux/module.h>
 #include <linux/interrupt.h>
 #include <linux/errno.h>
@@ -31,12 +33,12 @@
 /* Transceiver TDD Control (axi_ad*) */
 
 #define ADI_REG_TDD_CONTROL_0		0x0040
-#define ADI_TDD_DMA_GATE_TX_EN		(1 << 5)
-#define ADI_TDD_DMA_GATE_RX_EN		(1 << 4)
-#define ADI_TDD_TXONLY_EN			(1 << 3)
-#define ADI_TDD_RXONLY_EN			(1 << 2)
-#define ADI_TDD_SECONDARY			(1 << 1)
-#define ADI_TDD_ENABLE				(1 << 0)
+#define ADI_TDD_DMA_GATE_TX_EN		BIT(5)
+#define ADI_TDD_DMA_GATE_RX_EN		BIT(4)
+#define ADI_TDD_TXONLY_EN		BIT(3)
+#define ADI_TDD_RXONLY_EN		BIT(2)
+#define ADI_TDD_SECONDARY		BIT(1)
+#define ADI_TDD_ENABLE			BIT(0)
 
 #define ADI_REG_TDD_CONTROL_1		0x0044
 #define ADI_TDD_BURST_COUNT(x)		(((x) & 0xFF) << 0)
@@ -51,7 +53,7 @@
 #define ADI_TO_TDD_FRAME_LENGTH(x)	(((x) >> 0) & 0xFFFFFF)
 
 #define ADI_REG_TDD_SYNC_TERM_TYPE	0x0050
-#define ADI_TDD_SYNC_PULSE_ENABLE	(1 << 0)
+#define ADI_TDD_SYNC_PULSE_ENABLE	BIT(0)
 
 #define ADI_REG_TDD_VCO_RX_ON_1		0x0080
 #define ADI_TDD_VCO_RX_ON_1(x)		(((x) & 0xFFFFFF) << 0)
@@ -69,20 +71,20 @@
 #define ADI_TDD_VCO_TX_OFF_1(x)		(((x) & 0xFFFFFF) << 0)
 #define ADI_TO_TDD_VCO_TX_OFF_1(x)	(((x) >> 0) & 0xFFFFFF)
 
-#define ADI_REG_TDD_RX_ON_1			0x0090
-#define ADI_TDD_RX_ON_1(x)			(((x) & 0xFFFFFF) << 0)
+#define ADI_REG_TDD_RX_ON_1		0x0090
+#define ADI_TDD_RX_ON_1(x)		(((x) & 0xFFFFFF) << 0)
 #define ADI_TO_TDD_RX_ON_1(x)		(((x) >> 0) & 0xFFFFFF)
 
 #define ADI_REG_TDD_RX_OFF_1		0x0094
-#define ADI_TDD_RX_OFF_1(x)			(((x) & 0xFFFFFF) << 0)
+#define ADI_TDD_RX_OFF_1(x)		(((x) & 0xFFFFFF) << 0)
 #define ADI_TO_TDD_RX_OFF_1(x)		(((x) >> 0) & 0xFFFFFF)
 
-#define ADI_REG_TDD_TX_ON_1			0x0098
-#define ADI_TDD_TX_ON_1(x)			(((x) & 0xFFFFFF) << 0)
+#define ADI_REG_TDD_TX_ON_1		0x0098
+#define ADI_TDD_TX_ON_1(x)		(((x) & 0xFFFFFF) << 0)
 #define ADI_TO_TDD_TX_ON_1(x)		(((x) >> 0) & 0xFFFFFF)
 
 #define ADI_REG_TDD_TX_OFF_1		0x009C
-#define ADI_TDD_TX_OFF_1(x)			(((x) & 0xFFFFFF) << 0)
+#define ADI_TDD_TX_OFF_1(x)		(((x) & 0xFFFFFF) << 0)
 #define ADI_TO_TDD_TX_OFF_1(x)		(((x) >> 0) & 0xFFFFFF)
 
 #define ADI_REG_TDD_TX_DP_ON_1		0x00A0
@@ -117,20 +119,20 @@
 #define ADI_TDD_VCO_TX_OFF_2(x)		(((x) & 0xFFFFFF) << 0)
 #define ADI_TO_TDD_VCO_TX_OFF_2(x)	(((x) >> 0) & 0xFFFFFF)
 
-#define ADI_REG_TDD_RX_ON_2			0x00D0
-#define ADI_TDD_RX_ON_2(x)			(((x) & 0xFFFFFF) << 0)
+#define ADI_REG_TDD_RX_ON_2		0x00D0
+#define ADI_TDD_RX_ON_2(x)		(((x) & 0xFFFFFF) << 0)
 #define ADI_TO_TDD_RX_ON_2(x)		(((x) >> 0) & 0xFFFFFF)
 
 #define ADI_REG_TDD_RX_OFF_2		0x00D4
-#define ADI_TDD_RX_OFF_2(x)			(((x) & 0xFFFFFF) << 0)
+#define ADI_TDD_RX_OFF_2(x)		(((x) & 0xFFFFFF) << 0)
 #define ADI_TO_TDD_RX_OFF_2(x)		(((x) >> 0) & 0xFFFFFF)
 
-#define ADI_REG_TDD_TX_ON_2			0x00D8
-#define ADI_TDD_TX_ON_2(x)			(((x) & 0xFFFFFF) << 0)
+#define ADI_REG_TDD_TX_ON_2		0x00D8
+#define ADI_TDD_TX_ON_2(x)		(((x) & 0xFFFFFF) << 0)
 #define ADI_TO_TDD_TX_ON_2(x)		(((x) >> 0) & 0xFFFFFF)
 
 #define ADI_REG_TDD_TX_OFF_2		0x00DC
-#define ADI_TDD_TX_OFF_2(x)			(((x) & 0xFFFFFF) << 0)
+#define ADI_TDD_TX_OFF_2(x)		(((x) & 0xFFFFFF) << 0)
 #define ADI_TO_TDD_TX_OFF_2(x)		(((x) >> 0) & 0xFFFFFF)
 
 #define ADI_REG_TDD_TX_DP_ON_2		0x00E0
@@ -156,12 +158,12 @@ struct cf_axi_tdd_state {
 	void __iomem		*regs;
 	/* TDD core access locking */
 	struct mutex		lock;
-	unsigned			version;
-	unsigned			enable;
-	unsigned			mode;
-	unsigned			dma_mode;
-	unsigned			profile;
-	u32					config[MAX_NUM_PROFILES][27];
+	u32			version;
+	u32			enable;
+	u32			mode;
+	u32			dma_mode;
+	u32			profile;
+	u32			config[MAX_NUM_PROFILES][27];
 
 };
 
@@ -173,18 +175,17 @@ enum {
 	CF_AXI_TDD_PROFILE_CONFIG,
 };
 
-static inline void tdd_write(struct cf_axi_tdd_state *st,
-			     unsigned reg, unsigned val)
+static inline void tdd_write(struct cf_axi_tdd_state *st, const u32 reg, const u32 val)
 {
 	iowrite32(val, st->regs + reg);
 }
 
-static inline unsigned int tdd_read(struct cf_axi_tdd_state *st, unsigned reg)
+static inline unsigned int tdd_read(struct cf_axi_tdd_state *st, const u32 reg)
 {
 	return ioread32(st->regs + reg);
 }
 
-static inline void tdd_write_config(struct cf_axi_tdd_state *st, unsigned profile)
+static inline void tdd_write_config(struct cf_axi_tdd_state *st, const u32 profile)
 {
 	int i;
 
@@ -197,7 +198,7 @@ static inline void tdd_write_config(struct cf_axi_tdd_state *st, unsigned profil
 
 }
 
-static inline void tdd_read_config(struct cf_axi_tdd_state *st, unsigned profile)
+static inline void tdd_read_config(struct cf_axi_tdd_state *st, const u32 profile)
 {
 	int i;
 
@@ -228,8 +229,7 @@ static ssize_t cf_axi_tdd_store(struct device *dev,
 		if (ret < 0)
 			break;
 		st->enable = (state ? ADI_TDD_ENABLE : 0);
-		tdd_write(st, ADI_REG_TDD_CONTROL_0,
-				  st->dma_mode | st->mode | st->enable);
+		tdd_write(st, ADI_REG_TDD_CONTROL_0, st->dma_mode | st->mode | st->enable);
 		break;
 	case CF_AXI_TDD_ENABLE_MODE:
 		if (sysfs_streq(buf, "rx_tx"))
@@ -238,8 +238,7 @@ static ssize_t cf_axi_tdd_store(struct device *dev,
 			st->mode = ADI_TDD_RXONLY_EN;
 		else if (sysfs_streq(buf, "tx_only"))
 			st->mode = ADI_TDD_TXONLY_EN;
-		tdd_write(st, ADI_REG_TDD_CONTROL_0,
-				  st->dma_mode | st->mode | st->enable);
+		tdd_write(st, ADI_REG_TDD_CONTROL_0, st->dma_mode | st->mode | st->enable);
 		break;
 	case CF_AXI_TDD_DMA_GATEING_MODE:
 		if (sysfs_streq(buf, "rx_tx"))
@@ -250,8 +249,7 @@ static ssize_t cf_axi_tdd_store(struct device *dev,
 			st->dma_mode = ADI_TDD_DMA_GATE_TX_EN;
 		else if (sysfs_streq(buf, "none"))
 			st->dma_mode = 0;
-		tdd_write(st, ADI_REG_TDD_CONTROL_0,
-				  st->dma_mode | st->mode | st->enable);
+		tdd_write(st, ADI_REG_TDD_CONTROL_0, st->dma_mode | st->mode | st->enable);
 		break;
 	case CF_AXI_TDD_BURST_COUNT:
 		ret = kstrtoul(buf, 0, &readin);
@@ -282,9 +280,7 @@ static ssize_t cf_axi_tdd_store(struct device *dev,
 	return ret ? ret : len;
 }
 
-static ssize_t cf_axi_tdd_show(struct device *dev,
-			struct device_attribute *attr,
-			char *buf)
+static ssize_t cf_axi_tdd_show(struct device *dev, struct device_attribute *attr, char *buf)
 {
 	struct iio_dev *indio_dev = dev_to_iio_dev(dev);
 	struct iio_dev_attr *this_attr = to_iio_dev_attr(attr);
@@ -302,7 +298,7 @@ static ssize_t cf_axi_tdd_show(struct device *dev,
 			"tx_only" : "rx_tx");
 		break;
 	case CF_AXI_TDD_DMA_GATEING_MODE:
-		switch(st->dma_mode) {
+		switch (st->dma_mode) {
 		case ADI_TDD_DMA_GATE_RX_EN | ADI_TDD_DMA_GATE_TX_EN:
 			ret = sprintf(buf, "%s\n", "rx_tx");
 			break;
@@ -331,31 +327,31 @@ static ssize_t cf_axi_tdd_show(struct device *dev,
 	return ret;
 }
 
-static IIO_DEVICE_ATTR(enable, S_IRUGO | S_IWUSR,
+static IIO_DEVICE_ATTR(enable, 0644,
 			cf_axi_tdd_show,
 			cf_axi_tdd_store,
 			CF_AXI_TDD_ENABLE);
 
-static IIO_DEVICE_ATTR(enable_mode, S_IRUGO | S_IWUSR,
+static IIO_DEVICE_ATTR(enable_mode, 0644,
 			cf_axi_tdd_show,
 			cf_axi_tdd_store,
 			CF_AXI_TDD_ENABLE_MODE);
 
 static IIO_CONST_ATTR(enable_mode_available, "rx_tx rx_only tx_only");
 
-static IIO_DEVICE_ATTR(dma_gateing_mode, S_IRUGO | S_IWUSR,
+static IIO_DEVICE_ATTR(dma_gateing_mode, 0644,
 			cf_axi_tdd_show,
 			cf_axi_tdd_store,
 			CF_AXI_TDD_DMA_GATEING_MODE);
 
 static IIO_CONST_ATTR(dma_gateing_mode_available, "none rx_only tx_only rx_tx");
 
-static IIO_DEVICE_ATTR(burst_count, S_IRUGO | S_IWUSR,
+static IIO_DEVICE_ATTR(burst_count, 0644,
 			cf_axi_tdd_show,
 			cf_axi_tdd_store,
 			CF_AXI_TDD_BURST_COUNT);
 
-static IIO_DEVICE_ATTR(profile_config, S_IRUGO | S_IWUSR,
+static IIO_DEVICE_ATTR(profile_config, 0644,
 			cf_axi_tdd_show,
 			cf_axi_tdd_store,
 			CF_AXI_TDD_PROFILE_CONFIG);
@@ -375,15 +371,13 @@ static const struct attribute_group cf_axi_tdd_attribute_group = {
 	.attrs = cf_axi_tdd_attributes,
 };
 
-static int cf_axi_tdd_reg_access(struct iio_dev *indio_dev,
-			      unsigned reg, unsigned writeval,
-			      unsigned *readval)
+static int cf_axi_tdd_reg_access(struct iio_dev *indio_dev, u32 reg, u32 writeval, u32 *readval)
 {
 	struct cf_axi_tdd_state *st = iio_priv(indio_dev);
 	int ret;
 
 	mutex_lock(&st->lock);
-	if (readval == NULL) {
+	if (!readval) {
 		tdd_write(st, reg & 0xFFFF, writeval);
 		ret = 0;
 	} else {
@@ -405,7 +399,7 @@ static const struct iio_info cf_axi_tdd_info = {
 /* Match table for of_platform binding */
 static const struct of_device_id cf_axi_tdd_of_match[] = {
 	{ .compatible = "adi,axi-tdd-1.00", .data = 0},
-	{ },
+	{ }
 };
 MODULE_DEVICE_TABLE(of, cf_axi_tdd_of_match);
 
@@ -418,9 +412,6 @@ static int cf_axi_tdd_probe(struct platform_device *pdev)
 	struct resource *res;
 	int ret, i;
 	char buf[32];
-
-	dev_err(&pdev->dev, "Device Tree Probing \'%s\'\n",
-			np->name);
 
 	indio_dev = devm_iio_device_alloc(&pdev->dev, sizeof(*st));
 	if (!indio_dev)
@@ -466,13 +457,12 @@ static int cf_axi_tdd_probe(struct platform_device *pdev)
 	if (ret < 0)
 		return ret;
 
-	dev_info(&pdev->dev, "Analog Devices CF_AXI_TDD %s (%d.%.2d.%c) at 0x%08llX mapped"
-		" to 0x%p\n",
-		tdd_read(st, ADI_AXI_REG_ID) ? "SLAVE" : "MASTER",
-		ADI_AXI_PCORE_VER_MAJOR(st->version),
-		ADI_AXI_PCORE_VER_MINOR(st->version),
-		ADI_AXI_PCORE_VER_PATCH(st->version),
-		(unsigned long long)res->start, st->regs);
+	dev_info(&pdev->dev, "Analog Devices CF_AXI_TDD %s (%d.%.2d.%c) at 0x%08llX mapped to 0x%p\n",
+		 tdd_read(st, ADI_AXI_REG_ID) ? "SLAVE" : "MASTER",
+		 ADI_AXI_PCORE_VER_MAJOR(st->version),
+		 ADI_AXI_PCORE_VER_MINOR(st->version),
+		 ADI_AXI_PCORE_VER_PATCH(st->version),
+		 (unsigned long long)res->start, st->regs);
 
 	return 0;
 }

--- a/drivers/iio/adc/cf_axi_tdd.c
+++ b/drivers/iio/adc/cf_axi_tdd.c
@@ -462,7 +462,7 @@ static int cf_axi_tdd_probe(struct platform_device *pdev)
 
 	tdd_write_config(st, 0);
 
-	ret = iio_device_register(indio_dev);
+	ret = devm_iio_device_register(&pdev->dev, indio_dev);
 	if (ret < 0)
 		return ret;
 
@@ -474,28 +474,15 @@ static int cf_axi_tdd_probe(struct platform_device *pdev)
 		ADI_AXI_PCORE_VER_PATCH(st->version),
 		(unsigned long long)res->start, st->regs);
 
-	platform_set_drvdata(pdev, indio_dev);
-
-	return 0;
-}
-
-static int cf_axi_tdd_remove(struct platform_device *pdev)
-{
-	struct iio_dev *indio_dev = platform_get_drvdata(pdev);
-
-	iio_device_unregister(indio_dev);
-
 	return 0;
 }
 
 static struct platform_driver cf_axi_tdd_driver = {
 	.driver = {
 		.name = "cf_axi_tdd",
-		.owner = THIS_MODULE,
 		.of_match_table = cf_axi_tdd_of_match,
 	},
 	.probe		= cf_axi_tdd_probe,
-	.remove		= cf_axi_tdd_remove,
 };
 module_platform_driver(cf_axi_tdd_driver);
 

--- a/drivers/iio/adc/navassa/adrv9002.h
+++ b/drivers/iio/adc/navassa/adrv9002.h
@@ -54,6 +54,8 @@ enum adrv9002_clocks {
 	RX2_SAMPL_CLK,
 	TX1_SAMPL_CLK,
 	TX2_SAMPL_CLK,
+	TDD1_INTF_CLK,
+	TDD2_INTF_CLK,
 	NUM_ADRV9002_CLKS,
 };
 
@@ -110,6 +112,7 @@ struct adrv9002_rx_chan {
 	struct adrv9002_chan channel;
 	struct adi_adrv9001_GainControlCfg *agc;
 	struct adi_adrv9001_RxGainControlPinCfg *pin_cfg;
+	struct clk *tdd_clk;
 #ifdef CONFIG_DEBUG_FS
 	struct adi_adrv9001_RxSsiTestModeCfg ssi_test;
 	struct adi_adrv9001_GainControlCfg debug_agc;
@@ -189,6 +192,7 @@ int adrv9002_intf_change_delay(struct adrv9002_rf_phy *phy, const int channel, u
 			       u8 data_delay, const bool tx,
 			       const adi_adrv9001_SsiType_e ssi_type);
 adi_adrv9001_SsiType_e adrv9002_axi_ssi_type_get(struct adrv9002_rf_phy *phy);
+u32 adrv9002_axi_dds_rate_get(struct adrv9002_rf_phy *phy, const int chan);
 /* get init structs */
 struct adi_adrv9001_SpiSettings *adrv9002_spi_settings_get(void);
 struct adi_adrv9001_Init *adrv9002_init_get(void);

--- a/drivers/iio/adc/navassa/adrv9002_conv.c
+++ b/drivers/iio/adc/navassa/adrv9002_conv.c
@@ -707,7 +707,24 @@ int __maybe_unused adrv9002_axi_tx_test_pattern_cfg(struct adrv9002_rf_phy *phy,
 }
 EXPORT_SYMBOL(adrv9002_axi_tx_test_pattern_cfg);
 
+u32 adrv9002_axi_dds_rate_get(struct adrv9002_rf_phy *phy, const int chan)
+{
+	struct axiadc_converter *conv = spi_get_drvdata(phy->spi);
+	struct axiadc_state *st = iio_priv(conv->indio_dev);
+	const int off = chan ? ADI_TX2_REG_OFF : ADI_TX1_REG_OFF;
+
+	/* the rate is decremented by one when configured on the core */
+	return axiadc_read(st, AIM_AXI_REG(off, ADI_TX_REG_RATE)) + 1;
+}
+EXPORT_SYMBOL(adrv9002_axi_dds_rate_get);
+
 #else  /* CONFIG_CF_AXI_ADC */
+
+u32 adrv9002_axi_dds_rate_get(struct adrv9002_rf_phy *phy, const int chan)
+{
+	return -ENODEV;
+}
+EXPORT_SYMBOL(adrv9002_axi_dds_rate_get);
 
 int adrv9002_axi_interface_set(struct adrv9002_rf_phy *phy, const u8 n_lanes,
 			       const u8 ssi_intf, const bool cmos_ddr,


### PR DESCRIPTION
This series refactors the TDD core register. The biggest change is to replace the `profile_config` attribute. This attribute was getting all it's possible values as a devicetree property using raw values. The user could then select the index of the profile to use. Each profile had a set of TDD configurations values. This gives low flexibility when configuring the core and it's not that user friendly. Now, all the TDD parameters are changeable at runtime and the values are given in milliseconds. The driver takes care of the conversion to raw values to configure the core. For that, the adrv9002 driver has to export new clocks to be used by TDD.