### PR TITLE
Ad9545 add ref priorities

### DIFF
--- a/Documentation/devicetree/bindings/clock/clk-ad9545.yaml
+++ b/Documentation/devicetree/bindings/clock/clk-ad9545.yaml
@@ -170,27 +170,53 @@ patternProperties:
           PLL number. AD9545 has two PLLs.
         maxItems: 1
 
-      adi,pll-source:
-        description: |
-          Each PLL can have 1 signal source. Choose from Ref-A to Ref-BB [0-3] or aux NCOs [4-5].
-        allOf:
-          - $ref: /schemas/types.yaml#/definitions/uint32
-          - enum: [0, 1, 2, 3, 4, 5]
-        maxItems: 1
+      '#address-cells':
+         const: 1
 
-      adi,pll-loop-bandwidth-uhz:
+      '#size-cells':
+         const: 0
+
+    patternProperties:
+      "^profile@[0-5]$":
         description: |
-          PLL loop bandwidth in microhertz.
-        allOf:
-          - $ref: /schemas/types.yaml#/definitions/uint32
-          - minimum: 1
-          - maximum: 1850
-        maxItems: 1
+          Represents a DPLL profile. Each DPLL can have up to 6 specified sources
+          wih priorities assigned.
+        type: object
+
+        properties:
+          reg:
+            description: |
+              Profile number. A DPLL can have up to 6 translation profiles.
+            maxItems: 1
+          adi,profile-priority:
+            description: |
+              Profile selection priority. 0 is the highest, 31 is the lowest. For revertive
+              reference switching, ensure that priority difference is > 7.
+            $ref: /schemas/types.yaml#/definitions/uint32
+            minimum: 0
+            maximum: 31
+
+          adi,pll-source:
+            description: |
+              Each PLL can have 1 signal source. Choose from Ref-A to Ref-BB [0-3] or aux NCOs [4-5].
+            $ref: /schemas/types.yaml#/definitions/uint32
+            enum: [0, 1, 2, 3, 4, 5]
+
+          adi,pll-loop-bandwidth-uhz:
+            description: |
+              PLL loop bandwidth in microhertz.
+            $ref: /schemas/types.yaml#/definitions/uint32
+            minimum: 1
+            maximum: 1850000000
+            default: 200000000
+
+        required:
+          - reg
+          - adi,pll-source
+          - adi,pll-loop-bandwidth-uhz
 
     required:
       - reg
-      - adi,pll-source
-      - adi,pll-loop-bandwidth-hz
 
   "^aux-nco-clk@[0-1]$":
     description: |
