### PR TITLE
usb: chipidea: Hook up ULPI support

### DIFF
--- a/drivers/usb/chipidea/Kconfig
+++ b/drivers/usb/chipidea/Kconfig
@@ -3,6 +3,7 @@
 config USB_CHIPIDEA
 	tristate "ChipIdea Highspeed Dual Role Controller"
 	depends on ((USB_EHCI_HCD && USB_GADGET) || (USB_EHCI_HCD && !USB_GADGET) || (!USB_EHCI_HCD && USB_GADGET)) && HAS_DMA
+	select USB_ULPI_VIEWPORT if USB_ULPI
 	select EXTCON
 	select RESET_CONTROLLER
 	select USB_ULPI_BUS

--- a/drivers/usb/chipidea/core.c
+++ b/drivers/usb/chipidea/core.c
@@ -59,7 +59,10 @@
 #include <linux/usb/otg.h>
 #include <linux/usb/chipidea.h>
 #include <linux/usb/of.h>
+#include <linux/usb/ulpi.h>
 #include <linux/of.h>
+#include <linux/of_gpio.h>
+#include <linux/phy.h>
 #include <linux/regulator/consumer.h>
 #include <linux/usb/ehci_def.h>
 
@@ -923,6 +926,46 @@ static void ci_get_otg_capable(struct ci_hdrc *ci)
 	}
 }
 
+#ifdef CONFIG_USB_ULPI
+
+static int ci_hdrc_create_ulpi_phy(struct device *dev, struct ci_hdrc *ci)
+{
+	struct usb_phy *ulpi;
+	int reset_gpio;
+	int ret;
+
+	reset_gpio = of_get_named_gpio(dev->parent->of_node, "xlnx,phy-reset-gpio", 0);
+	if (gpio_is_valid(reset_gpio)) {
+		ret = devm_gpio_request_one(dev, reset_gpio,
+				GPIOF_INIT_LOW, "ulpi resetb");
+		if (ret) {
+			dev_err(dev, "Failed to request ULPI reset gpio: %d\n", ret);
+			return ret;
+		}
+		msleep(5);
+		gpio_set_value_cansleep(reset_gpio, 1);
+		msleep(1);
+	}
+
+	ulpi = otg_ulpi_create(&ulpi_viewport_access_ops,
+		ULPI_OTG_DRVVBUS | ULPI_OTG_DRVVBUS_EXT);
+	if (ulpi) {
+		ulpi->io_priv = ci->hw_bank.abs + 0x170;
+		ci->usb_phy = ulpi;
+	}
+
+	return 0;
+}
+
+#else
+
+static int ci_hdrc_create_ulpi_phy(struct device *dev, struct ci_hdrc *ci)
+{
+	return 0;
+}
+
+#endif
+
 static ssize_t role_show(struct device *dev, struct device_attribute *attr,
 			  char *buf)
 {
@@ -1058,8 +1101,14 @@ static int ci_hdrc_probe(struct platform_device *pdev)
 
 		/* No USB PHY was found in the end */
 		if (!ci->phy && !ci->usb_phy) {
-			ret = -ENXIO;
-			goto ulpi_exit;
+			if (ci->platdata->phy_mode == USBPHY_INTERFACE_MODE_ULPI) {
+				ret = ci_hdrc_create_ulpi_phy(dev, ci);
+				if (ret)
+					return ret;
+			} else {
+				ret = -ENXIO;
+				goto ulpi_exit;
+			}
 		}
 	}
 


### PR DESCRIPTION
This is a reboot of commit f91cd514718ce ("usb: chipidea: Hook up ULPI
support"). The code for this got lost during the merge, but this is
required, since we have a GPIO that we need to make this work.

This is required for M2k and Pluto, so that the flash-drive gets mounted
and the USB ethernet is probed.

Signed-off-by: Lars-Peter Clausen <lars@metafoo.de>
Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>