### PR TITLE
jesd204,adrv9009: misc jesd204 updates & fixes

### DIFF
--- a/drivers/iio/adc/adrv9009.c
+++ b/drivers/iio/adc/adrv9009.c
@@ -5339,14 +5339,14 @@ static int adrv9009_jesd204_link_init(struct jesd204_dev *jdev,
 
 	struct adrv9009_jesd204_priv *priv = jesd204_dev_priv(jdev);
 
+	dev_dbg(dev, "%s:%d link_num %u reason %s\n", __func__, __LINE__, lnk->link_id, jesd204_state_op_reason_str(reason));
+
 	switch (reason) {
 	case JESD204_STATE_OP_REASON_INIT:
 		break;
 	default:
 		return JESD204_STATE_CHANGE_DONE;
 	}
-
-	dev_dbg(dev, "%s:%d link_num %u reason %s\n", __func__, __LINE__, lnk->link_id, jesd204_state_op_reason_str(reason));
 
 	priv->phy = phy;
 
@@ -5433,10 +5433,10 @@ static int adrv9009_jesd204_clks_enable(struct jesd204_dev *jdev,
 	struct adrv9009_rf_phy *phy = priv->phy;
 	int ret;
 
+	dev_dbg(dev, "%s:%d link_num %u reason %s\n", __func__, __LINE__, lnk->link_id, jesd204_state_op_reason_str(reason));
+
 	if (reason != JESD204_STATE_OP_REASON_INIT)
 		return JESD204_STATE_CHANGE_DONE;
-
-	dev_dbg(dev, "%s:%d link_num %u reason %s\n", __func__, __LINE__, lnk->link_id, jesd204_state_op_reason_str(reason));
 
 	if (!lnk->num_converters)
 		return JESD204_STATE_CHANGE_DONE;
@@ -5485,10 +5485,10 @@ static int adrv9009_jesd204_link_enable(struct jesd204_dev *jdev,
 	struct adrv9009_rf_phy *phy = priv->phy;
 	int ret;
 
+	dev_dbg(dev, "%s:%d link_num %u reason %s\n", __func__, __LINE__, lnk->link_id, jesd204_state_op_reason_str(reason));
+
 	if (reason != JESD204_STATE_OP_REASON_INIT)
 		return JESD204_STATE_CHANGE_DONE;
-
-	dev_dbg(dev, "%s:%d link_num %u reason %s\n", __func__, __LINE__, lnk->link_id, jesd204_state_op_reason_str(reason));
 
 	if (!lnk->num_converters)
 		return JESD204_STATE_CHANGE_DONE;
@@ -5605,10 +5605,10 @@ int adrv9009_jesd204_link_setup(struct jesd204_dev *jdev,
 	int ret = TALACT_NO_ACTION;
 	long dev_clk;
 
+	dev_dbg(dev, "%s:%d reason %s\n", __func__, __LINE__, jesd204_state_op_reason_str(reason));
+
 	if (reason != JESD204_STATE_OP_REASON_INIT)
 		return JESD204_STATE_CHANGE_DONE;
-
-	dev_dbg(dev, "%s:%d reason %s\n", __func__, __LINE__, jesd204_state_op_reason_str(reason));
 
 	/**********************************************************/
 	/**********************************************************/
@@ -5701,10 +5701,10 @@ static int adrv9009_jesd204_setup_stage1(struct jesd204_dev *jdev,
 	int ret;
 	u8 mcsStatus;
 
+	dev_dbg(dev, "%s:%d reason %s\n", __func__, __LINE__, jesd204_state_op_reason_str(reason));
+
 	if (reason != JESD204_STATE_OP_REASON_INIT)
 		return JESD204_STATE_CHANGE_DONE;
-
-	dev_dbg(dev, "%s:%d reason %s\n", __func__, __LINE__, jesd204_state_op_reason_str(reason));
 
 	ret = TALISE_enableMultichipSync(phy->talDevice, 0, &mcsStatus);
 	if (ret != TALACT_NO_ACTION)
@@ -5729,10 +5729,10 @@ static int adrv9009_jesd204_setup_stage2(struct jesd204_dev *jdev,
 	u8 pllLockStatus_mask, pllLockStatus = 0;
 	int ret;
 
+	dev_dbg(dev, "%s:%d reason %s\n", __func__, __LINE__, jesd204_state_op_reason_str(reason));
+
 	if (reason != JESD204_STATE_OP_REASON_INIT)
 		return JESD204_STATE_CHANGE_DONE;
-
-	dev_dbg(dev, "%s:%d reason %s\n", __func__, __LINE__, jesd204_state_op_reason_str(reason));
 
 	/*******************/
 	/**** Verify MCS ***/
@@ -5835,10 +5835,10 @@ static int adrv9009_jesd204_setup_stage3(struct jesd204_dev *jdev,
 	struct adrv9009_rf_phy *phy = priv->phy;
 	int ret;
 
+	dev_dbg(dev, "%s:%d reason %s\n", __func__, __LINE__, jesd204_state_op_reason_str(reason));
+
 	if (reason != JESD204_STATE_OP_REASON_INIT)
 		return JESD204_STATE_CHANGE_DONE;
-
-	dev_dbg(dev, "%s:%d reason %s\n", __func__, __LINE__, jesd204_state_op_reason_str(reason));
 
 	ret = TALISE_enableMultichipRfLOPhaseSync(phy->talDevice, 0);
 
@@ -5859,10 +5859,10 @@ static int adrv9009_jesd204_setup_stage4(struct jesd204_dev *jdev,
 	struct adrv9009_rf_phy *phy = priv->phy;
 	int ret;
 
+	dev_dbg(dev, "%s:%d reason %s\n", __func__, __LINE__, jesd204_state_op_reason_str(reason));
+
 	if (reason != JESD204_STATE_OP_REASON_INIT)
 		return JESD204_STATE_CHANGE_DONE;
-
-	dev_dbg(dev, "%s:%d reason %s\n", __func__, __LINE__, jesd204_state_op_reason_str(reason));
 
 	/* Parallelization stage ... */
 
@@ -5892,10 +5892,10 @@ static int adrv9009_jesd204_setup_stage5(struct jesd204_dev *jdev,
 	int ret;
 	u8 errorFlag;
 
+	dev_dbg(dev, "%s:%d reason %s\n", __func__, __LINE__, jesd204_state_op_reason_str(reason));
+
 	if (reason != JESD204_STATE_OP_REASON_INIT)
 		return JESD204_STATE_CHANGE_DONE;
-
-	dev_dbg(dev, "%s:%d reason %s\n", __func__, __LINE__, jesd204_state_op_reason_str(reason));
 
 	ret = TALISE_waitInitCals(phy->talDevice, 20000, &errorFlag);
 	if (ret != TALACT_NO_ACTION) {
@@ -5940,12 +5940,12 @@ static int adrv9009_jesd204_post_running_stage(struct jesd204_dev *jdev,
 
 	u32 trackingCalMask = phy->tracking_cal_mask =  TAL_TRACK_NONE;
 
+	dev_dbg(dev, "%s:%d reason %s\n", __func__, __LINE__, jesd204_state_op_reason_str(reason));
+
 	if (reason != JESD204_STATE_OP_REASON_INIT) {
 		phy->is_initialized = 0;
 		return JESD204_STATE_CHANGE_DONE;
 	}
-
-	dev_dbg(dev, "%s:%d reason %s\n", __func__, __LINE__, jesd204_state_op_reason_str(reason));
 
 	/***********************************************
 	 * Allow Rx1/2 QEC tracking and Tx1/2 QEC       *

--- a/drivers/jesd204/jesd204-fsm.c
+++ b/drivers/jesd204/jesd204-fsm.c
@@ -231,9 +231,8 @@ static int jesd204_dev_set_error(struct jesd204_dev *jdev,
 static int jesd204_fsm_propagate_cb_inputs(struct jesd204_dev *jdev_it,
 					   struct jesd204_fsm_data *data)
 {
-	struct jesd204_dev_con_out *con = NULL;
-	unsigned int i;
-	int ret = 0;
+	struct jesd204_dev_con_out *con;
+	int i, ret = 0;
 
 	for (i = 0; i < jdev_it->inputs_count; i++) {
 		con = jdev_it->inputs[i];
@@ -249,10 +248,29 @@ static int jesd204_fsm_propagate_cb_inputs(struct jesd204_dev *jdev_it,
 	return ret;
 }
 
+static int jesd204_fsm_propagate_rollback_cb_inputs(struct jesd204_dev *jdev_it,
+						    struct jesd204_fsm_data *data)
+{
+	struct jesd204_dev_con_out *con;
+	int i;
+
+	if (jdev_it->inputs_count == 0)
+		return 0;
+
+	for (i = jdev_it->inputs_count - 1; i >= 0; i--) {
+		con = jdev_it->inputs[i];
+
+		jesd204_fsm_handle_con(con->owner, con, data);
+		jesd204_fsm_propagate_rollback_cb_inputs(con->owner, data);
+	}
+
+	return 0;
+}
+
 static int jesd204_fsm_propagate_cb_outputs(struct jesd204_dev *jdev_it,
 					    struct jesd204_fsm_data *data)
 {
-	struct jesd204_dev_con_out *con = NULL;
+	struct jesd204_dev_con_out *con;
 	struct jesd204_dev_list_entry *e;
 	int ret = 0;
 
@@ -271,11 +289,26 @@ done:
 	return ret;
 }
 
+static int jesd204_fsm_propagate_rollback_cb_outputs(struct jesd204_dev *jdev_it,
+						     struct jesd204_fsm_data *data)
+{
+	struct jesd204_dev_con_out *con;
+	struct jesd204_dev_list_entry *e;
+
+	list_for_each_entry_reverse(con, &jdev_it->outputs, entry) {
+		list_for_each_entry_reverse(e, &con->dests, entry) {
+			jesd204_fsm_propagate_rollback_cb_outputs(e->jdev, data);
+			jesd204_fsm_handle_con(e->jdev, con, data);
+		}
+	}
+
+	return 0;
+}
+
 static int jesd204_fsm_propagate_cb_top_level(struct jesd204_dev *jdev_it,
 					      struct jesd204_fsm_data *fsm_data)
 {
-	unsigned int i;
-	int ret;
+	int i, ret;
 
 	if (fsm_data->link_idx != JESD204_LINKS_ALL)
 		return jesd204_fsm_handle_con_cb(jdev_it, NULL,
@@ -292,6 +325,49 @@ static int jesd204_fsm_propagate_cb_top_level(struct jesd204_dev *jdev_it,
 	return ret;
 }
 
+static int jesd204_fsm_propagate_rollback_cb_top_level(struct jesd204_dev *jdev_it,
+						       struct jesd204_fsm_data *fsm_data)
+{
+	int i;
+
+	if (fsm_data->link_idx != JESD204_LINKS_ALL) {
+		jesd204_fsm_handle_con_cb(jdev_it, NULL, fsm_data->link_idx,
+					   fsm_data);
+		return 0;
+	}
+
+	for (i = fsm_data->jdev_top->num_links - 1; i >= 0; i--)
+		jesd204_fsm_handle_con_cb(jdev_it, NULL, i, fsm_data);
+
+	return 0;
+}
+
+static int __jesd204_fsm_propagate_cb(struct jesd204_dev *jdev,
+				      struct jesd204_fsm_data *data)
+{
+	int ret;
+
+	ret = jesd204_fsm_propagate_cb_inputs(jdev, data);
+	if (ret)
+		return ret;
+
+	ret = jesd204_fsm_propagate_cb_outputs(jdev, data);
+	if (ret)
+		return ret;
+
+	return jesd204_fsm_propagate_cb_top_level(jdev, data);
+}
+
+static int __jesd204_fsm_propagate_rollback_cb(struct jesd204_dev *jdev,
+					       struct jesd204_fsm_data *data)
+{
+	jesd204_fsm_propagate_rollback_cb_top_level(jdev, data);
+	jesd204_fsm_propagate_rollback_cb_outputs(jdev, data);
+	jesd204_fsm_propagate_rollback_cb_inputs(jdev, data);
+
+	return 0;
+}
+
 static int jesd204_fsm_propagate_cb(struct jesd204_dev *jdev,
 				    struct jesd204_fsm_data *data)
 {
@@ -306,16 +382,11 @@ static int jesd204_fsm_propagate_cb(struct jesd204_dev *jdev,
 	if (!data->per_device_ran)
 		return -ENOMEM;
 
-	ret = jesd204_fsm_propagate_cb_inputs(jdev, data);
-	if (ret)
-		goto out;
+	if (data->rollback)
+		ret = __jesd204_fsm_propagate_rollback_cb(jdev, data);
+	else
+		ret = __jesd204_fsm_propagate_cb(jdev, data);
 
-	ret = jesd204_fsm_propagate_cb_outputs(jdev, data);
-	if (ret)
-		goto out;
-
-	ret = jesd204_fsm_propagate_cb_top_level(jdev, data);
-out:
 	kfree(data->per_device_ran);
 	data->per_device_ran = NULL;
 	return ret;
@@ -391,14 +462,21 @@ static void __jesd204_all_links_fsm_done_cb(struct kref *ref)
 	struct jesd204_dev *jdev = &jdev_top->jdev;
 	struct jesd204_fsm_data *fsm_data = jdev_top->fsm_data;
 	struct jesd204_link_opaque *ol;
-	unsigned int link_idx;
+	int link_idx;
 	int ret;
 
-	for (link_idx = 0; link_idx < jdev_top->num_links; link_idx++) {
-		ol = &jdev_top->active_links[link_idx];
-		ret = __jesd204_link_fsm_update_state(jdev, ol, fsm_data);
-		if (ret)
-			goto out;
+	if (fsm_data->rollback) {
+		for (link_idx = jdev_top->num_links - 1; link_idx >= 0; link_idx--) {
+			ol = &jdev_top->active_links[link_idx];
+			__jesd204_link_fsm_update_state(jdev, ol, fsm_data);
+		}
+	} else {
+		for (link_idx = 0; link_idx < jdev_top->num_links; link_idx++) {
+			ol = &jdev_top->active_links[link_idx];
+			ret = __jesd204_link_fsm_update_state(jdev, ol, fsm_data);
+			if (ret)
+				goto out;
+		}
 	}
 
 	if (!fsm_data->fsm_complete_cb)

--- a/drivers/jesd204/jesd204-fsm.c
+++ b/drivers/jesd204/jesd204-fsm.c
@@ -547,7 +547,8 @@ static int jesd204_fsm_handle_con(struct jesd204_dev *jdev_it,
 		return 0;
 
 	/* if this transitioned already, we're done */
-	if (con->state == fsm_data->nxt_state)
+	/* FIXME: see if this check is still needed; it may not be required in the current state */
+	if (con->state == fsm_data->nxt_state && !fsm_data->rollback)
 		return 0;
 
 	ret = jesd204_con_validate_cur_state(jdev_it, con, fsm_data);


### PR DESCRIPTION
For ADRV9009, printing state callbacks regardless of reason.
To better debug the FSM.

Fixing connection callback when starting rollback. These would get skipped when a rollback would get started.

Also handling the callback propagation in reverse order during rollback.
This is not super important now. It may be useful later.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>