### PR TITLE
drivers:iio:frequency: remove unused header

### DIFF
--- a/drivers/iio/frequency/admv1013.c
+++ b/drivers/iio/frequency/admv1013.c
@@ -20,8 +20,6 @@
 #include <linux/regulator/consumer.h>
 #include <linux/spi/spi.h>
 
-#include <linux/iio/sysfs.h>
-
 /* ADMV1013 Register Map */
 #define ADMV1013_REG_SPI_CONTROL		0x00
 #define ADMV1013_REG_ALARM			0x01

--- a/drivers/iio/frequency/admv1014.c
+++ b/drivers/iio/frequency/admv1014.c
@@ -20,8 +20,6 @@
 #include <linux/regulator/consumer.h>
 #include <linux/spi/spi.h>
 
-#include <linux/iio/sysfs.h>
-
 /* ADMV1014 Register Map */
 #define ADMV1014_REG_SPI_CONTROL		0x00
 #define ADMV1014_REG_ALARM			0x01


### PR DESCRIPTION
Remove `sysfs.h` includes after removal of the custom IIO device
attributes.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>