### PR TITLE
clk: axi-clkgen: Don't display error when -EPROBE_DEFER

### DIFF
--- a/drivers/clk/clk-axi-clkgen.c
+++ b/drivers/clk/clk-axi-clkgen.c
@@ -577,7 +577,8 @@ static int axi_clkgen_probe(struct platform_device *pdev)
 
 	axi_clkgen->axi_clk = devm_clk_get(&pdev->dev, "s_axi_aclk");
 	if (IS_ERR(axi_clkgen->axi_clk)) {
-		dev_err(&pdev->dev, "failed to get s_axi_aclk\n");
+		if (PTR_ERR(axi_clkgen->axi_clk) != -EPROBE_DEFER)
+			dev_err(&pdev->dev, "failed to get s_axi_aclk\n");
 		return PTR_ERR(axi_clkgen->axi_clk);
 	}
 


### PR DESCRIPTION
Displaying an error message when s_axi_aclk is not yet ready
might be confusing for the users.

An example for which this happens before axi-clkgens get
registered, is the zcu102-adrv9009 project:
	adi-axi-clkgen 83c00000.axi-clkgen: failed to get s_axi_aclk
	adi-axi-clkgen 83c10000.axi-clkgen: failed to get s_axi_aclk
	adi-axi-clkgen 83c20000.axi-clkgen: failed to get s_axi_aclk

Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>