### PR TITLE
adrv9002 tx only profiles

### DIFF
--- a/drivers/iio/adc/navassa/adrv9002.h
+++ b/drivers/iio/adc/navassa/adrv9002.h
@@ -200,6 +200,11 @@ struct adrv9002_rf_phy {
 	u8				rx2tx2;
 	/* ssi type of the axi cores - cannot really change at runtime */
 	enum adi_adrv9001_SsiType	ssi_type;
+	/*
+	 * Tells if TX only profiles are valid. If not set, it means that TX1/TX2 SSI clocks are
+	 * derived from RX1/RX2 which means that TX cannot be enabled if RX is not...
+	 */
+	u8				tx_only;
 #ifdef CONFIG_DEBUG_FS
 	struct adi_adrv9001_SsiCalibrationCfg ssi_delays;
 #endif
@@ -220,10 +225,11 @@ int __adrv9002_dev_err(const struct adrv9002_rf_phy *phy, const char *function, 
 
 int adrv9002_register_axi_converter(struct adrv9002_rf_phy *phy);
 int adrv9002_axi_interface_set(struct adrv9002_rf_phy *phy, const u8 n_lanes,
-			       const bool cmos_ddr, const int channel);
+			       const bool cmos_ddr, const int channel, const bool tx);
 int adrv9002_axi_intf_tune(struct adrv9002_rf_phy *phy, const bool tx, const int chann,
 			   u8 *clk_delay, u8 *data_delay);
-void adrv9002_axi_interface_enable(struct adrv9002_rf_phy *phy, const int chan, const bool en);
+void adrv9002_axi_interface_enable(struct adrv9002_rf_phy *phy, const int chan, const bool tx,
+				   const bool en);
 int __maybe_unused adrv9002_axi_tx_test_pattern_cfg(struct adrv9002_rf_phy *phy, const int channel,
 						    const adi_adrv9001_SsiTestModeData_e data);
 int adrv9002_post_init(struct adrv9002_rf_phy *phy);

--- a/drivers/iio/adc/navassa/adrv9002_conv.c
+++ b/drivers/iio/adc/navassa/adrv9002_conv.c
@@ -440,21 +440,12 @@ int adrv9002_axi_intf_tune(struct adrv9002_rf_phy *phy, const bool tx, const int
 	u32 saved_ctrl_7[4];
 
 	if (tx) {
-		if (phy->rx2tx2 || !chann)
-			off = ADI_TX1_REG_OFF;
-		else
-			off = ADI_TX2_REG_OFF;
-
+		off = chann ? ADI_TX2_REG_OFF : ADI_TX1_REG_OFF;
 		/* generate test pattern for tx test  */
 		adrv9002_axi_tx_test_pattern_set(conv, off, saved_ctrl_7);
 	} else {
-		if (phy->rx2tx2 || !chann)
-			off = 0;
-		else
-			off = ADI_RX2_REG_OFF;
-
+		off = chann ? ADI_RX2_REG_OFF : 0;
 		adrv9002_axi_rx_test_pattern_pn_sel(conv, off);
-
 		/* start test */
 		ret = adrv9002_intf_test_cfg(phy, chann, tx, false);
 		if (ret)


### PR DESCRIPTION
The assumption until now was that TX ports could only be enabled if the RX port on the same channel (some differences in rx2tx2) was also enabled. The reason for this is that the TX clock is derived from RX SSI interface. While this will still be true for LVDS interfaces, it won't apply anymore for CMOS. In that case, we will be able to have TX ports enabled without the corresponding RX. Hence, the profile validations have to be done in a different way. These are the restrictions being applied on systems supporting tx only profiles:

1. Split mode can have all 4 ports with different rates;
2. Split mode can have any combination for enabling/disabling ports;
3. rx2tx2 mode cannot have RX2 enabled while RX1 is off (same for TX);
4. rx2tx2 mode cannot have RX2 rate != RX1 rate (same for TX).

These are the restrictions for non tx only profiles:

1. Split mode must have RX rate == TX rate;
2. Split mode cannot have TX enabled while RX is off on the same channel;
3. rx2tx2 mode must have the same rate in all ports;
4. rx2tx2 mode must have RX1 enabled otherwise the validations only passif all ports are disabled (which does not make sense);
5. rx2tx2 mode cannot have TX2 enabled while TX1 is off.

We get the information about supporting tx only profiles from the hdl core.