### PR TITLE
Fix adrv9002 ORx

### DIFF
--- a/drivers/iio/adc/navassa/adrv9002.c
+++ b/drivers/iio/adc/navassa/adrv9002.c
@@ -2291,8 +2291,6 @@ static int adrv9002_validate_profile(struct adrv9002_rf_phy *phy)
 		rx->channel.enabled = true;
 		rx->channel.nco_freq = 0;
 		rx->channel.rate = rx_cfg[i].profile.rxOutputRate_Hz;
-		rx->orx_en = ADRV9001_BF_EQUAL(phy->curr_profile->rx.rxInitChannelMask,
-					       orx_channels[i]);
 tx:
 		/* tx validations*/
 		if (!ADRV9001_BF_EQUAL(phy->curr_profile->tx.txInitChannelMask, tx_channels[i]))
@@ -2349,6 +2347,9 @@ tx:
 		}
 
 		dev_dbg(&phy->spi->dev, "TX%d enabled\n", i + 1);
+		/* orx actually depends on whether or not TX is enabled and not RX */
+		rx->orx_en = ADRV9001_BF_EQUAL(phy->curr_profile->rx.rxInitChannelMask,
+					       orx_channels[i]);
 		tx->power = true;
 		tx->enabled = true;
 		tx->nco_freq = 0;

--- a/drivers/iio/adc/navassa/adrv9002.c
+++ b/drivers/iio/adc/navassa/adrv9002.c
@@ -2957,6 +2957,9 @@ static void adrv9002_cleanup(struct adrv9002_rf_phy *phy)
 
 	for (i = 0; i < ADRV9002_CHANN_MAX; i++) {
 		phy->rx_channels[i].orx_en = 0;
+		/* make sure we have the ORx GPIO low */
+		if (phy->rx_channels[i].orx_gpio)
+			gpiod_set_value_cansleep(phy->rx_channels[i].orx_gpio, 0);
 		phy->rx_channels[i].channel.enabled = 0;
 		phy->tx_channels[i].channel.enabled = 0;
 	}

--- a/drivers/iio/adc/navassa/adrv9002.c
+++ b/drivers/iio/adc/navassa/adrv9002.c
@@ -1756,7 +1756,7 @@ static int adrv9002_phy_read_raw(struct iio_dev *indio_dev,
 
 			if (!rx->orx_gpio) {
 				mutex_unlock(&phy->lock);
-				return -ENODEV;
+				return -ENOTSUPP;
 			}
 
 			*val = gpiod_get_value_cansleep(rx->orx_gpio);
@@ -1874,7 +1874,7 @@ static int adrv9002_phy_write_raw(struct iio_dev *indio_dev,
 
 			if (!rx->orx_gpio) {
 				mutex_unlock(&phy->lock);
-				return -ENODEV;
+				return -ENOTSUPP;
 			}
 			gpiod_set_value_cansleep(rx->orx_gpio, !!val);
 		} else {


### PR DESCRIPTION
Fixes ORx not being enabled if the RX on the same channel is not... ORx actually depends on TX. The second patch is a minor change on a return value that (at this moment) should not have "side" effects