### PR TITLE
socfpga_cyclone5_de10_nano_cn0540.dts: Fix a typo

### DIFF
--- a/arch/arm/boot/dts/socfpga_cyclone5_de10_nano_cn0540.dts
+++ b/arch/arm/boot/dts/socfpga_cyclone5_de10_nano_cn0540.dts
@@ -5,7 +5,7 @@
  * https://www.analog.com/en/products/ad7768-1.html
  * https://wiki.analog.com/resources/tools-software/linux-build/generic/socfpga
  *
- * hdl_project: <cn0540/de10>
+ * hdl_project: <cn0540/de10nano>
  * board_revision: <A>
  *
  * Copyright (C) 2020 Analog Devices Inc.


### PR DESCRIPTION
Update HDL project tag in socfpga_cyclone5_de10_nano_cn0540.dts, from 'cn0540/de10' to 'cn0540/de10nano'.