### PR TITLE
iio: adc: talise: Add missing halError variables for debugging with TALISE_VERBOSE=1

### DIFF
--- a/drivers/iio/adc/talise/talise.c
+++ b/drivers/iio/adc/talise/talise.c
@@ -1776,6 +1776,7 @@ uint32_t TALISE_calculateDigitalClocks(taliseDevice_t *device, taliseDigClocks_t
     uint32_t localHsDigClk4or5_Hz = 0;
 
 #if TALISE_VERBOSE
+    adiHalErr_t halError = ADIHAL_OK;
     halError = talWriteToLog(device->devHalInfo, ADIHAL_LOG_MSG, TAL_ERR_OK, "TALISE_calculateDigitalClocks()\n");
     retVal = talApiErrHandler(device, TAL_ERRHDL_HAL_LOG, halError, retVal, TALACT_WARN_RESET_LOG);
 #endif
@@ -3187,6 +3188,7 @@ uint32_t TALISE_getApiVersion (taliseDevice_t *device, uint32_t *siVer, uint32_t
     talRecoveryActions_t retVal = TALACT_NO_ACTION;
 
 #if TALISE_VERBOSE
+    adiHalErr_t halError = ADIHAL_OK;
     halError = talWriteToLog(device->devHalInfo, ADIHAL_LOG_MSG, TAL_ERR_OK, "TALISE_getApiVersion()\n");
     retVal = talApiErrHandler(device, TAL_ERRHDL_HAL_LOG, halError, retVal, TALACT_WARN_RESET_LOG);
 #endif

--- a/drivers/iio/adc/talise/talise_arm.c
+++ b/drivers/iio/adc/talise/talise_arm.c
@@ -125,6 +125,7 @@ uint32_t TALISE_writeArmProfile(taliseDevice_t *device, taliseInit_t *init)
     static const uint8_t length = 84;
 
 #if TALISE_VERBOSE
+    adiHalErr_t halError = ADIHAL_OK;
     halError = talWriteToLog(device->devHalInfo, ADIHAL_LOG_MSG, TAL_ERR_OK, "TALISE_writeArmConfig()\n");
     retVal = talApiErrHandler(device, TAL_ERRHDL_HAL_LOG, halError, retVal, TALACT_WARN_RESET_LOG);
 #endif
@@ -566,6 +567,7 @@ uint32_t TALISE_loadAdcProfiles(taliseDevice_t *device, uint16_t *rxAdcProfile, 
     static const uint32_t ARM_ORXMERGEFILTERPROFILE_OFFSET = 332;
 
 #if TALISE_VERBOSE
+    adiHalErr_t halError = ADIHAL_OK;
     halError = talWriteToLog(device->devHalInfo, ADIHAL_LOG_MSG, TAL_ERR_OK, "TALISE_loadAdcProfiles\n");
     retVal = talApiErrHandler(device, TAL_ERRHDL_HAL_LOG, halError, retVal, TALACT_WARN_RESET_LOG);
 #endif
@@ -868,6 +870,7 @@ uint32_t TALISE_writeArmConfig(taliseDevice_t *device, uint8_t objectId, uint16_
     uint8_t cmdStatusByte = 0;
 
 #if TALISE_VERBOSE
+    adiHalErr_t halError = ADIHAL_OK;
     halError = talWriteToLog(device->devHalInfo, ADIHAL_LOG_MSG, TAL_ERR_OK, "TALISE_writeArmConfig()\n");
     retVal = talApiErrHandler(device, TAL_ERRHDL_HAL_LOG, halError, retVal, TALACT_WARN_RESET_LOG);
 #endif
@@ -916,6 +919,7 @@ uint32_t TALISE_readArmConfig(taliseDevice_t *device, uint8_t objectId, uint16_t
     static const uint8_t AUTO_INC_BIT = 0;
 
 #if TALISE_VERBOSE
+    adiHalErr_t halError = ADIHAL_OK;
     halError = talWriteToLog(device->devHalInfo, ADIHAL_LOG_MSG, TAL_ERR_OK, "TALISE_readArmConfig()\n");
     retVal = talApiErrHandler(device, TAL_ERRHDL_HAL_LOG, halError, retVal, TALACT_WARN_RESET_LOG);
 #endif
@@ -1193,6 +1197,7 @@ uint32_t TALISE_getArmVersion_v2(taliseDevice_t *device, taliseArmVersionInfo_t 
     uint32_t fullVersion = 0;
 
 #if TALISE_VERBOSE
+    adiHalErr_t halError = ADIHAL_OK;
     halError = talWriteToLog(device->devHalInfo, ADIHAL_LOG_MSG, TAL_ERR_OK, "TALISE_getArmVersion()\n");
     retVal = talApiErrHandler(device, TAL_ERRHDL_HAL_LOG, halError, retVal, TALACT_WARN_RESET_LOG);
 #endif
@@ -1238,6 +1243,7 @@ uint32_t TALISE_getArmVersion(taliseDevice_t *device, uint8_t *majorVer, uint8_t
     uint32_t fullVersion = 0;
 
 #if TALISE_VERBOSE
+    adiHalErr_t halError = ADIHAL_OK;
     halError = talWriteToLog(device->devHalInfo, ADIHAL_LOG_MSG, TAL_ERR_OK, "TALISE_getArmVersion()\n");
     retVal = talApiErrHandler(device, TAL_ERRHDL_HAL_LOG, halError, retVal, TALACT_WARN_RESET_LOG);
 #endif


### PR DESCRIPTION
"halError" is not defined in some functions, which leads to compile errors for undeclared variables when compiling with TALISE_VERBOSE=1.

This change defines the variable in the functions where it was previously missing.

Signed-off-by: Isaac True <isaac@is.having.coffee>