### PR TITLE
iio: adc: ad9361: Fix ad9361_get_rx_gain() in split table mode

### DIFF
--- a/drivers/iio/adc/ad9361.c
+++ b/drivers/iio/adc/ad9361.c
@@ -1531,9 +1531,9 @@ static int ad9361_get_split_table_gain(struct ad9361_rf_phy *phy, u32 idx_reg,
 
 	rx_gain->tia_index = ad9361_spi_readf(spi, REG_GAIN_TABLE_READ_DATA2, TIA_GAIN);
 
-	rx_gain->lmt_gain = lna_table[ad9361_gt(phy)][rx_gain->lna_index] +
-				mixer_table[ad9361_gt(phy)][rx_gain->mixer_index] +
-				tia_table[rx_gain->tia_index];
+	rx_gain->lmt_gain = lna_table[ad9361_gt(phy) - RXGAIN_TBLS_END][rx_gain->lna_index] +
+			mixer_table[ad9361_gt(phy) - RXGAIN_TBLS_END][rx_gain->mixer_index] +
+			tia_table[rx_gain->tia_index];
 
 	ad9361_spi_write(spi, REG_GAIN_TABLE_ADDRESS, tbl_addr);
 


### PR DESCRIPTION
ad9361_gt() is returning the index from ad9361_adi_gt_info[]. Since this
gain_table_info containts full table information too, the returned value
will not be valid as an index for lna_table[][] and mixer_table[][].

Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>