### PR TITLE
arch: arm: dts: Remove SW_LID events

### DIFF
--- a/arch/arm/boot/dts/zynq-adrv9361-z7035-bob.dts
+++ b/arch/arm/boot/dts/zynq-adrv9361-z7035-bob.dts
@@ -82,7 +82,7 @@
 		sw0 {
 			label = "SW0";
 			linux,input-type = <5>;
-			linux,code = <0>;
+			linux,code = <13>;
 			gpios = <&gpio0 62 0>;
 		};
 

--- a/arch/arm/boot/dts/zynq-adrv9361-z7035-fmc.dts
+++ b/arch/arm/boot/dts/zynq-adrv9361-z7035-fmc.dts
@@ -345,7 +345,7 @@
 		sw0 {
 			label = "SW0";
 			linux,input-type = <5>;
-			linux,code = <0>;
+			linux,code = <13>;
 			gpios = <&gpio0 65 0>;
 		};
 

--- a/arch/arm/boot/dts/zynq-adrv9364-z7020-bob.dts
+++ b/arch/arm/boot/dts/zynq-adrv9364-z7020-bob.dts
@@ -82,7 +82,7 @@
 		sw0 {
 			label = "SW0";
 			linux,input-type = <5>;
-			linux,code = <0>;
+			linux,code = <13>;
 			gpios = <&gpio0 62 0>;
 		};
 

--- a/arch/arm/boot/dts/zynq-zc702.dtsi
+++ b/arch/arm/boot/dts/zynq-zc702.dtsi
@@ -89,7 +89,7 @@
 
 		sw15_0 {
 			label = "SW15_0";
-			linux,code = <0>; // SW_LID
+			linux,code = <13>; // SW_LINEIN_INSERT
 			linux,input-type = <0x5>; // EV_SW
 			gpios = <&gpio0 56 0>;
 		};


### PR DESCRIPTION
This will prevent the boards from directly going into sleep/standby mode
during their boot process.

SW_LID event was replaced by SW_LINEIN_INSERT for consistency reasons
(it is used by adrv9009-zu11eg too).

Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>