### PR TITLE
Fix ad9162

### DIFF
--- a/drivers/iio/frequency/ad9162.c
+++ b/drivers/iio/frequency/ad9162.c
@@ -465,17 +465,6 @@ static int ad9162_write_raw(struct iio_dev *indio_dev,
 	return 0;
 }
 
-static int ad9162_prepare(struct cf_axi_converter *conv)
-{
-	struct cf_axi_dds_state *st = iio_priv(conv->indio_dev);
-	struct ad9162_state *ad9162 = to_ad916x_state(conv);
-
-	/* FIXME This needs documenation */
-	dds_write(st, 0x428, (ad9162->complex_mode ? 0x1 : 0x0) |
-		  (ad9162->iq_swap ? 0x2 : 0x0));
-	return 0;
-}
-
 static const struct regmap_config ad9162_regmap_config = {
 	.reg_bits = 16,
 	.val_bits = 8,
@@ -566,7 +555,7 @@ static ssize_t ad9162_attr_show(struct device *dev,
 }
 
 
-static IIO_DEVICE_ATTR(out_altvoltage2_frequency_nco,
+static IIO_DEVICE_ATTR(out_altvoltage4_frequency_nco,
 		       0644,
 		       ad9162_attr_show,
 		       ad9162_attr_store,
@@ -580,7 +569,7 @@ static IIO_DEVICE_ATTR(out_voltage_fir85_enable,
 		       1);
 
 static struct attribute *ad9162_attributes[] = {
-	&iio_dev_attr_out_altvoltage2_frequency_nco.dev_attr.attr,
+	&iio_dev_attr_out_altvoltage4_frequency_nco.dev_attr.attr,
 	&iio_dev_attr_out_voltage_fir85_enable.dev_attr.attr,
 	NULL,
 };
@@ -893,7 +882,6 @@ static int ad9162_probe(struct spi_device *spi)
 
 	conv->write = ad9162_write;
 	conv->read = ad9162_read;
-	conv->setup = ad9162_prepare;
 
 	conv->get_data_clk = ad9162_get_data_clk;
 	conv->write_raw = ad9162_write_raw;

--- a/drivers/iio/frequency/cf_axi_dds.c
+++ b/drivers/iio/frequency/cf_axi_dds.c
@@ -1187,13 +1187,16 @@ static struct cf_axi_dds_chip_info cf_axi_dds_chip_info_tbl[] = {
 	[ID_AD9162_COMPLEX] = {
 		.name = "AD9162",
 		.channel = {
-			CF_AXI_DDS_CHAN_BUF(0),
-			CF_AXI_DDS_CHAN_BUF(1),
-			CF_AXI_DDS_CHAN(0, 0, "1A"),
-			CF_AXI_DDS_CHAN(1, 0, "1B"),
+			CF_AXI_DDS_CHAN_BUF_MOD(0, IIO_MOD_I, 0),
+			CF_AXI_DDS_CHAN_BUF_MOD(0, IIO_MOD_Q, 1),
+			CF_AXI_DDS_CHAN(0, 0, "TX1_I_F1"),
+			CF_AXI_DDS_CHAN(1, 0, "TX1_I_F2"),
+			CF_AXI_DDS_CHAN(2, 0, "TX1_Q_F1"),
+			CF_AXI_DDS_CHAN(3, 0, "TX1_Q_F2"),
 		},
-		.num_channels = 4,
-		.num_dds_channels = 2,
+		.num_channels = 6,
+		.num_dp_disable_channels = 2,
+		.num_dds_channels = 4,
 		.num_buf_channels = 2,
 	},
 	[ID_AD9172_M2] = {
@@ -2134,7 +2137,7 @@ static int cf_axi_dds_probe(struct platform_device *pdev)
 	if (info && !info->rate_format_skip_en)
 		dds_write(st, ADI_REG_RATECNTRL, ADI_RATE(rate));
 
-	if (conv) {
+	if (conv && conv->setup) {
 		ret = conv->setup(conv);
 		if (ret < 0)
 			goto err_converter_put;


### PR DESCRIPTION
iio: frequency: ad9162: Fix complex NCO mode

Some time ago the HDL design was updated to use M=2, so the complex mode
workaround using HDL TPL core register 0x428 is no longer necessary.
In addition the DDS channel defines are missing two channels.
This patch fixes this. However this caused the
out_altvoltage2_frequency_nco channel attribute to collide with the added
out_altvoltage2_TX1_Q_F1_raw attribute and libiio wasn't able to resolve
the extended_name anymore. This fixes this issue by changing the
requency_nco attribute to channel4.