### PR TITLE
arm64: kernel: armv8: Remove debug logs for deprecated instructions

### DIFF
--- a/arch/arm64/kernel/armv8_deprecated.c
+++ b/arch/arm64/kernel/armv8_deprecated.c
@@ -501,8 +501,6 @@ static int cp15barrier_handler(struct pt_regs *regs, u32 instr)
 	}
 
 ret:
-	pr_warn_ratelimited("\"%s\" (%ld) uses deprecated CP15 Barrier instruction at 0x%llx\n",
-			current->comm, (unsigned long)current->pid, regs->pc);
 
 	arm64_skip_faulting_instruction(regs, 4);
 	return 0;
@@ -569,8 +567,6 @@ static int compat_setend_handler(struct pt_regs *regs, u32 big_endian)
 	}
 
 	trace_instruction_emulation(insn, regs->pc);
-	pr_warn_ratelimited("\"%s\" (%ld) uses deprecated setend instruction at 0x%llx\n",
-			current->comm, (unsigned long)current->pid, regs->pc);
 
 	return 0;
 }


### PR DESCRIPTION
These prints are filling the debug log, and are generated because we use a
rootfs compiled with armv6 from Raspberry Pi repositories. We don't have
control on what compiler is used to generate these binaries so the best
approach for now is to silence these warnings.

These instructions are no longer available for ARMv8 so they have to be
emulated to ensure that the rootfs won't crash.

Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>