### PR TITLE
drivers:iio:admv1014: update clk_notifier usage

### DIFF
--- a/drivers/iio/frequency/admv1014.c
+++ b/drivers/iio/frequency/admv1014.c
@@ -419,15 +419,19 @@ static const struct iio_info admv1014_info = {
 	.debugfs_reg_access = &admv1014_reg_access,
 };
 
-static int admv1014_freq_change(struct notifier_block *nb, unsigned long flags, void *data)
+static int admv1014_freq_change(struct notifier_block *nb, unsigned long action, void *data)
 {
 	struct admv1014_dev *dev = container_of(nb, struct admv1014_dev, nb);
 	struct clk_notifier_data *cnd = data;
 
-	/* cache the new rate */
-	dev->clkin_freq = clk_get_rate_scaled(cnd->clk, &dev->clkscale);
+	if (action == POST_RATE_CHANGE) {
+		/* cache the new rate */
+		dev->clkin_freq = clk_get_rate_scaled(cnd->clk, &dev->clkscale);
 
-	return notifier_from_errno(admv1014_update_quad_filters(dev));
+		return notifier_from_errno(admv1014_update_quad_filters(dev));
+	}
+
+	return NOTIFY_OK;
 }
 
 static void admv1014_clk_notifier_unreg(void *data)


### PR DESCRIPTION
Rename second argument of the `admv1014_freq_change` function to
`action` as in `linux/notifier.h`

Update rate only on the `POST_RATE_CHANGE` callback.

In the other cases, no changes are made.

Fixes: a0b4049 (iio:frequency:admv1014: add support for ADMV1014)

Reference: #1598 

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>