### PR TITLE
iio: adrv9002: fix the DDS rate calculation

### DIFF
--- a/drivers/iio/adc/navassa/adrv9002_conv.c
+++ b/drivers/iio/adc/navassa/adrv9002_conv.c
@@ -194,10 +194,13 @@ int adrv9002_axi_interface_set(struct adrv9002_rf_phy *phy, const u8 n_lanes,
 
 	axiadc_write(st, AIM_AXI_REG(off, reg_ctrl), reg_value);
 	if (tx) {
+		u32 ddr = cmos_ddr;
+
 		divider = axiadc_read(st, AIM_AXI_REG(off, ADI_REG_CLK_RATIO));
-		rate = 32 / ((1 << n_lanes) * (1 +
-			(phy->ssi_type == ADI_ADRV9001_SSI_TYPE_LVDS) ?
-				1 : cmos_ddr) * divider) - 1;
+		/* in LVDS, data type is always DDR */
+		if (phy->ssi_type == ADI_ADRV9001_SSI_TYPE_LVDS)
+			ddr = 1;
+		rate = 32 / ((1 << n_lanes) * (1 + ddr) * divider) - 1;
 		axiadc_write(st, AIM_AXI_REG(off, ADI_TX_REG_RATE), rate);
 	}
 


### PR DESCRIPTION
There was a precedence issue in the rate calculation. The issue was on the
expression using the ternary operator making it a bit harder than usual to
spot. With this patch, we make things more explicit by removing the ternary
operator. We add some more lines of code but we make the code (and the
expression) more readable.

Fixes: 6fe83818f07f5 ("iio: adc: adrv9002_conv: Fix the DDS rate calculation")
Signed-off-by: Nuno Sá <nuno.sa@analog.com>