### PR TITLE
spi: spi-bcm2835: Fix deadlock

### DIFF
--- a/drivers/spi/spi-bcm2835.c
+++ b/drivers/spi/spi-bcm2835.c
@@ -84,6 +84,7 @@ MODULE_PARM_DESC(polling_limit_us,
  * struct bcm2835_spi - BCM2835 SPI controller
  * @regs: base address of register map
  * @clk: core clock, divided to calculate serial clock
+ * @clk_hz: core clock cached speed
  * @irq: interrupt, signals TX FIFO empty or RX FIFO ¾ full
  * @tfr: SPI transfer currently processed
  * @tx_buf: pointer whence next transmitted byte is read
@@ -123,6 +124,7 @@ MODULE_PARM_DESC(polling_limit_us,
 struct bcm2835_spi {
 	void __iomem *regs;
 	struct clk *clk;
+	unsigned long clk_hz;
 	int irq;
 	struct spi_transfer *tfr;
 	const u8 *tx_buf;
@@ -1074,13 +1076,12 @@ static int bcm2835_spi_transfer_one(struct spi_controller *ctlr,
 
 	/* set clock */
 	spi_hz = tfr->speed_hz;
-	clk_hz = clk_get_rate(bs->clk);
 
-	if (spi_hz >= clk_hz / 2) {
+	if (spi_hz >= bs->clk_hz / 2) {
 		cdiv = 2; /* clk_hz/2 is the fastest we can go */
 	} else if (spi_hz) {
 		/* CDIV must be a multiple of two */
-		cdiv = DIV_ROUND_UP(clk_hz, spi_hz);
+		cdiv = DIV_ROUND_UP(bs->clk_hz, spi_hz);
 		cdiv += (cdiv % 2);
 
 		if (cdiv >= 65536)
@@ -1088,7 +1089,7 @@ static int bcm2835_spi_transfer_one(struct spi_controller *ctlr,
 	} else {
 		cdiv = 0; /* 0 is the slowest we can go */
 	}
-	spi_used_hz = cdiv ? (clk_hz / cdiv) : (clk_hz / 65536);
+	spi_used_hz = cdiv ? (bs->clk_hz / cdiv) : (bs->clk_hz / 65536);
 	bcm2835_wr(bs, BCM2835_SPI_CLK, cdiv);
 
 	/* handle all the 3-wire mode */
@@ -1317,6 +1318,7 @@ static int bcm2835_spi_probe(struct platform_device *pdev)
 	}
 
 	clk_prepare_enable(bs->clk);
+	bs->clk_hz = clk_get_rate(bs->clk);
 
 	bcm2835_dma_init(ctlr, &pdev->dev, bs);
 


### PR DESCRIPTION
The bcm2835_spi_transfer_one function can create a deadlock
if it is called while another thread already has the
CCF lock.

The summary of the stack exception caused by this when trying to print the clk_summary:
Exception stack:
 - spi_pump_messages -> spi_transfer_one_message -> clk_get_rate
 - spi_pump_messages -> bcm2835_spi_transfer_one -> clk_get_rate
 - ksys_ioctl -> do_vfs_ioctl ->v3d_clock_up_get -> clk_set_rate
 - clk_summary_show -> clk_summary_show_subtree -> ad9545_out_clk_get_phase
 - spi_transfer_one_message -> clk_get_rate
 - drm_ioctl_kernel -> v3d_job_init -> v3d_clock_up_get -> clk_set_rate
 - ksys_read -> full_proxy_read -> clk_summary_show -> clk_summary_show_subtree -> ad9545_out_clk_get_phase
 - do_vfs_ioctl -> v3d_submit_cl_ioctl -> v3d_clock_up_get -> clk_set_rate
 - spi_pump_messages -> spi_transfer_one_message -> clk_get_rate

Multiple threads wait on CCF lock.
Trying to read , using the bcm2835 of the spi driver, AD9545 parameters, such as rate/phase/nshot, can create a deadlock.
