### PR TITLE
iio: frequency: adf4371: Keep RF8 ports disabled

### DIFF
--- a/drivers/iio/frequency/adf4371.c
+++ b/drivers/iio/frequency/adf4371.c
@@ -198,7 +198,7 @@ static const struct reg_sequence adf4371_reg_defaults[] = {
 	{ ADF4371_REG(0x22), 0x00 },
 	{ ADF4371_REG(0x23), 0x00 },
 	{ ADF4371_REG(0x24), 0x80 },
-	{ ADF4371_REG(0x25), 0x07 },
+	{ ADF4371_REG(0x25), 0x03 },
 	{ ADF4371_REG(0x27), 0xC5 },
 	{ ADF4371_REG(0x28), 0x83 },
 	{ ADF4371_REG(0x2C), 0x44 },


### PR DESCRIPTION
Those ports will be enabled by the CCF or can be optionally
enabled from the dt. Keep them default disabled to save power.

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>