### PR TITLE
[ADRV9002 - 2019_R2] Fix low rate profiles

### DIFF
--- a/drivers/iio/adc/navassa/adrv9002.c
+++ b/drivers/iio/adc/navassa/adrv9002.c
@@ -2421,7 +2421,7 @@ int adrv9002_check_tx_test_pattern(struct adrv9002_rf_phy *phy, const int chann,
 	struct adrv9002_chan *chan = &phy->tx_channels[chann].channel;
 	adi_adrv9001_SsiTestModeData_e test_data = ssi_type == ADI_ADRV9001_SSI_TYPE_CMOS ?
 						ADI_ADRV9001_SSI_TESTMODE_DATA_RAMP_NIBBLE :
-						ADI_ADRV9001_SSI_TESTMODE_DATA_PRBS15;
+						ADI_ADRV9001_SSI_TESTMODE_DATA_PRBS7;
 	struct adi_adrv9001_TxSsiTestModeCfg cfg = {0};
 	struct adi_adrv9001_TxSsiTestModeStatus status = {0};
 
@@ -2468,9 +2468,6 @@ int adrv9002_intf_test_cfg(struct adrv9002_rf_phy *phy, const int chann, const b
 {
 	int ret;
 	struct adrv9002_chan *chan;
-	adi_adrv9001_SsiTestModeData_e test_data = ssi_type == ADI_ADRV9001_SSI_TYPE_CMOS ?
-						ADI_ADRV9001_SSI_TESTMODE_DATA_RAMP_NIBBLE :
-						ADI_ADRV9001_SSI_TESTMODE_DATA_PRBS15;
 
 	dev_dbg(&phy->spi->dev, "cfg test stop:%u, ssi:%d, c:%d, tx:%d\n", stop, ssi_type, chann,
 		tx);
@@ -2479,7 +2476,21 @@ int adrv9002_intf_test_cfg(struct adrv9002_rf_phy *phy, const int chann, const b
 		struct adi_adrv9001_TxSsiTestModeCfg cfg = {0};
 		chan = &phy->tx_channels[chann].channel;
 
-		cfg.testData = stop ? ADI_ADRV9001_SSI_TESTMODE_DATA_NORMAL : test_data;
+		if (stop)
+			cfg.testData = ADI_ADRV9001_SSI_TESTMODE_DATA_NORMAL;
+		else if (ssi_type == ADI_ADRV9001_SSI_TYPE_LVDS)
+			/*
+			 * Some low rate profiles don't play well with prbs15. The reason is
+			 * still unclear. We suspect that the chip error checker might have
+			 * some time constrains and cannot reliable validate prbs15 full
+			 * sequences in the test time. Using a shorter sequence fixes the
+			 * problem...
+			 */
+			cfg.testData = ADI_ADRV9001_SSI_TESTMODE_DATA_PRBS7;
+		else
+			/* CMOS */
+			cfg.testData = ADI_ADRV9001_SSI_TESTMODE_DATA_RAMP_NIBBLE;
+
 		ret = adi_adrv9001_Ssi_Tx_TestMode_Configure(phy->adrv9001, chan->number, ssi_type,
 							     ADI_ADRV9001_SSI_FORMAT_16_BIT_I_Q_DATA,
 							     &cfg);
@@ -2503,7 +2514,14 @@ int adrv9002_intf_test_cfg(struct adrv9002_rf_phy *phy, const int chann, const b
 		struct adi_adrv9001_RxSsiTestModeCfg cfg = {0};
 		chan = &phy->rx_channels[chann].channel;
 
-		cfg.testData = stop ? ADI_ADRV9001_SSI_TESTMODE_DATA_NORMAL : test_data;
+		if (stop)
+			cfg.testData = ADI_ADRV9001_SSI_TESTMODE_DATA_NORMAL;
+		else if (ssi_type == ADI_ADRV9001_SSI_TYPE_LVDS)
+			cfg.testData = ADI_ADRV9001_SSI_TESTMODE_DATA_PRBS15;
+		else
+			/* CMOS */
+			cfg.testData = ADI_ADRV9001_SSI_TESTMODE_DATA_RAMP_NIBBLE;
+
 		ret = adi_adrv9001_Ssi_Rx_TestMode_Configure(phy->adrv9001, chan->number, ssi_type,
 							     ADI_ADRV9001_SSI_FORMAT_16_BIT_I_Q_DATA,
 							     &cfg);

--- a/drivers/iio/adc/navassa/adrv9002_conv.c
+++ b/drivers/iio/adc/navassa/adrv9002_conv.c
@@ -407,8 +407,8 @@ static void adrv9002_axi_tx_test_pattern_set(const struct axiadc_converter *conv
 		/* RAMP nibble */
 		sel = 10;
 	else
-		/* pn15 */
-		sel = 7;
+		/* pn7 */
+		sel = 6;
 
 	for (c = 0; c < n_chan; c++) {
 		ctrl_7[c] = axiadc_read(st, AIM_AXI_REG(off, ADI_TX_REG_CHAN_CTRL_7(c)));


### PR DESCRIPTION
Some low rate profiles don't play well with prbs15. The reason is still unclear. We suspect that the chip error checker might have
some time constrains and cannot reliable validate prbs15 full sequences in the test time. Using a shorter sequence as prbs7 fixes the problem...