### PR TITLE
dts: zynqmp-adrv9009-zu11eg-reva.dtsi: Fix UART1 pinctrl assignments

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-reva.dtsi
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-reva.dtsi
@@ -1064,23 +1064,23 @@
 
 	pinctrl_uart1_default: uart1-default {
 		mux {
-			groups = "uart1_5_grp";
+			groups = "uart1_4_grp";
 			function = "uart1";
 		};
 
 		conf {
-			groups = "uart1_5_grp";
+			groups = "uart1_4_grp";
 			slew-rate = <SLEW_RATE_SLOW>;
 			io-standard = <IO_STANDARD_LVCMOS18>;
 		};
 
 		conf-rx {
-			pins = "MIO21";
+			pins = "MIO17";
 			bias-high-impedance;
 		};
 
 		conf-tx {
-			pins = "MIO20";
+			pins = "MIO16";
 			bias-disable;
 		};
 	};


### PR DESCRIPTION
ZU11EG uses MIO16, MIO17 for UART1 these two pins belong to uart1_4_grp

group: uart1_4_grp
pin 16 (MIO16)
pin 17 (MIO17)

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>