### PR TITLE
Revert "iio: axi_adxcvr: print warning on set_rate in adxcvr_enforce_…

### DIFF
--- a/drivers/iio/jesd204/axi_adxcvr.c
+++ b/drivers/iio/jesd204/axi_adxcvr.c
@@ -597,7 +597,6 @@ MODULE_DEVICE_TABLE(of, adxcvr_of_match);
 static void adxcvr_enforce_settings(struct adxcvr_state *st)
 {
 	unsigned long lane_rate, parent_rate;
-	int ret;
 
 	/*
 	 * Make sure filter settings, etc. are correct for the supplied reference
@@ -619,11 +618,7 @@ static void adxcvr_enforce_settings(struct adxcvr_state *st)
 
 	lane_rate = adxcvr_clk_recalc_rate(&st->lane_clk_hw, parent_rate);
 
-	ret = adxcvr_clk_set_rate(&st->lane_clk_hw, lane_rate, parent_rate);
-	if (ret)
-		dev_err(st->dev,
-			"%s: Rate %lu Hz Parent Rate %lu Hz, error: %d",
-			__func__, lane_rate, parent_rate, ret);
+	adxcvr_clk_set_rate(&st->lane_clk_hw, lane_rate, parent_rate);
 }
 
 static void adxcvr_get_info(struct adxcvr_state *st)


### PR DESCRIPTION
…settings()"

This reverts commit 0f796d2e3612435f32c32268650171d4d43ee947.

The sole purpose of this function is to enforce the settings what the
Linux Common Clock Framework anticipates the HW is set for.
This is likely to fail because the default synthesis parameters were
calculated for a different reference rate. So when we ask for the
PLL rate and give twice the assumed reference rate, we end up with
twice the lanerate. Now if we ask to program this rate it’ll likely fail.
But will succeed (or real error) later if we set a rate based on
proper reference and target lanerate.

So revert this patch which emits an noisy error.

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>