### PR TITLE
.travis.yml: limit BUILD_TYPE=sync_branches_with_master build on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
   include:
     - sync_branches: 1
       env: BUILD_TYPE=sync_branches_with_master_travis DO_NOT_DOCKERIZE=1
+      if: branch = master
     - checkpatch: 1
       env: BUILD_TYPE=checkpatch DO_NOT_DOCKERIZE=1
     - env: BUILD_TYPE=dtb_build_test DO_NOT_DOCKERIZE=1


### PR DESCRIPTION
We do this anyway in the script.
So, tell Travis-CI to do it.
Saves a few minutes from the build run, because the docker won't start.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>