### PR TITLE
microblaze: boot: dts: Fix/update intc xlnx,kind-of-intr properties

### DIFF
--- a/arch/microblaze/boot/dts/kc705_ad9467_fmc.dts
+++ b/arch/microblaze/boot/dts/kc705_ad9467_fmc.dts
@@ -16,6 +16,11 @@
 #define fmc_i2c fmc_lpc_iic
 #define fmc_spi axi_spi
 
+/* ad9467_fmc_kc705: updated 2019_R2 */
+&axi_intc {
+	xlnx,kind-of-intr = <0xffffe5de>;
+};
+
 &amba_pl {
 	axi_ad9467: cf-ad9467-core-lpc@44a00000 {
 		compatible = "adi,axi-adc-10.0.a";

--- a/arch/microblaze/boot/dts/kc705_fmcdaq2.dts
+++ b/arch/microblaze/boot/dts/kc705_fmcdaq2.dts
@@ -14,6 +14,11 @@
 #define fmc_i2c fmc_hpc_iic
 #define fmc_spi axi_spi
 
+/* daq2_kc705: updated 2019_R2 */
+&axi_intc {
+	xlnx,kind-of-intr = <0xffff05de>;
+};
+
 &amba_pl {
 	rx_dma: rx-dmac@7c400000 {
 		#dma-cells = <1>;

--- a/arch/microblaze/boot/dts/kc705_fmcjesdadc1.dts
+++ b/arch/microblaze/boot/dts/kc705_fmcjesdadc1.dts
@@ -5,6 +5,11 @@
 #define fmc_i2c fmc_hpc_iic
 #define fmc_spi axi_spi
 
+/* fmcjesdadc1_kc705: updated 2019_R2 */
+&axi_intc {
+	xlnx,kind-of-intr = <0xffff85de>;
+};
+
 &amba_pl {
 	axi_ad9250_core0: axi-ad9250-hpc-0@44a10000 {
 		compatible = "xlnx,axi-ad9250-1.00.a";

--- a/arch/microblaze/boot/dts/kc705_fmcomms1.dts
+++ b/arch/microblaze/boot/dts/kc705_fmcomms1.dts
@@ -4,6 +4,11 @@
 
 #define fmc_i2c fmc_lpc_iic
 
+/* fmcomms2_vc707: updated 2019_R2 */
+&axi_intc {
+	xlnx,kind-of-intr = <0xffffc5d0>;
+};
+
 &amba_pl {
 	axi_ad9122: cf-ad9122-core-lpc@74204000 {
 		compatible = "adi,axi-ad9122-6.00.a";

--- a/arch/microblaze/boot/dts/kc705_fmcomms2-3.dts
+++ b/arch/microblaze/boot/dts/kc705_fmcomms2-3.dts
@@ -5,6 +5,11 @@
 #define fmc_i2c fmc_lpc_iic
 #define fmc_spi axi_spi
 
+/* fmcomms2_kc705: updated 2019_R2 */
+&axi_intc {
+	xlnx,kind-of-intr = <0xffffc5de>;
+};
+
 &amba_pl {
 	rx_dma: dma@7c400000 {
 		#dma-cells = <1>;

--- a/arch/microblaze/boot/dts/kc705_fmcomms4.dts
+++ b/arch/microblaze/boot/dts/kc705_fmcomms4.dts
@@ -5,6 +5,12 @@
 #define fmc_i2c fmc_lpc_iic
 #define fmc_spi axi_spi
 
+/* fmcomms2_kcu105: updated 2019_R2 */
+&axi_intc {
+	xlnx,kind-of-intr = <0xffffc5f0>;
+};
+
+
 &amba_pl {
 	rx_dma: dma@7c400000 {
 		#dma-cells = <1>;

--- a/arch/microblaze/boot/dts/kcu105_adrv9371x.dts
+++ b/arch/microblaze/boot/dts/kcu105_adrv9371x.dts
@@ -14,6 +14,11 @@
 #define fmc_i2c fmc_hpc_iic
 #define fmc_spi axi_spi
 
+/* adrv9371x_kcu105: updated 2019_R2 */
+&axi_intc {
+	xlnx,kind-of-intr = <0xffff0470>;
+};
+
 &amba_pl {
 	axi_ad9371_core_rx: axi-ad9371-rx-hpc@44a00000 {
 		compatible = "adi,axi-ad9371-rx-1.0";

--- a/arch/microblaze/boot/dts/kcu105_fmcdaq2.dts
+++ b/arch/microblaze/boot/dts/kcu105_fmcdaq2.dts
@@ -14,6 +14,11 @@
 #define fmc_i2c fmc_hpc_iic
 #define fmc_spi axi_spi
 
+/* daq2_kcu105: updated 2019_R2 */
+&axi_intc {
+	xlnx,kind-of-intr = <0xffff05f0>;
+};
+
 &amba_pl {
 	rx_dma: rx-dmac@7c400000 {
 		#dma-cells = <1>;

--- a/arch/microblaze/boot/dts/kcu105_fmcomms2-3.dts
+++ b/arch/microblaze/boot/dts/kcu105_fmcomms2-3.dts
@@ -5,6 +5,11 @@
 #define fmc_i2c fmc_lpc_iic
 #define fmc_spi axi_spi
 
+/* fmcomms2_kcu105: updated 2019_R2 */
+&axi_intc {
+	xlnx,kind-of-intr = <0xffffc5f0>;
+};
+
 &amba_pl {
 	rx_dma: dma@7c400000 {
 		#dma-cells = <1>;

--- a/arch/microblaze/boot/dts/kcu105_fmcomms4.dts
+++ b/arch/microblaze/boot/dts/kcu105_fmcomms4.dts
@@ -5,6 +5,11 @@
 #define fmc_i2c fmc_lpc_iic
 #define fmc_spi axi_spi
 
+/* fmcomms2_kcu105: updated 2019_R2 */
+&axi_intc {
+	xlnx,kind-of-intr = <0xffffc5f0>;
+};
+
 &amba_pl {
 	rx_dma: dma@7c400000 {
 		#dma-cells = <1>;

--- a/arch/microblaze/boot/dts/vc707_ad6676evb.dts
+++ b/arch/microblaze/boot/dts/vc707_ad6676evb.dts
@@ -15,6 +15,11 @@
 #define fmc_i2c fmc1_hpc_iic
 #define fmc_spi axi_spi
 
+/* ad6676evb_vc707: updated 2019_R2 */
+&axi_intc {
+	xlnx,kind-of-intr = <0xffffc5d0>;
+};
+
 / {
 	clocks {
 		ad6676_clkin: clock@1 {

--- a/arch/microblaze/boot/dts/vc707_fmcadc2.dts
+++ b/arch/microblaze/boot/dts/vc707_fmcadc2.dts
@@ -5,6 +5,11 @@
 #define fmc_i2c fmc1_hpc_iic
 #define fmc_spi axi_spi
 
+/* fmcadc2_vc707: updated 2019_R2 */
+&axi_intc {
+	xlnx,kind-of-intr = <0xffffc5d0>;
+};
+
 / {
 	clocks {
 		ad9625_clkin: clock@0 {

--- a/arch/microblaze/boot/dts/vc707_fmcadc5.dts
+++ b/arch/microblaze/boot/dts/vc707_fmcadc5.dts
@@ -5,6 +5,11 @@
 #define fmc_i2c fmc1_hpc_iic
 #define fmc_spi axi_spi
 
+/* fmcadc5_vc707: updated 2019_R2 */
+&axi_intc {
+	xlnx,kind-of-intr = <0xffff85d0>;
+};
+
 / {
 	clocks {
 		ad9625_clkin: clock@0 {

--- a/arch/microblaze/boot/dts/vc707_fmcjesdadc1.dts
+++ b/arch/microblaze/boot/dts/vc707_fmcjesdadc1.dts
@@ -5,6 +5,11 @@
 #define fmc_i2c fmc1_hpc_iic
 #define fmc_spi axi_spi
 
+/* fmcjesdadc1_vc707: updated 2019_R2 */
+&axi_intc {
+	xlnx,kind-of-intr = <0xffff85d0>;
+};
+
 &amba_pl {
 	axi_ad9250_core0: axi-ad9250-hpc-0@44a10000 {
 		compatible = "xlnx,axi-ad9250-1.00.a";

--- a/arch/microblaze/boot/dts/vc707_fmcomms2-3.dts
+++ b/arch/microblaze/boot/dts/vc707_fmcomms2-3.dts
@@ -5,6 +5,11 @@
 #define fmc_i2c fmc1_hpc_iic
 #define fmc_spi axi_spi
 
+/* fmcomms2_vc707: updated 2019_R2 */
+&axi_intc {
+	xlnx,kind-of-intr = <0xffffc5d0>;
+};
+
 &amba_pl {
 	rx_dma: dma@7c400000 {
 		#dma-cells = <1>;

--- a/arch/microblaze/boot/dts/vc707_fmcomms4.dts
+++ b/arch/microblaze/boot/dts/vc707_fmcomms4.dts
@@ -5,6 +5,11 @@
 #define fmc_i2c fmc1_hpc_iic
 #define fmc_spi axi_spi
 
+/* fmcomms2_vc707: updated 2019_R2 */
+&axi_intc {
+	xlnx,kind-of-intr = <0xffffc5d0>;
+};
+
 &amba_pl {
 	rx_dma: dma@7c400000 {
 		#dma-cells = <1>;

--- a/arch/microblaze/boot/dts/vcu118_ad9081.dts
+++ b/arch/microblaze/boot/dts/vcu118_ad9081.dts
@@ -16,8 +16,9 @@
 #define fmc_i2c fmcp_hspc_iic
 #define fmc_spi axi_spi
 
+/* ad9081_fmca_ebz_vcu118: updated 2019_R2 */
 &axi_intc {
-	xlnx,kind-of-intr = <0x4f0>;
+	xlnx,kind-of-intr = <0xffff05f0>;
 };
 
 &axi_ethernet {

--- a/arch/microblaze/boot/dts/vcu118_dual_ad9208.dts
+++ b/arch/microblaze/boot/dts/vcu118_dual_ad9208.dts
@@ -5,6 +5,11 @@
 #define fmc_i2c fmcp_hspc_iic
 #define fmc_spi axi_spi
 
+/* ad9208_dual_ebz_vcu118: updated 2019_R2 */
+&axi_intc {
+	xlnx,kind-of-intr = <0xffff85f0>;
+};
+
 &amba_pl {
 	rx_dma: rx-dmac@7c420000 {
 		#dma-cells = <1>;

--- a/arch/microblaze/boot/dts/vcu118_fmcdaq3.dts
+++ b/arch/microblaze/boot/dts/vcu118_fmcdaq3.dts
@@ -5,6 +5,11 @@
 #define fmc_i2c fmcp_hspc_iic
 #define fmc_spi axi_spi
 
+/* daq3_vcu118: updated 2019_R2 */
+&axi_intc {
+	xlnx,kind-of-intr = <0xffff05f0>;
+};
+
 &amba_pl {
 	rx_dma: rx-dmac@7c400000 {
 		#dma-cells = <1>;


### PR DESCRIPTION
The edge/level sensitivities are synthesis parameter. However Linux
needs to know what kind of handler to install.
Erroneous configuration can cause undesirable behavior, such as
stuck interrupts, etc.

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>