### PR TITLE
.github/actions: add build rules for the RPi branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,11 @@
 name: Build the ADI kernel matrix
 
-on: [pull_request]
+on:
+  pull_request:
+    branches:
+      - main
+      - master
+      - '20[1-9][0-9]_R[1-9]'
 
 jobs:
   checkpatch:

--- a/.github/workflows/build_rpi.yml
+++ b/.github/workflows/build_rpi.yml
@@ -1,0 +1,54 @@
+name: Build the Raspberry Pi kernel matrix (ADI flavours)
+
+on:
+  pull_request:
+    branches:
+      - 'rpi-[4-9].[0-9].y'
+      - 'rpi-[4-9].[1-9][0-9].y'
+  push:
+    branches:
+      - 'rpi-[4-9].[0-9].y'
+      - 'rpi-[4-9].[1-9][0-9].y'
+
+jobs:
+  checkpatch:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' }}
+    env:
+      BUILD_TYPE: checkpatch
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 50
+    - name: Run Linux's checkpatch script
+      run: ./ci/travis/run-build.sh
+
+  bcm2709_arm_adi:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build the BCM2709 ADI kernel flavour (all ADI drivers)
+      env:
+        DEFCONFIG: adi_bcm2709_defconfig
+        ARCH: arm
+      run: ./ci/travis/run-build-docker.sh
+
+  bcm2711_arm_adi:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build the BCM2711 ADI kernel flavour (all ADI drivers)
+      env:
+        DEFCONFIG: adi_bcm2711_defconfig
+        ARCH: arm
+      run: ./ci/travis/run-build-docker.sh
+
+  bcmrpi_arm_adi:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build the RPi Zero ADI kernel flavour (all ADI drivers)
+      env:
+        DEFCONFIG: adi_bcmrpi_defconfig
+        ARCH: arm
+      run: ./ci/travis/run-build-docker.sh


### PR DESCRIPTION
Most of the time these branches will build after being auto-sync-ed from
the main branch.
Sometimes, some PRs will be issued. In those cases we will also need to run
the build on a PR context.

So, these branches will need to build on both contexts (push &
pull_request).

The build_rpi.yml file can live in master, since the rules won't allow it
to build on any other branch than these branches. And the patch will get
auto-sync-ed to the rpi-4.19.y branch.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>