### PR TITLE
.github/actions: add dtb_build_test job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,20 @@ jobs:
     - name: Run Linux's checkpatch script
       run: ./ci/travis/run-build.sh
 
+  dtb_build_test:
+    runs-on: ubuntu-latest
+    env:
+      BUILD_TYPE: dtb_build_test
+      DTS_FILES: "arch/arm/boot/dts/zynq-*.dts
+                  arch/arm/boot/dts/socfpga_*.dts
+                  arch/arm64/boot/dts/xilinx/zynqmp-*.dts
+                  arch/microblaze/boot/dts/*.dts
+                  arch/nios2/boot/dts/*.dts"
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build device-trees
+      run: ./ci/travis/run-build.sh
+
   zynq_adi_default:
     runs-on: ubuntu-latest
     steps:

--- a/ci/travis/run-build.sh
+++ b/ci/travis/run-build.sh
@@ -237,7 +237,7 @@ build_dtb_build_test() {
 	local err=0
 	local last_arch
 
-	if [ "$TRAVIS" = "true" ] ; then
+	if [ "$TRAVIS" = "true" ] || [ "$CI" = "true" ] ; then
 		for patch in $(ls ci/travis/*.patch | sort) ; do
 			patch -p1 < $patch
 		done


### PR DESCRIPTION
This migrates the dtb_build_test job to Github Actions to build all
device-trees via CI.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>