### PR TITLE
clk: ad9545: Fix clk_init_data flags

### DIFF
--- a/drivers/clk/adi/clk-ad9545.c
+++ b/drivers/clk/adi/clk-ad9545.c
@@ -885,7 +885,7 @@ static const struct clk_ops ad9545_out_clk_ops = {
 
 static int ad9545_outputs_setup(struct ad9545_state *st)
 {
-	struct clk_init_data init[ARRAY_SIZE(ad9545_out_clk_names)];
+	struct clk_init_data init[ARRAY_SIZE(ad9545_out_clk_names)] = {0};
 	int out_i;
 	u16 addr;
 	int ret;
@@ -1028,7 +1028,7 @@ static const struct clk_ops ad9545_in_clk_ops = {
 
 static int ad9545_input_refs_setup(struct ad9545_state *st)
 {
-	struct clk_init_data init[4];
+	struct clk_init_data init[4] = {0};
 	__le32 regval;
 	__le64 regval64;
 	u64 period_es;
@@ -1307,7 +1307,7 @@ static const struct clk_ops ad9545_pll_clk_ops = {
 
 static int ad9545_plls_setup(struct ad9545_state *st)
 {
-	struct clk_init_data init[2];
+	struct clk_init_data init[2] = {0};
 	struct ad9545_ppl_clk *pll;
 	__le32 regval;
 	int ret;
@@ -1426,7 +1426,7 @@ static const struct clk_ops ad9545_nco_clk_ops = {
 
 static int ad9545_aux_ncos_setup(struct ad9545_state *st)
 {
-	struct clk_init_data init[2];
+	struct clk_init_data init[2] = {0};
 	struct ad9545_aux_nco_clk *nco;
 	__le32 regval;
 	int ret;


### PR DESCRIPTION
This patch sets clk_init_data structs fields to 0. Before
this patch .flag member was receiving random stack values.

Signed-off-by: Alexandru Tachici <alexandru.tachici@analog.com>