### PR TITLE
ci,travis: fix build with GCC 10

### DIFF
--- a/ci/travis/run-build-docker.sh
+++ b/ci/travis/run-build-docker.sh
@@ -17,12 +17,6 @@ else
 			echo "export ${env}=${val}" >> "${FULL_BUILD_DIR}/env"
 		fi
 	done
-
-	# Temporarily use Ubuntu 20.04; 'ubuntu:rolling' is now
-	# at 20.10 with GCC 10 and plenty of things to fix
-	prepare_docker_image "ubuntu:focal"
-	run_docker_script run-build.sh "ubuntu:focal"
-
-	#prepare_docker_image "ubuntu:rolling"
-	#run_docker_script run-build.sh "ubuntu:rolling"
+	prepare_docker_image "ubuntu:rolling"
+	run_docker_script run-build.sh "ubuntu:rolling"
 fi

--- a/ci/travis/run-build.sh
+++ b/ci/travis/run-build.sh
@@ -83,6 +83,10 @@ adjust_kcflags_against_gcc() {
 		KCFLAGS="$KCFLAGS -Wno-error=address-of-packed-member -Wno-error=attribute-alias="
 		KCFLAGS="$KCFLAGS -Wno-error=stringop-truncation"
 	fi
+	if [ "$($GCC -dumpversion | cut -d. -f1)" -ge "10" ]; then
+		KCFLAGS="$KCFLAGS -Wno-error=maybe-uninitialized -Wno-error=restrict"
+		KCFLAGS="$KCFLAGS -Wno-error=zero-length-bounds"
+	fi
 	export KCFLAGS
 }
 

--- a/ci/travis/run-build.sh
+++ b/ci/travis/run-build.sh
@@ -90,7 +90,7 @@ adjust_kcflags_against_gcc() {
 	export KCFLAGS
 }
 
-APT_LIST="build-essential bc u-boot-tools flex bison libssl-dev"
+APT_LIST="make bc u-boot-tools flex bison libssl-dev"
 
 if [ "$ARCH" == "arm64" ] ; then
 	if [ -z "$CROSS_COMPILE" ] ; then

--- a/drivers/firmware/xilinx/zynqmp.c
+++ b/drivers/firmware/xilinx/zynqmp.c
@@ -24,6 +24,8 @@
 #include <linux/firmware/xlnx-zynqmp.h>
 #include "zynqmp-debug.h"
 
+#pragma GCC diagnostic warning "-Warray-bounds"
+
 static unsigned long register_address;
 
 static const struct zynqmp_eemi_ops *eemi_ops_tbl;


### PR DESCRIPTION
Since Ubuntu 20.10, GCC 10 is used.
This one seems to find all kinds of new warnings, as it seems to do more static analysis by default.
The things it finds are pertinent, but they are in kernel core-code which we don't want to patch as it is hard to maintain afterwards when upgrading.

One thing that is a bit dubious is the warning in `drivers/firmware/xilinx/zynqmp.c`.
This one really looks valid. An index in a static array is accessed at index 2562, when the array is only 63 elements long.
This could be valid, since it may map over reserved memory area.
However, it could also be faulty.

A patch was sent to Xilinx to notify them about this.

Also, installing `make`  vs `build-essential` package, since we don't need everything from that package.
This would save some build-time.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>