### PR TITLE
arm64: dts: zynqmp-adrv9009-zu11eg: Add 200.00 and 250.00 MSPS examples

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-revb-adrv2crr-fmc-revb-jesd204-fsm-200p00msps.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-revb-adrv2crr-fmc-revb-jesd204-fsm-200p00msps.dts
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * ADRV2CRR-FMC using ADRV9009-ZU11EG Rev.B System on Module (200.000 MSPS)
+ *
+ * https://wiki.analog.com/resources/eval/user-guides/adrv9009
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9009
+ * https://wiki.analog.com/resources/tools-software/linux-software/adrv9009_advanced_plugin
+ * https://wiki.analog.com/resources/eval/user-guides/adrv9009-zu11eg/adrv2crr-fmc_carrier_board
+ *
+ * hdl_project: <adrv9009zu11eg/adrv2crr_fmc>
+ * board_revision: <B>
+ *
+ * Copyright (C) 2020 Analog Devices Inc.
+ */
+
+#include "zynqmp-adrv9009-zu11eg-revb-adrv2crr-fmc-revb-jesd204-fsm.dts"
+
+&hmc7044 {
+	adi,pll2-output-frequency = <2400000000>; /* VCO @ 2.400GHz */
+	hmc7044_c4: channel@4 {
+		adi,divider = <24>;	// 100000000
+	};
+};
+
+&hmc7044_car {
+	adi,pll2-output-frequency = <2400000000>; /* VCO @ 2.400GHz */
+};
+
+&axi_adrv9009_adxcvr_tx {
+	adi,sys-clk-select = <2>; /* Switch to QPLL1 */
+};
+
+&trx0_adrv9009 {
+	adi,rx-profile-rf-bandwidth_hz = <160000000>;
+	adi,rx-profile-rhb1-decimation = <1>;
+	adi,rx-profile-rx-bbf3d-bcorner_khz = <160000>;
+	adi,rx-profile-rx-ddc-mode = <0>;
+	adi,rx-profile-rx-dec5-decimation = <5>;
+	adi,rx-profile-rx-fir-decimation = <2>;
+	adi,rx-profile-rx-fir-gain_db = <250>;
+	adi,rx-profile-rx-fir-num-fir-coefs = <48>;
+	adi,rx-profile-rx-output-rate_khz = <200000>;
+	adi,rx-profile-rx-fir-coefs = /bits/ 16 <(-5) (-16) (23) (40) (-55) (-92) (120) (181) (-226) (-326) (397) (548) (-657) (-881) (1055) (1383) (-1704) (-2317) (2520) (3698) (-4362) (-7371) (9304) (31510) (31510) (9304) (-7371) (-4362) (3698) (2520) (-2317) (-1704) (1383) (1055) (-881) (-657) (548) (397) (-326) (-226) (181) (120) (-92) (-55) (40) (23) (-16) (-5)>;
+	adi,rx-profile-rx-adc-profile = /bits/ 16 <(210) (138) (173) (90) (1280) (683) (1303) (58) (1342) (32) (921) (28) (48) (48) (34) (191) (0) (0) (0) (0) (48) (0) (7) (6) (42) (0) (7) (6) (42) (0) (25) (27) (0) (0) (25) (27) (0) (0) (165) (44) (31) (905)>;
+	adi,orx-profile-orx-ddc-mode = <0>;
+	adi,orx-profile-orx-output-rate_khz = <200000>;
+	adi,orx-profile-rf-bandwidth_hz = <160000000>;
+	adi,orx-profile-rhb1-decimation = <1>;
+	adi,orx-profile-rx-bbf3d-bcorner_khz = <225000>;
+	adi,orx-profile-rx-dec5-decimation = <5>;
+	adi,orx-profile-rx-fir-decimation = <2>;
+	adi,orx-profile-rx-fir-gain_db = <250>;
+	adi,orx-profile-rx-fir-num-fir-coefs = <48>;
+	adi,orx-profile-rx-fir-coefs = /bits/ 16  <(-5) (-14) (23) (36) (-54) (-83) (116) (163) (-217) (-295) (380) (497) (-626) (-800) (1002) (1256) (-1620) (-2117) (2393) (3362) (-4175) (-6643) (9507) (30682) (30682) (9507) (-6643) (-4175) (3362) (2393) (-2117) (-1620) (1256) (1002) (-800) (-626) (497) (380) (-295) (-217) (163) (116) (-83) (-54) (36) (23) (-14) (-5)>;
+	adi,orx-profile-orx-low-pass-adc-profile = /bits/ 16  <(210) (138) (173) (90) (1280) (683) (1303) (58) (1342) (32) (921) (28) (48) (48) (34) (191) (0) (0) (0) (0) (48) (0) (7) (6) (42) (0) (7) (6) (42) (0) (25) (27) (0) (0) (25) (27) (0) (0) (165) (44) (31) (905)>;
+	adi,orx-profile-orx-band-pass-adc-profile = /bits/ 16  <(210) (138) (173) (90) (1280) (683) (1303) (58) (1342) (32) (921) (28) (48) (48) (34) (191) (0) (0) (0) (0) (48) (0) (7) (6) (42) (0) (7) (6) (42) (0) (25) (27) (0) (0) (25) (27) (0) (0) (165) (44) (31) (905)>;
+	adi,tx-profile-dac-div = <1>;
+	adi,tx-profile-primary-sig-bandwidth_hz = <75000000>;
+	adi,tx-profile-rf-bandwidth_hz = <160000000>;
+	adi,tx-profile-thb1-interpolation = <1>;
+	adi,tx-profile-thb2-interpolation = <1>;
+	adi,tx-profile-thb3-interpolation = <1>;
+	adi,tx-profile-tx-bbf3d-bcorner_khz = <80000>;
+	adi,tx-profile-tx-dac3d-bcorner_khz = <187000>;
+	adi,tx-profile-tx-fir-gain_db = <6>;
+	adi,tx-profile-tx-fir-interpolation = <2>;
+	adi,tx-profile-tx-fir-num-fir-coefs = <40>;
+	adi,tx-profile-tx-input-rate_khz = <200000>;
+	adi,tx-profile-tx-int5-interpolation = <5>;
+	adi,tx-profile-tx-fir-coefs = /bits/ 16  <(8) (-45) (12) (123) (-65) (-250) (157) (458) (-309) (-795) (564) (1307) (-962) (-2164) (1455) (3642) (-1949) (-6263) (3113) (17791) (17791) (3113) (-6263) (-1949) (3642) (1455) (-2164) (-962) (1307) (564) (-795) (-309) (458) (157) (-250) (-65) (123) (12) (-45) (8)>;
+	adi,tx-profile-loop-back-adc-profile = /bits/ 16 <(240) (140) (179) (90) (1280) (473) (1274) (36) (1316) (22) (804) (35) (48) (48) (30) (172) (0) (0) (0) (0) (43) (0) (7) (6) (42) (0) (7) (6) (42) (0) (25) (27) (0) (0) (25) (27) (0) (0) (165) (44) (31) (905)>;
+	adi,dig-clocks-clk-pll-hs-div = <0>;
+	adi,dig-clocks-clk-pll-vco-freq_khz = <8000000>;
+	adi,dig-clocks-device-clock_khz = <100000>;
+};
+
+&trx1_adrv9009 {
+ 	adi,rx-profile-rf-bandwidth_hz = <160000000>;
+ 	adi,rx-profile-rhb1-decimation = <1>;
+ 	adi,rx-profile-rx-bbf3d-bcorner_khz = <160000>;
+ 	adi,rx-profile-rx-ddc-mode = <0>;
+ 	adi,rx-profile-rx-dec5-decimation = <5>;
+ 	adi,rx-profile-rx-fir-decimation = <2>;
+ 	adi,rx-profile-rx-fir-gain_db = <250>;
+ 	adi,rx-profile-rx-fir-num-fir-coefs = <48>;
+ 	adi,rx-profile-rx-output-rate_khz = <200000>;
+	adi,rx-profile-rx-fir-coefs = /bits/ 16 <(-5) (-16) (23) (40) (-55) (-92) (120) (181) (-226) (-326) (397) (548) (-657) (-881) (1055) (1383) (-1704) (-2317) (2520) (3698) (-4362) (-7371) (9304) (31510) (31510) (9304) (-7371) (-4362) (3698) (2520) (-2317) (-1704) (1383) (1055) (-881) (-657) (548) (397) (-326) (-226) (181) (120) (-92) (-55) (40) (23) (-16) (-5)>;
+	adi,rx-profile-rx-adc-profile = /bits/ 16 <(210) (138) (173) (90) (1280) (683) (1303) (58) (1342) (32) (921) (28) (48) (48) (34) (191) (0) (0) (0) (0) (48) (0) (7) (6) (42) (0) (7) (6) (42) (0) (25) (27) (0) (0) (25) (27) (0) (0) (165) (44) (31) (905)>;
+
+ 	adi,orx-profile-orx-ddc-mode = <0>;
+ 	adi,orx-profile-orx-output-rate_khz = <200000>;
+ 	adi,orx-profile-rf-bandwidth_hz = <160000000>;
+ 	adi,orx-profile-rhb1-decimation = <1>;
+ 	adi,orx-profile-rx-bbf3d-bcorner_khz = <225000>;
+ 	adi,orx-profile-rx-dec5-decimation = <5>;
+ 	adi,orx-profile-rx-fir-decimation = <2>;
+ 	adi,orx-profile-rx-fir-gain_db = <250>;
+ 	adi,orx-profile-rx-fir-num-fir-coefs = <48>;
+	adi,orx-profile-rx-fir-coefs = /bits/ 16  <(-5) (-14) (23) (36) (-54) (-83) (116) (163) (-217) (-295) (380) (497) (-626) (-800) (1002) (1256) (-1620) (-2117) (2393) (3362) (-4175) (-6643) (9507) (30682) (30682) (9507) (-6643) (-4175) (3362) (2393) (-2117) (-1620) (1256) (1002) (-800) (-626) (497) (380) (-295) (-217) (163) (116) (-83) (-54) (36) (23) (-14) (-5)>;
+	adi,orx-profile-orx-low-pass-adc-profile = /bits/ 16  <(210) (138) (173) (90) (1280) (683) (1303) (58) (1342) (32) (921) (28) (48) (48) (34) (191) (0) (0) (0) (0) (48) (0) (7) (6) (42) (0) (7) (6) (42) (0) (25) (27) (0) (0) (25) (27) (0) (0) (165) (44) (31) (905)>;
+	adi,orx-profile-orx-band-pass-adc-profile = /bits/ 16  <(210) (138) (173) (90) (1280) (683) (1303) (58) (1342) (32) (921) (28) (48) (48) (34) (191) (0) (0) (0) (0) (48) (0) (7) (6) (42) (0) (7) (6) (42) (0) (25) (27) (0) (0) (25) (27) (0) (0) (165) (44) (31) (905)>;
+
+ 	adi,tx-profile-dac-div = <1>;
+ 	adi,tx-profile-primary-sig-bandwidth_hz = <75000000>;
+ 	adi,tx-profile-rf-bandwidth_hz = <160000000>;
+ 	adi,tx-profile-thb1-interpolation = <1>;
+ 	adi,tx-profile-thb2-interpolation = <1>;
+ 	adi,tx-profile-thb3-interpolation = <1>;
+ 	adi,tx-profile-tx-bbf3d-bcorner_khz = <80000>;
+ 	adi,tx-profile-tx-dac3d-bcorner_khz = <187000>;
+ 	adi,tx-profile-tx-fir-gain_db = <6>;
+ 	adi,tx-profile-tx-fir-interpolation = <2>;
+ 	adi,tx-profile-tx-fir-num-fir-coefs = <40>;
+ 	adi,tx-profile-tx-input-rate_khz = <200000>;
+ 	adi,tx-profile-tx-int5-interpolation = <5>;
+ 	adi,tx-profile-tx-fir-coefs = /bits/ 16  <(8) (-45) (12) (123) (-65) (-250) (157) (458) (-309) (-795) (564) (1307) (-962) (-2164) (1455) (3642) (-1949) (-6263) (3113) (17791) (17791) (3113) (-6263) (-1949) (3642) (1455) (-2164) (-962) (1307) (564) (-795) (-309) (458) (157) (-250) (-65) (123) (12) (-45) (8)>;
+	adi,tx-profile-loop-back-adc-profile = /bits/ 16 <(240) (140) (179) (90) (1280) (473) (1274) (36) (1316) (22) (804) (35) (48) (48) (30) (172) (0) (0) (0) (0) (43) (0) (7) (6) (42) (0) (7) (6) (42) (0) (25) (27) (0) (0) (25) (27) (0) (0) (165) (44) (31) (905)>;
+
+ 	adi,dig-clocks-clk-pll-hs-div = <0>;
+ 	adi,dig-clocks-clk-pll-vco-freq_khz = <8000000>;
+ 	adi,dig-clocks-device-clock_khz = <100000>;
+};

