### PR TITLE
ci: push artifacts to SWDownloads and Artifactory

### DIFF
--- a/azure-pipelines-rpi.yml
+++ b/azure-pipelines-rpi.yml
@@ -42,3 +42,12 @@ pr:
       clean: true
     - script: ./ci/travis/run-build-docker.sh
       displayName: "Build test for '$(DEFCONFIG)'"
+    - task: CopyFiles@2
+      inputs:
+        sourceFolder: '$(Agent.BuildDirectory)/s/arch/arm/boot/dts/overlays'
+        contents: '$(Agent.BuildDirectory)/s/arch/arm/boot/dts/overlays/?(*.dtbo)'
+        targetFolder: '$(Build.ArtifactStagingDirectory)'
+    - task: PublishPipelineArtifact@1
+      inputs:
+        targetPath: '$(Build.ArtifactStagingDirectory)'
+        artifactName: '$(artifactName)'

--- a/azure-pipelines-rpi.yml
+++ b/azure-pipelines-rpi.yml
@@ -7,15 +7,14 @@ pr:
 - rpi-4.19.y
 - rpi-5.4.y
 
-pool:
-  vmImage: 'ubuntu-latest'
-
   jobs:
   - job: checkpatch
     condition: eq(variables['Build.Reason'], 'PullRequest')
     variables:
       BUILD_TYPE: checkpatch
       TARGET_BRANCH: $[ variables['System.PullRequest.TargetBranch'] ]
+    pool:
+      vmImage: 'ubuntu-latest'
     steps:
     - checkout: self
       fetchDepth: 50
@@ -35,6 +34,8 @@ pool:
         bcmrpi_arm_adi:
           DEFCONFIG: adi_bcmrpi_defconfig
           ARCH: arm
+    pool:
+      vmImage: 'ubuntu-latest'
     steps:
     - checkout: self
       fetchDepth: 1

--- a/azure-pipelines-rpi.yml
+++ b/azure-pipelines-rpi.yml
@@ -10,35 +10,34 @@ pr:
 pool:
   vmImage: 'ubuntu-latest'
 
-jobs:
+  jobs:
+  - job: checkpatch
+    condition: eq(variables['Build.Reason'], 'PullRequest')
+    variables:
+      BUILD_TYPE: checkpatch
+      TARGET_BRANCH: $[ variables['System.PullRequest.TargetBranch'] ]
+    steps:
+    - checkout: self
+      fetchDepth: 50
+      clean: true
+    - script: ./ci/travis/run-build.sh
+      displayName: 'Checkpatch Script'
 
-- job: checkpatch
-  condition: eq(variables['Build.Reason'], 'PullRequest')
-  variables:
-    BUILD_TYPE: checkpatch
-    TARGET_BRANCH: $[ variables['System.PullRequest.TargetBranch'] ]
-  steps:
-  - checkout: self
-    fetchDepth: 50
-    clean: true
-  - script: ./ci/travis/run-build.sh
-    displayName: 'Checkpatch Script'
-
-- job: BuildDockerized
-  strategy:
-    matrix:
-      bcm2709_arm_adi:
-        DEFCONFIG: adi_bcm2709_defconfig
-        ARCH: arm
-      bcm2711_arm_adi:
-        DEFCONFIG: adi_bcm2711_defconfig
-        ARCH: arm
-      bcmrpi_arm_adi:
-        DEFCONFIG: adi_bcmrpi_defconfig
-        ARCH: arm
-  steps:
-  - checkout: self
-    fetchDepth: 1
-    clean: true
-  - script: ./ci/travis/run-build-docker.sh
-    displayName: "Build test for '$(DEFCONFIG)'"
+  - job: BuildDockerized
+    strategy:
+      matrix:
+        bcm2709_arm_adi:
+          DEFCONFIG: adi_bcm2709_defconfig
+          ARCH: arm
+        bcm2711_arm_adi:
+          DEFCONFIG: adi_bcm2711_defconfig
+          ARCH: arm
+        bcmrpi_arm_adi:
+          DEFCONFIG: adi_bcmrpi_defconfig
+          ARCH: arm
+    steps:
+    - checkout: self
+      fetchDepth: 1
+      clean: true
+    - script: ./ci/travis/run-build-docker.sh
+      displayName: "Build test for '$(DEFCONFIG)'"

