### PR TITLE
iio:gyro:adxrs290: fix data signedness

### DIFF
--- a/drivers/iio/gyro/adxrs290.c
+++ b/drivers/iio/gyro/adxrs290.c
@@ -124,7 +124,7 @@ static int adxrs290_get_rate_data(struct iio_dev *indio_dev, const u8 cmd, int *
 		goto err_unlock;
 	}
 
-	*val = temp;
+	*val = sign_extend32(temp, 15);
 
 err_unlock:
 	mutex_unlock(&st->lock);
@@ -146,7 +146,7 @@ static int adxrs290_get_temp_data(struct iio_dev *indio_dev, int *val)
 	}
 
 	/* extract lower 12 bits temperature reading */
-	*val = temp & 0x0FFF;
+	*val = sign_extend32(temp & 0x0FFF, 11);
 
 err_unlock:
 	mutex_unlock(&st->lock);


### PR DESCRIPTION
Sign-extend the rate and temperature data to
fix issue #1274.

Signed-off-by: KJimenez <kister.jimenez@analog.com>