### PR TITLE
Ad9545 add fast acquisition

### DIFF
--- a/Documentation/devicetree/bindings/clock/clk-ad9545.yaml
+++ b/Documentation/devicetree/bindings/clock/clk-ad9545.yaml
@@ -210,6 +210,30 @@ patternProperties:
             maximum: 1850000000
             default: 200000000
 
+          adi,fast-acq-excess-bw:
+            description: |
+              Controls the DPLL loop bandwidth scaling factor while in fast acquisition mode.
+              0 means this feature is disabled.
+            $ref: /schemas/types.yaml#/definitions/uint32
+            enum: [0, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024]
+            default: 0
+
+          adi,fast-acq-timeout-ms:
+            description: |
+              Fast acquisition timeout controls the maximum amount of time that DPLL waits to
+              achieve phase lock before reducing the loop bandwidth by a factor of two.
+            $ref: /schemas/types.yaml#/definitions/uint32
+            enum: [1, 10, 50, 100, 500, 1000, 10000, 50000]
+            default: 1
+
+          adi,fast-acq-lock-settle-ms:
+            description: |
+              Controls how long DPLL must wait after achieving phase lock before reducing
+              the loop bandwidth by a factor of 2.
+            $ref: /schemas/types.yaml#/definitions/uint32
+            enum: [1, 10, 50, 100, 500, 1000, 10000, 50000]
+            default: 1
+
         required:
           - reg
           - adi,pll-source


### PR DESCRIPTION
In fast acquisition the DPLL automatically reduces
the loop bandwidth by successive factors of 2 while the loop is
acquiring.

This mechanism drastically reduces DPLL locking time
for low loop bandwidth applications like 1 pps signals.