### PR TITLE
Adin1100 ethtool supp

### DIFF
--- a/drivers/net/phy/adin1100.c
+++ b/drivers/net/phy/adin1100.c
@@ -33,6 +33,7 @@ static __ETHTOOL_DECLARE_LINK_MODE_MASK(phy_adin_t1l_features)	__ro_after_init;
 #define   ADIN_PMA_STAT_B10L_LB_PMA_LOC_ABLE	BIT(13)
 #define   ADIN_PMA_STAT_B10L_TX_LVL_HI_ABLE	BIT(12)
 
+#define ADIN_AN_STATUS				0x0201
 #define ADIN_AN_ADV_ABILITY_L			0x0202
 #define ADIN_AN_ADV_ABILITY_M			0x0203
 #define ADIN_AN_ADV_ABILITY_H			0x0204U
@@ -134,7 +135,7 @@ static int adin_read_lpa(struct phy_device *phydev)
 
 	linkmode_zero(phydev->lp_advertising);
 
-	val = phy_read_mmd(phydev, MDIO_MMD_AN, MDIO_STAT1);
+	val = phy_read_mmd(phydev, MDIO_MMD_AN, ADIN_AN_STATUS);
 	if (val < 0)
 		return val;
 

--- a/drivers/net/phy/adin1100.c
+++ b/drivers/net/phy/adin1100.c
@@ -20,9 +20,6 @@ static const int phy_10_features_array[] = {
 	ETHTOOL_LINK_MODE_10baseT_Full_BIT,
 };
 
-static __ETHTOOL_DECLARE_LINK_MODE_MASK(phy_adin_t1l_features)	__ro_after_init;
-#define ADIN_T1L_FEATURES	((unsigned long *)&phy_adin_t1l_features)
-
 #define ADIN_B10L_PCS_CNTRL			0x08e6
 #define   ADIN_PCS_CNTRL_B10L_LB_PCS_EN		BIT(14)
 
@@ -381,6 +378,17 @@ static int adin_soft_reset(struct phy_device *phydev)
 	return -ETIMEDOUT;
 }
 
+static int adin_get_features(struct phy_device *phydev)
+{
+	linkmode_set_bit_array(phy_basic_ports_array, ARRAY_SIZE(phy_basic_ports_array),
+			       phydev->supported);
+
+	linkmode_set_bit_array(phy_10_features_array, ARRAY_SIZE(phy_10_features_array),
+			       phydev->supported);
+
+	return 0;
+}
+
 static int adin_probe(struct phy_device *phydev)
 {
 	struct device *dev = &phydev->mdio.dev;
@@ -392,15 +400,6 @@ static int adin_probe(struct phy_device *phydev)
 
 	phydev->priv = priv;
 
-	/* FIXME: Will be called on each probe, but should work for now */
-	linkmode_set_bit_array(phy_basic_ports_array,
-			       ARRAY_SIZE(phy_basic_ports_array),
-			       phy_adin_t1l_features);
-
-	linkmode_set_bit_array(phy_10_features_array,
-			       ARRAY_SIZE(phy_10_features_array),
-			       phy_adin_t1l_features);
-
 	return 0;
 }
 
@@ -408,7 +407,7 @@ static struct phy_driver adin_driver[] = {
 	{
 		PHY_ID_MATCH_MODEL(PHY_ID_ADIN1100),
 		.name			= "ADIN1100",
-		.features		= ADIN_T1L_FEATURES,
+		.get_features		= adin_get_features,
 		.match_phy_device	= adin_match_phy_device,
 		.soft_reset		= adin_soft_reset,
 		.probe			= adin_probe,

--- a/drivers/net/phy/adin1100.c
+++ b/drivers/net/phy/adin1100.c
@@ -140,11 +140,11 @@ static int adin_read_lpa(struct phy_device *phydev)
 		return val;
 
 	if (!(val & MDIO_AN_STAT1_COMPLETE)) {
-                phydev->pause = 0;
-                phydev->asym_pause = 0;
+		phydev->pause = 0;
+		phydev->asym_pause = 0;
 
-                return 0;
-        }
+		return 0;
+	}
 
 	linkmode_set_bit(ETHTOOL_LINK_MODE_Autoneg_BIT,
 			 phydev->lp_advertising);


### PR DESCRIPTION
net: phy: adin1100: Add get_features hook:
- move features selection in the get_features callback

net: phy: adin1100: Add reset ops:
- chip supports software reset

net: phy: adin1100: Fix aneg status read:
- Auto negotiation status is now read from 0x0201 C45 register
- Before this patch current speed and full/half duplex could not be printed by ethtool