### PR TITLE
ci,azure: use wildcard matching for branches

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,12 +4,13 @@ variables:
 trigger:
 - main
 - master
-- 'staging/**'
+- staging/*
+- 20*
 
 pr:
 - main
 - master
-- '20[1-9][0-9]_R[1-9]'
+- 20*
 
 pool:
   vmImage: 'ubuntu-latest'


### PR DESCRIPTION
Azure doesn't support regex matching. It does support wildcard matching,
which isn't too bad. The odds of branches prefixed with '20' being matched
is pretty low.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>