### PR TITLE
[2019_R2] navassa: add missing break statements

### DIFF
--- a/drivers/iio/adc/navassa/adrv9002.c
+++ b/drivers/iio/adc/navassa/adrv9002.c
@@ -135,14 +135,19 @@ int __adrv9002_dev_err(const struct adrv9002_rf_phy *phy, const char *function, 
 	case ADI_COMMON_ERR_INV_PARAM:
 	case ADI_COMMON_ERR_NULL_PARAM:
 		ret = -EINVAL;
+		break;
 	case ADI_COMMON_ERR_API_FAIL:
 		ret = -EFAULT;
+		break;
 	case ADI_COMMON_ERR_SPI_FAIL:
 		ret = -EIO;
+		break;
 	case ADI_COMMON_ERR_MEM_ALLOC_FAIL:
 		ret = -ENOMEM;
+		break;
 	default:
 		ret = -EFAULT;
+		break;
 	}
 
 	adi_common_ErrorClear(&phy->adrv9001->common);


### PR DESCRIPTION
This was raised as a warning, that turned out to be a bug.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>