### PR TITLE
clk: ad9545: Fix source selection

### DIFF
--- a/drivers/clk/adi/clk-ad9545.c
+++ b/drivers/clk/adi/clk-ad9545.c
@@ -1749,8 +1749,8 @@ static int ad9545_plls_setup(struct ad9545_state *st)
 			if (ret < 0)
 				return ret;
 
-			if (pll->profiles[j].tdc_source >= sizeof(ad9545_ref_clk_names))
-				hw = &st->aux_nco_clks[tdc_source - sizeof(ad9545_ref_clk_names)].hw;
+			if (pll->profiles[j].tdc_source >= ARRAY_SIZE(ad9545_ref_clk_names))
+				hw = &st->aux_nco_clks[tdc_source - ARRAY_SIZE(ad9545_ref_clk_names)].hw;
 			else
 				hw = &st->ref_in_clks[tdc_source].hw;
 			init[i].parent_hws[j] = hw;


### PR DESCRIPTION
Wrong macro used to translate source index.

Fixes: 86eb803984c3 ("clock: ad9545: Add reference priorities")
Signed-off-by: Alexandru Tachici <alexandru.tachici@analog.com>