### PR TITLE
arm: dts: zynq-zc706-adv7511-adrv9371.dts: Fix AXI-CLKGEN ENOENT issue

### DIFF
--- a/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9371.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9371.dts
@@ -191,8 +191,8 @@
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x43c00000 0x10000>;
 		#clock-cells = <0>;
-		clocks = <&clk0_ad9528 1>;
-		clock-names = "clkin1";
+		clocks = <&clkc 15>, <&clk0_ad9528 1>;
+		clock-names = "s_axi_aclk", "clkin1";
 		clock-output-names = "axi_tx_clkgen";
 	};
 
@@ -200,8 +200,8 @@
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x43c10000 0x10000>;
 		#clock-cells = <0>;
-		clocks = <&clk0_ad9528 1>;
-		clock-names = "clkin1";
+		clocks = <&clkc 15>, <&clk0_ad9528 1>;
+		clock-names = "s_axi_aclk", "clkin1";
 		clock-output-names = "axi_rx_clkgen";
 
 	};


### PR DESCRIPTION
adi-axi-clkgen 43c00000.axi-clkgen: failed to get s_axi_aclk
adi-axi-clkgen: probe of 43c00000.axi-clkgen failed with error -2
adi-axi-clkgen 43c10000.axi-clkgen: failed to get s_axi_aclk
adi-axi-clkgen: probe of 43c10000.axi-clkgen failed with error -2


Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>