### PR TITLE
iio: jesd204: axi_adxcvr: Support for physical layer PRBS

### DIFF
--- a/drivers/iio/jesd204/axi_adxcvr.h
+++ b/drivers/iio/jesd204/axi_adxcvr.h
@@ -13,6 +13,7 @@
 
 #include <linux/clk.h>
 #include <linux/clk-provider.h>
+#include <linux/mutex.h>
 #include <linux/fpga/adi-axi-common.h>
 #include <linux/jesd204/jesd204.h>
 
@@ -49,6 +50,15 @@
 #define ADXCVR_DRP_PORT_COMMON(x)	(x)
 #define ADXCVR_DRP_PORT_CHANNEL(x)	(0x100 + (x))
 
+#define ADXCVR_REG_REG_PRBS_CNTRL	0x0180
+#define ADXCVR_PRBSEL(x)		(((x) & 0xF) << 0)
+#define ADXCVR_PRBS_CNT_RESET		BIT(8)
+#define ADXCVR_PRBS_FORCE_ERR		BIT(16)
+
+#define ADXCVR_REG_REG_PRBS_STATUS	0x0184
+#define ADXCVR_PRBS_ERR(x)		((x) & BIT(8))
+#define ADXCVR_PRBS_LOCKED(x)		((x) & BIT(0))
+
 struct adxcvr_state {
 	struct device		*dev;
 	void __iomem		*regs;
@@ -59,6 +69,7 @@ struct adxcvr_state {
 	struct clk_hw		lane_clk_hw;
 	struct clk_hw		qpll_clk_hw;
 	struct work_struct	work;
+	struct mutex		mutex;
 	unsigned long		lane_rate;
 	bool			tx_enable;
 	bool			qpll_enable;

--- a/drivers/iio/jesd204/xilinx_transceiver.h
+++ b/drivers/iio/jesd204/xilinx_transceiver.h
@@ -124,4 +124,10 @@ int xilinx_xcvr_drp_update(struct xilinx_xcvr *xcvr,
 	unsigned int drp_port, unsigned int reg, unsigned int mask,
 	unsigned int val);
 
+int xilinx_xcvr_prbsel_enc_get(struct xilinx_xcvr *xcvr,
+	unsigned int prbs, bool reverse_lu);
+
+int xilinx_xcvr_prbs_err_cnt_get(struct xilinx_xcvr *xcvr,
+	unsigned int drp_port, unsigned int *cnt);
+
 #endif


### PR DESCRIPTION
This commit adds support for physical layer PRBS Generation and Checking.
The new feature is supported starting with HDL core version 17.02.a
Depending on the direction AXI-ADXCVR-RX or AXI-ADXCVR-TX different new
sysfs files are supported which are explained below.


axi-adxcvr-rx:
prbs_select
  Writing selects the PRBS type. (accepted values depend on the GT
  architecture) Reading returns the selected type.
    0: PRBS_DISABLE
    7: PRBS7
    9: PRBS9
    15: PRBS15
    23: PRBS23
    31: PRBS31

prbs_status:
  Reading returns a status string. Values are:
    unlocked: The PRBS is unlocked
    valid: The PRBS is locked and no errors are detected
    error: The PRBS has locked but errors were detected

  These conditions are sticky and can be cleared by writing 1 to
  prbs_counter_reset

prbs_error_counters:
  Reading returns a string with error counts for each physical
  JESD204 lane.

prbs_counter_reset:
  Writing 1 will clear the prbs_status and reset the prbs_error_counters


axi-adxcvr-tx:
prbs_select
  Writing selects the PRBS type. (accepted values depend on the GT
  architecture) Reading returns the selected type.
    0: PRBS_DISABLE
    7: PRBS7
    9: PRBS9
    15: PRBS15
    23: PRBS23
    31: PRBS31

prbs_error_inject:
  Writing 1 injects a series of errors´(used for testing)

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>