### PR TITLE
iio: adrv9002: support reading profile_config

### DIFF
--- a/drivers/iio/adc/navassa/adrv9002.h
+++ b/drivers/iio/adc/navassa/adrv9002.h
@@ -153,8 +153,8 @@ struct adrv9002_rf_phy {
 	struct clk			*clks[NUM_ADRV9002_CLKS];
 	struct adrv9002_clock		clk_priv[NUM_ADRV9002_CLKS];
 	struct clk_onecell_data		clk_data;
-	struct bin_attribute		bin;
 	char				*bin_attr_buf;
+	size_t				bin_attr_sz;
 	u8				*stream_buf;
 	u16				stream_size;
 	struct adrv9002_rx_chan		rx_channels[ADRV9002_CHANN_MAX];


### PR DESCRIPTION
There is some information that might be useful to know about the current
profile which is not exported trough common IIO infrastructure. Hence, we
use the bin attribute used to load the profile to fetch this info. We
need to make the size of the attr 0 otherwise `cat profile_config` would
try to read the compete size and we don't have that much info to share.
For now this is an example of data exported:

```
root@analog:/sys/bus/iio/devices/iio:device1# cat profile_config
Device clk(Hz): 38400000
Clk PLL VCO(Hz): 8847360000
ARM Power Saving Clk Divider: 1
RX1 LO: L02
RX2 LO: L02
TX1 LO: L01
TX2 LO: L01
RX Channel Mask: 0xf3
TX Channel Mask: 0xc
Duplex Mode: FDD
FH enable: 0
MCS mode: Disabled
SSI interface: LVDS
```

Since I'm touching the bin attr, I took the opportunity to declare it
as static. There's no reason to dynamically initialize it and have it in
the `adrv9002_rf_phy` struct.

Signed-off-by: Nuno Sá <nuno.sa@analog.com>