### PR TITLE
arch: arm64: zcu102-fmcomms4: Use proper dac_core compatible string

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9364-fmcomms4.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9364-fmcomms4.dts
@@ -91,7 +91,7 @@
 		};
 
 		cf_ad9361_dac_core_0: cf-ad9361-dds-core-lpc@99024000 {
-			compatible = "adi,axi-ad9361-dds-6.00.a";
+			compatible = "adi,axi-ad9364-dds-6.00.a";
 			reg = <0x99024000 0x1000>;
 			clocks = <&adc0_ad9364 13>;
 			clock-names = "sampl_clk";


### PR DESCRIPTION
Since AD9364 is installed on FMCOMMS4, dac_core should be configured accordingly.

Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>