### PR TITLE
arch: dts: fmcomms4: Add license and HDL project tag

### DIFF
--- a/arch/arm/boot/dts/zynq-zc702-adv7511-ad9364-fmcomms4.dts
+++ b/arch/arm/boot/dts/zynq-zc702-adv7511-ad9364-fmcomms4.dts
@@ -1,3 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD-FMCOMMS4-EBZ
+ * https://wiki.analog.com/resources/eval/user-guides/ad-fmcomms4-ebz
+ *
+ * hdl_project: <fmcomms2/zc702>
+ * board_revision: <>
+ *
+ * Copyright (C) 2014-2020 Analog Devices Inc.
+ */
 /dts-v1/;
 
 #include "zynq-zc702.dtsi"

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad9364-fmcomms4.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad9364-fmcomms4.dts
@@ -1,3 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD-FMCOMMS4-EBZ
+ * https://wiki.analog.com/resources/eval/user-guides/ad-fmcomms4-ebz
+ *
+ * hdl_project: <fmcomms2/zc706>
+ * board_revision: <>
+ *
+ * Copyright (C) 2014-2020 Analog Devices Inc.
+ */
 /dts-v1/;
 
 #include "zynq-zc706.dtsi"

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9364-fmcomms4.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9364-fmcomms4.dts
@@ -1,9 +1,12 @@
+// SPDX-License-Identifier: GPL-2.0
 /*
- * dts file for FMCOMMS4 AD9364 on Xilinx ZynqMP ZCU102 Rev 1.0
+ * Analog Devices AD-FMCOMMS4-EBZ
+ * https://wiki.analog.com/resources/eval/user-guides/ad-fmcomms4-ebz
  *
- * Copyright (C) 2016-2017 Analog Devices Inc.
+ * hdl_project: <fmcomms2/zcu102>
+ * board_revision: <>
  *
- * Licensed under the GPL-2.
+ * Copyright (C) 2014-2020 Analog Devices Inc.
  */
 
 #include "zynqmp-zcu102-rev1.0.dts"


### PR DESCRIPTION
Similar to https://github.com/analogdevicesinc/linux/commit/f9afb38dd02fedc7ee6f4dcdcb6f6c06b1f7bec1.

Note: FMCOMMS4 and FMCOMMS2/3 are sharing the same HDL project.

Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>