### PR TITLE
drivers:iio:light: add ADPD188 driver support

### DIFF
--- a/drivers/iio/Kconfig.adi
+++ b/drivers/iio/Kconfig.adi
@@ -156,3 +156,5 @@ config IIO_ALL_ADI_DRIVERS
 	select AXI_JESD204_RX
 	select AXI_ADXCVR
 	select ONE_BIT_ADC_DAC
+	select ADPD188_I2C if I2C
+	select ADPD188_SPI if SPI

--- a/drivers/iio/light/Kconfig
+++ b/drivers/iio/light/Kconfig
@@ -526,4 +526,33 @@ config ZOPT2201
 	  To compile this driver as a module, choose M here: the
 	  module will be called zopt2201.
 
+config ADPD188
+	tristate
+
+config ADPD188_SPI
+	tristate "Analog Devices ADPD188 Integrated Optical Module for Smoke Detection SPI Driver"
+	depends on SPI
+	select ADPD188
+	select REGMAP_SPI
+	help
+	  Say yes here if you want to build a driver for the Analog Devices
+	  Integrated Optical Module for Smoke Detection.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called adpd188_spi and you will also get adpd188
+	  for the core module.
+
+config ADPD188_I2C
+	tristate "Analog Devices ADPD188 Integrated Optical Module for Smoke Detection I2C Driver"
+	depends on I2C
+	select ADPD188
+	select REGMAP_I2C
+	help
+	  Say yes here if you want to build a driver for the Analog Devices
+	  Integrated Optical Module for Smoke Detection.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called adpd188_i2c and you will also get adpd188
+	  for the core module.
+
 endmenu

--- a/drivers/iio/light/Makefile
+++ b/drivers/iio/light/Makefile
@@ -6,6 +6,9 @@
 # When adding new entries keep the list in alphabetical order
 obj-$(CONFIG_ACPI_ALS)		+= acpi-als.o
 obj-$(CONFIG_ADJD_S311)		+= adjd_s311.o
+obj-$(CONFIG_ADPD188)		+= adpd188.o
+obj-$(CONFIG_ADPD188_I2C)	+= adpd188_i2c.o
+obj-$(CONFIG_ADPD188_SPI)	+= adpd188_spi.o
 obj-$(CONFIG_AL3320A)		+= al3320a.o
 obj-$(CONFIG_APDS9300)		+= apds9300.o
 obj-$(CONFIG_APDS9960)		+= apds9960.o

--- a/drivers/iio/light/adpd188.c
+++ b/drivers/iio/light/adpd188.c
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-2.0+
+/*
+ * ADPD188 driver
+ *
+ * Copyright 2021 Analog Devices Inc.
+ */
+
+#include <linux/i2c.h>
+#include <linux/regmap.h>
+#include <linux/iio/iio.h>
+#include <linux/device.h>
+#include <linux/module.h>
+
+#include "adpd188.h"
+
+struct adpd188 {
+	struct regmap *regmap;
+};
+
+static int adpd188_reg_access(struct iio_dev *indio_dev,
+	unsigned int reg,
+	unsigned int tx_val,
+	unsigned int *rx_val)
+{
+	struct adpd188 *dev = iio_priv(indio_dev);
+
+	if (rx_val)
+		return regmap_read(dev->regmap, reg, rx_val);
+	else
+		return regmap_write(dev->regmap, reg, tx_val);
+}
+
+static const struct iio_info adpd188_info = {
+	.debugfs_reg_access = &adpd188_reg_access,
+};
+
+int adpd188_core_probe(struct device *dev, struct regmap *regmap,
+                       const char *name)
+{
+	struct iio_dev *indio_dev;
+	struct adpd188 *dev_data;
+	int ret;
+
+	indio_dev = devm_iio_device_alloc(dev, sizeof(*dev_data));
+	if (!indio_dev) {
+		dev_err(dev, "Error allocating IIO device memory: %ld\n",
+			PTR_ERR(indio_dev));
+		return -ENOMEM;
+	}
+
+	dev_set_drvdata(dev, indio_dev);
+	dev_data = iio_priv(indio_dev);
+	dev_data->regmap = regmap;
+
+	indio_dev->dev.parent = dev;
+	indio_dev->info = &adpd188_info;
+	indio_dev->name = name;
+
+	ret = iio_device_register(indio_dev);
+        if (ret < 0)
+                dev_err(dev, "iio_device_register failed: %d\n", ret);
+	else
+		dev_info(dev, "%s probed\n", indio_dev->name);
+
+	return ret;
+}
+EXPORT_SYMBOL_GPL(adpd188_core_probe);
+
+int adpd188_core_remove(struct device *dev)
+{
+        struct iio_dev *indio_dev = dev_get_drvdata(dev);
+
+        iio_device_unregister(indio_dev);
+
+	return 0;
+}
+
+MODULE_AUTHOR("Andrei Drimbarean <andrei.drimbarean@analog.com>");
+MODULE_DESCRIPTION("Analog Devices ADPD188core driver");
+MODULE_LICENSE("GPL v2");
+

--- a/drivers/iio/light/adpd188.h
+++ b/drivers/iio/light/adpd188.h
@@ -1,0 +1,20 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * ADPD188 Integrated Optical Module for Smoke Detection
+ *
+ * Copyright 2021 Analog Devices Inc.
+ */
+
+#ifndef _ADPD188_H_
+#define _ADPD188_H_
+
+enum supported_parts {
+	ADPD188
+};
+
+int adpd188_core_probe(struct device *dev, struct regmap *regmap,
+                       const char *name);
+int adpd188_core_remove(struct device *dev);
+
+#endif /* _ADPD188_H_ */
+

