### PR TITLE
Ad9545 sys clock compensation

### DIFF
--- a/Documentation/devicetree/bindings/clock/clk-ad9545.yaml
+++ b/Documentation/devicetree/bindings/clock/clk-ad9545.yaml
@@ -59,6 +59,9 @@ properties:
       - description: Ref AA clock input
       - description: Ref B clock input
       - description: Ref BB clock input
+      - description: Ref M0 clock input
+      - description: Ref M1 clock input
+      - description: Ref M2 clock input
     maxItems: 4
 
   assigned-clocks:
@@ -78,7 +81,63 @@ properties:
   clock-output-names:
     maxItems: 10
 
+  aux-dpll@0:
+    description: |
+      Auxiliary DPLL used for Closed-Loop method of system clock compensation.
+    type: object
+
+    properties:
+      reg:
+        maxItems: 1
+
+      adi,compensation-source:
+        description: |
+          System clock closed loop compensation source.
+          Choose from Ref-A to Ref-BB [0-3] or aux TDCs [4-5].
+        $ref: /schemas/types.yaml#/definitions/uint32
+        enum: [0, 1, 2, 3, 4, 5]
+
+      adi,aux-dpll-bw-mhz:
+        description: |
+          Auxiliary DPLL bandwidth.
+        minimum: 100
+        maximum: 2000000
+
+      adi,rate-change-limit:
+        description: |
+          Error compensation rate change limiting expressed in ppb/s. Disabled if property is
+          missing.
+        $ref: /schemas/types.yaml#/definitions/uint32
+        enum: [715, 1430, 2860, 5720, 11440, 22880, 45760]
+
+    required:
+      - reg
+      - adi,compensation-source
+      - adi,aux-dpll-bw-mhz
+
 patternProperties:
+  "^aux-tdc-clk@[0-1]$":
+    description: |
+      Represents a Mx pin reference clock input.
+    type: object
+
+    properties:
+      reg:
+        description: |
+          Address of the Auxiliary TDC.
+        maximum: 1
+
+      adi,pin-nr:
+        description: |
+          Pin number to be the source of this TDC.
+        $ref: /schemas/types.yaml#/definitions/uint32
+        minimum: 0
+        maximum: 6
+
+    required:
+      - reg
+      - adi,pin-nr
+
   "^ref-input-clk@[0-3]$":
     description: |
       Represents a reference clock input.

--- a/include/dt-bindings/clock/ad9545.h
+++ b/include/dt-bindings/clock/ad9545.h
@@ -34,6 +34,7 @@
 #define AD9545_CLK_OUT			0
 #define AD9545_CLK_PLL			1
 #define AD9545_CLK_NCO			2
+#define AD9545_CLK_AUX_TDC		3
 
 /* PLL addresses */
 #define AD9545_PLL0			0
@@ -54,6 +55,10 @@
 /* NCO addresses */
 #define AD9545_NCO0			0
 #define AD9545_NCO1			1
+
+/* TDC addresses */
+#define AD9545_CLK_AUX_TDC0		0
+#define AD9545_CLK_AUX_TDC1		1
 
 /* Ex:
  * Output Q0C clock: <&ad9545_clock AD9545_CLK_OUT AD9545_Q0C>;


### PR DESCRIPTION
Aux. DPLL can be used as closed loop compensation for the system clock.
A stable reference can be used as a source for the Aux. DPLL. This source
can be received at one of the Mx pins and routed through an aux. TDC
or can be an input Ref. X.