### PR TITLE
dts: zynq-zed-adrv9002-rx2tx2.dts: Fix hdl project tag

### DIFF
--- a/arch/arm/boot/dts/zynq-zed-adrv9002-rx2tx2.dts
+++ b/arch/arm/boot/dts/zynq-zed-adrv9002-rx2tx2.dts
@@ -2,7 +2,7 @@
 /*
  * Analog Devices ADRV9002
  *
- * hdl_project: <adrv9001/zcu102>
+ * hdl_project: <adrv9001/zed>
  * board_revision: <1.0>
  *
  * Copyright (C) 2020 Analog Devices Inc.


### PR DESCRIPTION
Update hdl project tag from 'adrv9001/zcu102' to 'adrv9001/zed'.

Signed-off-by: stefan.raus <stefan.raus@analog.com>