### PR TITLE
iio: cf_axi_tdd: Fix swapped values in DMA gating enum

### DIFF
--- a/drivers/iio/adc/cf_axi_tdd.c
+++ b/drivers/iio/adc/cf_axi_tdd.c
@@ -152,7 +152,7 @@ enum {
 };
 
 static const char * const cf_axi_tdd_dma_gateing_mode[] = {
-	"rx_tx", "rx_only", "tx_only", "none"
+	"none", "rx_only", "tx_only", "rx_tx"
 };
 
 static int cf_axi_tdd_get_dma_gateing_mode(struct iio_dev *indio_dev,


### PR DESCRIPTION
DMA gating is controlled by bit [5:4] of the TDD control word 0, where bit 5 represents TX and bit 4 RX. Going through the four possible values gives us:

* `0b00` : `0`: Gating disabled
* `0b01` : `1`: RX gated
* `0b10` : `2`: TX gated
* `0b11` : `3`: RX and TX gated

This commit simply swaps `rx_tx` and `none`.

References:
* [Regmap](https://wiki.analog.com/resources/fpga/docs/hdl/regmap)

Note: This is technically a change to the public api, i'm not sure about the policy here ...