### PR TITLE
jesd204,ad9081: introduce some helpers for loading JESD204 link params from DT

### DIFF
--- a/drivers/iio/adc/ad9081.c
+++ b/drivers/iio/adc/ad9081.c
@@ -25,7 +25,9 @@
 #include <linux/iio/iio.h>
 #include <linux/iio/sysfs.h>
 
+#define JESD204_OF_PREFIX	"adi,"
 #include <linux/jesd204/jesd204.h>
+#include <linux/jesd204/jesd204-of.h>
 
 #include "ad9081/adi_ad9081.h"
 #include "ad9081/adi_ad9081_hal.h"
@@ -74,8 +76,8 @@ struct ad9081_jesd204_priv {
 	struct ad9081_phy *phy;
 };
 struct ad9081_jesd_link {
-	bool is_jrx;
 	adi_cms_jesd_param_t jesd_param;
+	struct jesd204_link jesd204_link;
 	u32 jrx_tpl_phase_adjust;
 	u8 logiclane_mapping[8];
 	u8 link_converter_select[16];
@@ -2546,96 +2548,52 @@ static int ad9081_parse_jesd_link_dt(struct ad9081_phy *phy,
 				     struct device_node *np,
 				     struct ad9081_jesd_link *link, bool jtx)
 {
+	struct device *dev = &phy->spi->dev;
 	u32 tmp;
 	int ret;
 
-	link->is_jrx = !jtx;
+	link->jesd204_link.is_transmit = !jtx;
+	link->jesd204_link.scrambling = 1; /* Force scambling on */
 	link->jesd_param.jesd_scr = 1; /* Force scambling on */
 
 	tmp = 0;
-	of_property_read_u32(np, "adi,device-id", &tmp);
-	link->jesd_param.jesd_did = tmp;
 
-	ret = of_property_read_u32(np, "adi,octets-per-frame", &tmp);
-	if (ret) {
-		dev_err(&phy->spi->dev,
-			"Missing device tree property @ line %d ", __LINE__);
-		return -EINVAL;
-	}
-	link->jesd_param.jesd_f = tmp;
+	JESD204_LNK_READ_DEVICE_ID(dev, np, &link->jesd204_link,
+				   &link->jesd_param.jesd_did, 0);
 
-	ret = of_property_read_u32(np, "adi,frames-per-multiframe", &tmp);
-	if (ret) {
-		dev_err(&phy->spi->dev,
-			"Missing device tree property @ line %d ", __LINE__);
-		return -EINVAL;
-	}
-	link->jesd_param.jesd_k = tmp;
+	JESD204_LNK_READ_OCTETS_PER_FRAME(dev, np, &link->jesd204_link,
+					  &link->jesd_param.jesd_f, -1);
 
-	ret = of_property_read_u32(np, "adi,samples-per-converter-per-frame",
-				   &tmp);
-	if (ret) {
-		dev_err(&phy->spi->dev,
-			"Missing device tree property @ line %d ", __LINE__);
-		return -EINVAL;
-	}
-	link->jesd_param.jesd_s = tmp;
+	JESD204_LNK_READ_FRAMES_PER_MULTIFRAME(dev, np, &link->jesd204_link,
+					       &link->jesd_param.jesd_k, -1);
 
-	ret = of_property_read_u32(np, "adi,high-density", &tmp);
-	if (ret) {
-		dev_err(&phy->spi->dev,
-			"Missing device tree property @ line %d ", __LINE__);
-		return -EINVAL;
-	}
-	link->jesd_param.jesd_hd = tmp;
+	JESD204_LNK_READ_SAMPLES_PER_CONVERTER_PER_FRAME(dev, np,
+							 &link->jesd204_link,
+							 &link->jesd_param.jesd_s, -1);
 
-	ret = of_property_read_u32(np, "adi,converter-resolution", &tmp);
-	if (ret) {
-		dev_err(&phy->spi->dev,
-			"Missing device tree property @ line %d ", __LINE__);
-		return -EINVAL;
-	}
-	link->jesd_param.jesd_n = tmp;
+	JESD204_LNK_READ_HIGH_DENSITY(dev, np, &link->jesd204_link,
+				      &link->jesd_param.jesd_hd, -1);
 
-	ret = of_property_read_u32(np, "adi,bits-per-sample", &tmp);
-	if (ret) {
-		dev_err(&phy->spi->dev,
-			"Missing device tree property @ line %d ", __LINE__);
-		return -EINVAL;
-	}
-	link->jesd_param.jesd_np = tmp;
+	JESD204_LNK_READ_CONVERTER_RESOLUTION(dev, np, &link->jesd204_link,
+					      &link->jesd_param.jesd_n, -1);
 
-	ret = of_property_read_u32(np, "adi,converters-per-device", &tmp);
-	if (ret) {
-		dev_err(&phy->spi->dev,
-			"Missing device tree property @ line %d ", __LINE__);
-		return -EINVAL;
-	}
-	link->jesd_param.jesd_m = tmp;
+	JESD204_LNK_READ_BITS_PER_SAMPLE(dev, np, &link->jesd204_link,
+					 &link->jesd_param.jesd_np, -1);
 
-	ret = of_property_read_u32(np, "adi,control-bits-per-sample", &tmp);
-	if (ret) {
-		dev_err(&phy->spi->dev,
-			"Missing device tree property @ line %d ", __LINE__);
-		return -EINVAL;
-	}
-	link->jesd_param.jesd_cs = tmp;
+	JESD204_LNK_READ_NUM_CONVERTERS(dev, np, &link->jesd204_link,
+					&link->jesd_param.jesd_m, -1);
 
-	ret = of_property_read_u32(np, "adi,lanes-per-device", &tmp);
-	if (ret) {
-		dev_err(&phy->spi->dev,
-			"Missing device tree property @ line %d ", __LINE__);
-		return -EINVAL;
-	}
-	link->jesd_param.jesd_l = tmp;
+	JESD204_LNK_READ_CTRL_BITS_PER_SAMPLE(dev, np, &link->jesd204_link,
+					      &link->jesd_param.jesd_cs, -1);
 
-	ret = of_property_read_u32(np, "adi,subclass", &tmp);
-	if (ret) {
-		dev_err(&phy->spi->dev,
-			"Missing device tree property @ line %d ", __LINE__);
-		return -EINVAL;
-	}
-	link->jesd_param.jesd_subclass = tmp;
+	JESD204_LNK_READ_NUM_LANES(dev, np, &link->jesd204_link,
+				   &link->jesd_param.jesd_l, -1);
+
+	JESD204_LNK_READ_VERSION(dev, np, &link->jesd204_link,
+				 &link->jesd_param.jesd_jesdv, -1);
+
+	JESD204_LNK_READ_SUBCLASS(dev, np, &link->jesd204_link,
+				  &link->jesd_param.jesd_subclass, -1);
 
 	ret = of_property_read_u32(np, "adi,link-mode", &tmp);
 	if (ret) {
@@ -2652,14 +2610,6 @@ static int ad9081_parse_jesd_link_dt(struct ad9081_phy *phy,
 		return -EINVAL;
 	}
 	link->jesd_param.jesd_duallink = tmp;
-
-	ret = of_property_read_u32(np, "adi,version", &tmp);
-	if (ret) {
-		dev_err(&phy->spi->dev,
-			"Missing device tree property @ line %d ", __LINE__);
-		return -EINVAL;
-	}
-	link->jesd_param.jesd_jesdv = tmp;
 
 	ret = of_property_read_variable_u8_array(
 		np, "adi,logical-lane-mapping", link->logiclane_mapping, 1,
@@ -3090,7 +3040,6 @@ static int ad9081_jesd204_link_init(struct jesd204_dev *jdev,
 	struct ad9081_jesd204_priv *priv = jesd204_dev_priv(jdev);
 	struct ad9081_phy *phy = priv->phy;
 	struct ad9081_jesd_link *link;
-	adi_cms_jesd_param_t *p;
 
 	switch (reason) {
 	case JESD204_STATE_OP_REASON_INIT:
@@ -3116,21 +3065,7 @@ static int ad9081_jesd204_link_init(struct jesd204_dev *jdev,
 		return -EINVAL;
 	}
 
-	p = &link->jesd_param;
-
-	lnk->num_converters = p->jesd_m;
-	lnk->num_lanes = p->jesd_l;
-	lnk->octets_per_frame = p->jesd_f;
-	lnk->frames_per_multiframe = p->jesd_k;
-	lnk->device_id = p->jesd_did;
-	lnk->bank_id = p->jesd_lid0;
-	lnk->scrambling = p->jesd_scr;
-	lnk->bits_per_sample = p->jesd_np;
-	lnk->converter_resolution = p->jesd_n;
-	lnk->ctrl_bits_per_sample = p->jesd_cs;
-	lnk->jesd_version = p->jesd_jesdv;
-	lnk->subclass = p->jesd_subclass;
-	lnk->is_transmit = link->is_jrx;
+	jesd204_copy_link_params(lnk, &link->jesd204_link);
 
 	if (lnk->jesd_version == JESD204_VERSION_C)
 		lnk->jesd_encoder = JESD204_ENCODER_64B66B;

--- a/drivers/jesd204/jesd204-core.c
+++ b/drivers/jesd204/jesd204-core.c
@@ -250,6 +250,33 @@ int jesd204_link_get_device_clock(struct jesd204_link *lnk,
 }
 EXPORT_SYMBOL_GPL(jesd204_link_get_device_clock);
 
+void jesd204_copy_link_params(struct jesd204_link *dst,
+			      const struct jesd204_link *src)
+{
+	dst->is_transmit = src->is_transmit;
+	dst->num_lanes = src->num_lanes;
+	dst->num_converters = src->num_converters;
+	dst->octets_per_frame = src->octets_per_frame;
+	dst->frames_per_multiframe = src->frames_per_multiframe;
+	dst->num_of_multiblocks_in_emb = src->num_of_multiblocks_in_emb;
+	dst->bits_per_sample = src->bits_per_sample;
+	dst->converter_resolution = src->converter_resolution;
+	dst->jesd_version = src->jesd_version;
+	dst->jesd_encoder = src->jesd_encoder;
+	dst->subclass = src->subclass;
+	dst->device_id = src->device_id;
+	dst->bank_id = src->bank_id;
+	dst->scrambling = src->scrambling;
+	dst->high_density = src->high_density;
+	dst->ctrl_words_per_frame_clk = src->ctrl_words_per_frame_clk;
+	dst->ctrl_bits_per_sample = src->ctrl_bits_per_sample;
+	dst->samples_per_conv_frame = src->samples_per_conv_frame;
+	dst->dac_adj_resolution_steps = src->dac_adj_resolution_steps;
+	dst->dac_adj_direction = src->dac_adj_direction;
+	dst->dac_phase_adj = src->dac_phase_adj;
+}
+EXPORT_SYMBOL_GPL(jesd204_copy_link_params);
+
 int jesd204_link_get_lmfc_lemc_rate(struct jesd204_link *lnk,
 				    unsigned long *rate_hz)
 {

--- a/include/linux/jesd204/jesd204-of.h
+++ b/include/linux/jesd204/jesd204-of.h
@@ -1,0 +1,98 @@
+/* SPDX-License-Identifier: GPL-2.0+ */
+/**
+ * The JESD204 framework OF helpers
+ *
+ * Copyright (c) 2020 Analog Devices Inc.
+ */
+#ifndef _JESD204_OF_H_
+#define _JESD204_OF_H_
+
+#ifndef JESD204_OF_PREFIX
+#define JESD204_OF_PREFIX	"jesd204-"
+#endif
+
+/**
+ * Note: usually macros should not define control follows, but other methods
+ * can cause insanity.
+ */
+
+#define _JESD204_LNK_READ_PROP(dev, np, sprop, link, field, alt, dflt)	\
+{									\
+	int ret;							\
+	u32 tmp;							\
+									\
+	ret = of_property_read_u32(np, JESD204_OF_PREFIX sprop, &tmp);	\
+	if (ret) {							\
+		if (dflt < 0) {						\
+			dev_err(dev, "Missing DT prop '%s' @ line %d ",	\
+				JESD204_OF_PREFIX sprop, __LINE__);	\
+			return -EINVAL;					\
+		}							\
+		tmp = dflt;						\
+	}								\
+	(link)->field = tmp;						\
+	if (alt)							\
+		*(alt) = tmp;						\
+}
+
+#define JESD204_LNK_READ_DEVICE_ID(dev, np, link, alt, dflt)		\
+	_JESD204_LNK_READ_PROP(dev, np, "device-id", link, device_id, alt, dflt)
+
+#define JESD204_LNK_READ_BANK_ID(dev, np, link, alt, dflt)		\
+	_JESD204_LNK_READ_PROP(dev, np, "bank-id", link, bank_id, alt, dflt)
+
+#define JESD204_LNK_READ_NUM_LANES(dev, np, link, alt, dflt)		\
+	_JESD204_LNK_READ_PROP(dev, np, "lanes-per-device", link, num_lanes, alt, dflt)
+
+#define JESD204_LNK_READ_NUM_CONVERTERS(dev, np, link, alt, dflt)		\
+	_JESD204_LNK_READ_PROP(dev, np, "converters-per-device", link, num_converters, alt, dflt)
+
+#define JESD204_LNK_READ_OCTETS_PER_FRAME(dev, np, link, alt, dflt)	\
+	_JESD204_LNK_READ_PROP(dev, np, "octets-per-frame", link, octets_per_frame, alt, dflt)
+
+#define JESD204_LNK_READ_FRAMES_PER_MULTIFRAME(dev, np, link, alt, dflt)	\
+	_JESD204_LNK_READ_PROP(dev, np, "frames-per-multiframe", link, frames_per_multiframe, alt, dflt)
+
+#define JESD204_LNK_READ_NUM_OF_MULTIBLOCKS_IN_EMB(dev, np, link, alt, dflt)	\
+	_JESD204_LNK_READ_PROP(dev, np, "num-multiblocks-in-emb", link, num_of_multiblocks_in_emb, alt, dflt)
+
+#define JESD204_LNK_READ_BITS_PER_SAMPLE(dev, np, link, alt, dflt)	\
+	_JESD204_LNK_READ_PROP(dev, np, "bits-per-sample", link, bits_per_sample, alt, dflt)
+
+#define JESD204_LNK_READ_CONVERTER_RESOLUTION(dev, np, link, alt, dflt)	\
+	_JESD204_LNK_READ_PROP(dev, np, "converter-resolution", link, converter_resolution, alt, dflt)
+
+#define JESD204_LNK_READ_SCRAMBLING(dev, np, link, alt, dflt)		\
+	_JESD204_LNK_READ_PROP(dev, np, "scrambling", link, scrambling, alt, dflt)
+
+#define JESD204_LNK_READ_ENCODING(dev, np, link, alt, dflt)		\
+	_JESD204_LNK_READ_PROP(dev, np, "encoding", link, jesd_encoder, alt, dflt)
+
+#define JESD204_LNK_READ_HIGH_DENSITY(dev, np, link, alt, dflt)		\
+	_JESD204_LNK_READ_PROP(dev, np, "high-density", link, high_density, alt, dflt)
+
+#define JESD204_LNK_READ_VERSION(dev, np, link, alt, dflt)		\
+	_JESD204_LNK_READ_PROP(dev, np, "version", link, jesd_version, alt, dflt)
+
+#define JESD204_LNK_READ_SUBCLASS(dev, np, link, alt, dflt)		\
+	_JESD204_LNK_READ_PROP(dev, np, "subclass", link, subclass, alt, dflt)
+
+#define JESD204_LNK_READ_CTRL_WORDS_PER_FRAME_CLK(dev, np, link, alt, dflt)	\
+	_JESD204_LNK_READ_PROP(dev, np, "control-words-per-frame-clk", link, ctrl_words_per_frame_clk, alt, dflt)
+
+#define JESD204_LNK_READ_CTRL_BITS_PER_SAMPLE(dev, np, link, alt, dflt)		\
+	_JESD204_LNK_READ_PROP(dev, np, "control-bits-per-sample", link, ctrl_bits_per_sample, alt, dflt)
+
+#define JESD204_LNK_READ_SAMPLES_PER_CONVERTER_PER_FRAME(dev, np, link, alt, dflt)		\
+	_JESD204_LNK_READ_PROP(dev, np, "samples-per-converter-per-frame", link, samples_per_conv_frame, alt, dflt)
+
+#define JESD204_LNK_READ_DAC_ADJ_RESOLUTION_STEPS(dev, np, link, alt, dflt)	\
+	_JESD204_LNK_READ_PROP(dev, np, "dac-adj-resolution-steps", link, dac_adj_resolution_steps, alt, dflt)
+
+#define JESD204_LNK_READ_DAC_ADJ_DIRECTION(dev, np, link, alt, dflt)	\
+	_JESD204_LNK_READ_PROP(dev, np, "dac-adj-direction", link, dac_adj_direction, alt, dflt)
+
+#define JESD204_LNK_READ_DAC_ADJ_PHASE_ADJ(dev, np, link, alt, dflt)	\
+	_JESD204_LNK_READ_PROP(dev, np, "dac-phase-adjust", link, dac_phase_adj, alt, dflt)
+
+#endif /* _JESD204_OF_H_ */

--- a/include/linux/jesd204/jesd204.h
+++ b/include/linux/jesd204/jesd204.h
@@ -51,10 +51,10 @@ enum jesd204_state_change_result {
 #define JESD204_LMFC_OFFSET_UNINITIALIZED	((u16)-1)
 
 /** struct jesd204_sysref - JESD204 parameters for SYSREF
- * @mode			SYSREF mode (see @jesd204_sysref_mode)
- * @capture_falling_edge	true if it should capture falling edge
- * @valid_falling_edge		true if falling edge should be valid
- * @lmfc_offset			offset for LMFC
+ * @mode:			SYSREF mode (see @jesd204_sysref_mode)
+ * @capture_falling_edge:	true if it should capture falling edge
+ * @valid_falling_edge:		true if falling edge should be valid
+ * @lmfc_offset:		offset for LMFC
  */
 struct jesd204_sysref {
 	enum jesd204_sysref_mode	mode;
@@ -65,39 +65,39 @@ struct jesd204_sysref {
 
 /**
  * struct jesd204_link - JESD204 link configuration settings
- * @link_id			JESD204 link ID provided via DT configuration
- * @error			error code for this JESD204 link
- * @is_transmit			true if this link is transmit (digital to analog)
- * @sample_rate			sample rate for the link
- * @sample_rate_div		optional sample rate divider for the link
+ * @link_id:			JESD204 link ID provided via DT configuration
+ * @error:			error code for this JESD204 link
+ * @is_transmit:		true if this link is transmit (digital to analog)
+ * @sample_rate:		sample rate for the link
+ * @sample_rate_div:		optional sample rate divider for the link
  * 					final rate = sample_rate / sample_rate_div
- * @num_lanes			number of JESD204 lanes (L)
- * @num_converters		number of converters per link (M)
- * @octets_per_frame		number of octets per frame (F)
- * @frames_per_multiframe	number of frames per frame (K)
- * @num_of_multiblocks_in_emb	number of multiblocks in extended multiblock (E) (JESD204C)
- * @bits_per_sample		number of bits per sample (N')
- * @converter_resolution	converter resolution (N)
- * @jesd_version		JESD204 version (A, B or C) (JESDV)
- * @jesd_encoder		JESD204C encoder (8B10B, 64B66B, 64B80B)
- * @subclass			JESD204 subclass (0,1 or 2) (SUBCLASSV)
- * @device_id			device ID (DID)
- * @bank_id			bank ID (BID)
- * @scrambling			true if scrambling enabled (SCR)
- * @high_density		true if high-density format is used (HD)
- * @ctrl_words_per_frame_clk	number of control words per frame clock
+ * @num_lanes:			number of JESD204 lanes (L)
+ * @num_converters:		number of converters per link (M)
+ * @octets_per_frame:		number of octets per frame (F)
+ * @frames_per_multiframe:	number of frames per frame (K)
+ * @num_of_multiblocks_in_emb:	number of multiblocks in extended multiblock (E) (JESD204C)
+ * @bits_per_sample:		number of bits per sample (N')
+ * @converter_resolution:	converter resolution (N)
+ * @jesd_version:		JESD204 version (A, B or C) (JESDV)
+ * @jesd_encoder:		JESD204C encoder (8B10B, 64B66B, 64B80B)
+ * @subclass:			JESD204 subclass (0,1 or 2) (SUBCLASSV)
+ * @device_id:			device ID (DID)
+ * @bank_id:			bank ID (BID)
+ * @scrambling:			true if scrambling enabled (SCR)
+ * @high_density:		true if high-density format is used (HD)
+ * @ctrl_words_per_frame_clk:	number of control words per frame clock
  *				period (CF)
- * @ctrl_bits_per_sample	number of control bits per sample (CS)
- * @samples_per_conv_frame	number of samples per converter per frame
+ * @ctrl_bits_per_sample:	number of control bits per sample (CS)
+ * @samples_per_conv_frame:	number of samples per converter per frame
  *				cycle (S)
- * @lane_ids			array of lane IDs (LID); note that this is an
+ * @lane_ids:			array of lane IDs (LID); note that this is an
  *				array the size of @num_lanes
- * @sysref			JESD204 sysref config, see @jesd204_sysref
- * @dac_adj_resolution_steps	number of adjustment resolution steps to adjust
+ * @sysref:			JESD204 sysref config, see @jesd204_sysref
+ * @dac_adj_resolution_steps:	number of adjustment resolution steps to adjust
  *				DAC LMFC (ADJCNT) - Subclass 2 only
- * @dac_adj_direction		direction to adjust DAC LMFC (ADJDIR)
+ * @dac_adj_direction:		direction to adjust DAC LMFC (ADJDIR)
  *				Subclass 2 only
- * @dac_phase_adj		true to do phase adjustment request to DAC
+ * @dac_phase_adj:		true to do phase adjustment request to DAC
  *				Subclass 2 only
  */
 struct jesd204_link {
@@ -193,12 +193,12 @@ enum jesd204_state_op_mode {
 
 /**
  * struct jesd204_state_op - JESD204 device per-state op
- * @mode		mode for this state op, depending on this @per_device or @per_link is called
- * @per_device		op called for each JESD204 **device** during a transition
+ * @mode:		mode for this state op, depending on this @per_device or @per_link is called
+ * @per_device:		op called for each JESD204 **device** during a transition
  * @per_link		op called for each JESD204 **link** individually during a transition
  * // FIXME: maybe pass 'struct jesd204_sysref' for post_state_sysref, to make this configurable? we'll see later
  * // FIXME: for now, the device should also be a top-level device, in case of multi-chip setups
- * @post_state_sysref	true if a SYSREF should be issued after the state change
+ * @post_state_sysref:	true if a SYSREF should be issued after the state change
  */
 struct jesd204_state_op {
 	enum jesd204_state_op_mode	mode;
@@ -231,13 +231,13 @@ enum jesd204_dev_op {
 
 /**
  * struct jesd204_dev_data - JESD204 device initialization data
- * @sysref_cb		SYSREF callback, if this device/driver supports it
- * @fsm_finished_cb	callback for when the FSM finishes a series of transitions
- * @sizeof_priv		amount of data to allocate for private information
- * @links		JESD204 initial link configuration
- * @max_num_links	maximum number of JESD204 links this device can support
- * @num_retries		number of retries in case of error (only for top-level device)
- * @state_ops		ops for each state transition of type @struct jesd204_state_op
+ * @sysref_cb:		SYSREF callback, if this device/driver supports it
+ * @fsm_finished_cb:	callback for when the FSM finishes a series of transitions
+ * @sizeof_priv:	amount of data to allocate for private information
+ * @links:		JESD204 initial link configuration
+ * @max_num_links:	maximum number of JESD204 links this device can support
+ * @num_retries:	number of retries in case of error (only for top-level device)
+ * @state_ops:		ops for each state transition of type @struct jesd204_state_op
  */
 struct jesd204_dev_data {
 	jesd204_sysref_cb			sysref_cb;

--- a/include/linux/jesd204/jesd204.h
+++ b/include/linux/jesd204/jesd204.h
@@ -290,6 +290,9 @@ bool jesd204_link_get_paused(const struct jesd204_link *lnk);
 
 const char *jesd204_link_get_state_str(const struct jesd204_link *lnk);
 
+void jesd204_copy_link_params(struct jesd204_link *dst,
+			      const struct jesd204_link *src);
+
 #else /* !IS_ENABLED(CONFIG_JESD204) */
 
 static inline struct jesd204_dev *devm_jesd204_dev_register(
@@ -391,6 +394,9 @@ static inline const char *jesd204_link_get_state_str(const struct jesd204_link *
 {
 	return NULL;
 }
+
+static inline void jesd204_copy_link_params(struct jesd204_link *dst,
+					    const struct jesd204_link *src) {}
 
 #endif /* #ifdef CONFIG_JESD204 */
 


### PR DESCRIPTION
This changeset is a quick stab at implementing a slightly more generic mechanism of loading device-tree parameters from the devicetree.

A more complete mechanism would require some more re-design of device-trees and trying to impose a more generic mechanism.
This is an intermediate mechanism to reduce some boiler-plate code in the meantime.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>