### PR TITLE
[2019_R2] jesd204: fsm: handle connection callbacks when starting rollback

### DIFF
--- a/drivers/jesd204/jesd204-fsm.c
+++ b/drivers/jesd204/jesd204-fsm.c
@@ -547,7 +547,8 @@ static int jesd204_fsm_handle_con(struct jesd204_dev *jdev_it,
 		return 0;
 
 	/* if this transitioned already, we're done */
-	if (con->state == fsm_data->nxt_state)
+	/* FIXME: see if this check is still needed; it may not be required in the current state */
+	if (con->state == fsm_data->nxt_state && !fsm_data->rollback)
 		return 0;
 
 	ret = jesd204_con_validate_cur_state(jdev_it, con, fsm_data);


### PR DESCRIPTION
When a state N fails, calling the callbacks for the connections during
state N - 1 will not happen because the FSM is in state N - 1.

So, we need to allow that check to function, only if the FSM isn't rolling
back. It could be that the check is redundant. It could be removed during
an FSM rework/overhaul/rewrite.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>