### PR TITLE
Adrv9002 misc enhancements

### DIFF
--- a/drivers/iio/adc/navassa/adrv9002.c
+++ b/drivers/iio/adc/navassa/adrv9002.c
@@ -2689,10 +2689,8 @@ static void adrv9002_cleanup(struct adrv9002_rf_phy *phy)
 {
 	int i;
 
-	for (i = 0; i < ADRV9002_CHANN_MAX; i++) {
-		phy->rx_channels[i].channel.enabled = 0;
-		phy->tx_channels[i].channel.enabled = 0;
-	}
+	for (i = 0; i < ARRAY_SIZE(phy->channels); i++)
+		phy->channels[i]->enabled = 0;
 
 	memset(&phy->adrv9001->devStateInfo, 0,
 	       sizeof(phy->adrv9001->devStateInfo));

--- a/drivers/iio/adc/navassa/adrv9002.c
+++ b/drivers/iio/adc/navassa/adrv9002.c
@@ -2415,16 +2415,16 @@ static int adrv9002_setup(struct adrv9002_rf_phy *phy)
 	else
 		init_state = ADI_ADRV9001_CHANNEL_RF_ENABLED;
 
+	adi_common_ErrorClear(&phy->adrv9001->common);
+	ret = adi_adrv9001_HwOpen(adrv9001_device, adrv9002_spi_settings_get());
+	if (ret)
+		return adrv9002_dev_err(phy);
+
 	ret = adrv9002_validate_profile(phy);
 	if (ret)
 		return ret;
 
 	adrv9002_compute_init_cals(phy);
-
-	adi_common_ErrorClear(&phy->adrv9001->common);
-	ret = adi_adrv9001_HwOpen(adrv9001_device, adrv9002_spi_settings_get());
-	if (ret)
-		return adrv9002_dev_err(phy);
 
 	adrv9002_log_enable(&adrv9001_device->common);
 
@@ -3380,8 +3380,10 @@ int adrv9002_init(struct adrv9002_rf_phy *phy, struct adi_adrv9001_Init *profile
 	if (ret) {
 		/* try one more time */
 		ret = adrv9002_setup(phy);
-		if (ret)
+		if (ret) {
+			adrv9002_cleanup(phy);
 			return ret;
+		}
 	}
 
 	adrv9002_set_clk_rates(phy);

--- a/drivers/iio/adc/navassa/adrv9002.c
+++ b/drivers/iio/adc/navassa/adrv9002.c
@@ -2698,18 +2698,6 @@ static void adrv9002_cleanup(struct adrv9002_rf_phy *phy)
 	       sizeof(phy->adrv9001->devStateInfo));
 }
 
-int adrv9002_clean_setup(struct adrv9002_rf_phy *phy)
-{
-	int ret;
-
-	mutex_lock(&phy->lock);
-	adrv9002_cleanup(phy);
-	ret = adrv9002_setup(phy);
-	mutex_unlock(&phy->lock);
-
-	return ret;
-}
-
 static u32 adrv9002_get_arm_clk(const struct adrv9002_rf_phy *phy)
 {
 	struct adi_adrv9001_ClockSettings *clks = &phy->curr_profile->clocks;
@@ -3373,7 +3361,7 @@ of_channels_put:
 	return ret;
 }
 