--- a/azure-pipelines-rpi.yml
+++ b/azure-pipelines-rpi.yml
@@ -7,6 +7,8 @@ pr:
 - rpi-4.19.y
 - rpi-5.4.y
 
+stages:
+- stage: Builds
   jobs:
   - job: checkpatch
     condition: eq(variables['Build.Reason'], 'PullRequest')
@@ -51,3 +53,47 @@ pr:
       inputs:
         targetPath: '$(Build.ArtifactStagingDirectory)'
         artifactName: '$(artifactName)'
+
+- stage: PushArtifacts
+  dependsOn: Builds
+  jobs:
+  - job: SWDownloads
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/rpi-5.4.y'))
+    pool:
+      vmImage: 'ubuntu-latest'
+    steps:
+      - task: DownloadPipelineArtifact@2
+        inputs:
+          path: $(Build.SourcesDirectory)/bin
+      - bash: tar -zcvf $(Build.SourcesDirectory)/bin/adi_bcm2709_defconfig.tar $(Build.SourcesDirectory)/bin/adi_bcm2709_defconfig/ ; tar -zcvf $(Build.SourcesDirectory)/bin/adi_bcm2711_defconfig.tar $(Build.SourcesDirectory)/bin/adi_bcm2711_defconfig/ ; tar -zcvf $(Build.SourcesDirectory)/bin/adi_bcmrpi_defconfig.tar $(Build.SourcesDirectory)/bin/adi_bcmrpi_defconfig/
+        displayName: 'Archive artifacts'
+      - task: DownloadSecureFile@1
+        name: key
+        displayName: 'Download rsa key'
+        inputs:
+          secureFile: 'id_rsa'
+      - bash: chmod 600 $(key.secureFilePath) ; scp -2 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o HostKeyAlgorithms=+ssh-dss -vv -i $(key.secureFilePath) -r $(Build.SourcesDirectory)/bin/adi_bcm2709_defconfig.tar $(Build.SourcesDirectory)/bin/adi_bcm2711_defconfig.tar $(Build.SourcesDirectory)/bin/adi_bcmrpi_defconfig.tar $DEST_SERVER
+        env:
+          DEST_SERVER: $(SERVER_ADDRESS)
+        displayName: "PushToSWDownloads"
+
+  - job: Artifactory
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/rpi-5.4.y'))
+    pool:
+      name: Default
+      demands:
+        - agent.name -equals lab2_b5
+    steps:
+      - task: DownloadPipelineArtifact@2
+        inputs:
+          path: $(Build.SourcesDirectory)/bin
+      - bash: tar -zcvf $(Build.SourcesDirectory)/bin/adi_bcm2709_defconfig.tar $(Build.SourcesDirectory)/bin/adi_bcm2709_defconfig/ ; tar -zcvf $(Build.SourcesDirectory)/bin/adi_bcm2711_defconfig.tar $(Build.SourcesDirectory)/bin/adi_bcm2711_defconfig/ ; tar -zcvf $(Build.SourcesDirectory)/bin/adi_bcmrpi_defconfig.tar $(Build.SourcesDirectory)/bin/adi_bcmrpi_defconfig/
+        displayName: 'Archive artifacts'
+      - bash: curl -u$USERNAME:$PASSWORD -T $(Build.SourcesDirectory)/bin/adi_bcm2709_defconfig.tar $ARTIFACTORY_PATH1 ; curl -u$USERNAME:$PASSWORD -T $(Build.SourcesDirectory)/bin/adi_bcm2711_defconfig.tar $ARTIFACTORY_PATH2 ; curl -u$USERNAME:$PASSWORD -T $(Build.SourcesDirectory)/bin/adi_bcmrpi_defconfig.tar $ARTIFACTORY_PATH3
+        env:
+          USERNAME: $(USER)
+          PASSWORD: $(PASS)
+          ARTIFACTORY_PATH1: $(PATH1)
+          ARTIFACTORY_PATH2: $(PATH2)
+          ARTIFACTORY_PATH3: $(PATH3)
+        displayName: "PushToArtifactory"


### PR DESCRIPTION
A new "PushArtifacts" stage was added in order to save resulted artifacts to SWDownloads and Artifactory.
Artifacts are saved in three separat archives:
    -adi_bcm2709_defconfig.tar
    -adi_bcm2711_defconfig.tar
    -adi_bcmrpi_defconfig.tar
For each build on rpi-5.4.y branch, this archives are overwritten.

Signed-off-by: Raluca Chis <raluca.chis@analog.com>