### PR TITLE
iio: adc: ad9083: Add missing mutex_init

### DIFF
--- a/drivers/iio/adc/ad9083.c
+++ b/drivers/iio/adc/ad9083.c
@@ -910,6 +910,8 @@ static int ad9083_probe(struct spi_device *spi)
 	if (!phy)
 		return -ENOMEM;
 
+	mutex_init(&phy->lock);
+
 	spi_set_drvdata(spi, conv);
 
 	conv->reset_gpio =


### PR DESCRIPTION
This commit simply adds the missing mutex_init to the AD9083 driver.

Fixes #1535