### PR TITLE
spi: cadence: remove caching of clk rate

### DIFF
--- a/drivers/spi/spi-cadence.c
+++ b/drivers/spi/spi-cadence.c
@@ -119,7 +119,6 @@ struct cdns_spi {
 	void __iomem *regs;
 	struct clk *ref_clk;
 	struct clk *pclk;
-	unsigned int clk_rate;
 	u32 speed_hz;
 	const u8 *txbuf;
 	u8 *rxbuf;
@@ -259,7 +258,7 @@ static void cdns_spi_config_clock_freq(struct spi_device *spi,
 	u32 ctrl_reg, baud_rate_val;
 	unsigned long frequency;
 
-	frequency = xspi->clk_rate;
+	frequency = clk_get_rate(xspi->ref_clk);
 
 	ctrl_reg = cdns_spi_read(xspi, CDNS_SPI_CR);
 
@@ -629,8 +628,8 @@ static int cdns_spi_probe(struct platform_device *pdev)
 	master->auto_runtime_pm = true;
 	master->mode_bits = SPI_CPOL | SPI_CPHA;
 
-	xspi->clk_rate = clk_get_rate(xspi->ref_clk);
-	master->max_speed_hz = xspi->clk_rate / 4;
+	/* Set to default valid value */
+	master->max_speed_hz = clk_get_rate(xspi->ref_clk) / 4;
 	xspi->speed_hz = master->max_speed_hz;
 
 	master->bits_per_word_mask = SPI_BPW_MASK(8);


### PR DESCRIPTION
That code isn't present in the upstream version, so remove it. The upstream
driver queries the rate from the clock framework via clk_get_rate().

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>