### PR TITLE
ci: define env-vars for docker builds

### DIFF
--- a/ci/travis/run-build-docker.sh
+++ b/ci/travis/run-build-docker.sh
@@ -17,6 +17,8 @@ else
 			echo "export ${env}=${val}" >> "${FULL_BUILD_DIR}/env"
 		fi
 	done
-	prepare_docker_image "ubuntu:rolling"
-	run_docker_script run-build.sh "ubuntu:rolling"
+	export OS_TYPE=ubuntu
+	export OS_VERSION=rolling
+	prepare_docker_image
+	run_docker_script run-build.sh
 fi


### PR DESCRIPTION
A recent change in the common lib.sh script requires that these be passed
as env-vars.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>