### PR TITLE
arch: arm,arm64: adin1100: add support for evall board (MII/RMII modes)

### DIFF
--- a/arch/arm/boot/dts/adi-adin1100-mii.dtsi
+++ b/arch/arm/boot/dts/adi-adin1100-mii.dtsi
@@ -1,0 +1,4 @@
+&gem1 {
+	status = "okay";
+	phy-mode = "mii";
+};

--- a/arch/arm/boot/dts/adi-adin1100-rmii.dtsi
+++ b/arch/arm/boot/dts/adi-adin1100-rmii.dtsi
@@ -1,0 +1,4 @@
+&gem1 {
+	status = "okay";
+	phy-mode = "rmii";
+};

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-adin1100-mii.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-adin1100-mii.dts
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * ADIN1100 Eval board on ZedBoard carrier
+ *
+ * hdl_project: <>
+ * board_revision: <>
+ *
+ * Copyright 2020 Analog Devices Inc.
+ */
+/dts-v1/;
+
+#include "zynq-zc706.dtsi"
+#include "zynq-zc706-adv7511.dtsi"
+#include "adi-adin1100-mii.dtsi"

--- a/arch/arm/boot/dts/zynq-zed-adv7511-adin1100-mii.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-adin1100-mii.dts
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * ADIN1100 Eval board on ZedBoard carrier
+ *
+ * hdl_project: <>
+ * board_revision: <>
+ *
+ * Copyright 2020 Analog Devices Inc.
+ */
+/dts-v1/;
+
+#include "zynq-zed.dtsi"
+#include "zynq-zed-adv7511.dtsi"
+#include "adi-adin1100-mii.dtsi"

--- a/arch/arm/boot/dts/zynq-zed-adv7511-adin1100-rmii.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-adin1100-rmii.dts
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * ADIN1100 Eval board on ZedBoard carrier
+ *
+ * hdl_project: <>
+ * board_revision: <>
+ *
+ * Copyright 2020 Analog Devices Inc.
+ */
+/dts-v1/;
+
+#include "zynq-zed.dtsi"
+#include "zynq-zed-adv7511.dtsi"
+#include "adi-adin1100-rmii.dtsi"

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adin1100-mii.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adin1100-mii.dts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * ADIN1100 Eval board on ZCU102 carrier
+ *
+ * hdl_project: <>
+ * board_revision: <>
+ *
+ * Copyright 2020 Analog Devices Inc.
+ */
+#include "zynqmp-zcu102-rev1.0.dts"
+
+&i2c1 {
+	i2c-mux@75 {
+		i2c@1 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <1>;
+			/* HPC1_IIC */
+			eeprom@50 {
+				compatible = "at24,24c02";
+				reg = <0x50>;
+			};
+		};
+	};
+};
+
+&gem1 {
+	status = "okay";
+	phy-mode = "mii";
+};

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adin1100-rmii.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adin1100-rmii.dts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * ADIN1100 Eval board on ZCU102 carrier
+ *
+ * hdl_project: <>
+ * board_revision: <>
+ *
+ * Copyright 2020 Analog Devices Inc.
+ */
+#include "zynqmp-zcu102-rev1.0.dts"
+
+&i2c1 {
+	i2c-mux@75 {
+		i2c@1 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <1>;
+			/* HPC1_IIC */
+			eeprom@50 {
+				compatible = "at24,24c02";
+				reg = <0x50>;
+			};
+		};
+	};
+};
+
+&gem1 {
+	status = "okay";
+	phy-mode = "rmii";
+};


### PR DESCRIPTION
We just need to enable GEM1 and set it to MII/RMII.
The ADIN T1 driver will do the rest.

Also, since the eval board has the PHY address configurable via
dip-switches, we won't be setting the PHY address in the DT. That way, we
can probably avoid silly situations where the PHY doesn't probe if a
dip-switch is played-with.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>