### PR TITLE
arch: arm64: dts: Move data_offload enabled design to separate dts

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9081-m8-l4-do.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9081-m8-l4-do.dts
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD9081-FMC-EBZ
+ * https://wiki.analog.com/resources/eval/user-guides/quadmxfe/quick-start
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-mxfe/ad9081
+ *
+ * hdl_project: <ad9081_fmca_ebz/zcu102>
+ * board_revision: <>
+ *
+ * Copyright (C) 2019-2020 Analog Devices Inc.
+ */
+
+#include "zynqmp-zcu102-rev10-ad9081-m8-l4.dts"
+
+&fpga_axi {
+	axi_data_offload_tx: axi-data-offload-0@9c440000 {
+		compatible = "adi,axi-data-offload-1.0.a";
+		reg = <0x9c440000 0x10000>;
+		// adi,bringup;
+		// adi,oneshot;
+		// adi,bypass;
+		// adi,sync-config = <2>;
+		// adi,transfer-length = /bits/ 64 <0x10000>; // 2**16 bytes
+	};
+};
+
+&axi_ad9081_core_tx {
+	adi,axi-data-offload-connected = <&axi_data_offload_tx>;
+};

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9081.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9081.dts
@@ -76,7 +76,6 @@
 			clocks = <&trx0_ad9081 1>;
 			clock-names = "sampl_clk";
 			spibus-connected = <&trx0_ad9081>;
-			adi,axi-data-offload-connected = <&axi_data_offload_tx>;
 			//adi,axi-pl-fifo-enable;
 
 			jesd204-device;
@@ -162,16 +161,6 @@
 		axi_sysid_0: axi-sysid-0@85000000 {
 			compatible = "adi,axi-sysid-1.00.a";
 			reg = <0x85000000 0x10000>;
-		};
-
-		axi_data_offload_tx: axi-data-offload-0@9c440000 {
-			compatible = "adi,axi-data-offload-1.0.a";
-			reg = <0x9c440000 0x10000>;
-			// adi,bringup;
-			// adi,oneshot;
-			// adi,bypass;
-			// adi,sync-config = <2>;
-			// adi,transfer-length = /bits/ 64 <0x10000>; // 2**16 bytes
 		};
 	};
 };


### PR DESCRIPTION
To prevent current designs from breaking, the data offload engine should
only be enabled when explicitly requested.

This commit removes the device tree entry from the generic AD9081 / ZCU102
reference design and moves it into its own file.