### PR TITLE
adrv9002 bugfixes backport

### DIFF
--- a/drivers/iio/adc/navassa/adrv9002.c
+++ b/drivers/iio/adc/navassa/adrv9002.c
@@ -2502,7 +2502,7 @@ int adrv9002_intf_test_cfg(struct adrv9002_rf_phy *phy, const int chann, const b
 	return 0;
 }
 
-static int adrv9002_intf_tuning_unlocked(struct adrv9002_rf_phy *phy)
+static int adrv9002_intf_tuning(struct adrv9002_rf_phy *phy)
 {
 	struct adi_adrv9001_SsiCalibrationCfg delays = {0};
 	int ret;
@@ -2577,17 +2577,6 @@ static int adrv9002_intf_tuning_unlocked(struct adrv9002_rf_phy *phy)
 		return adrv9002_dev_err(phy);
 
 	return 0;
-}
-
-int adrv9002_intf_tuning(struct adrv9002_rf_phy *phy)
-{
-	int ret;
-
-	mutex_lock(&phy->lock);
-	ret = adrv9002_intf_tuning_unlocked(phy);
-	mutex_unlock(&phy->lock);
-
-	return ret;
 }
 
 static void adrv9002_cleanup(struct adrv9002_rf_phy *phy)
@@ -3166,7 +3155,7 @@ static int adrv9002_init(struct adrv9002_rf_phy *phy, struct adi_adrv9001_Init *
 	if (ret)
 		return ret;
 
-	return adrv9002_intf_tuning_unlocked(phy);
+	return adrv9002_intf_tuning(phy);
 }
 
 static ssize_t adrv9002_stream_bin_write(struct file *filp, struct kobject *kobj,

--- a/drivers/iio/adc/navassa/adrv9002.c
+++ b/drivers/iio/adc/navassa/adrv9002.c
@@ -199,8 +199,6 @@ static int adrv9002_ssi_configure(struct adrv9002_rf_phy *phy)
 		if (!rx->channel.enabled)
 			continue;
 
-		/* the SSI settings should be done with the core in reset */
-		adrv9002_axi_interface_enable(phy, c, false);
 		adrv9002_sync_gpio_toogle(phy);
 
 		adrv9002_get_ssi_interface(phy, c, &ssi_intf, &n_lanes, &cmos_ddr);
@@ -210,7 +208,6 @@ static int adrv9002_ssi_configure(struct adrv9002_rf_phy *phy)
 
 		rate = adrv9002_axi_dds_rate_get(phy, c) * rx_cfg[c].profile.rxOutputRate_Hz;
 		clk_set_rate(rx->tdd_clk, rate);
-		adrv9002_axi_interface_enable(phy, c, true);
 
 		if (phy->rx2tx2)
 			break;
@@ -3135,9 +3132,17 @@ of_channels_put:
 
 int adrv9002_init(struct adrv9002_rf_phy *phy, struct adi_adrv9001_Init *profile)
 {
-	int ret;
+	int ret, c;
 
 	adrv9002_cleanup(phy);
+	/*
+	 * Disable all the cores as it might interfere with init calibrations.
+	 */
+	for (c = 0; c < ADRV9002_CHANN_MAX; c++) {
+		adrv9002_axi_interface_enable(phy, c, false);
+		if (phy->rx2tx2)
+			break;
+	}
 
 	phy->curr_profile = profile;
 	ret = adrv9002_setup(phy);
@@ -3155,6 +3160,16 @@ int adrv9002_init(struct adrv9002_rf_phy *phy, struct adi_adrv9001_Init *profile
 	ret = adrv9002_ssi_configure(phy);
 	if (ret)
 		return ret;
+
+	/* re-enable the cores */
+	for (c = 0; c < ADRV9002_CHANN_MAX; c++) {
+		if (!phy->rx_channels[c].channel.enabled)
+			continue;
+
+		adrv9002_axi_interface_enable(phy, c, true);
+		if (phy->rx2tx2)
+			break;
+	}
 
 	return adrv9002_intf_tuning(phy);
 }

--- a/drivers/iio/adc/navassa/adrv9002.c
+++ b/drivers/iio/adc/navassa/adrv9002.c
@@ -1698,83 +1698,87 @@ static const struct iio_info adrv9002_phy_info = {
 	.debugfs_reg_access = &adrv9002_phy_reg_access,
 };
 
-static const char * const adrv9002_irqs[] = {
-	"ARM error",
-	"Force GP interrupt(Set by firmware to send an interrupt to BBIC)",
-	"ARM System error",
-	"ARM Calibration error",
-	"ARM monitor interrupt",
-	"TX1 PA protection error",
-	"TX2 PA protection error",
-	"low-power PLL lock indicator",
-	"RF PLL1 lock indicator",
-	"RF PLL2 lock indicator",
-	"auxiliary Clock PLL lock indicator",
-	"Clock PLL lock indicator",
-	"main clock 1105 MCS",
-	"main clock 1105 second MCS",
-	"RX1 LSSI MCS",
-	"RX2 LSSI MCS",
-	"core stream processor error",
-	"stream0 error",
-	"stream1 error",
-	"stream2 error",
-	"stream3 error",
-	"Unknown Interrupt",
-	"Unknown Interrupt",
-	"Unknown Interrupt",
-	"TX DP write request error",
-	"RX DP read request error",
-	"SPI interface transmit error",
-	"SPI interface receive error",
+static const struct {
+	char *irq_source;
+	int action;
+} adrv9002_irqs[] = {
+	{"ARM error", ADI_COMMON_ACT_ERR_RESET_FULL},
+	{"Force GP interrupt(Set by firmware to send an interrupt to BBIC)",
+	 ADI_ADRV9001_ACT_ERR_BBIC_LOG_ERROR},
+	{"ARM System error", ADI_COMMON_ACT_ERR_RESET_FULL},
+	{"ARM Calibration error", ADI_ADRV9001_ACT_WARN_RERUN_TRCK_CAL},
+	{"ARM monitor interrupt", ADI_COMMON_ACT_ERR_RESET_FULL},
+	{"TX1 PA protection error", ADI_COMMON_ACT_ERR_RESET_FULL},
+	{"TX2 PA protection error", ADI_COMMON_ACT_ERR_RESET_FULL},
+	{"Low-power PLL lock indicator", ADI_ADRV9001_ACT_ERR_BBIC_LOG_ERROR},
+	{"RF PLL1 lock indicator", ADI_ADRV9001_ACT_ERR_BBIC_LOG_ERROR},
+	{"RF PLL2 lock indicator", ADI_ADRV9001_ACT_ERR_BBIC_LOG_ERROR},
+	{"Auxiliary Clock PLL lock indicator", ADI_ADRV9001_ACT_ERR_BBIC_LOG_ERROR},
+	{"Clock PLL lock indicator", ADI_ADRV9001_ACT_ERR_BBIC_LOG_ERROR},
+	{"Main clock 1105 MCS", ADI_COMMON_ACT_ERR_RESET_FULL},
+	{"Main clock 1105 second MCS", ADI_COMMON_ACT_ERR_RESET_FULL},
+	{"RX1 LSSI MCS", ADI_COMMON_ACT_ERR_RESET_FULL},
+	{"RX2 LSSI MCS", ADI_COMMON_ACT_ERR_RESET_FULL},
+	{"Core stream processor error", ADI_COMMON_ACT_ERR_RESET_FULL},
+	{"Stream0 error", ADI_COMMON_ACT_ERR_RESET_FULL},
+	{"Stream1 error", ADI_COMMON_ACT_ERR_RESET_FULL},
+	{"Stream2 error", ADI_COMMON_ACT_ERR_RESET_FULL},
+	{"Stream3 error", ADI_COMMON_ACT_ERR_RESET_FULL},
+	{"Unknown GP Interrupt source"},
+	{"Unknown GP Interrupt source"},
+	{"Unknown GP Interrupt source"},
+	{"TX DP write request error", ADI_COMMON_ACT_ERR_RESET_FULL},
+	{"RX DP write request error", ADI_COMMON_ACT_ERR_RESET_FULL},
+	{"SPI interface transmit error", ADI_COMMON_ACT_ERR_RESET_FULL},
+	{"SPI interface receive error", ADI_COMMON_ACT_ERR_RESET_FULL},
 };
 
 static irqreturn_t adrv9002_irq_handler(int irq, void *p)
 {
 	struct iio_dev *indio_dev = p;
 	struct adrv9002_rf_phy *phy = iio_priv(indio_dev);
-	adi_adrv9001_gpIntStatus_t gp_stat;
 	int ret, bit;
+	u32 status;
 	unsigned long active_irq;
 	u8 error;
 
 	mutex_lock(&phy->lock);
-	ret = adi_adrv9001_gpio_GpIntHandler(phy->adrv9001, &gp_stat);
-	mutex_unlock(&phy->lock);
+	ret = adi_adrv9001_gpio_GpIntStatus_Get(phy->adrv9001, &status);
+	if (ret)
+		goto irq_done;
 
-	/* clear the logger */
-	adi_common_ErrorClear(&phy->adrv9001->common);
+	dev_dbg(&phy->spi->dev, "GP Interrupt Status 0x%08X Mask 0x%08X\n",
+		status, ADRV9002_IRQ_MASK);
 
-	dev_warn(&phy->spi->dev, "GP Interrupt Status 0x%08X Mask 0x%08X\n",
-		 gp_stat.gpIntStatus, ~gp_stat.gpIntSaveIrqMask & 0x0FFFFFFF);
-
-	active_irq = gp_stat.gpIntActiveSources;
+	active_irq = status & ADRV9002_IRQ_MASK;
 	for_each_set_bit(bit, &active_irq, ARRAY_SIZE(adrv9002_irqs)) {
-		dev_warn(&phy->spi->dev, "%d: %s\n",bit, adrv9002_irqs[bit]);
+		/* check if there's something to be done */
+		switch (adrv9002_irqs[bit].action) {
+		case ADI_ADRV9001_ACT_WARN_RERUN_TRCK_CAL:
+			dev_warn(&phy->spi->dev, "Re-running tracking calibrations\n");
+			ret = adi_adrv9001_cals_InitCals_Run(phy->adrv9001, &phy->init_cals,
+							     60000, &error);
+			if (ret)
+				/* just log the error */
+				adrv9002_dev_err(phy);
+			break;
+		case ADI_COMMON_ACT_ERR_RESET_FULL:
+			dev_warn(&phy->spi->dev, "[%s]: Reset might be needed...\n",
+				 adrv9002_irqs[bit].irq_source);
+			break;
+		case ADI_ADRV9001_ACT_ERR_BBIC_LOG_ERROR:
+			/* just log the irq */
+			dev_dbg(&phy->spi->dev, "%s\n", adrv9002_irqs[bit].irq_source);
+			break;
+		default:
+			/* no defined action. print out interrupt source */
+			dev_warn(&phy->spi->dev, "%s\n", adrv9002_irqs[bit].irq_source);
+			break;
+		}
 	}
 
-	/* check if there's something to be done */
-	switch (ret) {
-	case ADI_ADRV9001_ACT_WARN_RERUN_TRCK_CAL:
-		dev_warn(&phy->spi->dev, "Re-running tracking calibrations\n");
-		ret = adi_adrv9001_cals_InitCals_Run(phy->adrv9001,
-						     &phy->init_cals, 60000,
-						     &error);
-		if (ret)
-			/* just log the error */
-			adrv9002_dev_err(phy);
-		break;
-	case ADI_COMMON_ACT_ERR_RESET_FULL:
-		dev_warn(&phy->spi->dev, "Reset might be needed...\n");
-		break;
-	case ADI_ADRV9001_ACT_ERR_BBIC_LOG_ERROR:
-		/* nothing to do. IRQ already logged... */
-		break;
-	default:
-		dev_err(&phy->spi->dev, "Unkonwn action: %d", ret);
-		break;
-	}
-
+irq_done:
+	mutex_unlock(&phy->lock);
 	return IRQ_HANDLED;
 }
 

--- a/drivers/iio/adc/navassa/adrv9002.c
+++ b/drivers/iio/adc/navassa/adrv9002.c
@@ -2592,18 +2592,6 @@ static void adrv9002_cleanup(struct adrv9002_rf_phy *phy)
 	       sizeof(phy->adrv9001->devStateInfo));
 }
 
-int adrv9002_clean_setup(struct adrv9002_rf_phy *phy)
-{
-	int ret;
-
-	mutex_lock(&phy->lock);
-	adrv9002_cleanup(phy);
-	ret = adrv9002_setup(phy);
-	mutex_unlock(&phy->lock);
-
-	return ret;
-}
-
 #define ADRV9002_OF_U32_GET_VALIDATE(dev, node, key, def, min, max,	\
 				     val, mandatory) ({			\
 	u32 tmp;							\
@@ -3132,7 +3120,7 @@ of_channels_put:
 	return ret;
 }
 
-static int adrv9002_init(struct adrv9002_rf_phy *phy, struct adi_adrv9001_Init *profile)
+int adrv9002_init(struct adrv9002_rf_phy *phy, struct adi_adrv9001_Init *profile)
 {
 	int ret;
 

--- a/drivers/iio/adc/navassa/adrv9002.h
+++ b/drivers/iio/adc/navassa/adrv9002.h
@@ -191,8 +191,6 @@ int __maybe_unused adrv9002_axi_tx_test_pattern_cfg(struct adrv9002_rf_phy *phy,
 						    const adi_adrv9001_SsiTestModeData_e data);
 int adrv9002_spi_read(struct spi_device *spi, u32 reg);
 int adrv9002_spi_write(struct spi_device *spi, u32 reg, u32 val);
-void adrv9002_get_ssi_interface(struct adrv9002_rf_phy *phy, const int channel,
-				u8 *ssi_intf, u8 *n_lanes, bool *cmos_ddr_en);
 int adrv9002_post_init(struct adrv9002_rf_phy *phy);
 int adrv9002_intf_test_cfg(struct adrv9002_rf_phy *phy, const int chann, const bool tx,
 			   const bool stop, const adi_adrv9001_SsiType_e ssi_type);

--- a/drivers/iio/adc/navassa/adrv9002.h
+++ b/drivers/iio/adc/navassa/adrv9002.h
@@ -193,7 +193,6 @@ int adrv9002_spi_read(struct spi_device *spi, u32 reg);
 int adrv9002_spi_write(struct spi_device *spi, u32 reg, u32 val);
 void adrv9002_get_ssi_interface(struct adrv9002_rf_phy *phy, const int channel,
 				u8 *ssi_intf, u8 *n_lanes, bool *cmos_ddr_en);
-int adrv9002_ssi_configure(struct adrv9002_rf_phy *phy);
 int adrv9002_post_init(struct adrv9002_rf_phy *phy);
 int adrv9002_intf_tuning(struct adrv9002_rf_phy *phy);
 int adrv9002_intf_test_cfg(struct adrv9002_rf_phy *phy, const int chann, const bool tx,

--- a/drivers/iio/adc/navassa/adrv9002.h
+++ b/drivers/iio/adc/navassa/adrv9002.h
@@ -194,7 +194,6 @@ int adrv9002_spi_write(struct spi_device *spi, u32 reg, u32 val);
 void adrv9002_get_ssi_interface(struct adrv9002_rf_phy *phy, const int channel,
 				u8 *ssi_intf, u8 *n_lanes, bool *cmos_ddr_en);
 int adrv9002_post_init(struct adrv9002_rf_phy *phy);
-int adrv9002_intf_tuning(struct adrv9002_rf_phy *phy);
 int adrv9002_intf_test_cfg(struct adrv9002_rf_phy *phy, const int chann, const bool tx,
 			   const bool stop, const adi_adrv9001_SsiType_e ssi_type);
 int adrv9002_check_tx_test_pattern(struct adrv9002_rf_phy *phy, const int chann,

--- a/drivers/iio/adc/navassa/adrv9002.h
+++ b/drivers/iio/adc/navassa/adrv9002.h
@@ -174,7 +174,7 @@ struct adrv9002_rf_phy {
 #endif
 };
 
-int adrv9002_clean_setup(struct adrv9002_rf_phy *phy);
+int adrv9002_init(struct adrv9002_rf_phy *phy, struct adi_adrv9001_Init *profile);
 int __adrv9002_dev_err(const struct adrv9002_rf_phy *phy, const char *function, const int line);
 #define adrv9002_dev_err(phy)	__adrv9002_dev_err(phy, __func__, __LINE__)
 

--- a/drivers/iio/adc/navassa/adrv9002_conv.c
+++ b/drivers/iio/adc/navassa/adrv9002_conv.c
@@ -320,12 +320,7 @@ static int adrv9002_post_setup(struct iio_dev *indio_dev)
 	conv->clk = phy->clks[RX1_SAMPL_CLK];
 	conv->adc_clk = clk_get_rate(conv->clk);
 
-	ret = adrv9002_ssi_configure(phy);
-	if (ret)
-		return ret;
-
-	/* start interface tuning */
-	return adrv9002_intf_tuning(phy);
+	return 0;
 }
 
 #ifdef DEBUG

--- a/drivers/iio/adc/navassa/adrv9002_conv.c
+++ b/drivers/iio/adc/navassa/adrv9002_conv.c
@@ -148,31 +148,53 @@ static int adrv9002_reg_access(struct iio_dev *indio_dev, u32 reg, u32 writeval,
 	return 0;
 }
 
-static int adrv9002_interface_validate(const struct adrv9002_rf_phy *phy,
-				       struct axiadc_state *st,
-				       const u8 ssi_intf)
+int adrv9002_hdl_loopback(struct adrv9002_rf_phy *phy, bool enable)
 {
-	u32 axi_config = 0;
+	struct axiadc_converter *conv = spi_get_drvdata(phy->spi);
+	struct axiadc_state *st;
+	unsigned int reg, addr, chan, version;
 
-	axi_config = axiadc_read(st, ADI_REG_CONFIG);
-	if (IS_CMOS(axi_config) && ssi_intf == ADI_ADRV9001_SSI_TYPE_LVDS) {
-		dev_err(&phy->spi->dev,
-			 "AXI interface is CMOS and device profile is LVDS...\n");
-		return -EINVAL;
-	} else if (!IS_CMOS(axi_config) &&
-		   ssi_intf == ADI_ADRV9001_SSI_TYPE_CMOS) {
-		dev_err(&phy->spi->dev,
-			 "AXI interface is LVDS and device profile is CMOS...\n");
-		return -EINVAL;
+	if (!conv)
+		return -ENODEV;
+
+	st = iio_priv(conv->indio_dev);
+	version = axiadc_read(st, 0x4000);
+
+	/* Still there but implemented a bit different */
+	if (ADI_AXI_PCORE_VER_MAJOR(version) > 7)
+		addr = 0x4418;
+	else
+		addr = 0x4414;
+
+	for (chan = 0; chan < conv->chip_info->num_channels; chan++) {
+		reg = axiadc_read(st, addr + (chan) * 0x40);
+
+		if (ADI_AXI_PCORE_VER_MAJOR(version) > 7) {
+			if (enable && reg != 0x8) {
+				conv->scratch_reg[chan] = reg;
+				reg = 0x8;
+			} else if (reg == 0x8) {
+				reg = conv->scratch_reg[chan];
+			}
+		} else {
+			/* DAC_LB_ENB If set enables loopback of receive data */
+			if (enable)
+				reg |= BIT(1);
+			else
+				reg &= ~BIT(1);
+		}
+		axiadc_write(st, addr + (chan) * 0x40, reg);
 	}
 
 	return 0;
 }
 
-static int adrv9002_interface_config(struct axiadc_state *st, const u8 n_lanes,
-				     const u8 ssi_intf, const bool cmos_ddr,
-				     const int channel)
+int adrv9002_axi_interface_set(struct adrv9002_rf_phy *phy, const u8 n_lanes,
+			       const u8 ssi_intf, const bool cmos_ddr,
+			       const int channel)
 {
+	struct axiadc_converter *conv = spi_get_drvdata(phy->spi);
+	struct axiadc_state *st = iio_priv(conv->indio_dev);
 	u32 reg_ctrl = 0, tx_reg_ctrl;
 	u8 rate;
 	const int rx_off = channel ? ADI_RX2_REG_OFF : 0;
@@ -223,63 +245,6 @@ static int adrv9002_interface_config(struct axiadc_state *st, const u8 n_lanes,
 	axiadc_write(st, AIM_AXI_REG(tx_off, ADI_TX_REG_CTRL_2), tx_reg_ctrl);
 
 	return 0;
-}
-
-int adrv9002_hdl_loopback(struct adrv9002_rf_phy *phy, bool enable)
-{
-	struct axiadc_converter *conv = spi_get_drvdata(phy->spi);
-	struct axiadc_state *st;
-	unsigned int reg, addr, chan, version;
-
-	if (!conv)
-		return -ENODEV;
-
-	st = iio_priv(conv->indio_dev);
-	version = axiadc_read(st, 0x4000);
-
-	/* Still there but implemented a bit different */
-	if (ADI_AXI_PCORE_VER_MAJOR(version) > 7)
-		addr = 0x4418;
-	else
-		addr = 0x4414;
-
-	for (chan = 0; chan < conv->chip_info->num_channels; chan++) {
-		reg = axiadc_read(st, addr + (chan) * 0x40);
-
-		if (ADI_AXI_PCORE_VER_MAJOR(version) > 7) {
-			if (enable && reg != 0x8) {
-				conv->scratch_reg[chan] = reg;
-				reg = 0x8;
-			} else if (reg == 0x8) {
-				reg = conv->scratch_reg[chan];
-			}
-		} else {
-			/* DAC_LB_ENB If set enables loopback of receive data */
-			if (enable)
-				reg |= BIT(1);
-			else
-				reg &= ~BIT(1);
-		}
-		axiadc_write(st, addr + (chan) * 0x40, reg);
-	}
-
-	return 0;
-}
-
-int adrv9002_axi_interface_set(struct adrv9002_rf_phy *phy, const u8 n_lanes,
-			       const u8 ssi_intf, const bool cmos_ddr,
-			       const int channel)
-{
-	struct axiadc_converter *conv = spi_get_drvdata(phy->spi);
-	struct axiadc_state *st = iio_priv(conv->indio_dev);
-	int ret;
-
-	ret = adrv9002_interface_validate(phy, st, ssi_intf);
-	if (ret)
-		return ret;
-
-	return adrv9002_interface_config(st, n_lanes, ssi_intf, cmos_ddr,
-					 channel);
 }
 
 static int adrv9002_post_setup(struct iio_dev *indio_dev)

--- a/drivers/iio/adc/navassa/adrv9002_debugfs.c
+++ b/drivers/iio/adc/navassa/adrv9002_debugfs.c
@@ -594,11 +594,16 @@ DEFINE_DEBUGFS_ATTRIBUTE(adrv9002_tx_ssi_test_mode_fixed_pattern_fops,
 static int adrv9002_init_set(void *arg, const u64 val)
 {
 	struct adrv9002_rf_phy *phy = arg;
+	int ret;
 
 	if (!val)
 		return -EINVAL;
 
-	return adrv9002_clean_setup(phy);
+	mutex_lock(&phy->lock);
+	ret = adrv9002_init(phy, phy->curr_profile);
+	mutex_unlock(&phy->lock);
+
+	return ret;
 }
 DEFINE_DEBUGFS_ATTRIBUTE(adrv9002_init_fops,
 			 NULL, adrv9002_init_set, "%llu");

--- a/drivers/iio/adc/navassa/adrv9002_debugfs.c
+++ b/drivers/iio/adc/navassa/adrv9002_debugfs.c
@@ -163,7 +163,7 @@ static int adrv9002_rx_agc_config_show(struct seq_file *s, void *ignored)
 	adrv9002_agc_seq_printf(peak.hbGainStepHighRecovery);
 	adrv9002_agc_seq_printf(peak.hbGainStepLowRecovery);
 	adrv9002_agc_seq_printf(peak.hbGainStepMidRecovery);
-	adrv9002_agc_seq_printf(peak.hbGainStepMidRecovery);
+	adrv9002_agc_seq_printf(peak.hbGainStepAttack);
 	adrv9002_agc_seq_printf(peak.hbOverloadPowerMode);
 	adrv9002_agc_seq_printf(peak.hbUnderRangeMidThreshExceededCount);
 	adrv9002_agc_seq_printf(peak.hbUnderRangeLowThreshExceededCount);
@@ -280,7 +280,7 @@ void adrv9002_debugfs_agc_config_create(struct adrv9002_rx_chan *rx, struct dent
 	adrv9002_agc_add_file_u8(peak.hbGainStepHighRecovery);
 	adrv9002_agc_add_file_u8(peak.hbGainStepLowRecovery);
 	adrv9002_agc_add_file_u8(peak.hbGainStepMidRecovery);
-	adrv9002_agc_add_file_u8(peak.hbGainStepMidRecovery);
+	adrv9002_agc_add_file_u8(peak.hbGainStepAttack);
 	adrv9002_agc_add_file_u8(peak.hbOverloadPowerMode);
 	adrv9002_agc_add_file_u8(peak.hbUnderRangeMidThreshExceededCount);
 	adrv9002_agc_add_file_u8(peak.hbUnderRangeLowThreshExceededCount);


### PR DESCRIPTION
iio: adrv9002: fix irq handling
iio: adrv9002: Fix debugfs AGC parameter
iio: adrv9002: disable axi core before device setup
iio: adrv9002: validate ssi interface before device setup
iio: adrv9002: call adrv9002_init() on debugfs
iio: adrv9002: remove adrv9002_intf_tuning_unlocked()
iio: adrv9002: centralize device initialization

The first 2 patches are just "helper" patches to the real bugfixes..