### PR TITLE
arm64: dts: fix axi-fan-control probing

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-reva.dtsi
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-reva.dtsi
@@ -1318,7 +1318,7 @@
 			clocks = <&zynqmp_clk 71>;
 			interrupts = <0 110 IRQ_TYPE_LEVEL_HIGH>;
 
-			adi,pulses-per-revolution = <2>;
+			pulses-per-revolution = <2>;
 		};
 
 		rx_dma: dma@9c420000 {


### PR DESCRIPTION
With commit cb7956a28117 ("hwmon: axi-fan-contro: Sync with upstream"),
the devicetree binding for "adi,pulses-per-revolution" changed to
"pulses-per-revolution" as this a generic property of a FAN. Hence, the
talise devicetree needs to be properly updated otherwise the driver
won't probe.

Signed-off-by: Nuno Sá <nuno.sa@analog.com>