### PR TITLE
arch: dts: zynq-zed-adrv9002: Enable HDMI output

### DIFF
--- a/arch/arm/boot/dts/zynq-zed-adrv9002-rx2tx2.dts
+++ b/arch/arm/boot/dts/zynq-zed-adrv9002-rx2tx2.dts
@@ -10,6 +10,7 @@
 /dts-v1/;
 
 #include "zynq-zed.dtsi"
+#include "zynq-zed-adv7511.dtsi"
 #include <dt-bindings/interrupt-controller/irq.h>
 #include <dt-bindings/gpio/gpio.h>
 
@@ -104,11 +105,6 @@
 			#clock-cells = <0>;
 			clock-frequency = <100000000>;
 			compatible = "fixed-clock";
-		};
-
-		axi_sysid_0: axi-sysid-0@85000000 {
-			compatible = "adi,axi-sysid-1.00.a";
-			reg = <0x45000000 0x10000>;
 		};
 	};
 };

--- a/arch/arm/boot/dts/zynq-zed-adrv9002.dts
+++ b/arch/arm/boot/dts/zynq-zed-adrv9002.dts
@@ -10,6 +10,7 @@
 /dts-v1/;
 
 #include "zynq-zed.dtsi"
+#include "zynq-zed-adv7511.dtsi"
 #include <dt-bindings/interrupt-controller/irq.h>
 #include <dt-bindings/gpio/gpio.h>
 
@@ -175,11 +176,6 @@
 			#clock-cells = <0>;
 			clock-frequency = <100000000>;
 			compatible = "fixed-clock";
-		};
-
-		axi_sysid_0: axi-sysid-0@85000000 {
-			compatible = "adi,axi-sysid-1.00.a";
-			reg = <0x45000000 0x10000>;
 		};
 	};
 };


### PR DESCRIPTION
Include AD7511 and related nodes so user can connect a monitor to the
HDMI interface.
Remove SYSID since it is already included in the zynq-zed-adv7511.dtsi

Signed-off-by: Laszlo Nagy <laszlo.nagy@analog.com>