### PR TITLE
drivers: pwm: pwm-axi-pwmgen.c: Fix name

### DIFF
--- a/drivers/pwm/pwm-axi-pwmgen.c
+++ b/drivers/pwm/pwm-axi-pwmgen.c
@@ -227,7 +227,7 @@ static int axi_pwmgen_remove(struct platform_device *pdev)
 }
 static struct platform_driver axi_pwmgen_driver = {
 	.driver = {
-		.name = "adi-axi-pwmgen",
+		.name = "adi,axi-pwmgen",
 		.of_match_table = axi_pwmgen_ids,
 	},
 	.probe = axi_pwmgen_probe,


### PR DESCRIPTION
In Documentation/devicetree/bindings/pwm/pwm-axi-pwmgen.yaml
is documented as adi,axi-pwmgen and this is the corect naming

Signed-off-by: Mihail Chindris <mihail.chindris@analog.com>