### PR TITLE
ci: (actually) re-enable checkpatch job

### DIFF
--- a/azure-pipelines-rpi.yml
+++ b/azure-pipelines-rpi.yml
@@ -15,6 +15,7 @@ jobs:
   condition: eq(variables['Build.Reason'], 'PullRequest')
   variables:
     BUILD_TYPE: checkpatch
+    TARGET_BRANCH: $[ variables['System.PullRequest.TargetBranch'] ]
   steps:
   - checkout: self
     fetchDepth: 50

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,7 +21,7 @@ jobs:
   condition: and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables.isMain, true))
   variables:
     BUILD_TYPE: sync_branches_with_main
-    MAIN_BRANCH:  $[ variables['Build.SourceBranchName'] ]
+    MAIN_BRANCH: $[ variables['Build.SourceBranchName'] ]
     CI: true
   steps:
   - checkout: self
@@ -35,6 +35,7 @@ jobs:
   condition: eq(variables['Build.Reason'], 'PullRequest')
   variables:
     BUILD_TYPE: checkpatch
+    TARGET_BRANCH: $[ variables['System.PullRequest.TargetBranch'] ]
   steps:
   - checkout: self
     fetchDepth: 50
@@ -46,6 +47,7 @@ jobs:
   condition: eq(variables['Build.Reason'], 'PullRequest')
   variables:
     BUILD_TYPE: check_is_new_adi_driver_dual_licensed
+    TARGET_BRANCH: $[ variables['System.PullRequest.TargetBranch'] ]
   steps:
   - checkout: self
     fetchDepth: 50

--- a/ci/travis/run-build.sh
+++ b/ci/travis/run-build.sh
@@ -153,6 +153,8 @@ build_check_is_new_adi_driver_dual_licensed() {
 
 	COMMIT_RANGE="${ref_branch}.."
 
+	echo_green "Running checkpatch for commit range '$COMMIT_RANGE'"
+
 	ret=0
 	# Get list of files in the commit range
 	for file in $(git diff --name-only "$COMMIT_RANGE") ; do
@@ -221,6 +223,8 @@ build_checkpatch() {
 	pip3 install git+https://github.com/devicetree-org/dt-schema.git@master
 
 	local ref_branch="$(get_ref_branch)"
+
+	echo_green "Running checkpatch for commit range '$ref_branch..'"
 
 	if [ -z "$ref_branch" ] ; then
 		echo_red "Could not get a base_ref for checkpatch"

--- a/ci/travis/run-build.sh
+++ b/ci/travis/run-build.sh
@@ -130,7 +130,9 @@ check_all_adi_files_have_been_built() {
 }
 
 get_ref_branch() {
-	if [ -n "$TRAVIS_BRANCH" ] ; then
+	if [ -n "$TARGET_BRANCH" ] ; then
+		echo -n "$TARGET_BRANCH"
+	elif [ -n "$TRAVIS_BRANCH" ] ; then
 		echo -n "$TRAVIS_BRANCH"
 	elif [ -n "$GITHUB_BASE_REF" ] ; then
 		echo -n "$GITHUB_BASE_REF"
@@ -217,8 +219,6 @@ build_checkpatch() {
 	apt_install python-ply python-git libyaml-dev python3-pip python3-setuptools
 	pip3 install wheel
 	pip3 install git+https://github.com/devicetree-org/dt-schema.git@master
-
-	[ "$TRAVIS_PULL_REQUEST" = "true" ] || return 0
 
 	local ref_branch="$(get_ref_branch)"
 


### PR DESCRIPTION
This was not omitted by accident during migration to Azure, and wasn't
working because the TRAVIS_PULL_REQUEST check was still around.
    
Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>
