### PR TITLE
arm: dts: zynq-zc702.dtsi: Add missing spi-max-frequency property

### DIFF
--- a/arch/arm/boot/dts/zynq-zc702.dtsi
+++ b/arch/arm/boot/dts/zynq-zc702.dtsi
@@ -140,6 +140,7 @@
 		reg = <0x0>;
 		spi-tx-bus-width = <1>;
 		spi-rx-bus-width = <4>;
+		spi-max-frequency = <50000000>;
 		partition@0 {
 			label = "boot";
 			reg = <0x00000000 0x00500000>;


### PR DESCRIPTION
Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>