### PR TITLE
arch: arm: overlays: rpi-adxrs290 support

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -164,6 +164,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	rpi-adxl345.dtbo \
 	rpi-adxl372.dtbo \
 	rpi-adxl375.dtbo \
+	rpi-adxrs290.dtbo \
 	rpi-ad5770r.dtbo \
 	rpi-ad5791.dtbo \
 	rpi-backlight.dtbo \

--- a/arch/arm/boot/dts/overlays/rpi-adxrs290-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-adxrs290-overlay.dts
@@ -1,0 +1,32 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2836", "brcm,bcm2835";
+
+	fragment@0 {
+		target = <&spi0>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			adxrs290@0 {
+				compatible = "adi,adxrs290";
+				reg = <0>;
+				spi-max-frequency = <1000000>;
+				spi-cpha;
+				spi-cpol;
+				interrupts = <19 1>;
+				interrupt-parent = <&gpio>;
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&spidev0>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+};


### PR DESCRIPTION
Added support for adxrs290 via SPI0 of RPI.

Signed-off-by: kimpaller <kimchesed.paller@analog.com>