### PR TITLE
iio: adrv9002: set the correct string for duplex mode

### DIFF
--- a/drivers/iio/adc/navassa/adrv9002.c
+++ b/drivers/iio/adc/navassa/adrv9002.c
@@ -3769,7 +3769,7 @@ const char *const lo_maps[] = {
 };
 
 const char *const duplex[] = {
-	"TDM",
+	"TDD",
 	"FDD"
 };
 


### PR DESCRIPTION
The driver was returning TDM instead of TDD for TDD profiles...

Fixes: 13c38fb977a6e ("iio: adrv9002: support reading profile_config")
Signed-off-by: Nuno Sá <nuno.sa@analog.com>