### PR TITLE
drivers: frequency: cf_axi_dds: Add dacfifo singleshot output support

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9081-m8-l4.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9081-m8-l4.dts
@@ -355,3 +355,7 @@
 		};
 	};
 };
+
+&axi_ad9081_core_tx {
+	single-shot-output-gpios = <&gpio 139 0>;
+};


### PR DESCRIPTION
This commit adds support for a new single-shot mode of util_dacfifo.

Note: This feature requires HDL support and is only enabled if the
single-shot-output-gpios attribute is provided in the device tree!

Signed-off-by: David Winter <david.winter@analog.com>