--- a/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-revb-adrv2crr-fmc-revb-jesd204-fsm-250p00msps.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-revb-adrv2crr-fmc-revb-jesd204-fsm-250p00msps.dts
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * ADRV2CRR-FMC using ADRV9009-ZU11EG Rev.B System on Module (250.000 MSPS)
+ *
+ * https://wiki.analog.com/resources/eval/user-guides/adrv9009
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9009
+ * https://wiki.analog.com/resources/tools-software/linux-software/adrv9009_advanced_plugin
+ * https://wiki.analog.com/resources/eval/user-guides/adrv9009-zu11eg/adrv2crr-fmc_carrier_board
+ *
+ * hdl_project: <adrv9009zu11eg/adrv2crr_fmc>
+ * board_revision: <B>
+ *
+ * Copyright (C) 2020 Analog Devices Inc.
+ */
+
+#include "zynqmp-adrv9009-zu11eg-revb-adrv2crr-fmc-revb-jesd204-fsm.dts"
+
+&hmc7044 {
+	adi,pll2-output-frequency = <3000000000>; /* VCO @ 3.000GHz */
+};
+
+&hmc7044_car {
+	adi,pll2-output-frequency = <3000000000>; /* VCO @ 3.000GHz */
+};
+
+&trx0_adrv9009 {
+	adi,rx-profile-rx-output-rate_khz = <250000>;
+	adi,rx-profile-rx-fir-num-fir-coefs = <48>;
+	adi,rx-profile-rx-fir-coefs = /bits/ 16 <(-9) (14) (32) (38) (-28) (-122) (-149) (9) (289) (434) (154) (-497) (-995) (-668) (593) (1919) (1891) (-213) (-3330) (-4788) (-2016) (5298) (14341) (20572) (20572) (14341) (5298) (-2016) (-4788) (-3330) (-213) (1891) (1919) (593) (-668) (-995) (-497) (154) (434) (289) (9) (-149) (-122) (-28) (38) (32) (14) (-9)>;
+	adi,rx-profile-rx-adc-profile = /bits/ 16 <(261) (144) (181) (90) (1280) (366) (1258) (27) (1280) (17) (731) (39) (48) (47) (28) (160) (0) (0) (0) (0) (40) (0) (7) (6) (42) (0) (7) (6) (42) (0) (25) (27) (0) (0) (25) (27) (0) (0) (165) (44) (31) (905)>;
+	adi,orx-profile-rx-fir-decimation = <2>;
+	adi,orx-profile-rx-dec5-decimation = <4>;
+	adi,orx-profile-rhb1-decimation = <1>;
+	adi,orx-profile-orx-output-rate_khz = <250000>;
+	adi,orx-profile-rx-fir-num-fir-coefs = <48>;
+	adi,orx-profile-rx-fir-coefs = /bits/ 16  <(-5) (-15) (23) (38) (-54) (-88) (102) (139) (-246) (-302) (405) (514) (-654) (-832) (1028) (1312) (-1596) (-2080) (2514) (3463) (-4281) (-6896) (9413) (30864) (30864) (9413) (-6896) (-4281) (3463) (2514) (-2080) (-1596) (1312) (1028) (-832) (-654) (514) (405) (-302) (-246) (139) (102) (-88) (-54) (38) (23) (-15) (-5)>;
+	adi,orx-profile-orx-low-pass-adc-profile = /bits/ 16  <(184) (138) (169) (90) (1280) (921) (1331) (87) (1367) (44) (1025) (20) (48) (48) (37) (207) (0) (0) (0) (0) (52) (0) (7) (6) (42) (0) (7) (6) (42) (0) (25) (27) (0) (0) (25) (27) (0) (0) (165) (44) (31) (905)>;
+	adi,orx-profile-orx-band-pass-adc-profile = /bits/ 16  <(184) (138) (169) (90) (1280) (921) (1331) (87) (1367) (44) (1025) (20) (48) (48) (37) (207) (0) (0) (0) (0) (52) (0) (7) (6) (42) (0) (7) (6) (42) (0) (25) (27) (0) (0) (25) (27) (0) (0) (165) (44) (31) (905)>;
+	adi,tx-profile-tx-input-rate_khz = <250000>;
+	adi,tx-profile-tx-fir-num-fir-coefs = <20>;
+	adi,tx-profile-tx-fir-coefs = /bits/ 16  <(32) (-79) (132) (-178) (204) (-156) (-110) (1031) (-3097) (20270) (-3097) (1031) (-110) (-156) (204) (-178) (132) (-79) (32) (0)>;
+	adi,tx-profile-loop-back-adc-profile = /bits/ 16 <(240) (140) (179) (90) (1280) (473) (1274) (36) (1316) (22) (804) (35) (48) (48) (30) (172) (0) (0) (0) (0) (43) (0) (7) (6) (42) (0) (7) (6) (42) (0) (25) (27) (0) (0) (25) (27) (0) (0) (165) (44) (31) (905)>;
+	adi,dig-clocks-device-clock_khz = <250000>;
+	adi,dig-clocks-clk-pll-vco-freq_khz = <10000000>;
+};
+
+&trx1_adrv9009 {
+	adi,rx-profile-rx-output-rate_khz = <250000>;
+	adi,rx-profile-rx-fir-num-fir-coefs = <48>;
+	adi,rx-profile-rx-fir-coefs = /bits/ 16 <(-9) (14) (32) (38) (-28) (-122) (-149) (9) (289) (434) (154) (-497) (-995) (-668) (593) (1919) (1891) (-213) (-3330) (-4788) (-2016) (5298) (14341) (20572) (20572) (14341) (5298) (-2016) (-4788) (-3330) (-213) (1891) (1919) (593) (-668) (-995) (-497) (154) (434) (289) (9) (-149) (-122) (-28) (38) (32) (14) (-9)>;
+	adi,rx-profile-rx-adc-profile = /bits/ 16 <(261) (144) (181) (90) (1280) (366) (1258) (27) (1280) (17) (731) (39) (48) (47) (28) (160) (0) (0) (0) (0) (40) (0) (7) (6) (42) (0) (7) (6) (42) (0) (25) (27) (0) (0) (25) (27) (0) (0) (165) (44) (31) (905)>;
+	adi,orx-profile-rx-fir-decimation = <2>;
+	adi,orx-profile-rx-dec5-decimation = <4>;
+	adi,orx-profile-rhb1-decimation = <1>;
+	adi,orx-profile-orx-output-rate_khz = <250000>;
+	adi,orx-profile-rx-fir-num-fir-coefs = <48>;
+	adi,orx-profile-rx-fir-coefs = /bits/ 16  <(-5) (-15) (23) (38) (-54) (-88) (102) (139) (-246) (-302) (405) (514) (-654) (-832) (1028) (1312) (-1596) (-2080) (2514) (3463) (-4281) (-6896) (9413) (30864) (30864) (9413) (-6896) (-4281) (3463) (2514) (-2080) (-1596) (1312) (1028) (-832) (-654) (514) (405) (-302) (-246) (139) (102) (-88) (-54) (38) (23) (-15) (-5)>;
+	adi,orx-profile-orx-low-pass-adc-profile = /bits/ 16  <(184) (138) (169) (90) (1280) (921) (1331) (87) (1367) (44) (1025) (20) (48) (48) (37) (207) (0) (0) (0) (0) (52) (0) (7) (6) (42) (0) (7) (6) (42) (0) (25) (27) (0) (0) (25) (27) (0) (0) (165) (44) (31) (905)>;
+	adi,orx-profile-orx-band-pass-adc-profile = /bits/ 16  <(184) (138) (169) (90) (1280) (921) (1331) (87) (1367) (44) (1025) (20) (48) (48) (37) (207) (0) (0) (0) (0) (52) (0) (7) (6) (42) (0) (7) (6) (42) (0) (25) (27) (0) (0) (25) (27) (0) (0) (165) (44) (31) (905)>;
+	adi,tx-profile-tx-input-rate_khz = <250000>;
+	adi,tx-profile-tx-fir-num-fir-coefs = <20>;
+	adi,tx-profile-tx-fir-coefs = /bits/ 16  <(32) (-79) (132) (-178) (204) (-156) (-110) (1031) (-3097) (20270) (-3097) (1031) (-110) (-156) (204) (-178) (132) (-79) (32) (0)>;
+	adi,tx-profile-loop-back-adc-profile = /bits/ 16 <(240) (140) (179) (90) (1280) (473) (1274) (36) (1316) (22) (804) (35) (48) (48) (30) (172) (0) (0) (0) (0) (43) (0) (7) (6) (42) (0) (7) (6) (42) (0) (25) (27) (0) (0) (25) (27) (0) (0) (165) (44) (31) (905)>;
+	adi,dig-clocks-device-clock_khz = <250000>;
+	adi,dig-clocks-clk-pll-vco-freq_khz = <10000000>;
+};


### PR DESCRIPTION
This configures the HMC7044 to configure the VCO for 2.4 and 3.0GHz
from a 122.880 MHz VXCO. So the divider values N/R will be large,
and the PFD frequency thus low. Which might have a performance impact.

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>