-static int adrv9002_init(struct adrv9002_rf_phy *phy, struct adi_adrv9001_Init *profile)
+int adrv9002_init(struct adrv9002_rf_phy *phy, struct adi_adrv9001_Init *profile)
 {
 	int ret;
 

--- a/drivers/iio/adc/navassa/adrv9002.c
+++ b/drivers/iio/adc/navassa/adrv9002.c
@@ -2619,7 +2619,7 @@ int adrv9002_intf_test_cfg(struct adrv9002_rf_phy *phy, const int chann, const b
 	return 0;
 }
 
-static int adrv9002_intf_tuning_unlocked(struct adrv9002_rf_phy *phy)
+static int adrv9002_intf_tuning(struct adrv9002_rf_phy *phy)
 {
 	struct adi_adrv9001_SsiCalibrationCfg delays = {0};
 	int ret;
@@ -2683,17 +2683,6 @@ static int adrv9002_intf_tuning_unlocked(struct adrv9002_rf_phy *phy)
 		return adrv9002_dev_err(phy);
 
 	return 0;
-}
-
-int adrv9002_intf_tuning(struct adrv9002_rf_phy *phy)
-{
-	int ret;
-
-	mutex_lock(&phy->lock);
-	ret = adrv9002_intf_tuning_unlocked(phy);
-	mutex_unlock(&phy->lock);
-
-	return ret;
 }
 
 static void adrv9002_cleanup(struct adrv9002_rf_phy *phy)
@@ -3405,7 +3394,7 @@ static int adrv9002_init(struct adrv9002_rf_phy *phy, struct adi_adrv9001_Init *
 	if (ret)
 		return ret;
 
-	return adrv9002_intf_tuning_unlocked(phy);
+	return adrv9002_intf_tuning(phy);
 }
 
 static ssize_t adrv9002_stream_bin_write(struct file *filp, struct kobject *kobj,

--- a/drivers/iio/adc/navassa/adrv9002.h
+++ b/drivers/iio/adc/navassa/adrv9002.h
@@ -206,7 +206,6 @@ void adrv9002_get_ssi_interface(struct adrv9002_rf_phy *phy, const int channel,
 				u8 *ssi_intf, u8 *n_lanes, bool *cmos_ddr_en);
 int adrv9002_post_init(struct adrv9002_rf_phy *phy);
 void adrv9002_cmos_default_set(void);
-int adrv9002_intf_tuning(struct adrv9002_rf_phy *phy);
 int adrv9002_intf_test_cfg(struct adrv9002_rf_phy *phy, const int chann, const bool tx,
 			   const bool stop, const adi_adrv9001_SsiType_e ssi_type);
 int adrv9002_check_tx_test_pattern(struct adrv9002_rf_phy *phy, const int chann,

--- a/drivers/iio/adc/navassa/adrv9002.h
+++ b/drivers/iio/adc/navassa/adrv9002.h
@@ -213,7 +213,6 @@ int adrv9002_intf_test_cfg(struct adrv9002_rf_phy *phy, const int chann, const b
 int adrv9002_check_tx_test_pattern(struct adrv9002_rf_phy *phy, const int chann);
 int adrv9002_intf_change_delay(struct adrv9002_rf_phy *phy, const int channel, u8 clk_delay,
 			       u8 data_delay, const bool tx);
-adi_adrv9001_SsiType_e adrv9002_axi_ssi_type_get(struct adrv9002_rf_phy *phy);
 u32 adrv9002_axi_dds_rate_get(struct adrv9002_rf_phy *phy, const int chan);
 /* get init structs */
 struct adi_adrv9001_SpiSettings *adrv9002_spi_settings_get(void);

--- a/drivers/iio/adc/navassa/adrv9002.h
+++ b/drivers/iio/adc/navassa/adrv9002.h
@@ -171,6 +171,8 @@ struct adrv9002_rf_phy {
 	int				spi_device_id;
 	int				ngpios;
 	u8				rx2tx2;
+	/* ssi type of the axi cores - cannot really change at runtime */
+	enum adi_adrv9001_SsiType	ssi_type;
 #ifdef CONFIG_DEBUG_FS
 	struct adi_adrv9001_SsiCalibrationCfg ssi_delays;
 #endif
@@ -196,7 +198,7 @@ int adrv9002_axi_interface_set(struct adrv9002_rf_phy *phy, const u8 n_lanes,
 			       const int channel);
 struct adrv9002_rf_phy *adrv9002_spi_to_phy(struct spi_device *spi);
 int adrv9002_axi_intf_tune(struct adrv9002_rf_phy *phy, const bool tx, const int chann,
-			   const adi_adrv9001_SsiType_e ssi_type, u8 *clk_delay, u8 *data_delay);
+			   u8 *clk_delay, u8 *data_delay);
 void adrv9002_axi_interface_enable(struct adrv9002_rf_phy *phy, const int chan, const bool en);
 int __maybe_unused adrv9002_axi_tx_test_pattern_cfg(struct adrv9002_rf_phy *phy, const int channel,
 						    const adi_adrv9001_SsiTestModeData_e data);
@@ -207,12 +209,10 @@ void adrv9002_get_ssi_interface(struct adrv9002_rf_phy *phy, const int channel,
 int adrv9002_post_init(struct adrv9002_rf_phy *phy);
 void adrv9002_cmos_default_set(void);
 int adrv9002_intf_test_cfg(struct adrv9002_rf_phy *phy, const int chann, const bool tx,
-			   const bool stop, const adi_adrv9001_SsiType_e ssi_type);
-int adrv9002_check_tx_test_pattern(struct adrv9002_rf_phy *phy, const int chann,
-				   const adi_adrv9001_SsiType_e ssi_type);
+			   const bool stop);
+int adrv9002_check_tx_test_pattern(struct adrv9002_rf_phy *phy, const int chann);
 int adrv9002_intf_change_delay(struct adrv9002_rf_phy *phy, const int channel, u8 clk_delay,
-			       u8 data_delay, const bool tx,
-			       const adi_adrv9001_SsiType_e ssi_type);
+			       u8 data_delay, const bool tx);
 adi_adrv9001_SsiType_e adrv9002_axi_ssi_type_get(struct adrv9002_rf_phy *phy);
 u32 adrv9002_axi_dds_rate_get(struct adrv9002_rf_phy *phy, const int chan);
 /* get init structs */

--- a/drivers/iio/adc/navassa/adrv9002.h
+++ b/drivers/iio/adc/navassa/adrv9002.h
@@ -185,7 +185,7 @@ void adrv9002_en_delays_arm_to_ns(const struct adrv9002_rf_phy *phy,
 /* phy lock must be held before entering the API */
 int adrv9002_channel_to_state(struct adrv9002_rf_phy *phy, struct adrv9002_chan *chann,
 			      const adi_adrv9001_ChannelState_e state, const bool cache_state);
-int adrv9002_clean_setup(struct adrv9002_rf_phy *phy);
+int adrv9002_init(struct adrv9002_rf_phy *phy, struct adi_adrv9001_Init *profile);
 int __adrv9002_dev_err(const struct adrv9002_rf_phy *phy, const char *function, const int line);
 #define adrv9002_dev_err(phy)	__adrv9002_dev_err(phy, __func__, __LINE__)
 

--- a/drivers/iio/adc/navassa/adrv9002.h
+++ b/drivers/iio/adc/navassa/adrv9002.h
@@ -204,7 +204,6 @@ int adrv9002_spi_read(struct spi_device *spi, u32 reg);
 int adrv9002_spi_write(struct spi_device *spi, u32 reg, u32 val);
 void adrv9002_get_ssi_interface(struct adrv9002_rf_phy *phy, const int channel,
 				u8 *ssi_intf, u8 *n_lanes, bool *cmos_ddr_en);
-int adrv9002_ssi_configure(struct adrv9002_rf_phy *phy);
 int adrv9002_post_init(struct adrv9002_rf_phy *phy);
 void adrv9002_cmos_default_set(void);
 int adrv9002_intf_tuning(struct adrv9002_rf_phy *phy);

--- a/drivers/iio/adc/navassa/adrv9002.h
+++ b/drivers/iio/adc/navassa/adrv9002.h
@@ -194,8 +194,7 @@ int __adrv9002_dev_err(const struct adrv9002_rf_phy *phy, const char *function, 
 int adrv9002_hdl_loopback(struct adrv9002_rf_phy *phy, bool enable);
 int adrv9002_register_axi_converter(struct adrv9002_rf_phy *phy);
 int adrv9002_axi_interface_set(struct adrv9002_rf_phy *phy, const u8 n_lanes,
-			       const u8 ssi_intf, const bool cmos_ddr,
-			       const int channel);
+			       const bool cmos_ddr, const int channel);
 struct adrv9002_rf_phy *adrv9002_spi_to_phy(struct spi_device *spi);
 int adrv9002_axi_intf_tune(struct adrv9002_rf_phy *phy, const bool tx, const int chann,
 			   u8 *clk_delay, u8 *data_delay);
@@ -204,8 +203,6 @@ int __maybe_unused adrv9002_axi_tx_test_pattern_cfg(struct adrv9002_rf_phy *phy,
 						    const adi_adrv9001_SsiTestModeData_e data);
 int adrv9002_spi_read(struct spi_device *spi, u32 reg);
 int adrv9002_spi_write(struct spi_device *spi, u32 reg, u32 val);
-void adrv9002_get_ssi_interface(struct adrv9002_rf_phy *phy, const int channel,
-				u8 *ssi_intf, u8 *n_lanes, bool *cmos_ddr_en);
 int adrv9002_post_init(struct adrv9002_rf_phy *phy);
 void adrv9002_cmos_default_set(void);
 int adrv9002_intf_test_cfg(struct adrv9002_rf_phy *phy, const int chann, const bool tx,

--- a/drivers/iio/adc/navassa/adrv9002_conv.c
+++ b/drivers/iio/adc/navassa/adrv9002_conv.c
@@ -633,19 +633,6 @@ struct adrv9002_rf_phy *adrv9002_spi_to_phy(struct spi_device *spi)
 	return conv->phy;
 }
 
-adi_adrv9001_SsiType_e adrv9002_axi_ssi_type_get(struct adrv9002_rf_phy *phy)
-{
-	struct axiadc_converter *conv = spi_get_drvdata(phy->spi);
-	struct axiadc_state *st = iio_priv(conv->indio_dev);
-	u32 axi_config = 0;
-
-	axi_config = axiadc_read(st, ADI_REG_CONFIG);
-	if (IS_CMOS(axi_config))
-		return ADI_ADRV9001_SSI_TYPE_CMOS;
-	else
-		return ADI_ADRV9001_SSI_TYPE_LVDS;
-}
-
 int __maybe_unused adrv9002_axi_tx_test_pattern_cfg(struct adrv9002_rf_phy *phy, const int channel,
 						    const adi_adrv9001_SsiTestModeData_e data)
 {
@@ -732,11 +719,6 @@ int adrv9002_axi_intf_tune(struct adrv9002_rf_phy *phy, const bool tx, const int
 }
 
 void adrv9002_axi_interface_enable(struct adrv9002_rf_phy *phy, const int chan, const bool en)
-{
-	return -ENODEV;
-}
-
-adi_adrv9001_SsiType_e adrv9002_axi_ssi_type_get(struct adrv9002_rf_phy *phy)
 {
 	return -ENODEV;
 }

--- a/drivers/iio/adc/navassa/adrv9002_conv.c
+++ b/drivers/iio/adc/navassa/adrv9002_conv.c
@@ -335,12 +335,7 @@ static int adrv9002_post_setup(struct iio_dev *indio_dev)
 	conv->clk = phy->clks[RX1_SAMPL_CLK];
 	conv->adc_clk = clk_get_rate(conv->clk);
 
-	ret = adrv9002_ssi_configure(phy);
-	if (ret)
-		return ret;
-
-	/* start interface tuning */
-	return adrv9002_intf_tuning(phy);
+	return 0;
 }
 
 #ifdef DEBUG

--- a/drivers/iio/adc/navassa/adrv9002_debugfs.c
+++ b/drivers/iio/adc/navassa/adrv9002_debugfs.c
@@ -181,7 +181,7 @@ static int adrv9002_rx_agc_config_show(struct seq_file *s, void *ignored)
 	adrv9002_agc_seq_printf(peak.hbGainStepHighRecovery);
 	adrv9002_agc_seq_printf(peak.hbGainStepLowRecovery);
 	adrv9002_agc_seq_printf(peak.hbGainStepMidRecovery);
-	adrv9002_agc_seq_printf(peak.hbGainStepMidRecovery);
+	adrv9002_agc_seq_printf(peak.hbGainStepAttack);
 	adrv9002_agc_seq_printf(peak.hbOverloadPowerMode);
 	adrv9002_agc_seq_printf(peak.hbUnderRangeMidThreshExceededCount);
 	adrv9002_agc_seq_printf(peak.hbUnderRangeLowThreshExceededCount);
@@ -298,7 +298,7 @@ void adrv9002_debugfs_agc_config_create(struct adrv9002_rx_chan *rx, struct dent
 	adrv9002_agc_add_file_u8(peak.hbGainStepHighRecovery);
 	adrv9002_agc_add_file_u8(peak.hbGainStepLowRecovery);
 	adrv9002_agc_add_file_u8(peak.hbGainStepMidRecovery);
-	adrv9002_agc_add_file_u8(peak.hbGainStepMidRecovery);
+	adrv9002_agc_add_file_u8(peak.hbGainStepAttack);
 	adrv9002_agc_add_file_u8(peak.hbOverloadPowerMode);
 	adrv9002_agc_add_file_u8(peak.hbUnderRangeMidThreshExceededCount);
 	adrv9002_agc_add_file_u8(peak.hbUnderRangeLowThreshExceededCount);

--- a/drivers/iio/adc/navassa/adrv9002_debugfs.c
+++ b/drivers/iio/adc/navassa/adrv9002_debugfs.c
@@ -612,11 +612,16 @@ DEFINE_DEBUGFS_ATTRIBUTE(adrv9002_tx_ssi_test_mode_fixed_pattern_fops,
 static int adrv9002_init_set(void *arg, const u64 val)
 {
 	struct adrv9002_rf_phy *phy = arg;
+	int ret;
 
 	if (!val)
 		return -EINVAL;
 
-	return adrv9002_clean_setup(phy);
+	mutex_lock(&phy->lock);
+	ret = adrv9002_init(phy, phy->curr_profile);
+	mutex_unlock(&phy->lock);
+
+	return ret;
 }
 DEFINE_DEBUGFS_ATTRIBUTE(adrv9002_init_fops,
 			 NULL, adrv9002_init_set, "%llu");

--- a/drivers/iio/adc/navassa/adrv9002_init_data.c
+++ b/drivers/iio/adc/navassa/adrv9002_init_data.c
@@ -2803,7 +2803,7 @@ static struct adi_adrv9001_Init adrv9002_init_cmos = {
 	}
 };
 
-static struct adi_adrv9001_Init *adrv9002_init = &adrv9002_init_lvds;
+static struct adi_adrv9001_Init *adrv9002_profile = &adrv9002_init_lvds;
 
 struct adi_adrv9001_SpiSettings *adrv9002_spi_settings_get(void)
 {
@@ -2812,7 +2812,7 @@ struct adi_adrv9001_SpiSettings *adrv9002_spi_settings_get(void)
 
 struct adi_adrv9001_Init *adrv9002_init_get(void)
 {
-	return adrv9002_init;
+	return adrv9002_profile;
 }
 
 void adrv9002_cmos_default_set(void)
@@ -2821,6 +2821,6 @@ void adrv9002_cmos_default_set(void)
 	 * If we are here, it means that we are on a cmos bitfile and we should
 	 * use the cmos default profile
 	 */
-	adrv9002_init = &adrv9002_init_cmos;
+	adrv9002_profile = &adrv9002_init_cmos;
 }
 


### PR DESCRIPTION
iio: adrv9002: Fix debugfs AGC parameter
iio: adrv9002: Improve device setup error path
iio: adrv9002: disable axi core before device setup
iio: adrv9002: validate ssi interface before device setup
iio: adrv9002: remove `adrv9002_axi_ssi_type_get()`
iio: adrv9002: save axi interface type at startup
iio: adrv9002: minor improvement on `adrv9002_cleanup()`
iio: adrv9002: call `adrv9002_init()` on debugfs
iio: adrv9002: remove `adrv9002_intf_tuning_unlocked()`
iio: adrv9002: centralize device initialization
