### PR TITLE
.github/workflows/build.yml: build 'staging/' prefixed pushed branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   checkpatch:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' }}
     env:
       BUILD_TYPE: checkpatch
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,9 @@
 name: Build the ADI kernel matrix
 
 on:
+  push:
+    branches:
+      - 'staging/**'
   pull_request:
     branches:
       - main

--- a/ci/travis/run-build.sh
+++ b/ci/travis/run-build.sh
@@ -212,6 +212,8 @@ build_checkpatch() {
 	pip3 install wheel
 	pip3 install git+https://github.com/devicetree-org/dt-schema.git@master
 
+	[ "$TRAVIS_PULL_REQUEST" = "true" ] || return 0
+
 	local ref_branch
 
 	if [ -n "$TRAVIS_BRANCH" ] ; then


### PR DESCRIPTION
By default we only build PRs targeting the main branch of release branches.
However if a user wants to build a push-branch, then the user will need to
prefix the branch with 'staging/'.

That way the same build rules will run as for a PR.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>