### PR TITLE
arch: arm64: dts: Change SW0 linux code to  SW_LINEIN_INSERT

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-reva-adrv2crr-fmc-reva.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-reva-adrv2crr-fmc-reva.dts
@@ -104,7 +104,7 @@
 		sw0 {
 			label = "SW0";
 			linux,input-type = <EV_SW>;
-			linux,code = <SW_LID>;
+			linux,code = <SW_LINEIN_INSERT>;
 			gpios = <&gpio 82 0>;
 		};
 


### PR DESCRIPTION
The SW_LID code was causing powering issues on adrv9009-zu11eg. Since we do
not require a SW_LID code to be sent it makes more sense to change it to
something else that would not impact functionality.

Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>

Related to https://github.com/analogdevicesinc/linux/issues/1464