### PR TITLE
arch: arm{64}: dts: fix adrv9001 overlapping pins

### DIFF
--- a/arch/arm/boot/dts/adi-adrv9002.dtsi
+++ b/arch/arm/boot/dts/adi-adrv9002.dtsi
@@ -31,8 +31,8 @@
 		rx_pinctrl0: rx-pinctrl@0 {
 			adi,increment-step-size = <1>;
 			adi,decrement-step-size = <1>;
-			adi,increment-pin = <2>;
-			adi,decrement-pin = <1>;
+			adi,increment-pin = <3>;
+			adi,decrement-pin = <2>;
 		};
 
 		rx_pinctrl1: rx-pinctrl@1 {

--- a/arch/arm64/boot/dts/xilinx/adi-adrv9002.dtsi
+++ b/arch/arm64/boot/dts/xilinx/adi-adrv9002.dtsi
@@ -31,8 +31,8 @@
 		rx_pinctrl0: rx-pinctrl@0 {
 			adi,increment-step-size = <1>;
 			adi,decrement-step-size = <1>;
-			adi,increment-pin = <2>;
-			adi,decrement-pin = <1>;
+			adi,increment-pin = <3>;
+			adi,decrement-pin = <2>;
 		};
 
 		rx_pinctrl1: rx-pinctrl@1 {


### PR DESCRIPTION
The decrement-pin of the rx0 pintcrl was overlapping with the ORX2 enable
pin.

Fixes: 7e92fd3b0f957 ("arch: dts: adrv9002: add orx support")
Signed-off-by: Nuno Sá <nuno.sa@analog.com>