### PR TITLE
Dev/stream bin file

### DIFF
--- a/drivers/iio/adc/navassa/adrv9002.c
+++ b/drivers/iio/adc/navassa/adrv9002.c
@@ -4019,17 +4019,8 @@ static ssize_t adrv9002_profile_bin_write(struct file *filp, struct kobject *kob
 	struct adrv9002_rf_phy *phy = iio_priv(indio_dev);
 	int ret;
 
-	if (off == 0) {
-		if (!phy->bin_attr_buf) {
-			phy->bin_attr_buf = devm_kzalloc(&phy->spi->dev,
-							 bin_attr->size,
-							 GFP_KERNEL);
-			if (!phy->bin_attr_buf)
-				return -ENOMEM;
-		} else {
-			memset(phy->bin_attr_buf, 0, bin_attr->size);
-		}
-	}
+	if (off == 0)
+		memset(phy->bin_attr_buf, 0, bin_attr->size);
 
 	memcpy(phy->bin_attr_buf + off, buf, count);
 
@@ -4164,6 +4155,11 @@ int adrv9002_post_init(struct adrv9002_rf_phy *phy)
 	phy->bin.attr.mode = 0200;
 	phy->bin.write = adrv9002_profile_bin_write;
 	phy->bin.size = 73728;
+
+	phy->bin_attr_buf = devm_kzalloc(&phy->spi->dev, phy->bin.size, GFP_KERNEL);
+	if (!phy->bin_attr_buf)
+		return -ENOMEM;
+
 	ret = sysfs_create_bin_file(&indio_dev->dev.kobj, &phy->bin);
 	if (ret < 0)
 		return ret;

--- a/drivers/iio/adc/navassa/adrv9002.h
+++ b/drivers/iio/adc/navassa/adrv9002.h
@@ -147,6 +147,8 @@ struct adrv9002_rf_phy {
 	struct clk_onecell_data		clk_data;
 	struct bin_attribute		bin;
 	char				*bin_attr_buf;
+	u8				*stream_buf;
+	u16				stream_size;
 	struct adrv9002_rx_chan		rx_channels[ADRV9002_CHANN_MAX];
 	struct adrv9002_tx_chan		tx_channels[ADRV9002_CHANN_MAX];
 	struct adrv9002_gpio 		*adrv9002_gpios;


### PR DESCRIPTION
This PR adds support to load a stream binary at runtime. In addition, it moves the profile binary buffer to the post_init() function. This fixes a possible subtle issue since we were doing the allocation outside the device lock, we could actually end up with a race where we would allocate the memory twice...
