### PR TITLE
update kconfig with missing select statements

### DIFF
--- a/drivers/iio/adc/Kconfig
+++ b/drivers/iio/adc/Kconfig
@@ -166,6 +166,9 @@ config AD7766
 config AD7768
 	tristate "Analog Devices AD7768 ADC driver"
 	depends on SPI
+	select IIO_BUFFER
+	select IIO_BUFFER_DMA
+	select IIO_BUFFER_DMAENGINE
 	help
 	  Say yes here to build support for Analog Devices AD7768 SPI analog to
 	  digital converter (ADC).
@@ -179,6 +182,8 @@ config AD7768_1
 	select IIO_BUFFER
 	select IIO_TRIGGER
 	select IIO_TRIGGERED_BUFFER
+	select IIO_BUFFER_DMA
+	select IIO_BUFFER_DMAENGINE
 	help
 	  Say yes here to build support for Analog Devices AD7768-1 SPI
 	  simultaneously sampling sigma-delta analog to digital converter (ADC).


### PR DESCRIPTION
These select statements allow AD7768 and AD7768-1 to be compiled as part of the kernel