### PR TITLE
arch: arm64: dts: stingray: Remove adf4371 device.

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-stingray.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-stingray.dts
@@ -327,19 +327,4 @@
 		clock-output-names = "pll0-clk-rf8", "pll0-clk-rfaux8",
 			"pll0-clk-rf16", "pll0-clk-rf32";
 	};
-
-	adf4371_clk1: adf4371-1@7 {
-		compatible = "adi,adf4371";
-		reg = <7>;
-
-		#address-cells = <1>;
-		#clock-cells = <1>;
-		#size-cells = <0>;
-
-		spi-max-frequency = <12500000>;
-		clocks = <&adf4371_clkin>;
-		clock-names = "clkin";
-		clock-output-names = "pll1-clk-rf8", "pll1-clk-rfaux8",
-			"pll1-clk-rf16", "pll1-clk-rf32";
-	};
 };


### PR DESCRIPTION
There is only one device left on the new revision C xud board.

Signed-off-by: Cristian Pop <cristian.pop@analog.com>