### PR TITLE
arm: dts: Add AD-FMCOMMS8-EBZ + Arria 10 SoC Development Kit support

### DIFF
--- a/arch/arm/boot/dts/adi-fmcomms8.dtsi
+++ b/arch/arm/boot/dts/adi-fmcomms8.dtsi
@@ -1,0 +1,831 @@
+
+&fmc_i2c {
+	ad7291@2f {
+		compatible = "adi,ad7291";
+		reg = <0x2f>;
+	};
+
+	eeprom@50 {
+		compatible = "at24,24c02";
+		reg = <0x50>;
+	};
+};
+
+&fmc_spi {
+	trx2_adrv9009: adrv9009-phy-c@0 {
+		compatible = "adrv9009-x2";
+		reg = <0>;
+
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		/* SPI Setup */
+		spi-max-frequency = <25000000>;
+
+		clock-output-names = "rx_sampl_clk", "rx_os_sampl_clk", "tx_sampl_clk";
+		#clock-cells = <1>;
+
+		/* JESD204 */
+
+		/* JESD204 RX */
+		adi,jesd204-framer-a-bank-id = <1>;
+		adi,jesd204-framer-a-device-id = <0>;
+		adi,jesd204-framer-a-lane0-id = <0>;
+		adi,jesd204-framer-a-m = <4>;
+		adi,jesd204-framer-a-k = <32>;
+		adi,jesd204-framer-a-f = <4>;
+		adi,jesd204-framer-a-np = <16>;
+		adi,jesd204-framer-a-scramble = <1>;
+		adi,jesd204-framer-a-external-sysref = <1>;
+		adi,jesd204-framer-a-serializer-lanes-enabled = <0x03>;
+		adi,jesd204-framer-a-serializer-lane-crossbar = <0xE4>;
+		adi,jesd204-framer-a-lmfc-offset = <5>;
+		adi,jesd204-framer-a-new-sysref-on-relink = <0>;
+		adi,jesd204-framer-a-syncb-in-select = <0>;
+		adi,jesd204-framer-a-over-sample = <0>;
+		adi,jesd204-framer-a-syncb-in-lvds-mode = <1>;
+		adi,jesd204-framer-a-syncb-in-lvds-pn-invert = <0>;
+		adi,jesd204-framer-a-enable-manual-lane-xbar = <0>;
+
+		/* JESD204 OBS */
+		adi,jesd204-framer-b-bank-id = <0>;
+		adi,jesd204-framer-b-device-id = <0>;
+		adi,jesd204-framer-b-lane0-id = <0>;
+		adi,jesd204-framer-b-m = <2>;
+		adi,jesd204-framer-b-k = <32>;
+		adi,jesd204-framer-b-f = <4>;
+		adi,jesd204-framer-b-np = <16>;
+		adi,jesd204-framer-b-scramble = <1>;
+		adi,jesd204-framer-b-external-sysref = <1>;
+		adi,jesd204-framer-b-serializer-lanes-enabled = <0x0C>;
+		adi,jesd204-framer-b-serializer-lane-crossbar = <0xE4>;
+		adi,jesd204-framer-b-lmfc-offset = <5>;
+		adi,jesd204-framer-b-new-sysref-on-relink = <0>;
+		adi,jesd204-framer-b-syncb-in-select = <1>;
+		adi,jesd204-framer-b-over-sample = <0>;
+		adi,jesd204-framer-b-syncb-in-lvds-mode = <1>;
+		adi,jesd204-framer-b-syncb-in-lvds-pn-invert = <0>;
+		adi,jesd204-framer-b-enable-manual-lane-xbar = <0>;
+
+		/* JESD204 TX */
+		adi,jesd204-deframer-a-bank-id = <0>;
+		adi,jesd204-deframer-a-device-id = <0>;
+		adi,jesd204-deframer-a-lane0-id = <0>;
+		adi,jesd204-deframer-a-m = <4>;
+		adi,jesd204-deframer-a-k = <32>;
+		adi,jesd204-deframer-a-scramble = <1>;
+		adi,jesd204-deframer-a-external-sysref = <1>;
+		adi,jesd204-deframer-a-deserializer-lanes-enabled = <0x0F>;
+		adi,jesd204-deframer-a-deserializer-lane-crossbar = <0xE4>;
+		adi,jesd204-deframer-a-lmfc-offset = <1>;
+		adi,jesd204-deframer-a-new-sysref-on-relink = <0>;
+		adi,jesd204-deframer-a-syncb-out-select = <0>;
+		adi,jesd204-deframer-a-np = <16>;
+		adi,jesd204-deframer-a-syncb-out-lvds-mode = <1>;
+		adi,jesd204-deframer-a-syncb-out-lvds-pn-invert = <0>;
+		adi,jesd204-deframer-a-syncb-out-cmos-slew-rate = <0>;
+		adi,jesd204-deframer-a-syncb-out-cmos-drive-level = <0>;
+		adi,jesd204-deframer-a-enable-manual-lane-xbar = <0>;
+
+		adi,jesd204-ser-amplitude = <15>;
+		adi,jesd204-ser-pre-emphasis = <1>;
+		adi,jesd204-ser-invert-lane-polarity = <0>;
+		adi,jesd204-des-invert-lane-polarity = <0>;
+		adi,jesd204-des-eq-setting = <1>;
+		adi,jesd204-sysref-lvds-mode = <1>;
+		adi,jesd204-sysref-lvds-pn-invert = <0>;
+
+		/* RX */
+
+		adi,rx-profile-rx-fir-gain_db = <(-6)>;
+		adi,rx-profile-rx-fir-num-fir-coefs = <48>;
+		adi,rx-profile-rx-fir-coefs = /bits/ 16 <(-2) (23) (46) (-17) (-104) (10) (208) (23) (-370) (-97) (607) (240) (-942) (-489) (1407) (910) (-2065) (-1637) (3058) (2995) (-4912) (-6526) (9941) (30489) (30489) (9941) (-6526) (-4912) (2995) (3058) (-1637) (-2065) (910) (1407) (-489) (-942) (240) (607) (-97) (-370) (23) (208) (10) (-104) (-17) (46) (23) (-2)>;
+
+		adi,rx-profile-rx-fir-decimation = <2>;
+		adi,rx-profile-rx-dec5-decimation = <4>;
+		adi,rx-profile-rhb1-decimation = <1>;
+		adi,rx-profile-rx-output-rate_khz = <245760>;
+		adi,rx-profile-rf-bandwidth_hz = <200000000>;
+		adi,rx-profile-rx-bbf3d-bcorner_khz = <200000>;
+		adi,rx-profile-rx-adc-profile = /bits/ 16 <182 142 173 90 1280 982 1335 96 1369 48 1012 18 48 48 37 208 0 0 0 0 52 0 7 6 42 0 7 6 42 0 25 27 0 0 25 27 0 0 165 44 31 905>;
+		adi,rx-profile-rx-ddc-mode = <0>;
+
+		adi,rx-nco-shifter-band-a-input-band-width_khz = <0>;
+		adi,rx-nco-shifter-band-a-input-center-freq_khz = <0>;
+		adi,rx-nco-shifter-band-a-nco1-freq_khz = <0>;
+		adi,rx-nco-shifter-band-a-nco2-freq_khz = <0>;
+		adi,rx-nco-shifter-band-binput-band-width_khz = <0>;
+		adi,rx-nco-shifter-band-binput-center-freq_khz = <0>;
+		adi,rx-nco-shifter-band-bnco1-freq_khz = <0>;
+		adi,rx-nco-shifter-band-bnco2-freq_khz = <0>;
+
+		adi,rx-gain-control-gain-mode = <0>;
+		adi,rx-gain-control-rx1-gain-index = <255>;
+		adi,rx-gain-control-rx2-gain-index = <255>;
+		adi,rx-gain-control-rx1-max-gain-index = <255>;
+		adi,rx-gain-control-rx1-min-gain-index = <195>;
+		adi,rx-gain-control-rx2-max-gain-index = <255>;
+		adi,rx-gain-control-rx2-min-gain-index = <195>;
+
+		adi,rx-settings-framer-sel = <0>;
+		adi,rx-settings-rx-channels = <3>;
+
+		/* ORX */
+
+		adi,orx-profile-rx-fir-gain_db = <6>;
+		adi,orx-profile-rx-fir-num-fir-coefs = <24>;
+		adi,orx-profile-rx-fir-coefs = /bits/ 16  <(-10) (7) (-10) (-12) (6) (-12) (16) (-16) (1) (63) (-431) (17235) (-431) (63) (1) (-16) (16) (-12) (6) (-12) (-10) (7) (-10) (0)>;
+		adi,orx-profile-rx-fir-decimation = <1>;
+		adi,orx-profile-rx-dec5-decimation = <4>;
+		adi,orx-profile-rhb1-decimation = <2>;
+		adi,orx-profile-orx-output-rate_khz = <245760>;
+		adi,orx-profile-rf-bandwidth_hz = <200000000>;
+		adi,orx-profile-rx-bbf3d-bcorner_khz = <225000>;
+		adi,orx-profile-orx-low-pass-adc-profile = /bits/ 16  <185 141 172 90 1280 942 1332 90 1368 46 1016 19 48 48 37 208 0 0 0 0 52 0 7 6 42 0 7 6 42 0 25 27 0 0 25 27 0 0 165 44 31 905>;
+		adi,orx-profile-orx-band-pass-adc-profile = /bits/ 16  <0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0>;
+		adi,orx-profile-orx-ddc-mode = <0>;
+		adi,orx-profile-orx-merge-filter = /bits/ 16  <0 0 0 0 0 0 0 0 0 0 0 0>;
+
+		adi,orx-gain-control-gain-mode = <0>;
+		adi,orx-gain-control-orx1-gain-index = <255>;
+		adi,orx-gain-control-orx2-gain-index = <255>;
+		adi,orx-gain-control-orx1-max-gain-index = <255>;
+		adi,orx-gain-control-orx1-min-gain-index = <195>;
+		adi,orx-gain-control-orx2-max-gain-index = <255>;
+		adi,orx-gain-control-orx2-min-gain-index = <195>;
+
+		adi,obs-settings-framer-sel = <1>;
+		adi,obs-settings-obs-rx-channels-enable = <3>;
+		adi,obs-settings-obs-rx-lo-source = <0>;
+
+		/* TX */
+
+		adi,tx-profile-tx-fir-gain_db = <6>;
+		adi,tx-profile-tx-fir-num-fir-coefs = <40>;
+		adi,tx-profile-tx-fir-coefs = /bits/ 16  <(-14) (5) (-9) (6) (-4) (19) (-29) (27) (-30) (46) (-63) (77) (-103) (150) (-218) (337) (-599) (1266) (-2718) (19537) (-2718) (1266) (-599) (337) (-218) (150) (-103) (77) (-63) (46) (-30) (27) (-29) (19) (-4) (6) (-9) (5) (-14) (0)>;
+
+		adi,tx-profile-dac-div = <1>;
+
+		adi,tx-profile-tx-fir-interpolation = <1>;
+		adi,tx-profile-thb1-interpolation = <2>;
+		adi,tx-profile-thb2-interpolation = <2>;
+		adi,tx-profile-thb3-interpolation = <2>;
+		adi,tx-profile-tx-int5-interpolation = <1>;
+		adi,tx-profile-tx-input-rate_khz = <245760>;
+		adi,tx-profile-primary-sig-bandwidth_hz = <100000000>;
+		adi,tx-profile-rf-bandwidth_hz = <225000000>;
+		adi,tx-profile-tx-dac3d-bcorner_khz = <225000>;
+		adi,tx-profile-tx-bbf3d-bcorner_khz = <113000>;
+		adi,tx-profile-loop-back-adc-profile = /bits/ 16 <206 132 168 90 1280 641 1307 53 1359 28 1039 30 48 48 37 210 0 0 0 0 53 0 7 6 42 0 7 6 42 0 25 27 0 0 25 27 0 0 165 44 31 905>;
+
+		adi,tx-settings-deframer-sel = <0>;
+		adi,tx-settings-tx-channels = <3>;
+		adi,tx-settings-tx-atten-step-size = <0>;
+		adi,tx-settings-tx1-atten_md-b = <10000>;
+		adi,tx-settings-tx2-atten_md-b = <10000>;
+		adi,tx-settings-dis-tx-data-if-pll-unlock = <0>;
+
+		/* Clocks */
+
+		adi,dig-clocks-device-clock_khz = <245760>;
+		adi,dig-clocks-clk-pll-vco-freq_khz = <9830400>;
+		adi,dig-clocks-clk-pll-hs-div = <1>;
+		adi,dig-clocks-rf-pll-use-external-lo = <0>;
+		adi,dig-clocks-rf-pll-phase-sync-mode = <3>;
+
+		/* AGC */
+
+		adi,rxagc-peak-agc-under-range-low-interval_ns = <205>;
+		adi,rxagc-peak-agc-under-range-mid-interval = <2>;
+		adi,rxagc-peak-agc-under-range-high-interval = <4>;
+		adi,rxagc-peak-apd-high-thresh = <39>;
+		adi,rxagc-peak-apd-low-gain-mode-high-thresh = <36>;
+		adi,rxagc-peak-apd-low-thresh = <23>;
+		adi,rxagc-peak-apd-low-gain-mode-low-thresh = <19>;
+		adi,rxagc-peak-apd-upper-thresh-peak-exceeded-cnt = <6>;
+		adi,rxagc-peak-apd-lower-thresh-peak-exceeded-cnt = <3>;
+		adi,rxagc-peak-apd-gain-step-attack = <4>;
+		adi,rxagc-peak-apd-gain-step-recovery = <2>;
+		adi,rxagc-peak-enable-hb2-overload = <1>;
+		adi,rxagc-peak-hb2-overload-duration-cnt = <1>;
+		adi,rxagc-peak-hb2-overload-thresh-cnt = <4>;
+		adi,rxagc-peak-hb2-high-thresh = <181>;
+		adi,rxagc-peak-hb2-under-range-low-thresh = <45>;
+		adi,rxagc-peak-hb2-under-range-mid-thresh = <90>;
+		adi,rxagc-peak-hb2-under-range-high-thresh = <128>;
+		adi,rxagc-peak-hb2-upper-thresh-peak-exceeded-cnt = <6>;
+		adi,rxagc-peak-hb2-lower-thresh-peak-exceeded-cnt = <3>;
+		adi,rxagc-peak-hb2-gain-step-high-recovery = <2>;
+		adi,rxagc-peak-hb2-gain-step-low-recovery = <4>;
+		adi,rxagc-peak-hb2-gain-step-mid-recovery = <8>;
+		adi,rxagc-peak-hb2-gain-step-attack = <4>;
+		adi,rxagc-peak-hb2-overload-power-mode = <1>;
+		adi,rxagc-peak-hb2-ovrg-sel = <0>;
+		adi,rxagc-peak-hb2-thresh-config = <3>;
+
+		adi,rxagc-power-power-enable-measurement = <1>;
+		adi,rxagc-power-power-use-rfir-out = <1>;
+		adi,rxagc-power-power-use-bbdc2 = <0>;
+		adi,rxagc-power-under-range-high-power-thresh = <9>;
+		adi,rxagc-power-under-range-low-power-thresh = <2>;
+		adi,rxagc-power-under-range-high-power-gain-step-recovery = <4>;
+		adi,rxagc-power-under-range-low-power-gain-step-recovery = <4>;
+		adi,rxagc-power-power-measurement-duration = <5>;
+		adi,rxagc-power-rx1-tdd-power-meas-duration = <5>;
+		adi,rxagc-power-rx1-tdd-power-meas-delay = <1>;
+		adi,rxagc-power-rx2-tdd-power-meas-duration = <5>;
+		adi,rxagc-power-rx2-tdd-power-meas-delay = <1>;
+		adi,rxagc-power-upper0-power-thresh = <2>;
+		adi,rxagc-power-upper1-power-thresh = <0>;
+		adi,rxagc-power-power-log-shift = <0>;
+
+		adi,rxagc-agc-peak-wait-time = <4>;
+		adi,rxagc-agc-rx1-max-gain-index = <255>;
+		adi,rxagc-agc-rx1-min-gain-index = <195>;
+		adi,rxagc-agc-rx2-max-gain-index = <255>;
+		adi,rxagc-agc-rx2-min-gain-index = <195>;
+		adi,rxagc-agc-gain-update-counter_us = <250>;
+		adi,rxagc-agc-rx1-attack-delay = <10>;
+		adi,rxagc-agc-rx2-attack-delay = <10>;
+		adi,rxagc-agc-slow-loop-settling-delay = <16>;
+		adi,rxagc-agc-low-thresh-prevent-gain = <0>;
+		adi,rxagc-agc-change-gain-if-thresh-high = <1>;
+		adi,rxagc-agc-peak-thresh-gain-control-mode = <1>;
+		adi,rxagc-agc-reset-on-rxon = <0>;
+		adi,rxagc-agc-enable-sync-pulse-for-gain-counter = <0>;
+		adi,rxagc-agc-enable-ip3-optimization-thresh = <0>;
+		adi,rxagc-ip3-over-range-thresh = <31>;
+		adi,rxagc-ip3-over-range-thresh-index = <246>;
+		adi,rxagc-ip3-peak-exceeded-cnt = <4>;
+		adi,rxagc-agc-enable-fast-recovery-loop = <0>;
+
+
+		/* Misc */
+
+		adi,aux-dac-enables = <0x00>; /* Mask */
+
+		adi,aux-dac-vref0 = <3>;
+		adi,aux-dac-resolution0 = <0>;
+		adi,aux-dac-values0 = <0>;
+		adi,aux-dac-vref1 = <3>;
+		adi,aux-dac-resolution1 = <0>;
+		adi,aux-dac-values1 = <0>;
+		adi,aux-dac-vref2 = <3>;
+		adi,aux-dac-resolution2 = <0>;
+		adi,aux-dac-values2 = <0>;
+		adi,aux-dac-vref3 = <3>;
+		adi,aux-dac-resolution3 = <0>;
+		adi,aux-dac-values3 = <0>;
+		adi,aux-dac-vref4 = <3>;
+		adi,aux-dac-resolution4 = <0>;
+		adi,aux-dac-values4 = <0>;
+		adi,aux-dac-vref5 = <3>;
+		adi,aux-dac-resolution5 = <0>;
+		adi,aux-dac-values5 = <0>;
+		adi,aux-dac-vref6 = <3>;
+		adi,aux-dac-resolution6 = <0>;
+		adi,aux-dac-values6 = <0>;
+		adi,aux-dac-vref7 = <3>;
+		adi,aux-dac-resolution7 = <0>;
+		adi,aux-dac-values7 = <0>;
+		adi,aux-dac-vref8 = <3>;
+		adi,aux-dac-resolution8 = <0>;
+		adi,aux-dac-values8 = <0>;
+		adi,aux-dac-vref9 = <3>;
+		adi,aux-dac-resolution9 = <0>;
+		adi,aux-dac-values9 = <0>;
+		adi,aux-dac-vref10 = <3>;
+		adi,aux-dac-resolution10 = <0>;
+		adi,aux-dac-values10 = <0>;
+		adi,aux-dac-vref11 = <3>;
+		adi,aux-dac-resolution11 = <0>;
+		adi,aux-dac-values11 = <0>;
+
+		adi,arm-gpio-config-orx1-tx-sel0-pin-gpio-pin-sel = <0>;
+		adi,arm-gpio-config-orx1-tx-sel0-pin-polarity = <0>;
+		adi,arm-gpio-config-orx1-tx-sel0-pin-enable = <0>;
+
+		adi,arm-gpio-config-orx1-tx-sel1-pin-gpio-pin-sel = <0>;
+		adi,arm-gpio-config-orx1-tx-sel1-pin-polarity = <0>;
+		adi,arm-gpio-config-orx1-tx-sel1-pin-enable = <0>;
+		adi,arm-gpio-config-orx2-tx-sel0-pin-gpio-pin-sel = <0>;
+		adi,arm-gpio-config-orx2-tx-sel0-pin-polarity = <0>;
+		adi,arm-gpio-config-orx2-tx-sel0-pin-enable = <0>;
+
+		adi,arm-gpio-config-orx2-tx-sel1-pin-gpio-pin-sel = <0>;
+		adi,arm-gpio-config-orx2-tx-sel1-pin-polarity = <0>;
+		adi,arm-gpio-config-orx2-tx-sel1-pin-enable = <0>;
+		adi,arm-gpio-config-en-tx-tracking-cals-gpio-pin-sel = <0>;
+		adi,arm-gpio-config-en-tx-tracking-cals-polarity = <0>;
+		adi,arm-gpio-config-en-tx-tracking-cals-enable = <0>;
+
+		adi,orx-lo-cfg-disable-aux-pll-relocking = <0>;
+		adi,orx-lo-cfg-gpio-select = <19>;
+
+		adi,fhm-config-fhm-gpio-pin = <0>;
+		adi,fhm-config-fhm-min-freq_mhz = <2400>;
+		adi,fhm-config-fhm-max-freq_mhz = <2500>;
+
+		adi,fhm-mode-fhm-enable = <0>;
+		adi,fhm-mode-enable-mcs-sync = <0>;
+		adi,fhm-mode-fhm-trigger-mode = <0>;
+		adi,fhm-mode-fhm-exit-mode = <1>;
+		adi,fhm-mode-fhm-init-frequency_hz = <2450000000>;
+
+		adi,rx1-gain-ctrl-pin-inc-step = <1>;
+		adi,rx1-gain-ctrl-pin-dec-step = <1>;
+		adi,rx1-gain-ctrl-pin-rx-gain-inc-pin = <0>;
+		adi,rx1-gain-ctrl-pin-rx-gain-dec-pin = <1>;
+		adi,rx1-gain-ctrl-pin-enable = <0>;
+
+		adi,rx2-gain-ctrl-pin-inc-step = <1>;
+		adi,rx2-gain-ctrl-pin-dec-step = <1>;
+		adi,rx2-gain-ctrl-pin-rx-gain-inc-pin = <3>;
+		adi,rx2-gain-ctrl-pin-rx-gain-dec-pin = <4>;
+		adi,rx2-gain-ctrl-pin-enable = <0>;
+
+		adi,tx1-atten-ctrl-pin-step-size = <0>;
+		adi,tx1-atten-ctrl-pin-tx-atten-inc-pin = <4>;
+		adi,tx1-atten-ctrl-pin-tx-atten-dec-pin = <5>;
+		adi,tx1-atten-ctrl-pin-enable = <0>;
+
+		adi,tx2-atten-ctrl-pin-step-size = <0>;
+		adi,tx2-atten-ctrl-pin-tx-atten-inc-pin = <6>;
+		adi,tx2-atten-ctrl-pin-tx-atten-dec-pin = <7>;
+		adi,tx2-atten-ctrl-pin-enable = <0>;
+
+		adi,tx-pa-protection-avg-duration = <3>;
+		adi,tx-pa-protection-tx-atten-step = <2>;
+		adi,tx-pa-protection-tx1-power-threshold = <4096>;
+		adi,tx-pa-protection-tx2-power-threshold = <4096>;
+		adi,tx-pa-protection-peak-count = <4>;
+		adi,tx-pa-protection-tx1-peak-threshold = <140>;
+		adi,tx-pa-protection-tx2-peak-threshold = <140>;
+	};
+
+	trx3_adrv9009: adrv9009-phy-d@1 {
+		compatible = "adrv9009";
+		reg = <1>;
+
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		/* SPI Setup */
+		spi-max-frequency = <25000000>;
+
+		clock-output-names = "rx_sampl_clk", "rx_os_sampl_clk", "tx_sampl_clk";
+		#clock-cells = <1>;
+
+		/* JESD204 */
+
+		/* JESD204 RX */
+		adi,jesd204-framer-a-bank-id = <1>;
+		adi,jesd204-framer-a-device-id = <0>;
+		adi,jesd204-framer-a-lane0-id = <0>;
+		adi,jesd204-framer-a-m = <4>;
+		adi,jesd204-framer-a-k = <32>;
+		adi,jesd204-framer-a-f = <4>;
+		adi,jesd204-framer-a-np = <16>;
+		adi,jesd204-framer-a-scramble = <1>;
+		adi,jesd204-framer-a-external-sysref = <1>;
+		adi,jesd204-framer-a-serializer-lanes-enabled = <0x03>;
+		adi,jesd204-framer-a-serializer-lane-crossbar = <0xE4>;
+		adi,jesd204-framer-a-lmfc-offset = <5>;
+		adi,jesd204-framer-a-new-sysref-on-relink = <0>;
+		adi,jesd204-framer-a-syncb-in-select = <0>;
+		adi,jesd204-framer-a-over-sample = <0>;
+		adi,jesd204-framer-a-syncb-in-lvds-mode = <1>;
+		adi,jesd204-framer-a-syncb-in-lvds-pn-invert = <0>;
+		adi,jesd204-framer-a-enable-manual-lane-xbar = <0>;
+
+		/* JESD204 OBS */
+		adi,jesd204-framer-b-bank-id = <0>;
+		adi,jesd204-framer-b-device-id = <0>;
+		adi,jesd204-framer-b-lane0-id = <0>;
+		adi,jesd204-framer-b-m = <2>;
+		adi,jesd204-framer-b-k = <32>;
+		adi,jesd204-framer-b-f = <4>;
+		adi,jesd204-framer-b-np = <16>;
+		adi,jesd204-framer-b-scramble = <1>;
+		adi,jesd204-framer-b-external-sysref = <1>;
+		adi,jesd204-framer-b-serializer-lanes-enabled = <0x0C>;
+		adi,jesd204-framer-b-serializer-lane-crossbar = <0xE4>;
+		adi,jesd204-framer-b-lmfc-offset = <5>;
+		adi,jesd204-framer-b-new-sysref-on-relink = <0>;
+		adi,jesd204-framer-b-syncb-in-select = <1>;
+		adi,jesd204-framer-b-over-sample = <0>;
+		adi,jesd204-framer-b-syncb-in-lvds-mode = <1>;
+		adi,jesd204-framer-b-syncb-in-lvds-pn-invert = <0>;
+		adi,jesd204-framer-b-enable-manual-lane-xbar = <0>;
+
+		/* JESD204 TX */
+		adi,jesd204-deframer-a-bank-id = <0>;
+		adi,jesd204-deframer-a-device-id = <0>;
+		adi,jesd204-deframer-a-lane0-id = <0>;
+		adi,jesd204-deframer-a-m = <4>;
+		adi,jesd204-deframer-a-k = <32>;
+		adi,jesd204-deframer-a-scramble = <1>;
+		adi,jesd204-deframer-a-external-sysref = <1>;
+		adi,jesd204-deframer-a-deserializer-lanes-enabled = <0x0F>;
+		adi,jesd204-deframer-a-deserializer-lane-crossbar = <0xE4>;
+		adi,jesd204-deframer-a-lmfc-offset = <1>;
+		adi,jesd204-deframer-a-new-sysref-on-relink = <0>;
+		adi,jesd204-deframer-a-syncb-out-select = <0>;
+		adi,jesd204-deframer-a-np = <16>;
+		adi,jesd204-deframer-a-syncb-out-lvds-mode = <1>;
+		adi,jesd204-deframer-a-syncb-out-lvds-pn-invert = <0>;
+		adi,jesd204-deframer-a-syncb-out-cmos-slew-rate = <0>;
+		adi,jesd204-deframer-a-syncb-out-cmos-drive-level = <0>;
+		adi,jesd204-deframer-a-enable-manual-lane-xbar = <0>;
+
+		adi,jesd204-ser-amplitude = <15>;
+		adi,jesd204-ser-pre-emphasis = <1>;
+		adi,jesd204-ser-invert-lane-polarity = <0>;
+		adi,jesd204-des-invert-lane-polarity = <0>;
+		adi,jesd204-des-eq-setting = <1>;
+		adi,jesd204-sysref-lvds-mode = <1>;
+		adi,jesd204-sysref-lvds-pn-invert = <0>;
+
+		/* RX */
+
+		adi,rx-profile-rx-fir-gain_db = <(-6)>;
+		adi,rx-profile-rx-fir-num-fir-coefs = <48>;
+		adi,rx-profile-rx-fir-coefs = /bits/ 16 <(-2) (23) (46) (-17) (-104) (10) (208) (23) (-370) (-97) (607) (240) (-942) (-489) (1407) (910) (-2065) (-1637) (3058) (2995) (-4912) (-6526) (9941) (30489) (30489) (9941) (-6526) (-4912) (2995) (3058) (-1637) (-2065) (910) (1407) (-489) (-942) (240) (607) (-97) (-370) (23) (208) (10) (-104) (-17) (46) (23) (-2)>;
+
+		adi,rx-profile-rx-fir-decimation = <2>;
+		adi,rx-profile-rx-dec5-decimation = <4>;
+		adi,rx-profile-rhb1-decimation = <1>;
+		adi,rx-profile-rx-output-rate_khz = <245760>;
+		adi,rx-profile-rf-bandwidth_hz = <200000000>;
+		adi,rx-profile-rx-bbf3d-bcorner_khz = <200000>;
+		adi,rx-profile-rx-adc-profile = /bits/ 16 <182 142 173 90 1280 982 1335 96 1369 48 1012 18 48 48 37 208 0 0 0 0 52 0 7 6 42 0 7 6 42 0 25 27 0 0 25 27 0 0 165 44 31 905>;
+		adi,rx-profile-rx-ddc-mode = <0>;
+
+		adi,rx-nco-shifter-band-a-input-band-width_khz = <0>;
+		adi,rx-nco-shifter-band-a-input-center-freq_khz = <0>;
+		adi,rx-nco-shifter-band-a-nco1-freq_khz = <0>;
+		adi,rx-nco-shifter-band-a-nco2-freq_khz = <0>;
+		adi,rx-nco-shifter-band-binput-band-width_khz = <0>;
+		adi,rx-nco-shifter-band-binput-center-freq_khz = <0>;
+		adi,rx-nco-shifter-band-bnco1-freq_khz = <0>;
+		adi,rx-nco-shifter-band-bnco2-freq_khz = <0>;
+
+		adi,rx-gain-control-gain-mode = <0>;
+		adi,rx-gain-control-rx1-gain-index = <255>;
+		adi,rx-gain-control-rx2-gain-index = <255>;
+		adi,rx-gain-control-rx1-max-gain-index = <255>;
+		adi,rx-gain-control-rx1-min-gain-index = <195>;
+		adi,rx-gain-control-rx2-max-gain-index = <255>;
+		adi,rx-gain-control-rx2-min-gain-index = <195>;
+
+		adi,rx-settings-framer-sel = <0>;
+		adi,rx-settings-rx-channels = <3>;
+
+		/* ORX */
+
+		adi,orx-profile-rx-fir-gain_db = <6>;
+		adi,orx-profile-rx-fir-num-fir-coefs = <24>;
+		adi,orx-profile-rx-fir-coefs = /bits/ 16  <(-10) (7) (-10) (-12) (6) (-12) (16) (-16) (1) (63) (-431) (17235) (-431) (63) (1) (-16) (16) (-12) (6) (-12) (-10) (7) (-10) (0)>;
+		adi,orx-profile-rx-fir-decimation = <1>;
+		adi,orx-profile-rx-dec5-decimation = <4>;
+		adi,orx-profile-rhb1-decimation = <2>;
+		adi,orx-profile-orx-output-rate_khz = <245760>;
+		adi,orx-profile-rf-bandwidth_hz = <200000000>;
+		adi,orx-profile-rx-bbf3d-bcorner_khz = <225000>;
+		adi,orx-profile-orx-low-pass-adc-profile = /bits/ 16  <185 141 172 90 1280 942 1332 90 1368 46 1016 19 48 48 37 208 0 0 0 0 52 0 7 6 42 0 7 6 42 0 25 27 0 0 25 27 0 0 165 44 31 905>;
+		adi,orx-profile-orx-band-pass-adc-profile = /bits/ 16  <0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0>;
+		adi,orx-profile-orx-ddc-mode = <0>;
+		adi,orx-profile-orx-merge-filter = /bits/ 16  <0 0 0 0 0 0 0 0 0 0 0 0>;
+
+		adi,orx-gain-control-gain-mode = <0>;
+		adi,orx-gain-control-orx1-gain-index = <255>;
+		adi,orx-gain-control-orx2-gain-index = <255>;
+		adi,orx-gain-control-orx1-max-gain-index = <255>;
+		adi,orx-gain-control-orx1-min-gain-index = <195>;
+		adi,orx-gain-control-orx2-max-gain-index = <255>;
+		adi,orx-gain-control-orx2-min-gain-index = <195>;
+
+		adi,obs-settings-framer-sel = <1>;
+		adi,obs-settings-obs-rx-channels-enable = <3>;
+		adi,obs-settings-obs-rx-lo-source = <0>;
+
+		/* TX */
+
+		adi,tx-profile-tx-fir-gain_db = <6>;
+		adi,tx-profile-tx-fir-num-fir-coefs = <40>;
+		adi,tx-profile-tx-fir-coefs = /bits/ 16  <(-14) (5) (-9) (6) (-4) (19) (-29) (27) (-30) (46) (-63) (77) (-103) (150) (-218) (337) (-599) (1266) (-2718) (19537) (-2718) (1266) (-599) (337) (-218) (150) (-103) (77) (-63) (46) (-30) (27) (-29) (19) (-4) (6) (-9) (5) (-14) (0)>;
+
+		adi,tx-profile-dac-div = <1>;
+
+		adi,tx-profile-tx-fir-interpolation = <1>;
+		adi,tx-profile-thb1-interpolation = <2>;
+		adi,tx-profile-thb2-interpolation = <2>;
+		adi,tx-profile-thb3-interpolation = <2>;
+		adi,tx-profile-tx-int5-interpolation = <1>;
+		adi,tx-profile-tx-input-rate_khz = <245760>;
+		adi,tx-profile-primary-sig-bandwidth_hz = <100000000>;
+		adi,tx-profile-rf-bandwidth_hz = <225000000>;
+		adi,tx-profile-tx-dac3d-bcorner_khz = <225000>;
+		adi,tx-profile-tx-bbf3d-bcorner_khz = <113000>;
+		adi,tx-profile-loop-back-adc-profile = /bits/ 16 <206 132 168 90 1280 641 1307 53 1359 28 1039 30 48 48 37 210 0 0 0 0 53 0 7 6 42 0 7 6 42 0 25 27 0 0 25 27 0 0 165 44 31 905>;
+
+		adi,tx-settings-deframer-sel = <0>;
+		adi,tx-settings-tx-channels = <3>;
+		adi,tx-settings-tx-atten-step-size = <0>;
+		adi,tx-settings-tx1-atten_md-b = <10000>;
+		adi,tx-settings-tx2-atten_md-b = <10000>;
+		adi,tx-settings-dis-tx-data-if-pll-unlock = <0>;
+
+		/* Clocks */
+
+		adi,dig-clocks-device-clock_khz = <245760>;
+		adi,dig-clocks-clk-pll-vco-freq_khz = <9830400>;
+		adi,dig-clocks-clk-pll-hs-div = <1>;
+		adi,dig-clocks-rf-pll-use-external-lo = <0>;
+		adi,dig-clocks-rf-pll-phase-sync-mode = <3>;
+
+		/* AGC */
+
+		adi,rxagc-peak-agc-under-range-low-interval_ns = <205>;
+		adi,rxagc-peak-agc-under-range-mid-interval = <2>;
+		adi,rxagc-peak-agc-under-range-high-interval = <4>;
+		adi,rxagc-peak-apd-high-thresh = <39>;
+		adi,rxagc-peak-apd-low-gain-mode-high-thresh = <36>;
+		adi,rxagc-peak-apd-low-thresh = <23>;
+		adi,rxagc-peak-apd-low-gain-mode-low-thresh = <19>;
+		adi,rxagc-peak-apd-upper-thresh-peak-exceeded-cnt = <6>;
+		adi,rxagc-peak-apd-lower-thresh-peak-exceeded-cnt = <3>;
+		adi,rxagc-peak-apd-gain-step-attack = <4>;
+		adi,rxagc-peak-apd-gain-step-recovery = <2>;
+		adi,rxagc-peak-enable-hb2-overload = <1>;
+		adi,rxagc-peak-hb2-overload-duration-cnt = <1>;
+		adi,rxagc-peak-hb2-overload-thresh-cnt = <4>;
+		adi,rxagc-peak-hb2-high-thresh = <181>;
+		adi,rxagc-peak-hb2-under-range-low-thresh = <45>;
+		adi,rxagc-peak-hb2-under-range-mid-thresh = <90>;
+		adi,rxagc-peak-hb2-under-range-high-thresh = <128>;
+		adi,rxagc-peak-hb2-upper-thresh-peak-exceeded-cnt = <6>;
+		adi,rxagc-peak-hb2-lower-thresh-peak-exceeded-cnt = <3>;
+		adi,rxagc-peak-hb2-gain-step-high-recovery = <2>;
+		adi,rxagc-peak-hb2-gain-step-low-recovery = <4>;
+		adi,rxagc-peak-hb2-gain-step-mid-recovery = <8>;
+		adi,rxagc-peak-hb2-gain-step-attack = <4>;
+		adi,rxagc-peak-hb2-overload-power-mode = <1>;
+		adi,rxagc-peak-hb2-ovrg-sel = <0>;
+		adi,rxagc-peak-hb2-thresh-config = <3>;
+
+		adi,rxagc-power-power-enable-measurement = <1>;
+		adi,rxagc-power-power-use-rfir-out = <1>;
+		adi,rxagc-power-power-use-bbdc2 = <0>;
+		adi,rxagc-power-under-range-high-power-thresh = <9>;
+		adi,rxagc-power-under-range-low-power-thresh = <2>;
+		adi,rxagc-power-under-range-high-power-gain-step-recovery = <4>;
+		adi,rxagc-power-under-range-low-power-gain-step-recovery = <4>;
+		adi,rxagc-power-power-measurement-duration = <5>;
+		adi,rxagc-power-rx1-tdd-power-meas-duration = <5>;
+		adi,rxagc-power-rx1-tdd-power-meas-delay = <1>;
+		adi,rxagc-power-rx2-tdd-power-meas-duration = <5>;
+		adi,rxagc-power-rx2-tdd-power-meas-delay = <1>;
+		adi,rxagc-power-upper0-power-thresh = <2>;
+		adi,rxagc-power-upper1-power-thresh = <0>;
+		adi,rxagc-power-power-log-shift = <0>;
+
+		adi,rxagc-agc-peak-wait-time = <4>;
+		adi,rxagc-agc-rx1-max-gain-index = <255>;
+		adi,rxagc-agc-rx1-min-gain-index = <195>;
+		adi,rxagc-agc-rx2-max-gain-index = <255>;
+		adi,rxagc-agc-rx2-min-gain-index = <195>;
+		adi,rxagc-agc-gain-update-counter_us = <250>;
+		adi,rxagc-agc-rx1-attack-delay = <10>;
+		adi,rxagc-agc-rx2-attack-delay = <10>;
+		adi,rxagc-agc-slow-loop-settling-delay = <16>;
+		adi,rxagc-agc-low-thresh-prevent-gain = <0>;
+		adi,rxagc-agc-change-gain-if-thresh-high = <1>;
+		adi,rxagc-agc-peak-thresh-gain-control-mode = <1>;
+		adi,rxagc-agc-reset-on-rxon = <0>;
+		adi,rxagc-agc-enable-sync-pulse-for-gain-counter = <0>;
+		adi,rxagc-agc-enable-ip3-optimization-thresh = <0>;
+		adi,rxagc-ip3-over-range-thresh = <31>;
+		adi,rxagc-ip3-over-range-thresh-index = <246>;
+		adi,rxagc-ip3-peak-exceeded-cnt = <4>;
+		adi,rxagc-agc-enable-fast-recovery-loop = <0>;
+
+
+		/* Misc */
+
+		adi,aux-dac-enables = <0x00>; /* Mask */
+
+		adi,aux-dac-vref0 = <3>;
+		adi,aux-dac-resolution0 = <0>;
+		adi,aux-dac-values0 = <0>;
+		adi,aux-dac-vref1 = <3>;
+		adi,aux-dac-resolution1 = <0>;
+		adi,aux-dac-values1 = <0>;
+		adi,aux-dac-vref2 = <3>;
+		adi,aux-dac-resolution2 = <0>;
+		adi,aux-dac-values2 = <0>;
+		adi,aux-dac-vref3 = <3>;
+		adi,aux-dac-resolution3 = <0>;
+		adi,aux-dac-values3 = <0>;
+		adi,aux-dac-vref4 = <3>;
+		adi,aux-dac-resolution4 = <0>;
+		adi,aux-dac-values4 = <0>;
+		adi,aux-dac-vref5 = <3>;
+		adi,aux-dac-resolution5 = <0>;
+		adi,aux-dac-values5 = <0>;
+		adi,aux-dac-vref6 = <3>;
+		adi,aux-dac-resolution6 = <0>;
+		adi,aux-dac-values6 = <0>;
+		adi,aux-dac-vref7 = <3>;
+		adi,aux-dac-resolution7 = <0>;
+		adi,aux-dac-values7 = <0>;
+		adi,aux-dac-vref8 = <3>;
+		adi,aux-dac-resolution8 = <0>;
+		adi,aux-dac-values8 = <0>;
+		adi,aux-dac-vref9 = <3>;
+		adi,aux-dac-resolution9 = <0>;
+		adi,aux-dac-values9 = <0>;
+		adi,aux-dac-vref10 = <3>;
+		adi,aux-dac-resolution10 = <0>;
+		adi,aux-dac-values10 = <0>;
+		adi,aux-dac-vref11 = <3>;
+		adi,aux-dac-resolution11 = <0>;
+		adi,aux-dac-values11 = <0>;
+
+		adi,arm-gpio-config-orx1-tx-sel0-pin-gpio-pin-sel = <0>;
+		adi,arm-gpio-config-orx1-tx-sel0-pin-polarity = <0>;
+		adi,arm-gpio-config-orx1-tx-sel0-pin-enable = <0>;
+
+		adi,arm-gpio-config-orx1-tx-sel1-pin-gpio-pin-sel = <0>;
+		adi,arm-gpio-config-orx1-tx-sel1-pin-polarity = <0>;
+		adi,arm-gpio-config-orx1-tx-sel1-pin-enable = <0>;
+		adi,arm-gpio-config-orx2-tx-sel0-pin-gpio-pin-sel = <0>;
+		adi,arm-gpio-config-orx2-tx-sel0-pin-polarity = <0>;
+		adi,arm-gpio-config-orx2-tx-sel0-pin-enable = <0>;
+
+		adi,arm-gpio-config-orx2-tx-sel1-pin-gpio-pin-sel = <0>;
+		adi,arm-gpio-config-orx2-tx-sel1-pin-polarity = <0>;
+		adi,arm-gpio-config-orx2-tx-sel1-pin-enable = <0>;
+		adi,arm-gpio-config-en-tx-tracking-cals-gpio-pin-sel = <0>;
+		adi,arm-gpio-config-en-tx-tracking-cals-polarity = <0>;
+		adi,arm-gpio-config-en-tx-tracking-cals-enable = <0>;
+
+		adi,orx-lo-cfg-disable-aux-pll-relocking = <0>;
+		adi,orx-lo-cfg-gpio-select = <19>;
+
+		adi,fhm-config-fhm-gpio-pin = <0>;
+		adi,fhm-config-fhm-min-freq_mhz = <2400>;
+		adi,fhm-config-fhm-max-freq_mhz = <2500>;
+
+		adi,fhm-mode-fhm-enable = <0>;
+		adi,fhm-mode-enable-mcs-sync = <0>;
+		adi,fhm-mode-fhm-trigger-mode = <0>;
+		adi,fhm-mode-fhm-exit-mode = <1>;
+		adi,fhm-mode-fhm-init-frequency_hz = <2450000000>;
+
+		adi,rx1-gain-ctrl-pin-inc-step = <1>;
+		adi,rx1-gain-ctrl-pin-dec-step = <1>;
+		adi,rx1-gain-ctrl-pin-rx-gain-inc-pin = <0>;
+		adi,rx1-gain-ctrl-pin-rx-gain-dec-pin = <1>;
+		adi,rx1-gain-ctrl-pin-enable = <0>;
+
+		adi,rx2-gain-ctrl-pin-inc-step = <1>;
+		adi,rx2-gain-ctrl-pin-dec-step = <1>;
+		adi,rx2-gain-ctrl-pin-rx-gain-inc-pin = <3>;
+		adi,rx2-gain-ctrl-pin-rx-gain-dec-pin = <4>;
+		adi,rx2-gain-ctrl-pin-enable = <0>;
+
+		adi,tx1-atten-ctrl-pin-step-size = <0>;
+		adi,tx1-atten-ctrl-pin-tx-atten-inc-pin = <4>;
+		adi,tx1-atten-ctrl-pin-tx-atten-dec-pin = <5>;
+		adi,tx1-atten-ctrl-pin-enable = <0>;
+
+		adi,tx2-atten-ctrl-pin-step-size = <0>;
+		adi,tx2-atten-ctrl-pin-tx-atten-inc-pin = <6>;
+		adi,tx2-atten-ctrl-pin-tx-atten-dec-pin = <7>;
+		adi,tx2-atten-ctrl-pin-enable = <0>;
+
+		adi,tx-pa-protection-avg-duration = <3>;
+		adi,tx-pa-protection-tx-atten-step = <2>;
+		adi,tx-pa-protection-tx1-power-threshold = <4096>;
+		adi,tx-pa-protection-tx2-power-threshold = <4096>;
+		adi,tx-pa-protection-peak-count = <4>;
+		adi,tx-pa-protection-tx1-peak-threshold = <140>;
+		adi,tx-pa-protection-tx2-peak-threshold = <140>;
+	};
+
+	hmc7044_fmc: hmc7044-fmc@2 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		#clock-cells = <1>;
+		compatible = "adi,hmc7044";
+		reg = <2>;
+		spi-max-frequency = <10000000>;
+
+		adi,pll1-clkin-frequencies = <122880000 122880000 0 0>;
+		adi,pll1-ref-prio-ctrl = <0xE5>; /* prefer CLKIN1 */
+
+		adi,clkin0-buffer-mode  = <0x09>;
+		adi,clkin1-buffer-mode  = <0x09>;
+		adi,sync-pin-mode = <1>;
+
+		adi,pll1-loop-bandwidth-hz = <200>;
+
+		adi,vcxo-frequency = <122880000>;
+
+		adi,pll2-output-frequency = <2949120000>;
+
+		adi,sysref-timer-divider = <3840>;
+		adi,pulse-generator-mode = <7>;
+
+		adi,oscin-buffer-mode = <0x15>;
+
+		adi,gpi-controls = <0x00 0x00 0x00 0x11>;
+		adi,gpo-controls = <0x1f 0x2b 0x00 0x00>;
+
+		adi,high-performance-mode-clock-dist-enable;
+		adi,high-performance-mode-pll-vco-enable;
+
+		clock-output-names =
+			"hmc7044_fmc_out0_DEV_REFCLK_C", "hmc7044_fmc_out1_DEV_SYSREF_C",
+			"hmc7044_fmc_out2_DEV_REFCLK_D", "hmc7044_fmc_out3_DEV_SYSREF_D",
+			"hmc7044_fmc_out4_JESD_REFCLK_TX_OBS_CD", "hmc7044_fmc_out5_JESD_REFCLK_RX_CD",
+			"hmc7044_fmc_out6_FPGA_SYSREF_TX_OBS_CD","hmc7044_fmc_out7_FPGA_SYSREF_RX_CD",
+			"hmc7044_fmc_out8_CORE_CLK_TX_OBS_CD", "hmc7044_fmc_out9_CORE_CLK_RX_CD",
+			"hmc7044_fmc_out10", "hmc7044_fmc_out11",
+			"hmc7044_fmc_out12", "hmc7044_fmc_out13";
+
+		hmc7044_fmc_c0: channel@0 {
+			reg = <0>;
+			adi,extended-name = "DEV_REFCLK_C";
+			adi,divider = <12>;	// 245760000
+			adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
+			adi,coarse-digital-delay = <15>;
+		};
+		hmc7044_fmc_c1: channel@1 {
+			reg = <1>;
+			adi,extended-name = "DEV_SYSREF_C";
+			adi,divider = <3840>;	// 768000
+			adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
+			adi,startup-mode-dynamic-enable;
+			adi,high-performance-mode-disable;
+			adi,driver-impedance-mode = <HMC7044_DRIVER_IMPEDANCE_100_OHM>;
+		};
+		hmc7044_fmc_c2: channel@2 {
+			reg = <2>;
+			adi,extended-name = "DEV_REFCLK_D";
+			adi,divider = <12>;	// 245760000
+			adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
+			adi,coarse-digital-delay = <15>;
+		};
+		hmc7044_fmc_c3: channel@3 {
+			reg = <3>;
+			adi,extended-name = "DEV_SYSREF_D";
+			adi,divider = <3840>;	// 768000
+			adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
+			adi,startup-mode-dynamic-enable;
+			adi,high-performance-mode-disable;
+			adi,driver-impedance-mode = <HMC7044_DRIVER_IMPEDANCE_100_OHM>;
+		};
+		hmc7044_fmc_c4: channel@4 {
+			reg = <4>;
+			adi,extended-name = "JESD_REFCLK_TX_OBS_CD";
+			adi,divider = <12>;	// 245760000
+			adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
+		};
+		hmc7044_fmc_c5: channel@5 {
+			reg = <5>;
+			adi,extended-name = "JESD_REFCLK_RX_CD";
+			adi,divider = <12>;	// 245760000
+			adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
+		};
+		hmc7044_fmc_c6: channel@6 {
+			reg = <6>;
+			adi,extended-name = "FPGA_SYSREF_TX_OBS_CD";
+			adi,divider = <3840>;	// 768000
+			adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
+			adi,startup-mode-dynamic-enable;
+			adi,high-performance-mode-disable;
+		};
+		hmc7044_fmc_c7: channel@7 {
+			reg = <7>;
+			adi,extended-name = "FPGA_SYSREF_RX_CD";
+			adi,divider = <3840>;	// 768000
+			adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
+			adi,startup-mode-dynamic-enable;
+			adi,high-performance-mode-disable;
+		};
+		hmc7044_fmc_c8: channel@8 {
+			reg = <8>;
+			adi,extended-name = "CORE_CLK_TX_OBS_CD";
+			adi,divider = <24>;	// 122880000
+			adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
+		};
+		hmc7044_fmc_c9: channel@9 {
+			reg = <9>;
+			adi,extended-name = "CORE_CLK_RX_CD";
+			adi,divider = <12>;	// 245760000
+			adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
+		};
+	};
+};

