### PR TITLE
iio: frequency: hmc7044: Remove option for High performance PLLs/VCO

### DIFF
--- a/arch/arm/boot/dts/adi-fmcomms8.dtsi
+++ b/arch/arm/boot/dts/adi-fmcomms8.dtsi
@@ -744,7 +744,6 @@
 		adi,gpo-controls = <0x1f 0x2b 0x00 0x00>;
 
 		adi,high-performance-mode-clock-dist-enable;
-		adi,high-performance-mode-pll-vco-enable;
 
 		clock-output-names =
 			"hmc7044_fmc_out0_DEV_REFCLK_C", "hmc7044_fmc_out1_DEV_SYSREF_C",

--- a/arch/arm64/boot/dts/xilinx/adi-fmcomms8.dtsi
+++ b/arch/arm64/boot/dts/xilinx/adi-fmcomms8.dtsi
@@ -744,7 +744,6 @@
 		adi,gpo-controls = <0x1f 0x2b 0x00 0x00>;
 
 		adi,high-performance-mode-clock-dist-enable;
-		adi,high-performance-mode-pll-vco-enable;
 
 		clock-output-names =
 			"hmc7044_fmc_out0_DEV_REFCLK_C", "hmc7044_fmc_out1_DEV_SYSREF_C",

--- a/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-reva.dtsi
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-reva.dtsi
@@ -929,7 +929,6 @@
 		adi,gpo-controls = <0x1f 0x2b 0x00 0x00>;
 
 		adi,high-performance-mode-clock-dist-enable;
-		adi,high-performance-mode-pll-vco-enable;
 
 		clock-output-names =
 			"hmc7044_out0_DEV_REFCLK_A", "hmc7044_out1_DEV_SYSREF_A",

--- a/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-revb-adrv2crr-fmc-revb-sync-fmcomms8.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-revb-adrv2crr-fmc-revb-sync-fmcomms8.dts
@@ -862,7 +862,6 @@
 		adi,gpo-controls = <0x1f 0x2b 0x00 0x00>;
 
 		adi,high-performance-mode-clock-dist-enable;
-		adi,high-performance-mode-pll-vco-enable;
 
 		adi,pll2-autocal-bypass-manual-cap-bank-sel = <0xf>;
 

--- a/drivers/iio/frequency/hmc7044.c
+++ b/drivers/iio/frequency/hmc7044.c
@@ -299,7 +299,6 @@ struct hmc7044 {
 	bool				clkin0_rfsync_en;
 	bool				clkin1_vcoin_en;
 	bool				high_performance_mode_clock_dist_en;
-	bool				high_performance_mode_pll_vco_en;
 	bool				rf_reseeder_en;
 	unsigned int			sync_pin_mode;
 	unsigned int			pulse_gen_mode;
@@ -1065,9 +1064,7 @@ static int hmc7044_setup(struct iio_dev *indio_dev)
 	mdelay(1);
 	hmc7044_write(indio_dev, HMC7044_REG_REQ_MODE_0,
 		      (hmc->high_performance_mode_clock_dist_en ?
-		      HMC7044_HIGH_PERF_DISTRIB_PATH : 0) |
-		      (hmc->high_performance_mode_pll_vco_en ?
-		      HMC7044_HIGH_PERF_PLL_VCO : 0));
+		      HMC7044_HIGH_PERF_DISTRIB_PATH : 0));
 	mdelay(1);
 
 	if (!hmc->clkin1_vcoin_en) {
@@ -1322,10 +1319,6 @@ static int hmc7044_parse_dt(struct device *dev,
 
 		hmc->clkin1_vcoin_en =
 			of_property_read_bool(np, "adi,clkin1-vco-in-enable");
-
-		hmc->high_performance_mode_pll_vco_en =
-			of_property_read_bool(np,
-				"adi,high-performance-mode-pll-vco-enable");
 	} else {
 		ret = of_property_read_u32_array(np, "adi,gpi-controls",
 				hmc->gpi_ctrl, 1);


### PR DESCRIPTION
Draws extra current and doesn't improve much.

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>