### PR TITLE
iio: adc: ad7768: cleanup the driver's exit & error paths

### DIFF
--- a/drivers/iio/adc/ad7768.c
+++ b/drivers/iio/adc/ad7768.c
@@ -370,8 +370,8 @@ static int ad7768_probe(struct spi_device *spi)
 	indio_dev->num_channels = ARRAY_SIZE(ad7768_channels);
 	indio_dev->info = &ad7768_info;
 
-	buffer = iio_dmaengine_buffer_alloc(indio_dev->dev.parent, "rx",
-					    &dma_buffer_ops, indio_dev);
+	buffer = devm_iio_dmaengine_buffer_alloc(indio_dev->dev.parent, "rx",
+						 &dma_buffer_ops, indio_dev);
 	if (IS_ERR(buffer))
 		return PTR_ERR(buffer);
 
@@ -400,8 +400,6 @@ error_disable_clk:
 error_disable_reg:
 	regulator_disable(st->vref);
 
-	iio_dmaengine_buffer_free(indio_dev->buffer);
-
 	return ret;
 }
 
@@ -410,7 +408,6 @@ static int ad7768_remove(struct spi_device *spi)
 	struct iio_dev *indio_dev = spi_get_drvdata(spi);
 	struct ad7768_state *st = iio_priv(indio_dev);
 
-	iio_dmaengine_buffer_free(indio_dev->buffer);
 	clk_disable_unprepare(st->mclk);
 	regulator_disable(st->vref);
 

--- a/drivers/iio/adc/ad7768.c
+++ b/drivers/iio/adc/ad7768.c
@@ -336,6 +336,20 @@ static const struct iio_dma_buffer_ops dma_buffer_ops = {
 	.abort = iio_dmaengine_buffer_abort,
 };
 
+static void ad7768_reg_disable(void *data)
+{
+	struct regulator *reg = data;
+
+	regulator_disable(reg);
+}
+
+static void ad7768_clk_disable(void *data)
+{
+	struct clk *clk = data;
+
+	clk_disable_unprepare(clk);
+}
+
 static int ad7768_probe(struct spi_device *spi)
 {
 	struct ad7768_state *st;
@@ -381,37 +395,23 @@ static int ad7768_probe(struct spi_device *spi)
 	if (ret)
 		return ret;
 
+	ret = devm_add_action_or_reset(&spi->dev, ad7768_reg_disable, st->vref);
+	if (ret)
+		return ret;
+
 	ret = clk_prepare_enable(st->mclk);
 	if (ret < 0)
-		goto error_disable_reg;
+		return ret;
+
+	ret = devm_add_action_or_reset(&spi->dev, ad7768_clk_disable, st->mclk);
+	if (ret)
+		return ret;
 
 	ret = ad7768_samp_freq_config(st, AD7768_MAX_SAMP_FREQ);
 	if (ret < 0)
-		goto error_disable_clk;
+		return ret;
 
-	ret = devm_iio_device_register(&spi->dev, indio_dev);
-	if (ret < 0)
-		goto error_disable_clk;
-
-	return 0;
-
-error_disable_clk:
-	clk_disable_unprepare(st->mclk);
-error_disable_reg:
-	regulator_disable(st->vref);
-
-	return ret;
-}
-
-static int ad7768_remove(struct spi_device *spi)
-{
-	struct iio_dev *indio_dev = spi_get_drvdata(spi);
-	struct ad7768_state *st = iio_priv(indio_dev);
-
-	clk_disable_unprepare(st->mclk);
-	regulator_disable(st->vref);
-
-	return 0;
+	return devm_iio_device_register(&spi->dev, indio_dev);
 }
 
 static const struct spi_device_id ad7768_id[] = {
@@ -425,7 +425,6 @@ static struct spi_driver ad7768_driver = {
 		.name	= "ad7768",
 	},
 	.probe		= ad7768_probe,
-	.remove		= ad7768_remove,
 	.id_table	= ad7768_id,
 };
 module_spi_driver(ad7768_driver);

--- a/drivers/iio/buffer/industrialio-buffer-dmaengine.c
+++ b/drivers/iio/buffer/industrialio-buffer-dmaengine.c
@@ -267,6 +267,46 @@ void iio_dmaengine_buffer_free(struct iio_buffer *buffer)
 }
 EXPORT_SYMBOL_GPL(iio_dmaengine_buffer_free);
 
+static void __devm_iio_dmaengine_buffer_free(struct device *dev, void *res)
+{
+	iio_dmaengine_buffer_free(*(struct iio_buffer **)res);
+}
+
+/**
+ * devm_iio_dmaengine_buffer_alloc() - Resource-managed iio_dmaengine_buffer_alloc()
+ * @dev: Parent device for the buffer
+ * @channel: DMA channel name, typically "rx".
+ *
+ * This allocates a new IIO buffer which internally uses the DMAengine framework
+ * to perform its transfers. The parent device will be used to request the DMA
+ * channel.
+ *
+ * The buffer will be automatically de-allocated once the device gets destroyed.
+ */
+struct iio_buffer *devm_iio_dmaengine_buffer_alloc(struct device *dev,
+	const char *channel, const struct iio_dma_buffer_ops *ops,
+	void *driver_data)
+{
+	struct iio_buffer **bufferp, *buffer;
+
+	bufferp = devres_alloc(__devm_iio_dmaengine_buffer_free,
+			       sizeof(*bufferp), GFP_KERNEL);
+	if (!bufferp)
+		return ERR_PTR(-ENOMEM);
+
+	buffer = iio_dmaengine_buffer_alloc(dev, channel, ops, driver_data);
+	if (IS_ERR(buffer)) {
+		devres_free(bufferp);
+		return buffer;
+	}
+
+	*bufferp = buffer;
+	devres_add(dev, bufferp);
+
+	return buffer;
+}
+EXPORT_SYMBOL_GPL(devm_iio_dmaengine_buffer_alloc);
+
 MODULE_AUTHOR("Lars-Peter Clausen <lars@metafoo.de>");
 MODULE_DESCRIPTION("DMA buffer for the IIO framework");
 MODULE_LICENSE("GPL");

--- a/include/linux/iio/buffer-dmaengine.h
+++ b/include/linux/iio/buffer-dmaengine.h
@@ -22,4 +22,9 @@ struct iio_buffer *iio_dmaengine_buffer_alloc(struct device *dev,
 	const char *channel, const struct iio_dma_buffer_ops *ops, void *data);
 void iio_dmaengine_buffer_free(struct iio_buffer *buffer);
 
+struct iio_buffer *devm_iio_dmaengine_buffer_alloc(struct device *dev,
+						   const char *channel,
+						   const struct iio_dma_buffer_ops *ops,
+						   void *data);
+
 #endif


### PR DESCRIPTION
Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>