### PR TITLE
ci,azure-pipelines: define CI=true env var for cherry-pick

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,6 +22,7 @@ jobs:
   variables:
     BUILD_TYPE: sync_branches_with_main
     MAIN_BRANCH:  $[ variables['Build.SourceBranchName'] ]
+    CI: true
   steps:
   - checkout: self
     fetchDepth: 50


### PR DESCRIPTION
When this is defined, the CSE CI user is configured as commiter for
cherry-picking.
Otherwise git complains it needs a user.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>