### PR TITLE
iio: adc: ad9361: Fix rssi_gain_step_error DEVICE_ATTR mode

### DIFF
--- a/drivers/iio/adc/ad9361.c
+++ b/drivers/iio/adc/ad9361.c
@@ -7170,7 +7170,7 @@ static IIO_DEVICE_ATTR(calib_mode_available, S_IRUGO,
 			NULL,
 			AD9361_CALIB_MODE_AVAIL);
 
-static IIO_DEVICE_ATTR(rssi_gain_step_error, S_IRUGO,
+static IIO_DEVICE_ATTR(rssi_gain_step_error, S_IRUGO | S_IWUSR,
 			ad9361_phy_show,
 			ad9361_phy_store,
 			AD9361_RSSI_GAIN_STEP_ERROR);


### PR DESCRIPTION
Since the attribute has a _store function defined, S_IWUSR
should be also set.

The issue was pointed by: https://github.com/analogdevicesinc/linux/issues/1461

Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>