### PR TITLE
adrv9002 2019 r2 backports

### DIFF
--- a/drivers/iio/adc/navassa/adrv9002.c
+++ b/drivers/iio/adc/navassa/adrv9002.c
@@ -2045,6 +2045,9 @@ static int adrv9002_compute_init_cals(struct adrv9002_rf_phy *phy)
 			dev_err(&phy->spi->dev, "SSI interface mismatch. PHY=%d, RX%d=%d\n",
 				ssi_type, i + 1, rx_cfg[i].profile.rxSsiConfig.ssiType);
 			return -EINVAL;
+		} else if (rx_cfg[i].profile.rxSsiConfig.strobeType == ADI_ADRV9001_SSI_LONG_STROBE) {
+			dev_err(&phy->spi->dev, "SSI interface Long Strobe not supported\n");
+			return -EINVAL;
 		}
 
 		dev_dbg(&phy->spi->dev, "RX%d enabled\n", i);
@@ -2061,6 +2064,9 @@ tx:
 		if (ssi_type != tx_cfg[i].txSsiConfig.ssiType) {
 			dev_err(&phy->spi->dev, "SSI interface mismatch. PHY=%d, TX%d=%d\n",
 				ssi_type, i + 1,  tx_cfg[i].txSsiConfig.ssiType);
+			return -EINVAL;
+		} else if (tx_cfg[i].txSsiConfig.strobeType == ADI_ADRV9001_SSI_LONG_STROBE) {
+			dev_err(&phy->spi->dev, "SSI interface Long Strobe not supported\n");
 			return -EINVAL;
 		} else if (phy->rx2tx2) {
 			if (!phy->tx_only && !phy->rx_channels[0].channel.enabled) {

--- a/drivers/iio/adc/navassa/adrv9002.h
+++ b/drivers/iio/adc/navassa/adrv9002.h
@@ -169,6 +169,11 @@ struct adrv9002_rf_phy {
 	int				spi_device_id;
 	int				ngpios;
 	u8				rx2tx2;
+	/*
+	 * Tells if TX only profiles are valid. If not set, it means that TX1/TX2 SSI clocks are
+	 * derived from RX1/RX2 which means that TX cannot be enabled if RX is not...
+	 */
+	u8				tx_only;
 #ifdef CONFIG_DEBUG_FS
 	struct adi_adrv9001_SsiCalibrationCfg ssi_delays;
 #endif
@@ -182,11 +187,12 @@ int adrv9002_hdl_loopback(struct adrv9002_rf_phy *phy, bool enable);
 int adrv9002_register_axi_converter(struct adrv9002_rf_phy *phy);
 int adrv9002_axi_interface_set(struct adrv9002_rf_phy *phy, const u8 n_lanes,
 			       const u8 ssi_intf, const bool cmos_ddr,
-			       const int channel);
+			       const int channel, const bool tx);
 struct adrv9002_rf_phy *adrv9002_spi_to_phy(struct spi_device *spi);
 int adrv9002_axi_intf_tune(struct adrv9002_rf_phy *phy, const bool tx, const int chann,
 			   const adi_adrv9001_SsiType_e ssi_type, u8 *clk_delay, u8 *data_delay);
-void adrv9002_axi_interface_enable(struct adrv9002_rf_phy *phy, const int chan, const bool en);
+void adrv9002_axi_interface_enable(struct adrv9002_rf_phy *phy, const int chan, const bool tx,
+				   const bool en);
 int __maybe_unused adrv9002_axi_tx_test_pattern_cfg(struct adrv9002_rf_phy *phy, const int channel,
 						    const adi_adrv9001_SsiTestModeData_e data);
 int adrv9002_spi_read(struct spi_device *spi, u32 reg);


### PR DESCRIPTION
This backports two fixes for 2019_R2:

* Allow TX only profiles to be loaded. Without this, we would return error in case tx is enabled and rx not. However, in some cases (as explained in the patch log) that is actually possible...
* With the new SDK release, we can select between long/short SSI strobes. However, we only support short strobe so we cannot allow profiles with long strobe configured.