### PR TITLE
dts: AD9081-FMCA-EBZ: Consider the VCXO=100.00 MHz the default

### DIFF
--- a/arch/arm/boot/dts/adi-ad9081-fmc-ebz.dtsi
+++ b/arch/arm/boot/dts/adi-ad9081-fmc-ebz.dtsi
@@ -31,11 +31,22 @@
 
 		adi,jesd204-max-sysref-frequency-hz = <2000000>; /* 2 MHz */
 
-		adi,pll1-clkin-frequencies = <122880000 30720000 0 0>;
+		/*
+		* There are different versions of the AD9081-FMCA-EBZ & AD9082-FMCA-EBZ
+		* VCXO = 122.880 MHz, XO = 122.880MHz (AD9081-FMC-EBZ & AD9082-FMC-EBZ)
+		* VCXO = 100.000 MHz, XO = 100.000MHz (AD9081-FMC-EBZ-A2 & AD9082-FMC-EBZ-A2)
+		* To determine which board is which, read the freqency printed on the VCXO
+		* or use the fru-dump utility:
+		* #fru-dump -b /sys/bus/i2c/devices/15-0050/eeprom
+		*/
+
+		//adi,pll1-clkin-frequencies = <122880000 30720000 0 0>;
+		//adi,vcxo-frequency = <122880000>;
+
+		adi,pll1-clkin-frequencies = <100000000 10000000 0 0>;
+		adi,vcxo-frequency = <100000000>;
 
 		adi,pll1-loop-bandwidth-hz = <200>;
-
-		adi,vcxo-frequency = <122880000>;
 
 		adi,pll2-output-frequency = <3000000000>;
 

--- a/arch/arm64/boot/dts/xilinx/adi-ad9081-fmc-ebz.dtsi
+++ b/arch/arm64/boot/dts/xilinx/adi-ad9081-fmc-ebz.dtsi
@@ -27,11 +27,22 @@
 
 		adi,jesd204-max-sysref-frequency-hz = <2000000>; /* 2 MHz */
 
-		adi,pll1-clkin-frequencies = <122880000 30720000 0 0>;
+		/*
+		* There are different versions of the AD9081-FMCA-EBZ & AD9082-FMCA-EBZ
+		* VCXO = 122.880 MHz, XO = 122.880MHz (AD9081-FMC-EBZ & AD9082-FMC-EBZ)
+		* VCXO = 100.000 MHz, XO = 100.000MHz (AD9081-FMC-EBZ-A2 & AD9082-FMC-EBZ-A2)
+		* To determine which board is which, read the freqency printed on the VCXO
+		* or use the fru-dump utility:
+		* #fru-dump -b /sys/bus/i2c/devices/15-0050/eeprom
+		*/
+
+		//adi,pll1-clkin-frequencies = <122880000 30720000 0 0>;
+		//adi,vcxo-frequency = <122880000>;
+
+		adi,pll1-clkin-frequencies = <100000000 10000000 0 0>;
+		adi,vcxo-frequency = <100000000>;
 
 		adi,pll1-loop-bandwidth-hz = <200>;
-
-		adi,vcxo-frequency = <122880000>;
 
 		adi,pll2-output-frequency = <3100000000>;
 

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9081-m8-l4-vcxo122p88.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9081-m8-l4-vcxo122p88.dts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 /*
- * Analog Devices AD9081-FMC-EBZ-A2
+ * Analog Devices AD9081-FMC-EBZ (VCXO 122.880 MHz)
  * https://wiki.analog.com/resources/eval/user-guides/quadmxfe/quick-start
  * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-mxfe/ad9081
  *
@@ -12,7 +12,6 @@
 
 #include "zynqmp-zcu102-rev10-ad9081-m8-l4.dts"
 
-
 /*
  * There are different versions of the AD9081-FMC-EBZ & AD9082-FMC-EBZ
  * VCXO = 122.880 MHz, XO = 122.880MHz (AD9081-FMC-EBZ & AD9082-FMC-EBZ)
@@ -23,6 +22,6 @@
  */
 
 &hmc7044 {
-	adi,pll1-clkin-frequencies = <100000000 10000000 0 0>;
-        adi,vcxo-frequency = <100000000>;
+	adi,pll1-clkin-frequencies = <122880000 30720000 0 0>;
+	adi,vcxo-frequency = <122880000>;
 };

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9081-m8-l4.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9081-m8-l4.dts
@@ -29,11 +29,22 @@
 
 		adi,jesd204-max-sysref-frequency-hz = <2000000>; /* 2 MHz */
 
-		adi,pll1-clkin-frequencies = <122880000 30720000 0 0>;
+		/*
+		* There are different versions of the AD9081-FMCA-EBZ & AD9082-FMCA-EBZ
+		* VCXO = 122.880 MHz, XO = 122.880MHz (AD9081-FMC-EBZ & AD9082-FMC-EBZ)
+		* VCXO = 100.000 MHz, XO = 100.000MHz (AD9081-FMC-EBZ-A2 & AD9082-FMC-EBZ-A2)
+		* To determine which board is which, read the freqency printed on the VCXO
+		* or use the fru-dump utility:
+		* #fru-dump -b /sys/bus/i2c/devices/15-0050/eeprom
+		*/
+
+		//adi,pll1-clkin-frequencies = <122880000 30720000 0 0>;
+		//adi,vcxo-frequency = <122880000>;
+
+		adi,pll1-clkin-frequencies = <100000000 10000000 0 0>;
+		adi,vcxo-frequency = <100000000>;
 
 		adi,pll1-loop-bandwidth-hz = <200>;
-
-		adi,vcxo-frequency = <122880000>;
 
 		adi,pll2-output-frequency = <3000000000>;
 

--- a/arch/microblaze/boot/dts/adi-ad9081-fmc-ebz.dtsi
+++ b/arch/microblaze/boot/dts/adi-ad9081-fmc-ebz.dtsi
@@ -25,11 +25,22 @@
 
 		adi,jesd204-max-sysref-frequency-hz = <2000000>;
 
-		adi,pll1-clkin-frequencies = <122880000 30720000 0 0>;
+		/*
+		* There are different versions of the AD9081-FMCA-EBZ & AD9082-FMCA-EBZ
+		* VCXO = 122.880 MHz, XO = 122.880MHz (AD9081-FMC-EBZ & AD9082-FMC-EBZ)
+		* VCXO = 100.000 MHz, XO = 100.000MHz (AD9081-FMC-EBZ-A2 & AD9082-FMC-EBZ-A2)
+		* To determine which board is which, read the freqency printed on the VCXO
+		* or use the fru-dump utility:
+		* #fru-dump -b /sys/bus/i2c/devices/15-0050/eeprom
+		*/
+
+		//adi,pll1-clkin-frequencies = <122880000 30720000 0 0>;
+		//adi,vcxo-frequency = <122880000>;
+
+		adi,pll1-clkin-frequencies = <100000000 10000000 0 0>;
+		adi,vcxo-frequency = <100000000>;
 
 		adi,pll1-loop-bandwidth-hz = <200>;
-
-		adi,vcxo-frequency = <122880000>;
 
 		adi,pll2-output-frequency = <3100000000>;
 


### PR DESCRIPTION
There are different variants of the AD9081-FMCA-EBZ & AD9082-FMCA-EBZ
They differ in the VCXO frequency. Let's make the 100MHz the default.

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>