### PR TITLE
zynq-m2k/pluto: reduce spi-rx-bus-width to 1 for M2k/Pluto

### DIFF
--- a/arch/arm/boot/dts/zynq-m2k.dtsi
+++ b/arch/arm/boot/dts/zynq-m2k.dtsi
@@ -70,7 +70,7 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 		spi-tx-bus-width = <1>;
-		spi-rx-bus-width = <4>;
+		spi-rx-bus-width = <1>;
 		compatible = "n25q256a", "n25q512a", "jedec,spi-nor"; /* same as S25FL256 */
 		reg = <0x0>;
 		spi-max-frequency = <50000000>;

--- a/arch/arm/boot/dts/zynq-pluto-sdr.dtsi
+++ b/arch/arm/boot/dts/zynq-pluto-sdr.dtsi
@@ -64,7 +64,7 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 		spi-tx-bus-width = <1>;
-		spi-rx-bus-width = <4>;
+		spi-rx-bus-width = <1>;
 		compatible = "n25q256a", "n25q512a", "jedec,spi-nor"; /* same as S25FL256 */
 		reg = <0x0>;
 		spi-max-frequency = <50000000>;


### PR DESCRIPTION
Previously this was handled by the M25P80 driver, which was wrapping the
spi-nor logic.
With the removal of the M25P80, the misconfiguration here was made evident
by the fact that the /dev/mtd2 partition wasn't mounting and showing
errors.

By reducing the spi-rx-bus-width to 1, this seems to work again.

This issue also appears on the 2019_R2 branch, if the M25P80 driver is
removed and SPI-MEM is being used. But since M25P80 is used anyway, we may
consider not backporting this to 2019_R2.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>