### PR TITLE
[RFC] Revert "clocksource/drivers/cadence-ttc: Use ttc driver as platform driver"

### DIFF
--- a/drivers/clocksource/timer-cadence-ttc.c
+++ b/drivers/clocksource/timer-cadence-ttc.c
@@ -15,8 +15,6 @@
 #include <linux/of_irq.h>
 #include <linux/slab.h>
 #include <linux/sched_clock.h>
-#include <linux/module.h>
-#include <linux/of_platform.h>
 
 /*
  * This driver configures the 2 16/32-bit count-up timers as follows:
@@ -466,7 +464,13 @@ static int __init ttc_setup_clockevent(struct clk *clk,
 	return 0;
 }
 
-static int __init ttc_timer_probe(struct platform_device *pdev)
+/**
+ * ttc_timer_init - Initialize the timer
+ *
+ * Initializes the timer hardware and register the clock source and clock event
+ * timers with Linux kernal timer framework
+ */
+static int __init ttc_timer_init(struct device_node *timer)
 {
 	unsigned int irq;
 	void __iomem *timer_baseaddr;
@@ -474,7 +478,6 @@ static int __init ttc_timer_probe(struct platform_device *pdev)
 	static int initialized;
 	int clksel, ret;
 	u32 timer_width = 16;
-	struct device_node *timer = pdev->dev.of_node;
 
 	if (initialized)
 		return 0;
@@ -529,17 +532,4 @@ static int __init ttc_timer_probe(struct platform_device *pdev)
 	return 0;
 }
 
-static const struct of_device_id ttc_timer_of_match[] = {
-	{.compatible = "cdns,ttc"},
-	{},
-};
-
-MODULE_DEVICE_TABLE(of, ttc_timer_of_match);
-
-static struct platform_driver ttc_timer_driver = {
-	.driver = {
-		.name	= "cdns_ttc_timer",
-		.of_match_table = ttc_timer_of_match,
-	},
-};
-builtin_platform_driver_probe(ttc_timer_driver, ttc_timer_probe);
+TIMER_OF_DECLARE(ttc, "cdns,ttc", ttc_timer_init);


### PR DESCRIPTION
This reverts commit f5ac896b6a23eb46681cdbef440c1d991b04e519.

Because of this change we sometimes get on some systems:

clocksource: ttc_clocksource: mask: 0xffff max_cycles: 0xffff, max_idle_ns: 716713566 ns
clocksource: Switched to clocksource ttc_clocksource
------------[ cut here ]------------
WARNING: CPU: 0 PID: 1 at kernel/time/sched_clock.c:179 sched_clock_register+0x50/0x260
Modules linked in:
CPU: 0 PID: 1 Comm: swapper/0 Not tainted 5.4.0-13598-g99be0914fc99-dirty #19
Hardware name: Xilinx Zynq Platform
[<c010db18>] (unwind_backtrace) from [<c010a218>] (show_stack+0x10/0x14)
[<c010a218>] (show_stack) from [<c05eaba8>] (dump_stack+0xb0/0xcc)
[<c05eaba8>] (dump_stack) from [<c011b144>] (__warn+0xb8/0xd0)
[<c011b144>] (__warn) from [<c011b1d4>] (warn_slowpath_fmt+0x78/0xac)
[<c011b1d4>] (warn_slowpath_fmt) from [<c090d430>] (sched_clock_register+0x50/0x260)
[<c090d430>] (sched_clock_register) from [<c091c370>] (ttc_timer_probe+0x274/0x420)
[<c091c370>] (ttc_timer_probe) from [<c0318080>] (platform_drv_probe+0x48/0x94)
[<c0318080>] (platform_drv_probe) from [<c03163e4>] (really_probe+0x1f4/0x314)
[<c03163e4>] (really_probe) from [<c03167a8>] (driver_probe_device+0x148/0x160)
[<c03167a8>] (driver_probe_device) from [<c0316944>] (device_driver_attach+0x44/0x5c)
[<c0316944>] (device_driver_attach) from [<c0316a08>] (__driver_attach+0xac/0xb4)
[<c0316a08>] (__driver_attach) from [<c0314910>] (bus_for_each_dev+0x64/0xa8)
[<c0314910>] (bus_for_each_dev) from [<c03158d4>] (bus_add_driver+0x150/0x1b0)
[<c03158d4>] (bus_add_driver) from [<c03171b8>] (driver_register+0xac/0xf0)
[<c03171b8>] (driver_register) from [<c0318150>] (__platform_driver_probe+0x54/0xc8)
[<c0318150>] (__platform_driver_probe) from [<c010274c>] (do_one_initcall+0x74/0x1ac)
[<c010274c>] (do_one_initcall) from [<c0900ee0>] (kernel_init_freeable+0x17c/0x1c8)
[<c0900ee0>] (kernel_init_freeable) from [<c05febb8>] (kernel_init+0x8/0x10c)
[<c05febb8>] (kernel_init) from [<c01010e8>] (ret_from_fork+0x14/0x2c)
Exception stack(0xdf445fb0 to 0xdf445ff8)
5fa0:                                     00000000 00000000 00000000 00000000
5fc0: 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
5fe0: 00000000 00000000 00000000 00000000 00000013 00000000
---[ end trace d9e36f73d86a9aab ]---

Reverting this patch fixes it.
What seems to happen is that the Cadence TTC timer initializes late, and
causes a warning that the IRQs are enabled.

In the Zynq machine code (arch/arm/mach-zynq/common.c) , this code exists:

static void __init zynq_timer_init(void)
{
        zynq_clock_init();
        of_clk_init(NULL);
        timer_probe();
}

So, that code should have made sure that all the Zynq clocks are
initialized. Not sure if the case is different for ZynqMP.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>