### PR TITLE
iio: adc: ad7768: Add axi_adc support

### DIFF
--- a/arch/arm/boot/dts/zynq-coraz7s-cn0501.dts
+++ b/arch/arm/boot/dts/zynq-coraz7s-cn0501.dts
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD7768
+ * https://www.analog.com/en/products/ad7768.html
+ *
+ * hdl_project: <cn0501/coraz7s>
+ * board_revision: <A>
+ *
+ * Copyright (C) 2020 Analog Devices Inc.
+ */
+/dts-v1/;
+#include "zynq-coraz7s.dtsi"
+#include <dt-bindings/interrupt-controller/irq.h>
+
+/ {
+	vref: regulator-vref {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-supply";
+		regulator-min-microvolt = <4096000>;
+		regulator-max-microvolt = <4096000>;
+		regulator-always-on;
+	};
+
+	clocks {
+		ad7768_mclk: clock@0 {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <32768000>;
+		};
+	};
+};
+
+&fpga_axi {
+	 rx_dma: rx-dmac@7c480000 {
+		compatible = "adi,axi-dmac-1.00.a";
+		reg = <0x7c480000 0x1000>;
+		#dma-cells = <1>;
+		interrupt-parent = <&intc>;
+		interrupts = <0 54 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&clkc 16>;
+
+		adi,channels {
+			#size-cells = <0>;
+			#address-cells = <1>;
+
+			dma-channel@0 {
+				reg = <0>;
+				adi,source-bus-width = <256>;
+				adi,source-bus-type = <2>;
+				adi,destination-bus-width = <64>;
+				adi,destination-bus-type = <0>;
+			};
+		};
+	};
+
+	axi_adc_ad7768: cf_axi_adc@43c00000 {
+		compatible = "adi,axi-ad7768-rx-1.0";
+		reg = <0x43c00000 0x10000>;
+		dmas = <&rx_dma 0>;
+		dma-names = "rx";
+		spibus-connected = <&ad7768>;
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	ad7768: adc@0 {
+		compatible = "adi,ad7768";
+		reg = <0>;
+		spi-max-frequency = <1000000>;
+
+		vref-supply = <&vref>;
+
+		clocks = <&ad7768_mclk>;
+		clock-names = "mclk";
+	};
+};

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad7768-axi-adc.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad7768-axi-adc.dts
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD7768
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-adc/ad7768
+ *
+ * hdl_project: <ad7768evb/zed>
+ * board_revision: <>
+ *
+ * Copyright (C) 2020 Analog Devices Inc.
+ */
+/dts-v1/;
+
+#include "zynq-zed.dtsi"
+#include "zynq-zed-adv7511.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	vref: regulator-vref {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-supply";
+		regulator-min-microvolt = <4096000>;
+		regulator-max-microvolt = <4096000>;
+		regulator-always-on;
+	};
+
+	clocks {
+		ad7768_mclk: clock@0 {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <32768000>;
+		};
+	};
+};
+
+&fpga_axi {
+	rx_dma: rx-dmac@0x7c480000 {
+		compatible = "adi,axi-dmac-1.00.a";
+		reg = <0x7c480000 0x10000>;
+		#dma-cells = <1>;
+		interrupts = <0 54 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&clkc 16>;
+
+		adi,channels {
+			#size-cells = <0>;
+			#address-cells = <1>;
+
+			dma-channel@0 {
+				reg = <0>;
+				adi,source-bus-width = <256>;
+				adi,source-bus-type = <2>;
+				adi,destination-bus-width = <64>;
+				adi,destination-bus-type = <0>;
+			};
+		};
+	};
+
+	axi_adc_ad7768: cf_axi_adc@43c00000 {
+		compatible = "adi,axi-ad7768-rx-1.0";
+		reg = <0x43c00000 0x10000>;
+		dmas = <&rx_dma 0>;
+		dma-names = "rx";
+		spibus-connected = <&ad7768>;
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	ad7768: adc@0 {
+		compatible = "adi,ad7768";
+		reg = <0>;
+		spi-max-frequency = <1000000>;
+
+		reset-gpios = <&gpio0 94 GPIO_ACTIVE_HIGH>;
+		vref-supply = <&vref>;
+
+		clocks = <&ad7768_mclk>;
+		clock-names = "mclk";
+	};
+};

--- a/drivers/iio/adc/ad7768.c
+++ b/drivers/iio/adc/ad7768.c
@@ -18,6 +18,8 @@
 #include <linux/iio/buffer-dma.h>
 #include <linux/iio/buffer-dmaengine.h>
 
+#include "cf_axi_adc.h"
+
 /* AD7768 registers definition */
 #define AD7768_CH_MODE				0x01
 #define AD7768_POWER_MODE			0x04
@@ -41,6 +43,8 @@
 
 #define AD7768_MAX_SAMP_FREQ	256000
 #define AD7768_WR_FLAG_MSK(x)	(0x80 | ((x) & 0x7F))
+
+#define AD7768_OUTPUT_MODE_TWOS_COMPLEMENT	0x01
 
 struct ad7768_state {
 	struct spi_device *spi;
@@ -118,6 +122,34 @@ static struct iio_chan_spec name[] = {	\
 
 DECLARE_AD7768_CHANNELS(ad7768_channels);
 
+static const struct axiadc_chip_info conv_chip_info = {
+	.name = "ad7768_axi_adc",
+	.max_rate = 256000000UL,
+	.num_channels = 8,
+	.channel[0] = AD7768_CHAN(0),
+	.channel[1] = AD7768_CHAN(1),
+	.channel[2] = AD7768_CHAN(2),
+	.channel[3] = AD7768_CHAN(3),
+	.channel[4] = AD7768_CHAN(4),
+	.channel[5] = AD7768_CHAN(5),
+	.channel[6] = AD7768_CHAN(6),
+	.channel[7] = AD7768_CHAN(7),
+};
+
+static struct ad7768_state *ad7768_get_data(struct iio_dev *indio_dev)
+{
+	struct axiadc_converter *conv;
+
+	if (!strcmp(indio_dev->name, "cf_axi_adc")) {
+		conv = iio_device_get_drvdata(indio_dev);
+		return conv->phy;
+	} else if (!strcmp(indio_dev->name, "ad7768")) {
+		return iio_priv(indio_dev);
+	}
+
+	return NULL;
+}
+
 static int ad7768_spi_reg_read(struct ad7768_state *st, unsigned int addr,
 			       unsigned int *val)
 {
@@ -176,8 +208,11 @@ static int ad7768_reg_access(struct iio_dev *indio_dev,
 			     unsigned int writeval,
 			     unsigned int *readval)
 {
-	struct ad7768_state *st = iio_priv(indio_dev);
+	struct ad7768_state *st = ad7768_get_data(indio_dev);
 	int ret;
+
+	if (!st)
+		return -EINVAL;
 
 	mutex_lock(&st->lock);
 	if (readval) {
@@ -283,8 +318,11 @@ static int ad7768_read_raw(struct iio_dev *indio_dev,
 			   const struct iio_chan_spec *chan,
 			   int *val, int *val2, long info)
 {
-	struct ad7768_state *st = iio_priv(indio_dev);
+	struct ad7768_state *st = ad7768_get_data(indio_dev);
 	int ret;
+
+	if (!st)
+		return -EINVAL;
 
 	switch (info) {
 	case IIO_CHAN_INFO_SCALE:
@@ -307,7 +345,10 @@ static int ad7768_write_raw(struct iio_dev *indio_dev,
 			    struct iio_chan_spec const *chan,
 			    int val, int val2, long mask)
 {
-	struct ad7768_state *st = iio_priv(indio_dev);
+	struct ad7768_state *st = ad7768_get_data(indio_dev);
+
+	if (!st)
+		return -EINVAL;
 
 	switch (mask) {
 	case IIO_CHAN_INFO_SAMP_FREQ:
@@ -338,6 +379,8 @@ static const struct iio_dma_buffer_ops dma_buffer_ops = {
 
 static int ad7768_probe(struct spi_device *spi)
 {
+	struct fwnode_handle *fwnode = dev_fwnode(&spi->dev);
+	struct axiadc_converter	*conv;
 	struct ad7768_state *st;
 	struct iio_dev *indio_dev;
 	struct iio_buffer *buffer;
@@ -352,46 +395,58 @@ static int ad7768_probe(struct spi_device *spi)
 	st->vref = devm_regulator_get(&spi->dev, "vref");
 	if (IS_ERR(st->vref))
 		return PTR_ERR(st->vref);
-
-	st->mclk = devm_clk_get(&spi->dev, "mclk");
-	if (IS_ERR(st->mclk))
-		return PTR_ERR(st->mclk);
-
-	spi_set_drvdata(spi, indio_dev);
-
-	st->spi = spi;
-
-	mutex_init(&st->lock);
-
-	indio_dev->dev.parent = &spi->dev;
-	indio_dev->name = spi_get_device_id(spi)->name;
-	indio_dev->modes = INDIO_DIRECT_MODE | INDIO_BUFFER_HARDWARE;
-	indio_dev->channels = ad7768_channels;
-	indio_dev->num_channels = ARRAY_SIZE(ad7768_channels);
-	indio_dev->info = &ad7768_info;
-
-	buffer = iio_dmaengine_buffer_alloc(indio_dev->dev.parent, "rx",
-					    &dma_buffer_ops, indio_dev);
-	if (IS_ERR(buffer))
-		return PTR_ERR(buffer);
-
-	iio_device_attach_buffer(indio_dev, buffer);
-
 	ret = regulator_enable(st->vref);
 	if (ret)
 		return ret;
 
+	st->mclk = devm_clk_get(&spi->dev, "mclk");
+	if (IS_ERR(st->mclk))
+		return PTR_ERR(st->mclk);
 	ret = clk_prepare_enable(st->mclk);
 	if (ret < 0)
 		goto error_disable_reg;
+
+	st->spi = spi;
 
 	ret = ad7768_samp_freq_config(st, AD7768_MAX_SAMP_FREQ);
 	if (ret < 0)
 		goto error_disable_clk;
 
-	ret = devm_iio_device_register(&spi->dev, indio_dev);
-	if (ret < 0)
-		goto error_disable_clk;
+	mutex_init(&st->lock);
+
+	if (!fwnode_property_present(fwnode, "dmas")) {
+		conv = devm_kzalloc(&spi->dev, sizeof(*conv), GFP_KERNEL);
+		if (conv == NULL)
+			return -ENOMEM;
+
+		conv->spi = spi;
+		conv->clk = st->mclk;
+		conv->chip_info = &conv_chip_info;
+		conv->adc_output_mode = AD7768_OUTPUT_MODE_TWOS_COMPLEMENT;
+		conv->reg_access = ad7768_reg_access;
+		conv->write_raw = ad7768_write_raw;
+		conv->read_raw = ad7768_read_raw;
+		conv->phy = st;
+		spi_set_drvdata(spi, conv); /* Take care here */
+	} else {
+		indio_dev->dev.parent = &spi->dev;
+		indio_dev->name = "ad7768";
+		indio_dev->modes = INDIO_DIRECT_MODE | INDIO_BUFFER_HARDWARE;
+		indio_dev->channels = ad7768_channels;
+		indio_dev->num_channels = ARRAY_SIZE(ad7768_channels);
+		indio_dev->info = &ad7768_info;
+
+		buffer = iio_dmaengine_buffer_alloc(indio_dev->dev.parent, "rx",
+						    &dma_buffer_ops, indio_dev);
+		if (IS_ERR(buffer))
+			return PTR_ERR(buffer);
+
+		iio_device_attach_buffer(indio_dev, buffer);
+
+		ret = devm_iio_device_register(&spi->dev, indio_dev);
+		if (ret < 0)
+			goto error_disable_clk;
+	}
 
 	return 0;
 
@@ -400,7 +455,8 @@ error_disable_clk:
 error_disable_reg:
 	regulator_disable(st->vref);
 
-	iio_dmaengine_buffer_free(indio_dev->buffer);
+	if (!fwnode_property_present(fwnode, "dmas"))
+		iio_dmaengine_buffer_free(indio_dev->buffer);
 
 	return ret;
 }
@@ -408,9 +464,13 @@ error_disable_reg:
 static int ad7768_remove(struct spi_device *spi)
 {
 	struct iio_dev *indio_dev = spi_get_drvdata(spi);
-	struct ad7768_state *st = iio_priv(indio_dev);
+	struct ad7768_state *st = ad7768_get_data(indio_dev);
 
-	iio_dmaengine_buffer_free(indio_dev->buffer);
+	if (!st)
+		return -EINVAL;
+
+	if (!strcmp(indio_dev->name, "ad7768"))
+		iio_dmaengine_buffer_free(indio_dev->buffer);
 	clk_disable_unprepare(st->mclk);
 	regulator_disable(st->vref);
 

--- a/drivers/iio/adc/cf_axi_adc_core.c
+++ b/drivers/iio/adc/cf_axi_adc_core.c
@@ -890,6 +890,7 @@ static const struct of_device_id axiadc_of_match[] = {
 	{ .compatible = "adi,axi-ad9694-1.0", .data = &axi_adc_10_0_a_info },
 	{ .compatible = "adi,axi-ad9625-1.0", .data = &axi_adc_10_0_a_info },
 	{ .compatible = "adi,axi-ad6676-1.0", .data = &axi_adc_10_0_a_info },
+	{ .compatible = "adi,axi-ad7768-rx-1.0", .data = &axi_adc_10_0_a_info },
 	{ .compatible = "adi,axi-ad9371-rx-1.0", .data = &axi_adc_10_0_a_info },
 	{ .compatible = "adi,axi-ad9684-1.0", .data = &axi_adc_10_0_a_info },
 	{ .compatible = "adi,axi-adrv9009-rx-1.0", .data = &axi_adc_10_0_a_info },


### PR DESCRIPTION
Add support for both axi_adc and single dma hdl implementation for the ad7768.