--- a/arch/arm/boot/dts/socfpga_arria10_socdk_fmcomms8.dts
+++ b/arch/arm/boot/dts/socfpga_arria10_socdk_fmcomms8.dts
@@ -1,0 +1,418 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD-FMCOMMS8-EBZ
+ * https://wiki.analog.com/resources/eval/user-guides/ad-fmcomms8-ebz
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9009
+ * https://wiki.analog.com/resources/tools-software/linux-software/adrv9009_advanced_plugin
+ *
+ * hdl_project: <fmcomms8/a10soc>
+ * board_revision: <>
+ *
+ * Copyright (C) 2020 Analog Devices Inc.
+ */
+/dts-v1/;
+#include "socfpga_arria10_socdk.dtsi"
+#include <dt-bindings/iio/frequency/hmc7044.h>
+#include <dt-bindings/iio/adc/adi,adrv9009.h>
+
+&mmc {
+	status = "okay";
+	num-slots = <1>;
+	cap-sd-highspeed;
+	broken-cd;
+	bus-width = <4>;
+	altr,dw-mshc-ciu-div = <3>;
+	altr,dw-mshc-sdr-timing = <0 3>;
+};
+
+/ {
+	clocks {
+		sys_clk: sys_clk {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <100000000>;
+			clock-output-names = "system_clock";
+		};
+
+		dma_clk: dma_clk {
+			#clock-cells = <0x0>;
+			compatible = "fixed-clock";
+			clock-frequency = <250000000>;
+			clock-output-names = "dma_clk";
+		};
+	};
+
+	soc {
+		sys_hps_bridges: bridge@ff200000 {
+			compatible = "simple-bus";
+			reg = <0xff200000 0x00200000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges = <0x00000000 0xff200000 0x00200000>;
+
+			sys_gpio_out: gpio@20 {
+				compatible = "altr,pio-1.0";
+				reg = <0x00000020 0x00000010>;
+				altr,gpio-bank-width = <32>;
+				resetvalue = <0>;
+				#gpio-cells = <2>;
+				gpio-controller;
+			};
+
+			sys_spi: spi@40 {
+				compatible = "altr,spi-1.0";
+				reg = <0x00000040 0x00000020>;
+				interrupt-parent = <&intc>;
+				interrupts = <0 26 4>;
+				#address-cells = <0x1>;
+				#size-cells = <0x0>;
+			};
+
+			axi_adrv9009_adxcvr_rx: axi-adrv9009-rx-xcvr@34000 {
+				compatible = "adi,altera-adxcvr-1.00.a";
+				reg = <0x00034000 0x00001000>,
+					<0x00038000 0x00001000>,
+					<0x00039000 0x00001000>,
+					<0x0003a000 0x00001000>,
+					<0x0003b000 0x00001000>;
+				reg-names = "adxcvr", "adxcfg-0", "adxcfg-1", "adxcfg-2", "adxcfg-3";
+
+				clocks = <&hmc7044_fmc 5>;
+				clock-names = "ref";
+
+				#clock-cells = <0>;
+				clock-output-names = "jesd204_rx_lane_clock";
+
+				jesd204-device;
+				#jesd204-cells = <2>;
+				jesd204-inputs =  <&hmc7044_fmc 0 FRAMER_LINK_RX>;
+			};
+
+			axi_adrv9009_adxcvr_rx_os: axi-adrv9009-rx-os-xcvr@44000 {
+				compatible = "adi,altera-adxcvr-1.00.a";
+				reg = <0x00044000 0x00001000>,
+					<0x00048000 0x00001000>,
+					<0x00049000 0x00001000>,
+					<0x0004a000 0x00001000>,
+					<0x0004b000 0x00001000>;
+				reg-names = "adxcvr", "adxcfg-0", "adxcfg-1", "adxcfg-2", "adxcfg-3";
+
+				clocks = <&hmc7044_fmc 4>;
+				clock-names = "ref";
+
+				#clock-cells = <0>;
+				clock-output-names = "jesd204_rx_os_lane_clock";
+
+				jesd204-device;
+				#jesd204-cells = <2>;
+				jesd204-inputs =  <&hmc7044_fmc 0 FRAMER_LINK_ORX>;
+			};
+
+			axi_adrv9009_adxcvr_tx: axi-adrv9009-tx-xcvr@24000 {
+				compatible = "adi,altera-adxcvr-1.00.a";
+				reg = <0x00024000 0x00001000>,
+					<0x00026000 0x00001000>,
+					<0x00028000 0x00001000>,
+					<0x00029000 0x00001000>,
+					<0x0002a000 0x00001000>,
+					<0x0002b000 0x00001000>,
+					<0x0002c000 0x00001000>,
+					<0x0002d000 0x00001000>,
+					<0x0002e000 0x00001000>,
+					<0x0002f000 0x00001000>;
+				reg-names = "adxcvr", "atx-pll", "adxcfg-0", "adxcfg-1", "adxcfg-2", "adxcfg-3",
+						"adxcfg-4", "adxcfg-5", "adxcfg-6", "adxcfg-7";
+
+				clocks = <&hmc7044_fmc 4>;
+				clock-names = "ref";
+
+				#clock-cells = <0>;
+				clock-output-names = "jesd204_tx_lane_clock";
+
+				jesd204-device;
+				#jesd204-cells = <2>;
+				jesd204-inputs =  <&hmc7044_fmc 0 DEFRAMER_LINK_TX>;
+			};
+
+			axi_adrv9009_rx_jesd: axi-jesd204-rx@30000 {
+				compatible = "adi,axi-jesd204-rx-1.0";
+				reg = <0x00030000 0x4000>;
+
+				interrupt-parent = <&intc>;
+				interrupts = <0 27 4>;
+
+				clocks = <&sys_clk>, <&hmc7044_fmc 7>, <&axi_adrv9009_adxcvr_rx 0>;
+				clock-names = "s_axi_aclk", "device_clk", "lane_clk";
+
+				#clock-cells = <0>;
+				clock-output-names = "jesd_rx_lane_clk";
+
+				adi,octets-per-frame = <4>;
+				adi,frames-per-multiframe = <32>;
+
+				jesd204-device;
+				#jesd204-cells = <2>;
+				jesd204-inputs = <&axi_adrv9009_adxcvr_rx 0 FRAMER_LINK_RX>;
+			};
+
+			axi_adrv9009_rx_os_jesd: axi-jesd204-rx@40000 {
+				compatible = "adi,axi-jesd204-rx-1.0";
+				reg = <0x00040000 0x4000>;
+
+				interrupt-parent = <&intc>;
+				interrupts = <0 29 4>;
+
+				clocks = <&sys_clk>, <&hmc7044_fmc 6>, <&axi_adrv9009_adxcvr_rx_os 0>;
+				clock-names = "s_axi_aclk", "device_clk", "lane_clk";
+
+				#clock-cells = <0>;
+				clock-output-names = "jesd_rx_os_lane_clk";
+
+				adi,octets-per-frame = <2>;
+				adi,frames-per-multiframe = <32>;
+
+				jesd204-device;
+				#jesd204-cells = <2>;
+				jesd204-inputs = <&axi_adrv9009_adxcvr_rx_os 0 FRAMER_LINK_ORX>;
+			};
+
+			axi_adrv9009_tx_jesd: axi-jesd204-tx@20000 {
+				compatible = "adi,axi-jesd204-tx-1.0";
+				reg = <0x00020000 0x4000>;
+
+				interrupt-parent = <&intc>;
+				interrupts = <0 28 4>;
+
+				clocks = <&sys_clk>, <&hmc7044_fmc 6>, <&axi_adrv9009_adxcvr_tx 0>;
+				clock-names = "s_axi_aclk", "device_clk", "lane_clk";
+
+				#clock-cells = <0>;
+				clock-output-names = "jesd_tx_lane_clk";
+
+				adi,octets-per-frame = <2>;
+				adi,frames-per-multiframe = <32>;
+				adi,converter-resolution = <16>;
+				adi,bits-per-sample = <16>;
+				adi,converters-per-device = <4>;
+				adi,control-bits-per-sample = <0>;
+
+				jesd204-device;
+				#jesd204-cells = <2>;
+				jesd204-inputs = <&axi_adrv9009_adxcvr_tx 0 DEFRAMER_LINK_TX>;
+			};
+
+			rx_dma: rx-dmac@3c000 {
+				compatible = "adi,axi-dmac-1.00.a";
+				reg = <0x0003c000 0x00004000>;
+				interrupt-parent = <&intc>;
+				interrupts = <0 31 4>;
+				#dma-cells = <1>;
+				clocks = <&dma_clk>;
+
+				adi,channels {
+					#size-cells = <0>;
+					#address-cells = <1>;
+
+					dma-channel@0 {
+						reg = <0>;
+						adi,source-bus-width = <256>;
+						adi,source-bus-type = <2>;
+						adi,destination-bus-width = <128>;
+						adi,destination-bus-type = <0>;
+					};
+				};
+			};
+
+			rx_obs_dma: rx-obs-dmac@4c000  {
+				compatible = "adi,axi-dmac-1.00.a";
+				reg = <0x0004c000 0x00004000>;
+				interrupt-parent = <&intc>;
+				interrupts = <0 32 4>;
+				#dma-cells = <1>;
+				clocks = <&dma_clk>;
+
+				adi,channels {
+					#size-cells = <0>;
+					#address-cells = <1>;
+
+					dma-channel@0 {
+						reg = <0>;
+						adi,source-bus-width = <128>;
+						adi,source-bus-type = <2>;
+						adi,destination-bus-width = <128>;
+						adi,destination-bus-type = <0>;
+					};
+				};
+			};
+
+			tx_dma: tx-dmac@70000 {
+				compatible = "adi,axi-dmac-1.00.a";
+				reg = <0x00070000 0x00004000>;
+				interrupt-parent = <&intc>;
+				interrupts = <0 30 4>;
+				#dma-cells = <1>;
+				clocks = <&dma_clk>;
+
+				adi,channels {
+					#size-cells = <0>;
+					#address-cells = <1>;
+
+					dma-channel@0 {
+						reg = <0>;
+						adi,source-bus-width = <128>;
+						adi,source-bus-type = <0>;
+						adi,destination-bus-width = <256>;
+						adi,destination-bus-type = <1>;
+					};
+				};
+			};
+
+
+		axi_adrv9009_core_rx: axi-adrv9009-rx-hpc@50000 {
+			compatible = "adi,axi-adrv9009-rx-1.0";
+			reg = <0x00050000 0x8000>;
+			dmas = <&rx_dma 0>;
+			dma-names = "rx";
+			spibus-connected = <&trx2_adrv9009>;
+		};
+
+		axi_adrv9009_core_rx_obs: axi-adrv9009-rx-obs-hpc@58000 {
+			compatible = "adi,axi-adrv9009-obs-1.0";
+			reg = <0x00058000 0x1000>;
+			dmas = <&rx_obs_dma 0>;
+			dma-names = "rx";
+			clocks = <&trx2_adrv9009 1>;
+			clock-names = "sampl_clk";
+		};
+
+		axi_adrv9009_core_tx: axi-adrv9009-tx-hpc@54000 {
+			compatible = "adi,axi-adrv9009-x2-tx-1.0";
+			reg = <0x00054000 0x4000>;
+			dmas = <&tx_dma 0>;
+			dma-names = "tx";
+			clocks = <&trx2_adrv9009 2>;
+			clock-names = "sampl_clk";
+			spibus-connected = <&trx2_adrv9009>;
+			adi,axi-pl-fifo-enable;
+			plddrbypass-gpios = <&sys_gpio_out 0 0>;
+		};
+
+		};
+	};
+};
+
+#define fmc_spi sys_spi
+#define fmc_i2c i2c1
+
+#include "adi-fmcomms8.dtsi"
+
+&hmc7044_fmc {
+	spi-max-frequency = <1000000>;
+
+	jesd204-device;
+	#jesd204-cells = <2>;
+	jesd204-sysref-provider;
+
+	adi,pulse-generator-mode = <HMC7044_PULSE_GEN_16_PULSE>;
+
+	/* REF CLK (J14) -> On board REF (Y4) */
+	adi,pll1-ref-prio-ctrl = <0x1E>; /* CLKIN2 -> CLKIN3 -> CLKIN1 -> CLKIN0 */
+	adi,pll1-clkin-frequencies = <30720000 30720000 30720000 19200000>;
+
+	adi,clkin0-buffer-mode = <0x07>; /* AC + 100 Ohm Term */
+	adi,clkin1-buffer-mode = <0x09>; /* LVPECL */
+	adi,clkin2-buffer-mode = <0x5>;  /* AC */
+	adi,clkin3-buffer-mode = <0x11>; /* HIGH-Z */
+};
+
+&hmc7044_fmc_c1 {
+	adi,driver-mode = <HMC7044_DRIVER_MODE_LVPECL>;
+	adi,control0-rb4-enable;
+	adi,force-mute-enable;
+};
+
+&hmc7044_fmc_c3 {
+	adi,driver-mode = <HMC7044_DRIVER_MODE_LVPECL>;
+	adi,control0-rb4-enable;
+	adi,force-mute-enable;
+};
+
+&hmc7044_fmc_c6 {
+	adi,extended-name = "CORE_CLK_TX_OBS_CD";
+	adi,divider = <24>;     // 122880000
+	adi,driver-mode = <HMC7044_DRIVER_MODE_LVPECL>;
+	/delete-property/ adi,startup-mode-dynamic-enable;
+	/delete-property/ adi,high-performance-mode-disable;
+};
+
+&hmc7044_fmc_c7 {
+	adi,extended-name = "CORE_CLK_RX_CD";
+	adi,divider = <12>;     // 245760000
+	adi,driver-mode = <HMC7044_DRIVER_MODE_LVPECL>;
+	/delete-property/ adi,startup-mode-dynamic-enable;
+	/delete-property/ adi,high-performance-mode-disable;
+};
+
+&hmc7044_fmc_c8 {
+	adi,extended-name = "FPGA_SYSREF_TX_OBS_CD";
+	adi,divider = <3840>;   // 768000
+	adi,driver-mode = <HMC7044_DRIVER_MODE_LVPECL>;
+	adi,startup-mode-dynamic-enable;
+	adi,high-performance-mode-disable;
+	adi,control0-rb4-enable;
+	adi,force-mute-enable;
+};
+
+&hmc7044_fmc_c9 {
+	adi,extended-name = "FPGA_SYSREF_RX_CD";
+	adi,divider = <3840>;   // 768000
+	adi,driver-mode = <HMC7044_DRIVER_MODE_LVPECL>;
+	adi,startup-mode-dynamic-enable;
+	adi,high-performance-mode-disable;
+	adi,control0-rb4-enable;
+	adi,force-mute-enable;
+};
+
+&trx2_adrv9009 {
+	spi-max-frequency = <1000000>;
+	adi,jesd204-ser-pre-emphasis = <4>;
+
+	reset-gpios = <&sys_gpio_out 5 0>;
+	rx1-enable-gpios = <&sys_gpio_out 3 0>;
+	rx2-enable-gpios = <&sys_gpio_out 4 0>;
+	tx1-enable-gpios = <&sys_gpio_out 1 0>;
+	tx2-enable-gpios = <&sys_gpio_out 2 0>;
+
+	clocks = <&hmc7044_fmc 0>;
+	clock-names = "dev_clk";
+
+	jesd204-device;
+	#jesd204-cells = <2>;
+	jesd204-inputs = <&axi_adrv9009_rx_jesd 0 FRAMER_LINK_RX>,
+		<&axi_adrv9009_rx_os_jesd 0 FRAMER_LINK_ORX>,
+		<&axi_adrv9009_tx_jesd 0 DEFRAMER_LINK_TX>;
+};
+
+&trx3_adrv9009 {
+	spi-max-frequency = <1000000>;
+	adi,jesd204-ser-pre-emphasis = <4>;
+
+	reset-gpios = <&sys_gpio_out 11 0>;
+	rx1-enable-gpios = <&sys_gpio_out 9 0>;
+	rx2-enable-gpios = <&sys_gpio_out 10 0>;
+	tx1-enable-gpios = <&sys_gpio_out 7 0>;
+	tx2-enable-gpios = <&sys_gpio_out 8 0>;
+
+	clocks = <&hmc7044_fmc 2>;
+	clock-names = "dev_clk";
+
+	jesd204-device;
+	#jesd204-cells = <2>;
+	jesd204-top-device = <0>;
+	jesd204-link-ids = <DEFRAMER_LINK_TX FRAMER_LINK_RX FRAMER_LINK_ORX>;
+
+	jesd204-inputs =
+		<&trx2_adrv9009 0 FRAMER_LINK_RX>,
+		<&trx2_adrv9009 0 FRAMER_LINK_ORX>,
+		<&trx2_adrv9009 0 DEFRAMER_LINK_TX>;
+};


### PR DESCRIPTION
adi-fmcomms8.dtsi is a copy of arch/arm64/boot/dts/xilinx/adi-fmcomms8.dtsi .

More information: https://wiki.analog.com/resources/eval/user-guides/ad-fmcomms8-ebz

Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>