### PR TITLE
iio: jesd204: xilinx_transceiver: Fix QPLL VCO1 min overwrite bug

### DIFF
--- a/drivers/iio/jesd204/xilinx_transceiver.c
+++ b/drivers/iio/jesd204/xilinx_transceiver.c
@@ -470,7 +470,7 @@ static int xilinx_xcvr_get_qpll_vco_ranges(struct xilinx_xcvr *xcvr,
 		*vco0_max = xcvr->vco0_max;
 
 	if (xcvr->vco1_min)
-		*vco0_min = xcvr->vco1_min;
+		*vco1_min = xcvr->vco1_min;
 
 	if (xcvr->vco1_max)
 		*vco1_max = xcvr->vco1_max;


### PR DESCRIPTION
There is a typo, which causes VCO0_min to be clobbered when VCO1_min
provided in the devicetree.

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>