### PR TITLE
iio: frequency: adf4371: Expose ADF4371_CH_RF32's IIO attributes

### DIFF
--- a/drivers/iio/frequency/adf4371.c
+++ b/drivers/iio/frequency/adf4371.c
@@ -1224,6 +1224,8 @@ static int adf4371_probe(struct spi_device *spi)
 	indio_dev->modes = INDIO_DIRECT_MODE;
 	indio_dev->channels = st->chip_info->channels;
 	indio_dev->num_channels = st->chip_info->num_channels;
+	if (id->driver_data == ADF4371)
+		indio_dev->num_channels++;	/* Include IIO_TEMP */
 
 	st->clkin = devm_clk_get(&spi->dev, "clkin");
 	if (IS_ERR(st->clkin))


### PR DESCRIPTION
The .num_channels from adf4371_chip_info is incorrectly set for ADF4371 from
the IIO point of view (however, correctly set from the clock framework point
of view) to 4, because IIO_TEMP is not taken into consideration. This makes
the last IIO channel (corresponding to ADF4371_CH_RF32 in this case)
unavailable.

Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>