### PR TITLE
arm64: dts: ad9081-204b-txmode9-rxmode4: Revise JRX TPL phase adjust

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9081-204b-txmode9-rxmode4.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9081-204b-txmode9-rxmode4.dts
@@ -283,6 +283,8 @@
 					adi,lanes-per-device = <4>;		/* JESD L */
 					adi,samples-per-converter-per-frame = <1>; /* JESD S */
 					adi,high-density = <1>;			/* JESD HD */
+
+					adi,tpl-phase-adjust = <13>;
 				};
 			};
 		};


### PR DESCRIPTION
This patch correctly sets the JRX TPL phase adjust.

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>