### PR TITLE
arch: arm: rpi-cn0504: add sense resistor value

### DIFF
--- a/arch/arm/boot/dts/overlays/rpi-cn0504-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-cn0504-overlay.dts
@@ -28,6 +28,8 @@
 			ltc2945@6f{
 				compatible = "adi,ltc2945";
 				reg = <0x6f>;
+
+				shunt-resistor-micro-ohms = <20000>;
 			};
 		};
 	};


### PR DESCRIPTION
The value of the sense resistor is 0.02 ohms. Add value in micro-ohms in
the device tree.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>