### PR TITLE
ci: (actually) re-enable checkpatch job

### DIFF
--- a/ci/travis/run-build.sh
+++ b/ci/travis/run-build.sh
@@ -212,8 +212,6 @@ build_checkpatch() {
 	pip3 install wheel
 	pip3 install git+https://github.com/devicetree-org/dt-schema.git@master
 
-	[ "$TRAVIS_PULL_REQUEST" = "true" ] || return 0
-
 	local ref_branch
 
 	if [ -n "$TRAVIS_BRANCH" ] ; then


### PR DESCRIPTION
This was not omitted by accident during migration to Azure, and wasn't
working because the TRAVIS_PULL_REQUEST check was still around.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>