@@ -298,8 +324,16 @@ examples:
 
                 ad9545_apll1: pll-clk@AD9545_PLL1 {
                         reg = <AD9545_PLL1>;
-                        adi,pll-source = <4>;
-                        adi,pll-loop-bandwidth-uhz = <200000000>;
+
+                        #address-cells = <1>;
+                        #size-cells = <0>;
+
+                        profile@0 {
+                               reg = <0>;
+                               adi,pll-source = <4>;
+                               adi,profile-priority = <0>;
+                               adi,pll-loop-bandwidth-uhz = <200000000>;
+                        };
                 };
 
                 output-clk@AD9545_Q1A {

--- a/Documentation/devicetree/bindings/clock/clk-ad9545.yaml
+++ b/Documentation/devicetree/bindings/clock/clk-ad9545.yaml
@@ -19,8 +19,14 @@ properties:
     enum:
       - adi,ad9545
 
-  "#clock-cells":
+  '#address-cells':
     const: 1
+
+  '#size-cells':
+    const: 0
+
+  "#clock-cells":
+    const: 2
 
   reg:
     description: |
@@ -43,13 +49,9 @@ properties:
       Otherwise it is assumed that there is a TCXO or OCXO connected.
     type: boolean
 
-  adi,ref-frequency-mhz:
+  adi,ref-frequency-hz:
     description: |
       Reference input frequency at XOA,XOB. This is used for the system clock.
-    allOf:
-      - $ref: /schemas/types.yaml#/definitions/uint32
-    minItems: 2
-    maxItems: 2
 
   clocks:
     items:
@@ -58,6 +60,20 @@ properties:
       - description: Ref B clock input
       - description: Ref BB clock input
     maxItems: 4
+
+  assigned-clocks:
+    description:
+      Clocks are identified using two cells <&ad9545 clock_type clock_address>.
+    minItems: 1
+    maxItems: 14
+
+  assigned-clock-rates:
+    minItems: 1
+    maxItems: 14
+
+  assigned-clock-phases:
+    minItems: 1
+    maxItems: 14
 
   clock-output-names:
     maxItems: 10
@@ -78,74 +94,61 @@ patternProperties:
       adi,single-ended-mode:
         description: |
           Single-ended configuration mode.
-        allOf:
-          - $ref: /schemas/types.yaml#/definitions/uint32
-          - enum: [0, 1, 2, 3]
-        maxItems: 1
+        $ref: /schemas/types.yaml#/definitions/uint32
+        enum: [0, 1, 2, 3]
 
       adi,differential-mode:
         description: |
           Differential configuration mode.
-        allOf:
-          - $ref: /schemas/types.yaml#/definitions/uint32
-          - enum: [0, 1, 2]
-        maxItems: 1
+        $ref: /schemas/types.yaml#/definitions/uint32
+        enum: [0, 1, 2]
 
       adi,r-divider-ratio:
         description: |
           Each reference input has a dedicated divider.
-        allOf:
-          - $ref: /schemas/types.yaml#/definitions/uint32
-          - minimum: 1
-          - maximum: 1073741824
-        maxItems: 1
+        $ref: /schemas/types.yaml#/definitions/uint32
+        minimum: 1
+        maximum: 1073741824
 
       adi,ref-dtol-pbb:
         description: |
           REFx offset limit. Constitutes a fractional portion of the corresponding nominal period.
           The 24-bit number represents fractional units of parts per billion (ppb) up to a
           maximum of approximately 17 million ppb (1.7%).
-        allOf:
-          - $ref: /schemas/types.yaml#/definitions/uint32
-          - minimum: 0
-          - maximum: 16777215
-          - default: 100000
+        $ref: /schemas/types.yaml#/definitions/uint32
+        minimum: 0
+        maximum: 16777215
+        default: 100000
 
       adi,ref-monitor-hysteresis-pbb:
         description: |
           Basis points of the offset limit representing per ten thousand of REFx offset limit.
-        allOf:
-          - $ref: /schemas/types.yaml#/definitions/uint32
-          - enum: [0, 3125, 6250, 12500, 25000, 50000, 75000, 87500]
-          - default: 12500
+        $ref: /schemas/types.yaml#/definitions/uint32
+        enum: [0, 3125, 6250, 12500, 25000, 50000, 75000, 87500]
+        default: 12500
 
       adi,ref-validation-timer-ms:
         description: |
           Time required for a reference to remain in tolerance condition before being
           available to be used.
-        allOf:
-          - $ref: /schemas/types.yaml#/definitions/uint32
-          - minimum: 1
-          - maximum: 1048574
-          - default: 10
+        $ref: /schemas/types.yaml#/definitions/uint32
+        minimum: 1
+        maximum: 1048574
+        default: 10
 
       adi,freq-lock-threshold-ps:
         description: |
           Phase lock detector threshold (in picoseconds).
-        allOf:
-          - $ref: /schemas/types.yaml#/definitions/uint32
-          - minimum: 1
-          - maximum: 16777215
-        maxItems: 1
+        $ref: /schemas/types.yaml#/definitions/uint32
+        minimum: 1
+        maximum: 16777215
 
       adi,phase-lock-threshold-ps:
         description: |
           Profile 0 frequency lock threshold. Frequency lock detector threshold (in picoseconds).
-        allOf:
-          - $ref: /schemas/types.yaml#/definitions/uint32
-          - minimum: 1
-          - maximum: 16777215
-        maxItems: 1
+        $ref: /schemas/types.yaml#/definitions/uint32
+        minimum: 1
+        maximum: 16777215
 
     required:
       - reg
@@ -204,27 +207,23 @@ patternProperties:
       adi,freq-lock-threshold-ps:
         description: |
           Phase lock detector threshold (in picoseconds).
-        allOf:
-          - $ref: /schemas/types.yaml#/definitions/uint32
-          - minimum: 1
-          - maximum: 16777215
-        maxItems: 1
+        $ref: /schemas/types.yaml#/definitions/uint32
+        minimum: 1
+        maximum: 16777215
 
       adi,phase-lock-threshold-ps:
         description: |
           Profile 0 frequency lock threshold. Frequency lock detector threshold (in picoseconds).
-        allOf:
-          - $ref: /schemas/types.yaml#/definitions/uint32
-          - minimum: 1
-          - maximum: 16777215
-        maxItems: 1
+        $ref: /schemas/types.yaml#/definitions/uint32
+        minimum: 1
+        maximum: 16777215
 
     required:
       - reg
       - adi,freq-lock-threshold-ps
       - adi,phase-lock-threshold-ps
 
-  "^output-clk@([0-5]|1[0-3])$":
+  "^output-clk@([0-9]|1[0-3])$":
     description: |
       Represents a clock output.
     type: object
@@ -245,18 +244,14 @@ patternProperties:
       adi,current-source-microamp:
         description: |
           The magnitude of the driver current.
-        allOf:
-          - $ref: /schemas/types.yaml#/definitions/uint32
-          - enum: [7500, 12500, 15000]
-        minItems: 1
+        $ref: /schemas/types.yaml#/definitions/uint32
+        enum: [7500, 12500, 15000]
 
       adi,output-mode:
         description: |
           Output driver mode.
-        allOf:
-          - $ref: /schemas/types.yaml#/definitions/uint32
-          - enum: [0, 1, 2]
-        maxItems: 1
+        $ref: /schemas/types.yaml#/definitions/uint32
+        enum: [0, 1, 2]
 
     required:
       - reg
@@ -266,7 +261,7 @@ patternProperties:
 required:
   - compatible
   - reg
-  - adi,ref-frequency-mhz
+  - adi,ref-frequency-hz
 
 "additionalProperties": false
 


### PR DESCRIPTION
Add support for TDC sources priorities.

TDC sources can be RefA, RefB and auxiliary NCOs. AD9545 will use as input for the DPLLs a valid TDC source with the highest priority specified in the DT. If an error occurs on a used TDC source AD9545 will automatically revert to a valid one with a lower priority.

Even if only one source can be used at a time by a DPLL, when setting the rate of the DPLL, the driver will
compute N div, FRAC, MOD for all possible TDC sources. Those parameters are stored on chip in Translation Profiles. See:
ad9545_pll_set_rate

This is needed in order to maintain the same PLL output frequency, even after reference switching.