### PR TITLE
drivers:iio:admv1013: add default case

### DIFF
--- a/drivers/iio/frequency/admv1013.c
+++ b/drivers/iio/frequency/admv1013.c
@@ -313,6 +313,8 @@ static int admv1013_update_mixer_vgate(struct admv1013_dev *dev)
 		mixer_vgate = (2389 * vcm / 1000000 + 8100) / 100;
 	else if (vcm > 1800000 && vcm < 2600000)
 		mixer_vgate = (2375 * vcm / 1000000 + 125) / 100;
+	else
+		return -EINVAL;
 
 	return admv1013_spi_update_bits(dev, ADMV1013_REG_LO_AMP_I,
 				 ADMV1013_MIXER_VGATE_MSK,


### PR DESCRIPTION
Return invalid argument if vcm value is outside of the supported bounds.

Fixes: 0538776 (iio:frequency:admv1013:add support for ADMV1013)

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>