### PR TITLE
iio: adrv9002: fix possible data races

### DIFF
--- a/drivers/iio/adc/navassa/adrv9002_debugfs.c
+++ b/drivers/iio/adc/navassa/adrv9002_debugfs.c
@@ -31,10 +31,12 @@ static ssize_t adrv9002_rx_adc_type_get(struct file *file, char __user *userbuf,
 	adi_adrv9001_AdcType_e adc_type;
 	int ret, len;
 
-	if (!rx->channel.enabled)
-		return -ENODEV;
-
 	mutex_lock(&phy->lock);
+	if (!rx->channel.enabled) {
+		mutex_unlock(&phy->lock);
+		return -ENODEV;
+	}
+
 	ret = adi_adrv9001_Rx_AdcType_Get(phy->adrv9001, rx->channel.number,
 					  &adc_type);
 	mutex_unlock(&phy->lock);
@@ -64,10 +66,12 @@ static int adrv9002_rx_gain_control_pin_mode_show(struct seq_file *s,
 	int ret;
 	struct adi_adrv9001_RxGainControlPinCfg cfg = {0};
 
-	if (!rx->channel.enabled)
-		return -ENODEV;
-
 	mutex_lock(&phy->lock);
+	if (!rx->channel.enabled) {
+		mutex_unlock(&phy->lock);
+		return -ENODEV;
+	}
+
 	ret = adi_adrv9001_Rx_GainControl_PinMode_Inspect(phy->adrv9001,
 							  rx->channel.number,
 							  &cfg);
@@ -93,10 +97,12 @@ static int adrv9002_rx_agc_config_show(struct seq_file *s, void *ignored)
 	struct adi_adrv9001_GainControlCfg agc = {0};
 	int ret;
 
-	if (!rx->channel.enabled)
-		return -ENODEV;
-
 	mutex_lock(&phy->lock);
+	if (!rx->channel.enabled) {
+		mutex_unlock(&phy->lock);
+		return -ENODEV;
+	}
+
 	ret = adi_adrv9001_Rx_GainControl_Inspect(phy->adrv9001,
 						  rx->channel.number, &agc);
 	mutex_unlock(&phy->lock);
@@ -176,6 +182,11 @@ static ssize_t adrv9002_rx_agc_config_write(struct file *file, const char __user
 	int ret;
 
 	mutex_lock(&phy->lock);
+	if (!rx->channel.enabled) {
+		mutex_unlock(&phy->lock);
+		return -ENODEV;
+	}
+
 	ret = adi_adrv9001_Rx_GainControl_Configure(phy->adrv9001, rx->channel.number,
 						    &rx->agc);
 	mutex_unlock(&phy->lock);
@@ -289,10 +300,12 @@ static int adrv9002_tx_dac_full_scale_get(void *arg, u64 *val)
 	int ret;
 	bool enable;
 
-	if (!tx->channel.enabled)
-		return -ENODEV;
-
 	mutex_lock(&phy->lock);
+	if (!tx->channel.enabled) {
+		mutex_unlock(&phy->lock);
+		return -ENODEV;
+	}
+
 	ret = adi_adrv9001_Tx_OutputPowerBoost_Get(phy->adrv9001,
 						   tx->channel.number, &enable);
 	mutex_unlock(&phy->lock);
@@ -314,10 +327,12 @@ static int adrv9002_tx_pin_atten_control_show(struct seq_file *s, void *ignored)
 	struct adi_adrv9001_TxAttenuationPinControlCfg cfg = {0};
 	int ret;
 
-	if (!tx->channel.enabled)
-		return -ENODEV;
-
 	mutex_lock(&phy->lock);
+	if (!tx->channel.enabled) {
+		mutex_unlock(&phy->lock);
+		return -ENODEV;
+	}
+
 	ret = adi_adrv9001_Tx_Attenuation_PinControl_Inspect(phy->adrv9001,
 							     tx->channel.number,
 							     &cfg);
@@ -511,10 +526,12 @@ static int adrv9002_ssi_rx_test_mode_set(void *arg, const u64 val)
 	struct adrv9002_rf_phy *phy = rx_to_phy(rx, rx->channel.idx);
 	int ret;
 
-	if (!rx->channel.enabled)
-		return -ENODEV;
-
 	mutex_lock(&phy->lock);
+	if (!rx->channel.enabled) {
+		mutex_unlock(&phy->lock);
+		return -ENODEV;
+	}
+
 	ret = adi_adrv9001_Ssi_Rx_TestMode_Configure(phy->adrv9001, rx->channel.number,
 						     phy->ssi_type,
 						     ADI_ADRV9001_SSI_FORMAT_16_BIT_I_Q_DATA,
@@ -620,8 +637,13 @@ static int adrv9002_tx_ssi_test_mode_loopback_set(void *arg, const u64 val)
 	if (enable == tx->loopback)
 		return 0;
 
-	tx->loopback = enable;
 	mutex_lock(&phy->lock);
+	if (!tx->channel.enabled) {
+		mutex_unlock(&phy->lock);
+		return -ENODEV;
+	}
+
+	tx->loopback = enable;
 	ret = adi_adrv9001_Ssi_Loopback_Set(phy->adrv9001, tx->channel.number, phy->ssi_type,
 					    enable);
 	mutex_unlock(&phy->lock);
@@ -642,10 +664,12 @@ static int adrv9002_ssi_tx_test_mode_set(void *arg, const u64 val)
 	struct adrv9002_rf_phy *phy = tx_to_phy(tx, tx->channel.idx);
 	int ret;
 
-	if (!tx->channel.enabled)
-		return -ENODEV;
-
 	mutex_lock(&phy->lock);
+	if (!tx->channel.enabled) {
+		mutex_unlock(&phy->lock);
+		return -ENODEV;
+	}
+
 	ret = adrv9002_axi_tx_test_pattern_cfg(phy, tx->channel.idx, tx->ssi_test.testData);
 	if (ret)
 		goto unlock;
@@ -672,10 +696,12 @@ static int adrv9002_ssi_tx_test_mode_status_show(struct seq_file *s,
 	adi_adrv9001_TxSsiTestModeStatus_t ssi_status = {0};
 	int ret;
 
-	if (!tx->channel.enabled)
-		return -ENODEV;
-
 	mutex_lock(&phy->lock);
+	if (!tx->channel.enabled) {
+		mutex_unlock(&phy->lock);
+		return -ENODEV;
+	}
+
 	ret = adi_adrv9001_Ssi_Tx_TestMode_Status_Inspect(phy->adrv9001,
 							  tx->channel.number,
 							  phy->ssi_type,
@@ -760,6 +786,11 @@ static int adrv9002_enablement_delays_show(struct seq_file *s, void *ignored)
 	int ret;
 
 	mutex_lock(&phy->lock);
+	if (!chan->enabled) {
+		mutex_unlock(&phy->lock);
+		return -ENODEV;
+	}
+
 	ret = adi_adrv9001_Radio_ChannelEnablementDelays_Inspect(phy->adrv9001, chan->port,
 								 chan->number, &en_delays);
 	mutex_unlock(&phy->lock);
@@ -789,6 +820,11 @@ static ssize_t adrv9002_enablement_delays_write(struct file *file, const char __
 	adrv9002_en_delays_ns_to_arm(phy, &chan->en_delays_ns, &en_delays);
 
 	mutex_lock(&phy->lock);
+	if (!chan->enabled) {
+		mutex_unlock(&phy->lock);
+		return -ENODEV;
+	}
+
 	ret = adrv9002_channel_to_state(phy, chan, ADI_ADRV9001_CHANNEL_CALIBRATED, true);
 	if (ret)
 		goto unlock;


### PR DESCRIPTION
We need to synchronize all IIO accesses on the device channels with
updating the device profile. This means, that all checks like:

```
if (!chan->enabled)
        return -ENODEV;
```

__must__ be done inside the device lock. Otherwise something like the
following could happen:
 1. CPU1 tries to do some configuration on TX1 (passes `the tx->enabled`);
 2. CPU2 starts a profile update and grabs the lock;
 3. CPU1 will wait on the lock before doing the configuration;
 4. CPU2 releases the lock (new profile disables TX1);
 5. CPU1 will try to do something on a disabled channel.

Best case scenario we just get an error from the device. Worst case, we
"lock" the device firmware...

While applying this change to debugfs interfaces, we just unify checking if
the channel is enabled or not (as this is simple enough to sneak in this
patch). In some places we were doing it while not in some other functions.
Now, we do the check in all functions...

Signed-off-by: Nuno Sá <nuno.sa@analog.com>