### PR TITLE
iio: jesd204: axi_jesd204_[rx|tx]: Allow the link to come up

### DIFF
--- a/drivers/iio/jesd204/axi_jesd204_rx.c
+++ b/drivers/iio/jesd204/axi_jesd204_rx.c
@@ -908,12 +908,16 @@ static int axi_jesd204_rx_jesd204_link_running(struct jesd204_dev *jdev,
 	struct device *dev = jesd204_dev_to_device(jdev);
 	struct axi_jesd204_rx *jesd = dev_get_drvdata(dev);
 	unsigned int link_status;
+	int retry = 10;
 
 	dev_dbg(dev, "%s:%d link_num %u reason %s\n", __func__, __LINE__,
 		lnk->link_id, jesd204_state_op_reason_str(reason));
 
 	if (reason == JESD204_STATE_OP_REASON_INIT) {
-		link_status = readl_relaxed(jesd->base + JESD204_RX_REG_LINK_STATUS) & 0x3;
+		do {
+			msleep(4);
+			link_status = readl_relaxed(jesd->base + JESD204_RX_REG_LINK_STATUS) & 0x3;
+		} while (link_status != JESD204_LINK_STATUS_DATA && retry--);
 
 		if (link_status != JESD204_LINK_STATUS_DATA) {
 			const char *_status = (jesd->encoder == JESD204_ENCODER_8B10B) ?

--- a/drivers/iio/jesd204/axi_jesd204_tx.c
+++ b/drivers/iio/jesd204/axi_jesd204_tx.c
@@ -682,12 +682,16 @@ static int axi_jesd204_tx_jesd204_link_running(struct jesd204_dev *jdev,
 	struct device *dev = jesd204_dev_to_device(jdev);
 	struct axi_jesd204_tx *jesd = dev_get_drvdata(dev);
 	unsigned int link_status;
+	int retry = 10;
 
 	dev_dbg(dev, "%s:%d link_num %u reason %s\n", __func__, __LINE__,
 		lnk->link_id, jesd204_state_op_reason_str(reason));
 
 	if (reason == JESD204_STATE_OP_REASON_INIT) {
-		link_status = readl_relaxed(jesd->base + JESD204_TX_REG_LINK_STATUS) & 0x3;
+		do {
+			msleep(4);
+			link_status = readl_relaxed(jesd->base + JESD204_TX_REG_LINK_STATUS) & 0x3;
+		} while (link_status != JESD204_LINK_STATUS_DATA && retry--);
 
 		if (link_status != JESD204_LINK_STATUS_DATA) {
 			dev_err(dev, "%s: Link%u status failed (%s)\n",


### PR DESCRIPTION
In the link_running cb, we need to allow the link to come up before
we error here.

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>