### PR TITLE
.github/actions: add yml file to sync branches with main branch

### DIFF
--- a/.github/workflows/sync_branches_with_main.yml
+++ b/.github/workflows/sync_branches_with_main.yml
@@ -1,0 +1,19 @@
+name: Synchronize legacy branches with main branch
+
+on: [push]
+on:
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Synchronize legacy branches with main branch
+      env:
+        MAIN_BRANCH: master
+        BUILD_TYPE: sync_branches_with_main
+      run: ./ci/travis/run-build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ notifications:
 matrix:
   include:
     - sync_branches: 1
-      env: BUILD_TYPE=sync_branches_with_master_travis DO_NOT_DOCKERIZE=1
+      env: BUILD_TYPE=sync_branches_with_main_travis DO_NOT_DOCKERIZE=1
       if: branch = master
     - checkpatch: 1
       env: BUILD_TYPE=checkpatch DO_NOT_DOCKERIZE=1


### PR DESCRIPTION
This migrates the job to sync the main branch with other branches to the
Github actions.
This is a re-adaption of the old build to synchronize legacy branches with
the main branch.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>