### PR TITLE
nvmem: axi_sys_id: fix sysid version enum & other cleanups

### DIFF
--- a/drivers/nvmem/adi_axi_sysid.c
+++ b/drivers/nvmem/adi_axi_sysid.c
@@ -257,7 +257,7 @@ static int axi_sysid_probe(struct platform_device *pdev)
 	struct axi_sysid *st;
 	struct resource *res;
 	u32 version;
-	int i;
+	int i, ret;
 
 	info = device_get_match_data(&pdev->dev);
 	if (!info)
@@ -301,7 +301,9 @@ static int axi_sysid_probe(struct platform_device *pdev)
 	st->size = (1 << axi_sysid_ioread(st, AXI_SYSID_REG_ROM_ADDR_WIDTH)) *
 		   AXI_SYSID_WORD_SIZE;
 
-	axi_sysid_validate(pdev, st);
+	ret = axi_sysid_validate(pdev, st);
+	if (ret)
+		return ret;
 
 	memcpy(config, &axi_sysid_nvmem_config, sizeof(*config));
 

--- a/drivers/nvmem/adi_axi_sysid.c
+++ b/drivers/nvmem/adi_axi_sysid.c
@@ -289,6 +289,11 @@ static int axi_sysid_probe(struct platform_device *pdev)
 		return -ENODEV;
 	}
 
+	dev_info(&pdev->dev, "AXI System ID core version (%d.%.2d.%c) found\n",
+		ADI_AXI_PCORE_VER_MAJOR(version),
+		ADI_AXI_PCORE_VER_MINOR(version),
+		ADI_AXI_PCORE_VER_PATCH(version));
+
 	st->size = (1 << axi_sysid_ioread(st, AXI_SYSID_REG_ROM_ADDR_WIDTH)) *
 		   AXI_SYSID_WORD_SIZE;
 

--- a/drivers/nvmem/adi_axi_sysid.c
+++ b/drivers/nvmem/adi_axi_sysid.c
@@ -303,22 +303,9 @@ static int axi_sysid_probe(struct platform_device *pdev)
 	axi_sysid_nvmem_config.dev = &pdev->dev;
 	axi_sysid_nvmem_config.priv = st;
 
-	nvmem = nvmem_register(&axi_sysid_nvmem_config);
-	if (IS_ERR(nvmem))
-		return PTR_ERR(nvmem);
+	nvmem = devm_nvmem_register(&pdev->dev, &axi_sysid_nvmem_config);
 
-	platform_set_drvdata(pdev, nvmem);
-
-	return 0;
-}
-
-static int axi_sysid_remove(struct platform_device *pdev)
-{
-	struct nvmem_device *nvmem = platform_get_drvdata(pdev);
-
-	nvmem_unregister(nvmem);
-
-	return 0;
+	return PTR_ERR_OR_ZERO(nvmem);
 }
 
 static const struct of_device_id axi_sysid_of_match[] = {
@@ -329,7 +316,6 @@ MODULE_DEVICE_TABLE(of, axi_sysid_of_match);
 
 static struct platform_driver axi_sysid_driver = {
 	.probe	= axi_sysid_probe,
-	.remove	= axi_sysid_remove,
 	.driver = {
 		.name	= "axi_sysid",
 		.of_match_table = axi_sysid_of_match,

--- a/drivers/nvmem/adi_axi_sysid.c
+++ b/drivers/nvmem/adi_axi_sysid.c
@@ -19,7 +19,7 @@
 #define AXI_SYSID_ROM_OFFSET		0x800
 
 enum {
-	AXI_SYSID_HEADER_V1,
+	AXI_SYSID_HEADER_V1 = 1,
 	AXI_SYSID_HEADER_V2,
 };
 
@@ -241,11 +241,11 @@ static const struct nvmem_config axi_sysid_nvmem_config = {
 static const struct axi_sysid_core_info version_1_0_0_info[] = {
 	{
 		.version = ADI_AXI_PCORE_VER(1, 0, 'a'),
-		.header_version = 1,
+		.header_version = AXI_SYSID_HEADER_V1,
 	},
 	{
 		.version = ADI_AXI_PCORE_VER(1, 1, 'a'),
-		.header_version = 2,
+		.header_version = AXI_SYSID_HEADER_V2,
 	},
 	{}
 };


### PR DESCRIPTION
The main fix is: `nvmem: axi_sys_id: fix sysid version enum`

The others are polishes to the driver.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>