### PR TITLE
iio: buffer: fix channel {en|dis}ablement

### DIFF
--- a/drivers/iio/industrialio-buffer.c
+++ b/drivers/iio/industrialio-buffer.c
@@ -448,7 +448,8 @@ static int iio_channel_mask_clear(struct iio_dev *indio_dev,
 
 	clear_bit(bit, buffer->channel_mask);
 
-	memset(buffer->scan_mask, 0, BITS_TO_LONGS(indio_dev->masklength));
+	memset(buffer->scan_mask, 0,
+	       BITS_TO_LONGS(indio_dev->masklength) * sizeof(*buffer->scan_mask));
 	for_each_set_bit(ch, buffer->channel_mask, indio_dev->num_channels)
 		set_bit(indio_dev->channels[ch].scan_index, buffer->scan_mask);
 	return 0;

--- a/drivers/iio/inkern.c
+++ b/drivers/iio/inkern.c
@@ -857,7 +857,8 @@ void iio_buffer_channel_enable(struct iio_buffer *buffer,
 
 	set_bit(chan->channel_index, buffer->channel_mask);
 
-	memset(buffer->scan_mask, 0, BITS_TO_LONGS(chan->indio_dev->masklength));
+	memset(buffer->scan_mask, 0,
+	       BITS_TO_LONGS(chan->indio_dev->masklength) * sizeof(*buffer->scan_mask));
 	for_each_set_bit(ch, buffer->channel_mask, chan->indio_dev->num_channels)
 		set_bit(chan->indio_dev->channels[ch].scan_index, buffer->scan_mask);
 }
@@ -870,7 +871,8 @@ void iio_buffer_channel_disable(struct iio_buffer *buffer,
 
 	clear_bit(chan->channel_index, buffer->channel_mask);
 
-	memset(buffer->scan_mask, 0, BITS_TO_LONGS(chan->indio_dev->masklength));
+	memset(buffer->scan_mask, 0,
+	       BITS_TO_LONGS(chan->indio_dev->masklength) * sizeof(*buffer->scan_mask));
 	for_each_set_bit(ch, buffer->channel_mask, chan->indio_dev->num_channels)
 		set_bit(chan->indio_dev->channels[ch].scan_index, buffer->scan_mask);
 }


### PR DESCRIPTION
Make sure that the complete buffer scan mask gets cleared before
computing a new one. For that we need to multiply the number of elements
by the element size.

Fixes: 81d00795b1537 ("iio: Track enabled channels on a per channel basis")
Signed-off-by: Nuno Sá <nuno.sa@analog.com>

The issue was brought up in the iio mailing list in this [thread](https://marc.info/?l=linux-iio&m=162205504405949&w=2).