### PR TITLE
adrv9002 misc enhancements

### DIFF
--- a/arch/arm/boot/dts/adi-adrv9002.dtsi
+++ b/arch/arm/boot/dts/adi-adrv9002.dtsi
@@ -28,54 +28,6 @@
 				"rx2_sampl_clk", "tx2_sampl_clk", "tdd2_intf_clk";
 		#clock-cells = <1>;
 
-		agc0: agc@0 {
-			adi,peak-wait-time = <4>;
-			adi,gain-update-counter = <11520>;
-			adi,attack-delax-us = <10>;
-			adi,slow-loop-settling-delay = <16>;
-			adi,change-gain-threshold-high = <3>;
-			adi,agc-mode = <1>;
-			adi,reset-on-rx-on-gain-index = <255>;
-			adi,power-measurement-en;
-			adi,power-under-range-high-threshold = <10>;
-			adi,power-under-range-low-threshold = <4>;
-			adi,power-under-range-high-gain-step-recovery = <2>;
-			adi,power-under-range-low-gain-step-recovery = <4>;
-			adi,power-measurement-duration = <10>;
-			adi,power-measurement-delay = <2>;
-			adi,power-rx-tdd-measurement-duration = <0>;
-			adi,power-rx-tdd-measurement-delay = <0>;
-			adi,power-over-range-high-threshold = <0>;
-			adi,power-over-range-low-threshold = <7>;
-			adi,power-over-range-high-gain-step-attack = <4>;
-			adi,power-over-range-low-gain-step-attack = <4>;
-			adi,peak-agc-under-range-low-interval = <50>;
-			adi,peak-agc-under-range-mid-interval = <2>;
-			adi,peak-agc-under-range-high-interval = <4>;
-			adi,peak-apd-high-threshold = <21>;
-			adi,peak-apd-low-threshold = <12>;
-			adi,peak-apd-upper-threshold-exceeded-count = <6>;
-			adi,peak-apd-lower-threshold-exceeded-count = <3>;
-			adi,peak-apd-gain-step-attack = <2>;
-			adi,peak-apd-gain-step-recovery = <0>;
-			adi,peak-hb-overload-en;
-			adi,peak-hb-overload-duration-count = <1>;
-			adi,peak-hb-overload-threshold-count = <1>;
-			adi,peak-hb-high-threshold = <13044>;
-			adi,peak-hb-under-range-low-threshold = <5826>;
-			adi,peak-hb-under-range-mid-threshold = <8230>;
-			adi,peak-hb-under-range-high-threshold = <7335>;
-			adi,peak-hb-upper-threshold-exceeded-count = <6>;
-			adi,peak-hb-under-range-high-threshold-exceeded-count = <3>;
-			adi,peak-hb-gain-step-high-recovery = <2>;
-			adi,peak-hb-gain-step-low-recovery = <6>;
-			adi,peak-hb-gain-step-mid-recovery = <4>;
-			adi,peak-hb-gain-step-attack = <2>;
-			adi,peak-hb-overload-power-mode = <0>;
-			adi,peak-hb-under-range-mid-threshold-exceeded-count = <3>;
-			adi,peak-hb-under-range-low-threshold-exceeded-count = <3>;
-		};
-
 		rx_pinctrl0: rx-pinctrl@0 {
 			adi,increment-step-size = <1>;
 			adi,decrement-step-size = <1>;
@@ -109,14 +61,12 @@
 			rx@0 {
 				reg = <0>;
 				adi,port = <0>;
-				adi,agc = <&agc0>;
 				adi,pinctrl = <&rx_pinctrl0>;
 			};
 
 			rx@1 {
 				reg = <1>;
 				adi,port = <0>;
-				adi,agc = <&agc0>;
 				adi,pinctrl = <&rx_pinctrl1>;
 			};
 

--- a/arch/arm64/boot/dts/xilinx/adi-adrv9002.dtsi
+++ b/arch/arm64/boot/dts/xilinx/adi-adrv9002.dtsi
@@ -28,54 +28,6 @@
 				"rx2_sampl_clk", "tx2_sampl_clk", "tdd2_intf_clk";
 		#clock-cells = <1>;
 
-		agc0: agc@0 {
-			adi,peak-wait-time = <4>;
-			adi,gain-update-counter = <11520>;
-			adi,attack-delax-us = <10>;
-			adi,slow-loop-settling-delay = <16>;
-			adi,change-gain-threshold-high = <3>;
-			adi,agc-mode = <1>;
-			adi,reset-on-rx-on-gain-index = <255>;
-			adi,power-measurement-en;
-			adi,power-under-range-high-threshold = <10>;
-			adi,power-under-range-low-threshold = <4>;
-			adi,power-under-range-high-gain-step-recovery = <2>;
-			adi,power-under-range-low-gain-step-recovery = <4>;
-			adi,power-measurement-duration = <10>;
-			adi,power-measurement-delay = <2>;
-			adi,power-rx-tdd-measurement-duration = <0>;
-			adi,power-rx-tdd-measurement-delay = <0>;
-			adi,power-over-range-high-threshold = <0>;
-			adi,power-over-range-low-threshold = <7>;
-			adi,power-over-range-high-gain-step-attack = <4>;
-			adi,power-over-range-low-gain-step-attack = <4>;
-			adi,peak-agc-under-range-low-interval = <50>;
-			adi,peak-agc-under-range-mid-interval = <2>;
-			adi,peak-agc-under-range-high-interval = <4>;
-			adi,peak-apd-high-threshold = <21>;
-			adi,peak-apd-low-threshold = <12>;
-			adi,peak-apd-upper-threshold-exceeded-count = <6>;
-			adi,peak-apd-lower-threshold-exceeded-count = <3>;
-			adi,peak-apd-gain-step-attack = <2>;
-			adi,peak-apd-gain-step-recovery = <0>;
-			adi,peak-hb-overload-en;
-			adi,peak-hb-overload-duration-count = <1>;
-			adi,peak-hb-overload-threshold-count = <1>;
-			adi,peak-hb-high-threshold = <13044>;
-			adi,peak-hb-under-range-low-threshold = <5826>;
-			adi,peak-hb-under-range-mid-threshold = <8230>;
-			adi,peak-hb-under-range-high-threshold = <7335>;
-			adi,peak-hb-upper-threshold-exceeded-count = <6>;
-			adi,peak-hb-under-range-high-threshold-exceeded-count = <3>;
-			adi,peak-hb-gain-step-high-recovery = <2>;
-			adi,peak-hb-gain-step-low-recovery = <6>;
-			adi,peak-hb-gain-step-mid-recovery = <4>;
-			adi,peak-hb-gain-step-attack = <2>;
-			adi,peak-hb-overload-power-mode = <0>;
-			adi,peak-hb-under-range-mid-threshold-exceeded-count = <3>;
-			adi,peak-hb-under-range-low-threshold-exceeded-count = <3>;
-		};
-
 		rx_pinctrl0: rx-pinctrl@0 {
 			adi,increment-step-size = <1>;
 			adi,decrement-step-size = <1>;
@@ -109,14 +61,12 @@
 			rx@0 {
 				reg = <0>;
 				adi,port = <0>;
-				adi,agc = <&agc0>;
 				adi,pinctrl = <&rx_pinctrl0>;
 			};
 
 			rx@1 {
 				reg = <1>;
 				adi,port = <0>;
-				adi,agc = <&agc0>;
 				adi,pinctrl = <&rx_pinctrl1>;
 			};
 

--- a/drivers/iio/adc/navassa/adrv9002.c
+++ b/drivers/iio/adc/navassa/adrv9002.c
@@ -2986,6 +2986,10 @@ static int adrv9002_parse_rx_agc_dt(struct adrv9002_rf_phy *phy,
 				     ADI_ADRV9001_GPIO_PIN_CRUMB_UNASSIGNED, \
 				     min, max, val, false)
 
+	/* set boolean settings that are enabled by default */
+	rx->agc.power.powerEnableMeasurement = true;
+	rx->agc.peak.enableHbOverload = true;
+
 	agc = of_parse_phandle(node, "adi,agc", 0);
 	if (!agc) {
 		adrv9002_set_agc_defaults(&rx->agc);
@@ -3023,11 +3027,11 @@ static int adrv9002_parse_rx_agc_dt(struct adrv9002_rf_phy *phy,
 	if (of_property_read_bool(agc, "adi,reset-on-rx-on"))
 		rx->agc.resetOnRxon = true;
 
-	if (of_property_read_bool(agc, "adi,power-measurement-en"))
-		rx->agc.power.powerEnableMeasurement = true;
+	if (of_property_read_bool(agc, "adi,no-power-measurement-en"))
+		rx->agc.power.powerEnableMeasurement = false;
 
-	if (of_property_read_bool(agc, "adi,peak-hb-overload-en"))
-		rx->agc.peak.enableHbOverload = true;
+	if (of_property_read_bool(agc, "adi,no-peak-hb-overload-en"))
+		rx->agc.peak.enableHbOverload = false;
 
 	/* check if there are any gpios */
 	ret = ADRV9002_OF_AGC_PIN("adi,agc-power-feedback-high-thres-exceeded",

--- a/drivers/iio/adc/navassa/adrv9002.h
+++ b/drivers/iio/adc/navassa/adrv9002.h
@@ -116,7 +116,7 @@ struct adrv9002_chan {
 
 struct adrv9002_rx_chan {
 	struct adrv9002_chan channel;
-	struct adi_adrv9001_GainControlCfg *agc;
+	struct adi_adrv9001_GainControlCfg agc;
 	struct adi_adrv9001_RxGainControlPinCfg *pin_cfg;
 	struct clk *tdd_clk;
 #ifdef CONFIG_DEBUG_FS

--- a/drivers/iio/adc/navassa/adrv9002.h
+++ b/drivers/iio/adc/navassa/adrv9002.h
@@ -106,12 +106,14 @@ struct adrv9002_chan {
 	 * @adrv9002_chan_ns_to_en_delay() before passing them to the API.
 	 */
 	struct adi_adrv9001_ChannelEnablementDelays en_delays_ns;
+	unsigned long rate;
 	adi_adrv9001_ChannelState_e cached_state;
 	adi_common_ChannelNumber_e number;
 	adi_common_Port_e port;
 	u32 power;
 	int nco_freq;
-	u8 enabled;
+	u8 idx;
+	u8 enabled;;
 };
 
 struct adrv9002_rx_chan {
@@ -157,6 +159,7 @@ struct adrv9002_rf_phy {
 	u16				stream_size;
 	struct adrv9002_rx_chan		rx_channels[ADRV9002_CHANN_MAX];
 	struct adrv9002_tx_chan		tx_channels[ADRV9002_CHANN_MAX];
+	struct adrv9002_chan		*channels[ADRV9002_CHANN_MAX * 2];
 	struct adrv9002_gpio 		*adrv9002_gpios;
 	struct adi_adrv9001_Device	adrv9001_device;
 	struct adi_adrv9001_Device	*adrv9001;

--- a/drivers/iio/adc/navassa/adrv9002.h
+++ b/drivers/iio/adc/navassa/adrv9002.h
@@ -121,7 +121,6 @@ struct adrv9002_rx_chan {
 	struct clk *tdd_clk;
 #ifdef CONFIG_DEBUG_FS
 	struct adi_adrv9001_RxSsiTestModeCfg ssi_test;
-	struct adi_adrv9001_GainControlCfg debug_agc;
 #endif
 };
 

--- a/drivers/iio/adc/navassa/adrv9002_debugfs.c
+++ b/drivers/iio/adc/navassa/adrv9002_debugfs.c
@@ -39,9 +39,9 @@
 	struct adrv9002_rf_phy *__phy;					\
 									\
 	if (__c->port == ADI_RX)					\
-		__phy = rx_to_phy(chan_to_rx(__c), __c->number - 1);	\
+		__phy = rx_to_phy(chan_to_rx(__c), __c->idx);	\
 	else								\
-		__phy = tx_to_phy(chan_to_tx(__c), __c->number - 1);	\
+		__phy = tx_to_phy(chan_to_tx(__c), __c->idx);	\
 									\
 	__phy;								\
 })
@@ -50,7 +50,7 @@ static ssize_t adrv9002_rx_adc_type_get(struct file *file, char __user *userbuf,
 					size_t count, loff_t *ppos)
 {
 	struct adrv9002_rx_chan	*rx = file->private_data;
-	struct adrv9002_rf_phy *phy = rx_to_phy(rx, rx->channel.number - 1);
+	struct adrv9002_rf_phy *phy = rx_to_phy(rx, rx->channel.idx);
 	char buf[8];
 	adi_adrv9001_AdcType_e adc_type;
 	int ret, len;
@@ -84,7 +84,7 @@ static int adrv9002_rx_gain_control_pin_mode_show(struct seq_file *s,
 						  void *ignored)
 {
 	struct adrv9002_rx_chan	*rx = s->private;
-	struct adrv9002_rf_phy *phy = rx_to_phy(rx, rx->channel.number - 1);
+	struct adrv9002_rf_phy *phy = rx_to_phy(rx, rx->channel.idx);
 	int ret;
 	struct adi_adrv9001_RxGainControlPinCfg cfg = {0};
 
@@ -113,7 +113,7 @@ DEFINE_SHOW_ATTRIBUTE(adrv9002_rx_gain_control_pin_mode);
 static int adrv9002_rx_agc_config_show(struct seq_file *s, void *ignored)
 {
 	struct adrv9002_rx_chan	*rx = s->private;
-	struct adrv9002_rf_phy *phy = rx_to_phy(rx, rx->channel.number - 1);
+	struct adrv9002_rf_phy *phy = rx_to_phy(rx, rx->channel.idx);
 	struct adi_adrv9001_GainControlCfg agc = {0};
 	int ret;
 
@@ -196,7 +196,7 @@ static ssize_t adrv9002_rx_agc_config_write(struct file *file, const char __user
 {
 	struct seq_file *s = file->private_data;
 	struct adrv9002_rx_chan	*rx = s->private;
-	struct adrv9002_rf_phy *phy = rx_to_phy(rx, rx->channel.number - 1);
+	struct adrv9002_rf_phy *phy = rx_to_phy(rx, rx->channel.idx);
 	int ret;
 
 	mutex_lock(&phy->lock);
@@ -309,7 +309,7 @@ void adrv9002_debugfs_agc_config_create(struct adrv9002_rx_chan *rx, struct dent
 static int adrv9002_tx_dac_full_scale_get(void *arg, u64 *val)
 {
 	struct adrv9002_tx_chan	*tx = arg;
-	struct adrv9002_rf_phy *phy = tx_to_phy(tx, tx->channel.number - 1);
+	struct adrv9002_rf_phy *phy = tx_to_phy(tx, tx->channel.idx);
 	int ret;
 	bool enable;
 
@@ -334,7 +334,7 @@ DEFINE_DEBUGFS_ATTRIBUTE(adrv9002_tx_dac_full_scale_fops,
 static int adrv9002_tx_pin_atten_control_show(struct seq_file *s, void *ignored)
 {
 	struct adrv9002_tx_chan	*tx = s->private;
-	struct adrv9002_rf_phy *phy = tx_to_phy(tx, tx->channel.number - 1);
+	struct adrv9002_rf_phy *phy = tx_to_phy(tx, tx->channel.idx);
 	struct adi_adrv9001_TxAttenuationPinControlCfg cfg = {0};
 	int ret;
 
@@ -514,7 +514,7 @@ static int adrv9002_rx_ssi_test_mode_fixed_pattern_get(void *arg, u64 *val)
 static int adrv9002_rx_ssi_test_mode_fixed_pattern_set(void *arg, const u64 val)
 {
 	struct adrv9002_rx_chan	*rx = arg;
-	struct adrv9002_rf_phy *phy = rx_to_phy(rx, rx->channel.number - 1);
+	struct adrv9002_rf_phy *phy = rx_to_phy(rx, rx->channel.idx);
 	adi_adrv9001_SsiType_e ssi_type = adrv9002_axi_ssi_type_get(phy);
 	int val_max = ssi_type == ADI_ADRV9001_SSI_TYPE_CMOS ? 0xf : U16_MAX;
 	int __val;
@@ -533,7 +533,7 @@ DEFINE_DEBUGFS_ATTRIBUTE(adrv9002_rx_ssi_test_mode_fixed_pattern_fops,
 static int adrv9002_ssi_rx_test_mode_set(void *arg, const u64 val)
 {
 	struct adrv9002_rx_chan	*rx = arg;
-	struct adrv9002_rf_phy *phy = rx_to_phy(rx, rx->channel.number - 1);
+	struct adrv9002_rf_phy *phy = rx_to_phy(rx, rx->channel.idx);
 	adi_adrv9001_SsiType_e ssi_type = adrv9002_axi_ssi_type_get(phy);
 	int ret;
 
@@ -633,7 +633,7 @@ static int adrv9002_tx_ssi_test_mode_loopback_get(void *arg, u64 *val)
 static int adrv9002_tx_ssi_test_mode_loopback_set(void *arg, const u64 val)
 {
 	struct adrv9002_tx_chan	*tx = arg;
-	struct adrv9002_rf_phy *phy = tx_to_phy(tx, tx->channel.number - 1);
+	struct adrv9002_rf_phy *phy = tx_to_phy(tx, tx->channel.idx);
 	adi_adrv9001_SsiType_e ssi_type = adrv9002_axi_ssi_type_get(phy);
 	bool enable = !!val;
 	int ret;
@@ -659,8 +659,7 @@ DEFINE_DEBUGFS_ATTRIBUTE(adrv9002_tx_ssi_test_mode_loopback_fops,
 static int adrv9002_ssi_tx_test_mode_set(void *arg, const u64 val)
 {
 	struct adrv9002_tx_chan	*tx = arg;
-	const int channel_idx = tx->channel.number - 1;
-	struct adrv9002_rf_phy *phy = tx_to_phy(tx, channel_idx);
+	struct adrv9002_rf_phy *phy = tx_to_phy(tx, tx->channel.idx);
 	adi_adrv9001_SsiType_e ssi_type = adrv9002_axi_ssi_type_get(phy);
 	int ret;
 
@@ -668,7 +667,7 @@ static int adrv9002_ssi_tx_test_mode_set(void *arg, const u64 val)
 		return -ENODEV;
 
 	mutex_lock(&phy->lock);
-	ret = adrv9002_axi_tx_test_pattern_cfg(phy, channel_idx, tx->ssi_test.testData);
+	ret = adrv9002_axi_tx_test_pattern_cfg(phy, tx->channel.idx, tx->ssi_test.testData);
 	if (ret)
 		goto unlock;
 
@@ -690,7 +689,7 @@ static int adrv9002_ssi_tx_test_mode_status_show(struct seq_file *s,
 						 void *ignored)
 {
 	struct adrv9002_tx_chan	*tx = s->private;
-	struct adrv9002_rf_phy *phy = tx_to_phy(tx, tx->channel.number - 1);
+	struct adrv9002_rf_phy *phy = tx_to_phy(tx, tx->channel.idx);
 	adi_adrv9001_SsiType_e ssi_type = adrv9002_axi_ssi_type_get(phy);
 	adi_adrv9001_TxSsiTestModeStatus_t ssi_status = {0};
 	int ret;

--- a/drivers/iio/adc/navassa/adrv9002_debugfs.c
+++ b/drivers/iio/adc/navassa/adrv9002_debugfs.c
@@ -201,7 +201,7 @@ static ssize_t adrv9002_rx_agc_config_write(struct file *file, const char __user
 
 	mutex_lock(&phy->lock);
 	ret = adi_adrv9001_Rx_GainControl_Configure(phy->adrv9001, rx->channel.number,
-						    &rx->debug_agc);
+						    &rx->agc);
 	mutex_unlock(&phy->lock);
 	if (ret)
 		return adrv9002_dev_err(phy);
@@ -230,22 +230,22 @@ void adrv9002_debugfs_agc_config_create(struct adrv9002_rx_chan *rx, struct dent
 
 #define adrv9002_agc_add_file_u8(member) { \
 	const char *attr = adrv9002_agc_get_attr(rx->channel.number, member); \
-	debugfs_create_u8(attr, 0600, d, (u8 *)&rx->debug_agc.member); \
+	debugfs_create_u8(attr, 0600, d, (u8 *)&rx->agc.member); \
 }
 
 #define adrv9002_agc_add_file_u16(member) { \
 	const char *attr = adrv9002_agc_get_attr(rx->channel.number, member); \
-	debugfs_create_u16(attr, 0600, d, &rx->debug_agc.member); \
+	debugfs_create_u16(attr, 0600, d, &rx->agc.member); \
 }
 
 #define adrv9002_agc_add_file_u32(member) { \
 	const char *attr = adrv9002_agc_get_attr(rx->channel.number, member); \
-	debugfs_create_u32(attr, 0600, d, &rx->debug_agc.member); \
+	debugfs_create_u32(attr, 0600, d, &rx->agc.member); \
 }
 
 #define adrv9002_agc_add_file_bool(member) { \
 	const char *attr = adrv9002_agc_get_attr(rx->channel.number, member); \
-	debugfs_create_bool(attr, 0600, d, &rx->debug_agc.member); \
+	debugfs_create_bool(attr, 0600, d, &rx->agc.member); \
 }
 	adrv9002_agc_add_file_u8(peakWaitTime);
 	adrv9002_agc_add_file_u8(maxGainIndex);


### PR DESCRIPTION
This adds some general improvements on the driver:

1. iio: adrv9002: Add default AGC settings
2. arch: dts: Remove AGC settings from adrv9002 node
3. iio: adrv9002: Fix AGC default booleans value
4. iio: adrv9002: Remove dedicated debugfs AGC variable
5. iio: adrv9002: Add generic channels handling
6. iio: adrv9002: Improve profile validations
7. iio: adrv9002: Improve internal channel state change