### PR TITLE
iio: adc: adrv9002_conv: Fix the DDS rate calculation

### DIFF
--- a/drivers/iio/adc/navassa/adrv9002_conv.c
+++ b/drivers/iio/adc/navassa/adrv9002_conv.c
@@ -195,7 +195,9 @@ int adrv9002_axi_interface_set(struct adrv9002_rf_phy *phy, const u8 n_lanes,
 	axiadc_write(st, AIM_AXI_REG(off, reg_ctrl), reg_value);
 	if (tx) {
 		divider = axiadc_read(st, AIM_AXI_REG(off, ADI_REG_CLK_RATIO));
-		rate = 32 / ((1 << n_lanes) * (1 + cmos_ddr) * divider) - 1;
+		rate = 32 / ((1 << n_lanes) * (1 +
+			(phy->ssi_type == ADI_ADRV9001_SSI_TYPE_LVDS) ?
+				1 : cmos_ddr) * divider) - 1;
 		axiadc_write(st, AIM_AXI_REG(off, ADI_TX_REG_RATE), rate);
 	}
 


### PR DESCRIPTION
When ADI_ADRV9001_SSI_TYPE_LVDS, data type is always DDR.

Fixes: https://github.com/analogdevicesinc/linux/commit/4e87369884e44a8a91df76f190f252d6229216e4

Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>