### PR TITLE
mtd: spi-nor: don't run SFDP for Zynq QSPI

### DIFF
--- a/arch/arm/boot/dts/zynq-m2k.dtsi
+++ b/arch/arm/boot/dts/zynq-m2k.dtsi
@@ -74,6 +74,7 @@
 		compatible = "n25q256a", "n25q512a", "jedec,spi-nor"; /* same as S25FL256 */
 		reg = <0x0>;
 		spi-max-frequency = <50000000>;
+		broken-nor-flash-lock-disable;
 		partition@qspi-fsbl-uboot {
 			label = "qspi-fsbl-uboot";
 			reg = <0x0 0x100000>; /* 1M */

--- a/arch/arm/boot/dts/zynq-pluto-sdr.dtsi
+++ b/arch/arm/boot/dts/zynq-pluto-sdr.dtsi
@@ -68,6 +68,7 @@
 		compatible = "n25q256a", "n25q512a", "jedec,spi-nor"; /* same as S25FL256 */
 		reg = <0x0>;
 		spi-max-frequency = <50000000>;
+		broken-nor-flash-lock-disable;
 		partition@qspi-fsbl-uboot {
 			label = "qspi-fsbl-uboot";
 			reg = <0x0 0x100000>; /* 1M */

--- a/drivers/mtd/spi-nor/spi-nor.c
+++ b/drivers/mtd/spi-nor/spi-nor.c
@@ -5222,12 +5222,21 @@ static void spi_nor_late_init_params(struct spi_nor *nor)
  */
 static void spi_nor_init_params(struct spi_nor *nor)
 {
+	bool is_zynq_qspi = false;
+
+#ifdef CONFIG_OF
+	struct device_node *np = spi_nor_get_flash_node(nor);
+	struct device_node *np_spi;
+	np_spi = of_get_next_parent(np);
+	is_zynq_qspi = of_property_match_string(np_spi, "compatible", "xlnx,zynq-qspi-1.0") >= 0;
+#endif
+
 	spi_nor_info_init_params(nor);
 
 	spi_nor_manufacturer_init_params(nor);
 
 	if ((nor->info->flags & (SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ)) &&
-	    !(nor->info->flags & SPI_NOR_SKIP_SFDP))
+	    !(nor->info->flags & SPI_NOR_SKIP_SFDP) && !is_zynq_qspi)
 		spi_nor_sfdp_init_params(nor);
 
 	spi_nor_post_sfdp_fixups(nor);

--- a/drivers/mtd/spi-nor/spi-nor.c
+++ b/drivers/mtd/spi-nor/spi-nor.c
@@ -5223,12 +5223,14 @@ static void spi_nor_late_init_params(struct spi_nor *nor)
 static void spi_nor_init_params(struct spi_nor *nor)
 {
 	bool is_zynq_qspi = false;
+	bool disable_broken_locking = false;
 
 #ifdef CONFIG_OF
 	struct device_node *np = spi_nor_get_flash_node(nor);
 	struct device_node *np_spi;
 	np_spi = of_get_next_parent(np);
 	is_zynq_qspi = of_property_match_string(np_spi, "compatible", "xlnx,zynq-qspi-1.0") >= 0;
+	disable_broken_locking = of_property_read_bool(np, "broken-nor-flash-lock-disable");
 #endif
 
 	spi_nor_info_init_params(nor);
@@ -5238,6 +5240,9 @@ static void spi_nor_init_params(struct spi_nor *nor)
 	if ((nor->info->flags & (SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ)) &&
 	    !(nor->info->flags & SPI_NOR_SKIP_SFDP) && !is_zynq_qspi)
 		spi_nor_sfdp_init_params(nor);
+
+	if (disable_broken_locking)
+		nor->flags &= ~SNOR_F_HAS_LOCK;
 
 	spi_nor_post_sfdp_fixups(nor);
 


### PR DESCRIPTION
According to commit 87fb64ac8af8 ("mtd: spi-nor: Add 4byte support for Zynq
QSPI controller"), "Zynq QSPI controller do not support 4byte addressing
mode.".

However, SFDP will detect it and try to use 4 byte addressing, which will
not work with Zynq QSPI.
Previously the 0x6B opcode was used with the M25P80 driver and SPI-NOR.
Now with SFDP, 0x6C is being attempted, but is failing.

With this change, 0x6B is being used again.

It's likely that there may be a better fix than this, but the way the
spi-nor driver has been patched, it's a bit difficult to identify it.
Commit 87fb64ac8af8 should have fixed it, but it did not take into account
the fact that SFDP run and can set some SPI NOR parameters.

So, the current solution is to skip SFDP if Zynq QSPI is configured.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>