### PR TITLE
drivers: iio: industrialio-buffer.c: Export symbol

### DIFF
--- a/drivers/iio/industrialio-buffer.c
+++ b/drivers/iio/industrialio-buffer.c
@@ -1537,6 +1537,7 @@ int iio_buffer_remove_sample(struct iio_buffer *buffer, u8 *data)
 {
 	return buffer->access->remove_from(buffer, data);
 }
+EXPORT_SYMBOL_GPL(iio_buffer_remove_sample);
 
 /**
  * iio_buffer_release() - Free a buffer's resources


### PR DESCRIPTION
iio_buffer_remove_sample is not exported as a symbol and it
can be used in modules.
Export it to solve the problem

Signed-off-by: Mihail Chindris <mihail.chindris@analog.com>
Fixes: 31bc846309388 ("iio: Move iio_buffer_remove_sample() to buffer.h")