### PR TITLE
arch: arm: boot: dts: Enable watchdog0 for DE10-Nano

### DIFF
--- a/arch/arm/boot/dts/socfpga_cyclone5_de10_nano.dtsi
+++ b/arch/arm/boot/dts/socfpga_cyclone5_de10_nano.dtsi
@@ -97,10 +97,6 @@
 	u-boot,dm-pre-reloc;
 };
 
-&watchdog0 {
-	status = "disabled";
-};
-
 &gpio0 {
 	status = "okay";
 };


### PR DESCRIPTION
Similar to Cyclone 5 SoCKit platform, enable watchdog0 for DE10-Nano
too. This is required when U-Boot also enables it - in the latest
versions this happens by default.

socfpga_cyclone5.dtsi (included by socfpga_cyclone5_de10_nano.dtsi)
enables watchdog0.

Signed-off-by: Liviu Adace <liviu.adace@analog.com>