### PR TITLE
ci: checkpatch: Replace python-git to python-git-doc

### DIFF
--- a/ci/travis/run-build.sh
+++ b/ci/travis/run-build.sh
@@ -208,7 +208,7 @@ build_checkpatch() {
 	# TODO: Re-visit periodically:
 	# https://github.com/torvalds/linux/blob/master/Documentation/devicetree/writing-schema.rst
 	# This seems to change every now-n-then
-	apt_install python-ply python-git libyaml-dev python3-pip python3-setuptools
+	apt_install python3-ply python-git-doc libyaml-dev python3-pip python3-setuptools
 	pip3 install wheel
 	pip3 install git+https://github.com/devicetree-org/dt-schema.git@master
 


### PR DESCRIPTION
Checkpatch was failing for Azure. This is the error and the fix:

Package python-git is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  python-git-doc

E: Package 'python-git' has no installation candidate
Error: Process completed with exit code 100.

Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>