### PR TITLE
include: jesd204.h: JESD204C fix u8 overflow in frames_per_multiframe

### DIFF
--- a/include/linux/jesd204/jesd204.h
+++ b/include/linux/jesd204/jesd204.h
@@ -112,7 +112,7 @@ struct jesd204_link {
 	u8 num_lanes;
 	u8 num_converters;
 	u8 octets_per_frame;
-	u8 frames_per_multiframe;
+	u16 frames_per_multiframe;
 	u8 num_of_multiblocks_in_emb; /* E */
 
 	u8 bits_per_sample;


### PR DESCRIPTION
In 204C modes frames per multiframe (JESD K) can be larger than 255.
Increase storage type to avoid overflows.

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>