### PR TITLE
 iio: frequency:  jesd204-fsm add support for desired SYSREF

### DIFF
--- a/drivers/iio/frequency/ad9528.c
+++ b/drivers/iio/frequency/ad9528.c
@@ -1319,9 +1319,17 @@ static int ad9528_jesd204_link_pre_setup(struct jesd204_dev *jdev,
 
 	dev_dbg(dev, "%s:%d link_num %u reason %s\n", __func__, __LINE__, lnk->link_id, jesd204_state_op_reason_str(reason));
 
-	while ((st->jdev_lmfc_lemc_gcd > st->pdata->jdev_max_sysref_freq) &&
-		(st->jdev_lmfc_lemc_gcd % (st->jdev_lmfc_lemc_gcd >> 1) == 0))
-		st->jdev_lmfc_lemc_gcd >>= 1;
+
+	if (st->pdata->jdev_desired_sysref_freq && (st->jdev_lmfc_lemc_gcd %
+		st->pdata->jdev_desired_sysref_freq == 0)) {
+		st->jdev_lmfc_lemc_gcd = st->pdata->jdev_desired_sysref_freq;
+	} else {
+		while ((st->jdev_lmfc_lemc_gcd >
+			st->pdata->jdev_max_sysref_freq) &&
+			(st->jdev_lmfc_lemc_gcd %
+			(st->jdev_lmfc_lemc_gcd >> 1) == 0))
+			st->jdev_lmfc_lemc_gcd >>= 1;
+	}
 
 	kdiv = DIV_ROUND_CLOSEST(st->sysref_src_pll2, st->jdev_lmfc_lemc_gcd);
 	kdiv = clamp_t(unsigned long, kdiv, 1UL, 65535UL);
@@ -1441,6 +1449,9 @@ static struct ad9528_platform_data *ad9528_parse_dt(struct device *dev)
 	pdata->jdev_max_sysref_freq = INT_MAX;
 	of_property_read_u32(np, "adi,jesd204-max-sysref-frequency-hz",
 			     &pdata->jdev_max_sysref_freq);
+
+	of_property_read_u32(np, "adi,jesd204-desired-sysref-frequency-hz",
+			     &pdata->jdev_desired_sysref_freq);
 
 	/* PLL2 Setting */
 	of_property_read_u32(np, "adi,pll2-charge-pump-current-nA",

--- a/include/linux/iio/frequency/ad9528.h
+++ b/include/linux/iio/frequency/ad9528.h
@@ -60,6 +60,8 @@ struct ad9528_channel_spec {
  * @sysref_nshot_mode: SYSREF pattern NSHOT mode
  * @sysref_req_trigger_mode: SYSREF request trigger mode
  * @sysref_req_en: SYSREF request pin mode enable (default SPI mode)
+ * @jdev_max_sysref_freq: Maximum SYSREF frequency allowed (Hz)
+ * @dev_desired_sysref_freq: Desired SYSREF frequency (Hz)
  * @pll2_charge_pump_current_nA: Magnitude of PLL2 charge pump current (nA).
  * @pll2_freq_doubler_en: PLL2 frequency doubler enable.
  * @pll2_r1_div: PLL2 R1 divider, range 1..31.
@@ -115,6 +117,7 @@ struct ad9528_platform_data {
 	unsigned char			sysref_req_trigger_mode;
 	bool				sysref_req_en;
 	u32				jdev_max_sysref_freq;
+	u32				jdev_desired_sysref_freq;
 
 	/* PLL2 Setting */
 	unsigned int			pll2_charge_pump_current_nA;


### PR DESCRIPTION
 iio: frequency: jesd204-fsm add support for desired SYSREF

The framework allows to specify a max SYSREF frequency. The drivers
then divide by powers of 2 the lmfc rate. This leaves out some possible
rates in between. Add an option to specify the SYSREF frequency.

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>