--- a/drivers/iio/light/adpd188_i2c.c
+++ b/drivers/iio/light/adpd188_i2c.c
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * ADPD188 I2C driver
+ *
+ * Copyright 2021 Analog Devices Inc.
+ *
+ * 7-bit I2C slave address: 0x64 
+ */
+
+#include <linux/i2c.h>
+#include <linux/module.h>
+#include <linux/regmap.h>
+
+#include "adpd188.h"
+
+const struct regmap_config adpd188_i2c_regmap_config = {
+	.reg_bits = 8,
+	.val_bits = 16,
+	.max_register = 0x7F,
+};
+
+static int adpd188_i2c_probe(struct i2c_client *i2c)
+{
+	//const struct i2c_device_id *id;
+	struct regmap *regmap;
+	int ret;
+
+	regmap = devm_regmap_init_i2c(i2c, &adpd188_i2c_regmap_config);
+	if (IS_ERR(regmap)) {
+		dev_err(&i2c->dev, "Error initializing i2c regmap: %ld\n",
+                        PTR_ERR(regmap));
+		return PTR_ERR(regmap);
+	}
+
+	return adpd188_core_probe(&i2c->dev, regmap, i2c->name);
+}
+
+static int adpd188_i2c_remove(struct i2c_client *client)
+{
+        return adpd188_core_remove(&client->dev);
+}
+
+static const struct i2c_device_id adpd188_i2c_id[] = {
+	{ "adpd188", ADPD188 },
+        {}
+};
+MODULE_DEVICE_TABLE(i2c, adpd188_i2c_id);
+
+static const struct of_device_id adpd188_of_match[] = {
+	{ .compatible = "adi,adpd188" },
+	{},
+};
+MODULE_DEVICE_TABLE(of, adpd188_of_match);
+
+static struct i2c_driver adpd188_i2c_driver = {
+	.driver = {
+			.name = "adpd188_i2c",
+			.of_match_table = of_match_ptr(adpd188_of_match),
+		},
+	.probe_new = adpd188_i2c_probe,
+	.remove = adpd188_i2c_remove,
+	.id_table = adpd188_i2c_id,
+};
+module_i2c_driver(adpd188_i2c_driver);
+
+MODULE_AUTHOR("Andrei Drimbarean <andrei.drimbarean@analog.com>");
+MODULE_DESCRIPTION("Analog Devices ADPD188 I2C driver");
+MODULE_LICENSE("GPL v2");
+

--- a/drivers/iio/light/adpd188_spi.c
+++ b/drivers/iio/light/adpd188_spi.c
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * ADPD188 SPI driver
+ *
+ * Copyright 2021 Analog Devices Inc.
+ *
+ * 7-bit I2C slave address: 0x64 
+ */
+
+#include <linux/module.h>
+#include <linux/regmap.h>
+#include <linux/spi/spi.h>
+#include <linux/of.h>
+
+#include "adpd188.h"
+
+const struct regmap_config adpd188_spi_regmap_config = {
+	.reg_bits = 7,
+	.pad_bits = 1,
+	.write_flag_mask = BIT(0),
+	.val_bits = 16,
+	.max_register = 0x7F,
+};
+
+static int adpd188_spi_probe(struct spi_device *spi)
+{
+        const struct spi_device_id *id = spi_get_device_id(spi);
+        struct regmap *regmap;
+
+	regmap = devm_regmap_init_spi(spi, &adpd188_spi_regmap_config);
+	if (IS_ERR(regmap)) {
+		dev_err(&spi->dev, "Error initializing spi regmap: %ld\n",
+			PTR_ERR(regmap));
+		return PTR_ERR(regmap);
+	}
+
+	return adpd188_core_probe(&spi->dev, regmap, id->name);
+}
+
+static int adpd188_spi_remove(struct spi_device *spi)
+{
+        return adpd188_core_remove(&spi->dev);
+}
+
+static const struct spi_device_id adpd188_spi_id[] = {
+	{ "adpd188", ADPD188 },
+        {}
+};
+MODULE_DEVICE_TABLE(spi, adpd188_spi_id);
+
+static const struct of_device_id adpd188_of_match[] = {
+	{ .compatible = "adi,adpd188" },
+	{},
+};
+MODULE_DEVICE_TABLE(of, adpd188_of_match);
+
+static struct spi_driver adpd188_spi_driver = {
+	.driver = {
+			.name = "adpd188_spi",
+			.of_match_table = of_match_ptr(adpd188_of_match),
+		},
+	.probe = adpd188_spi_probe,
+	.remove = adpd188_spi_remove,
+	.id_table = adpd188_spi_id,
+};
+module_spi_driver(adpd188_spi_driver);
+
+MODULE_AUTHOR("Andrei Drimbarean <andrei.drimbarean@analog.com>");
+MODULE_DESCRIPTION("Analog Devices ADPD188 SPI driver");
+MODULE_LICENSE("GPL v2");
+


### PR DESCRIPTION
Add IIO driver support for the ADPD188 device.

More information about the device at: https://www.analog.com/media/en/technical-documentation/data-sheets/adpd188bi.pdf

Signed-off-by: Andrei Drimbarean <Andrei.Drimbarean@analog.com>