### PR TITLE
iio: adf4350: fix a null pointer dereference during probe

### DIFF
--- a/drivers/iio/frequency/adf4350.c
+++ b/drivers/iio/frequency/adf4350.c
@@ -360,8 +360,7 @@ static struct adf4350_platform_data *adf4350_parse_dt(struct device *dev)
 	if (!pdata)
 		return ERR_PTR(-ENOMEM);
 
-	/* FIXME: make this more upstreamable */
-	snprintf(&pdata->name[0], SPI_NAME_SIZE - 1, "%pOFn", dev->of_node->name);
+	strncpy(&pdata->name[0], dev_name(dev), SPI_NAME_SIZE - 1);
 
 	if (device_property_read_u32(dev, "adi,channel-spacing", &tmp))
 		tmp = 10000;


### PR DESCRIPTION
The 'snprintf' formatting expects a pointer to a device_node (so that it
can gives us it's name) which we were not giving. This obviously leads to
null pointer dereference.

On top of this, it does not make sense to add the device_node name here as
we might not even have OF and we are already checking for the node name
(and set it as default for the 'indio_dev->name') further down in the
probe function. Hence, I'm reverting this to the state it was after
commit 100fe5035cc3 ("iio: frequency: adf4350: remove use of of.h").

Fixes: b6c8aa018518e ("Merge tag 'xilinx-v2020.1' into master-xilinx-v2020.1")
Signed-off-by: Nuno Sá <nuno.sa@analog.com>