### PR TITLE
spi: cadence: remove Zynq workaround for SPI Clocks

### DIFF
--- a/drivers/spi/spi-cadence.c
+++ b/drivers/spi/spi-cadence.c
@@ -542,7 +542,6 @@ static int cdns_spi_probe(struct platform_device *pdev)
 	struct spi_master *master;
 	struct cdns_spi *xspi;
 	struct resource *res;
-	unsigned long aper_clk_rate;
 	u32 num_cs;
 
 	master = spi_alloc_master(&pdev->dev, sizeof(*xspi));
@@ -629,11 +628,6 @@ static int cdns_spi_probe(struct platform_device *pdev)
 	master->cleanup = cdns_spi_cleanup;
 	master->auto_runtime_pm = true;
 	master->mode_bits = SPI_CPOL | SPI_CPHA;
-
-	/* Set to default valid value */
-	aper_clk_rate = clk_get_rate(xspi->pclk) / 2 * 3;
-	if (aper_clk_rate > clk_get_rate(xspi->ref_clk))
-		clk_set_rate(xspi->ref_clk, aper_clk_rate);
 
 	xspi->clk_rate = clk_get_rate(xspi->ref_clk);
 	master->max_speed_hz = xspi->clk_rate / 4;


### PR DESCRIPTION
This change was added via 931ac60d1aa503 ("spi: xilinx-ps: Make sure the
SPI peripheral clock is fast enough").

Then this was bumped to the rate of the aper_clk via commit 2cf70479bf673
("spi: xilinx-ps: Set ref_clk rate to 3/2 of the aper clock rate").

It took a while to find this out as this was buried in merge commit
5ea3bc963dcd5 ("Merge remote-tracking branch 'xilinx/master-next' into
xcomm_zynq").

In the meantime the section in Xilinx's user-guide about SPI clocks
(referenced in commit 931ac60d1aa503) has disappeared.
The fix in commit 2cf70479bf673 seems a bit empyrical.

After talking to Lars, the reply was:
-----------------------------------------------------------------------
The SPI controller has two clock domains and the signal that was used to
start the SPI transfer is not properly synchronized when the target
domain is slower. Which lead to SPI transfers sometimes randomly not
starting.

What Xilinx did is to modify the driver to not use this signal anymore.
The driver was changed from manual transfer start to automatic transfer
start. So strictly speaking that workaround that changes the clock speed
is not required with the current version of the upstream driver.
-----------------------------------------------------------------------

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>

This commit came up in this EZ thread https://ez.analog.com/linux-software-drivers/f/q-a/539947/kernel-version-sanity-check-error-rebuilding-kernel-on-petalinux