### PR TITLE
iio: frequency: adf4371: Export all IIO channels

### DIFF
--- a/drivers/iio/frequency/adf4371.c
+++ b/drivers/iio/frequency/adf4371.c
@@ -1209,7 +1209,7 @@ static int adf4371_probe(struct spi_device *spi)
 	indio_dev->info = &adf4371_info;
 	indio_dev->modes = INDIO_DIRECT_MODE;
 	indio_dev->channels = st->chip_info->channels;
-	indio_dev->num_channels = st->chip_info->num_channels;
+	indio_dev->num_channels = st->chip_info->num_channels + 1; /* Include IIO_TEMP */
 
 	st->clkin = devm_clk_get(&spi->dev, "clkin");
 	if (IS_ERR(st->clkin))


### PR DESCRIPTION
The .num_channels from adf4371_chip_info is incorrectly set for from
the IIO point of view (however, correctly set from the clock
framework point of view) to 4 (ADF4371) and 3 (ADF4372), because
IIO_TEMP is not taken into consideration. This makes the last
IIO channel (corresponding to ADF4371_CH_RF32 - ADF4371 and
ADF4371_CH_RF16 - ADF4372) unavailable.

Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>