### PR TITLE
Ad9545 add tub properties

### DIFF
--- a/Documentation/devicetree/bindings/clock/clk-ad9545.yaml
+++ b/Documentation/devicetree/bindings/clock/clk-ad9545.yaml
@@ -209,6 +209,38 @@ patternProperties:
         minimum: 1
         maximum: 16777215
 
+      adi,phase-lock-fill-rate:
+        description: |
+          Parameter used by the DPLL Phase Lock Detector.
+        $ref: /schemas/types.yaml#/definitions/uint32
+        minimum: 1
+        maximum: 255
+        default: 10
+
+      adi,phase-lock-drain-rate:
+        description: |
+          Parameter used by the DPLL Phase Lock Detector.
+        $ref: /schemas/types.yaml#/definitions/uint32
+        minimum: 1
+        maximum: 255
+        default: 10
+
+      adi,freq-lock-fill-rate:
+        description: |
+          Parameter used by the DPLL Frequency Lock Detector.
+        $ref: /schemas/types.yaml#/definitions/uint32
+        minimum: 1
+        maximum: 255
+        default: 10
+
+      adi,freq-lock-drain-rate:
+        description: |
+          Parameter used by the DPLL Frequency Lock Detector.
+        $ref: /schemas/types.yaml#/definitions/uint32
+        minimum: 1
+        maximum: 255
+        default: 10
+
     required:
       - reg
       - adi,r-divider-ratio


### PR DESCRIPTION
Allow user to change ,using the DT, the fill/drain rate parameters
of the PLL phase/lock detector. These must be customized
for low PLL bandwidth applications like 1 pps. Also affects
behavior of the fast acquisition process, which uses the lock status
in order to change the PLL loop bandwidth.