### PR TITLE
iio: cf_axi_tdd: Fix swapped values in DMA gating enum

### DIFF
--- a/drivers/iio/adc/cf_axi_tdd.c
+++ b/drivers/iio/adc/cf_axi_tdd.c
@@ -153,7 +153,7 @@ enum {
 };
 
 static const char * const cf_axi_tdd_dma_gateing_mode[] = {
-	"rx_tx", "rx_only", "tx_only", "none"
+	"none", "rx_only", "tx_only", "rx_tx"
 };
 
 static int cf_axi_tdd_get_dma_gateing_mode(struct iio_dev *indio_dev,


### PR DESCRIPTION
DMA gating is controlled by bit [5:4] of the TDD control word 0, where
bit 5 represents TX and bit 4 RX. Going through the four possible values
gives us:

* `0b00` : `0`: Gating disabled
* `0b01` : `1`: RX gated
* `0b10` : `2`: TX gated
* `0b11` : `3`: RX and TX gated

This commit simply swaps `rx_tx` and `none`.

Fixes: 20001b54229fc ("iio: cf_axi_tdd: Use iio ext_info for dev attributes")

Backport of 2b90499aa45aa10f0e21062b2eab696c8708480d (#1573)