### PR TITLE
misc: adi-axi-data-offload: Update transfer_length register use

### DIFF
--- a/drivers/misc/adi-axi-data-offload.c
+++ b/drivers/misc/adi-axi-data-offload.c
@@ -133,23 +133,15 @@ EXPORT_SYMBOL_GPL(axi_data_offload_ctrl_oneshot);
 
 static int axi_data_offload_ctrl_transfer_length(struct axi_data_offload_state *st, u64 len)
 {
-	/* Only accept values that are divisible by 64 */
-	if (len & ((1ULL << 6) - 1ULL))
+	/* Only accept values which are divisible by 64 */
+	if (len & 0x3fULL)
 		return -EINVAL;
 
 	/* Requested more memory than we have available! */
 	if (len > st->mem_size)
 		return -EINVAL;
 
-	/*
-	 * If a non-zero value is set, it is decremented before being written.
-	 * A zero on the other hand is written as is, and indicates that all available
-	 * memory should be used.
-	 */
-	if (len)
-		len--;
-
-	axi_data_offload_write(st, AXI_DO_REG_TRANSFER_LENGTH, (u32) len);
+	axi_data_offload_write(st, AXI_DO_REG_TRANSFER_LENGTH, len >> 6);
 	return 0;
 }
 


### PR DESCRIPTION
This commit adjusts use of the transfer length register to match the
latest hardware revision.

In short, the transfer_length % 64 == 0 constraint was moved into
hardware, by just storing REGMAP[TRANSFER_LENGTH] = length >> 6.

This is an improvement in two ways:

* The user can no longer request invalid transfer lengths which may result
  in an additional data beat.
* Transfer lengths larger than 4 GiB can now be represented in a single
  32-bit register. The hardware is expected to support storage sizes of
  up to 16 GiB, which would have been an issue with the previous setup.