### PR TITLE
drivers/usb/Kconfig.adi: Remove CONFIG_USB_OTG_FSM

### DIFF
--- a/drivers/usb/Kconfig.adi
+++ b/drivers/usb/Kconfig.adi
@@ -9,7 +9,6 @@ config USB_ALL_ADI_DRIVERS
 	select USB_HIDDEV
 	select USB_ANNOUNCE_NEW_DEVICES
 	select USB_OTG
-	select USB_OTG_FSM
 	select USB_UAS
 	select USB_EHCI_HCD
 	select USB_STORAGE


### PR DESCRIPTION
Most of your designed require only DRD support based on ID pin.
We don't need HNP or SRP. In fact OTG_FSM just causes issues on
most FPGA/SoC carriers.

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>