### PR TITLE
iio: adc: ad7768: Update spi_reg_read function

### DIFF
--- a/drivers/iio/adc/ad7768.c
+++ b/drivers/iio/adc/ad7768.c
@@ -118,7 +118,8 @@ static struct iio_chan_spec name[] = {	\
 
 DECLARE_AD7768_CHANNELS(ad7768_channels);
 
-static int ad7768_spi_reg_read(struct ad7768_state *st, unsigned int addr)
+static int ad7768_spi_reg_read(struct ad7768_state *st, unsigned int addr,
+			       unsigned int *val)
 {
 	struct spi_transfer t[] = {
 		{
@@ -138,7 +139,9 @@ static int ad7768_spi_reg_read(struct ad7768_state *st, unsigned int addr)
 	if (ret < 0)
 		return ret;
 
-	return be16_to_cpu(st->d16);
+	*val = be16_to_cpu(st->d16);
+
+	return ret;
 }
 
 static int ad7768_spi_reg_write(struct ad7768_state *st,
@@ -155,11 +158,12 @@ static int ad7768_spi_write_mask(struct ad7768_state *st,
 				 unsigned long int mask,
 				 unsigned int val)
 {
-	int regval;
+	unsigned int regval;
+	int ret;
 
-	regval = ad7768_spi_reg_read(st, addr);
-	if (regval < 0)
-		return regval;
+	ret = ad7768_spi_reg_read(st, addr, &regval);
+	if (ret < 0)
+		return ret;
 
 	regval &= ~mask;
 	regval |= val;
@@ -177,11 +181,9 @@ static int ad7768_reg_access(struct iio_dev *indio_dev,
 
 	mutex_lock(&st->lock);
 	if (readval) {
-		ret = ad7768_spi_reg_read(st, reg);
+		ret = ad7768_spi_reg_read(st, reg, readval);
 		if (ret < 0)
 			goto exit;
-
-		*readval = ret;
 		ret = 0;
 	} else {
 		ret = ad7768_spi_reg_write(st, reg, writeval);


### PR DESCRIPTION
This patch adds an additional parameter to the register read function.
By passing the data pointer to the function, the returned value will used
only for status check.
With this change, the status check won't be confused with a register value
check:

ret = ad7768_spi_reg_read()
if (ret){}

Signed-off-by: Sergiu Cuciurean <sergiu.cuciurean@analog.com>