### PR TITLE
[ADRV9002] Fix low rate profiles

### DIFF
--- a/drivers/iio/adc/navassa/adrv9002.c
+++ b/drivers/iio/adc/navassa/adrv9002.c
@@ -2613,7 +2613,7 @@ int adrv9002_check_tx_test_pattern(struct adrv9002_rf_phy *phy, const int chann)
 	struct adrv9002_chan *chan = &phy->tx_channels[chann].channel;
 	adi_adrv9001_SsiTestModeData_e test_data = phy->ssi_type == ADI_ADRV9001_SSI_TYPE_CMOS ?
 						ADI_ADRV9001_SSI_TESTMODE_DATA_RAMP_NIBBLE :
-						ADI_ADRV9001_SSI_TESTMODE_DATA_PRBS15;
+						ADI_ADRV9001_SSI_TESTMODE_DATA_PRBS7;
 	struct adi_adrv9001_TxSsiTestModeCfg cfg = {0};
 	struct adi_adrv9001_TxSsiTestModeStatus status = {0};
 
@@ -2660,9 +2660,6 @@ int adrv9002_intf_test_cfg(struct adrv9002_rf_phy *phy, const int chann, const b
 {
 	int ret;
 	struct adrv9002_chan *chan;
-	adi_adrv9001_SsiTestModeData_e test_data = phy->ssi_type == ADI_ADRV9001_SSI_TYPE_CMOS ?
-						ADI_ADRV9001_SSI_TESTMODE_DATA_RAMP_NIBBLE :
-						ADI_ADRV9001_SSI_TESTMODE_DATA_PRBS15;
 
 	dev_dbg(&phy->spi->dev, "cfg test stop:%u, ssi:%d, c:%d, tx:%d\n", stop,
 		phy->ssi_type, chann, tx);
@@ -2671,7 +2668,21 @@ int adrv9002_intf_test_cfg(struct adrv9002_rf_phy *phy, const int chann, const b
 		struct adi_adrv9001_TxSsiTestModeCfg cfg = {0};
 		chan = &phy->tx_channels[chann].channel;
 
-		cfg.testData = stop ? ADI_ADRV9001_SSI_TESTMODE_DATA_NORMAL : test_data;
+		if (stop)
+			cfg.testData = ADI_ADRV9001_SSI_TESTMODE_DATA_NORMAL;
+		else if (phy->ssi_type == ADI_ADRV9001_SSI_TYPE_LVDS)
+			/*
+			 * Some low rate profiles don't play well with prbs15. The reason is
+			 * still unclear. We suspect that the chip error checker might have
+			 * some time constrains and cannot reliable validate prbs15 full
+			 * sequences in the test time. Using a shorter sequence fixes the
+			 * problem...
+			 */
+			cfg.testData = ADI_ADRV9001_SSI_TESTMODE_DATA_PRBS7;
+		else
+			/* CMOS */
+			cfg.testData = ADI_ADRV9001_SSI_TESTMODE_DATA_RAMP_NIBBLE;
+
 		ret = adi_adrv9001_Ssi_Tx_TestMode_Configure(phy->adrv9001, chan->number, phy->ssi_type,
 							     ADI_ADRV9001_SSI_FORMAT_16_BIT_I_Q_DATA,
 							     &cfg);
@@ -2695,7 +2706,14 @@ int adrv9002_intf_test_cfg(struct adrv9002_rf_phy *phy, const int chann, const b
 		struct adi_adrv9001_RxSsiTestModeCfg cfg = {0};
 		chan = &phy->rx_channels[chann].channel;
 
-		cfg.testData = stop ? ADI_ADRV9001_SSI_TESTMODE_DATA_NORMAL : test_data;
+		if (stop)
+			cfg.testData = ADI_ADRV9001_SSI_TESTMODE_DATA_NORMAL;
+		else if (phy->ssi_type == ADI_ADRV9001_SSI_TYPE_LVDS)
+			cfg.testData = ADI_ADRV9001_SSI_TESTMODE_DATA_PRBS15;
+		else
+			/* CMOS */
+			cfg.testData = ADI_ADRV9001_SSI_TESTMODE_DATA_RAMP_NIBBLE;
+
 		ret = adi_adrv9001_Ssi_Rx_TestMode_Configure(phy->adrv9001, chan->number, phy->ssi_type,
 							     ADI_ADRV9001_SSI_FORMAT_16_BIT_I_Q_DATA,
 							     &cfg);

--- a/drivers/iio/adc/navassa/adrv9002.c
+++ b/drivers/iio/adc/navassa/adrv9002.c
@@ -2429,10 +2429,7 @@ static int adrv9002_radio_init(struct adrv9002_rf_phy *phy)
 		.detectionThreshold_mdBFS = -80000,
 		.measurementDuration_samples = 10
 	};
-	struct adi_adrv9001_Carrier carrier = {
-		.loGenOptimization = ADI_ADRV9001_LO_GEN_OPTIMIZATION_PHASE_NOISE,
-		.intermediateFrequency_Hz = 0
-	};
+	struct adi_adrv9001_Carrier carrier = {0};
 
 	ret = adi_adrv9001_Radio_PllLoopFilter_Set(phy->adrv9001, ADI_ADRV9001_PLL_LO1, &pll_loop_filter);
 	if (ret)
@@ -2456,6 +2453,16 @@ static int adrv9002_radio_init(struct adrv9002_rf_phy *phy)
 
 		if (!c->enabled)
 			continue;
+
+		/*
+		 * For some low rate profiles, the intermediate frequency is non 0.
+		 * In these cases, forcing it 0, will cause a firmware error. Hence, we need to
+		 * read what we have and make sure we just change the carrier frequency...
+		 */
+		ret = adi_adrv9001_Radio_Carrier_Inspect(phy->adrv9001, c->port, c->number,
+							 &carrier);
+		if (ret)
+			return adrv9002_dev_err(phy);
 
 		if (c->port == ADI_RX)
 			carrier.carrierFrequency_Hz = 2400000000ULL;

--- a/drivers/iio/adc/navassa/adrv9002_conv.c
+++ b/drivers/iio/adc/navassa/adrv9002_conv.c
@@ -379,8 +379,8 @@ static void adrv9002_axi_tx_test_pattern_set(const struct axiadc_converter *conv
 		/* RAMP nibble */
 		sel = 10;
 	else
-		/* pn15 */
-		sel = 7;
+		/* pn7 */
+		sel = 6;
 
 	for (c = 0; c < n_chan; c++) {
 		ctrl_7[c] = axiadc_read(st, AIM_AXI_REG(off, ADI_TX_REG_CHAN_CTRL_7(c)));

--- a/drivers/iio/adc/navassa/adrv9002_conv.c
+++ b/drivers/iio/adc/navassa/adrv9002_conv.c
@@ -474,26 +474,19 @@ int adrv9002_axi_intf_tune(struct adrv9002_rf_phy *phy, const bool tx, const int
 				ret = adrv9002_check_tx_test_pattern(phy, chann);
 
 			field[clk][data] |= ret;
-
-			if (tx) {
-				ret = adrv9002_intf_test_cfg(phy, chann, tx, true);
-				if (ret)
-					return ret;
-			}
 		}
 	}
 
 	adrv9002_axi_digital_tune_verbose(phy, field, tx, chann);
 
-	if (!tx) {
-		/* stop test */
-		ret = adrv9002_intf_test_cfg(phy, chann, tx, true);
-		if (ret)
-			return ret;
-	} else {
-		/* stop tx pattern */
+	/* stop test */
+	ret = adrv9002_intf_test_cfg(phy, chann, tx, true);
+	if (ret)
+		return ret;
+
+	/* stop tx pattern */
+	if (tx)
 		adrv9002_axi_tx_test_pattern_restore(conv, off, saved_ctrl_7);
-	}
 
 	for (clk = 0; clk < ARRAY_SIZE(field); clk++) {
 		cnt = adrv9002_axi_find_point(&field[clk][0], sizeof(*field), &data);


### PR DESCRIPTION
Some low rate profiles don't play well with prbs15. The reason is still unclear. We suspect that the chip error checker might have
some time constrains and cannot reliable validate prbs15 full sequences in the test time. Using a shorter sequence as prbs7 fixes the problem...

The last patch is just a small improvement on the tx tuning logic...