### PR TITLE
iio: adrv9002: add new kconfig options

### DIFF
--- a/drivers/iio/adc/Kconfig
+++ b/drivers/iio/adc/Kconfig
@@ -387,6 +387,21 @@ config ADRV9001
           ADRV9001/ADRV9002 RF Transceivers. Provides direct access
           via sysfs
 
+config ADRV9001_COMMON_VERBOSE
+	bool "Enables verbose error reports"
+	depends on ADRV9001
+	default y
+
+config ADRV9001_ARM_VERBOSE
+	bool "Enables ARM verbose error messages"
+	depends on ADRV9001
+	default y
+
+config ADRV9001_VALIDATE_PARAMS
+	bool "Causes the API to validate all the input parameters"
+	depends on ADRV9001
+	default y
+
 config ADRV9009
 	tristate "Analog Devices ADRV9009/ADRV9008 RF Transceiver driver"
 	depends on SPI

--- a/drivers/iio/adc/navassa/Makefile
+++ b/drivers/iio/adc/navassa/Makefile
@@ -53,7 +53,8 @@ ccflags-y += -I$(srctree)/$(src)/devices/adrv9001/private/include \
 	-I$(srctree)/$(src)/platforms/ \
 	-I$(srctree)/$(src)/third_party/jsmn/ \
 	-I$(srctree)/$(src)/third_party/adi_pmag_macros/ \
-	-DADI_COMMON_VERBOSE=1 \
-	-DADI_ADRV9001_ARM_VERBOSE \
-	-DADI_VALIDATE_PARAMS \
 	-DADI_DYNAMIC_PROFILE_LOAD
+
+ccflags-$(CONFIG_ADRV9001_COMMON_VERBOSE) += -DADI_COMMON_VERBOSE
+ccflags-$(CONFIG_ADRV9001_ARM_VERBOSE) += -DADI_ADRV9001_ARM_VERBOSE
+ccflags-$(CONFIG_ADRV9001_VALIDATE_PARAMS) += -DADI_VALIDATE_PARAMS


### PR DESCRIPTION
Instead of just enabling verbosity on errors and parameters validation on
the API, make this configurable through Kconfig. This makes things neater
and we still keep the same default behavior. But now we can disable things
without having to directly tweak the Makefile.

Signed-off-by: Nuno Sá <nuno.sa@analog.com>