### PR TITLE
arch: arm{64}: dts: add iio labels to the adrv9002 TDD core

### DIFF
--- a/arch/arm/boot/dts/zynq-zed-adv7511-adrv9002-rx2tx2.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-adrv9002-rx2tx2.dts
@@ -99,6 +99,7 @@
 			reg = <0x44A0C800 0x400>;
 			clocks = <&clkc 16>, <&adc0_adrv9002 2>;
 			clock-names = "s_axi_aclk", "intf_clk";
+			label = "axi-core-tdd";
 		};
 
 		misc_clk_0: misc_clk_0 {

--- a/arch/arm/boot/dts/zynq-zed-adv7511-adrv9002.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-adrv9002.dts
@@ -143,6 +143,7 @@
 			reg = <0x44A0C800 0x400>;
 			clocks = <&clkc 16>, <&adc0_adrv9002 2>;
 			clock-names = "s_axi_aclk", "intf_clk";
+			label = "axi-core-tdd-1";
 		};
 
 		axi_adrv9002_core_rx2: axi-adrv9002-rx2-lpc@44A02000 {
@@ -170,6 +171,7 @@
 			reg = <0x44A0CC00 0x400>;
 			clocks = <&clkc 16>, <&adc0_adrv9002 5>;
 			clock-names = "s_axi_aclk", "intf_clk";
+			label = "axi-core-tdd-2";
 		};
 
 		misc_clk_0: misc_clk_0 {

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9002-rx2tx2.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9002-rx2tx2.dts
@@ -102,6 +102,7 @@
 			reg = <0x84A0C800 0x400>;
 			clocks = <&zynqmp_clk 71>, <&adc0_adrv9002 2>;
 			clock-names = "s_axi_aclk", "intf_clk";
+			label = "axi-core-tdd";
 		};
 
 		axi_sysid_0: axi-sysid-0@85000000 {

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9002.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9002.dts
@@ -144,6 +144,7 @@
 			reg = <0x84A0C800 0x400>;
 			clocks = <&zynqmp_clk 71>, <&adc0_adrv9002 2>;
 			clock-names = "s_axi_aclk", "intf_clk";
+			label = "axi-core-tdd-1";
 		};
 
 		axi_adrv9002_core_rx2: axi-adrv9002-rx2-lpc@84A02000 {
@@ -171,6 +172,7 @@
 			reg = <0x84A0CC00 0x400>;
 			clocks = <&zynqmp_clk 71>, <&adc0_adrv9002 5>;
 			clock-names = "s_axi_aclk", "intf_clk";
+			label = "axi-core-tdd-2";
 		};
 
 		axi_sysid_0: axi-sysid-0@85000000 {


### PR DESCRIPTION
This patch adds IIO labels for the axi_tdd_core present on the adrv9002
based projects. This fixes some userland apps that have to identify
multiple instances of this core.

Signed-off-by: Nuno Sá <nuno.sa@analog.com>