### PR TITLE
[2019_R2] hwmon: ltc2945: fix private data reference

### DIFF
--- a/drivers/hwmon/ltc2945.c
+++ b/drivers/hwmon/ltc2945.c
@@ -506,7 +506,7 @@ static int ltc2945_probe(struct i2c_client *client,
 	regmap_write(regmap, LTC2945_FAULT, 0x00);
 
 	hwmon_dev = devm_hwmon_device_register_with_groups(dev, client->name,
-							   regmap,
+							   st,
 							   ltc2945_groups);
 	return PTR_ERR_OR_ZERO(hwmon_dev);
 }


### PR DESCRIPTION
When commit 91e4717fc9268 ("hwmon: (ltc2945): wrap regmap into an
ltc2945_state struct") it should have also contained this fix, to store the
new state struct, and not the regmap pointer.
This causes a crash when trying to read data from the device.

Fixes: 91e4717fc9268 ("hwmon: (ltc2945): wrap regmap into an ltc2945_state struct")
Reported-by: Pierre-Yves Lauzier Trépanier <Pierre-Yves.Lauzier.Trepanier@USherbrooke.ca>
Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>