### PR TITLE
spi: spi-bcm2835: Fix warning

### DIFF
--- a/drivers/spi/spi-bcm2835.c
+++ b/drivers/spi/spi-bcm2835.c
@@ -1070,7 +1070,7 @@ static int bcm2835_spi_transfer_one(struct spi_controller *ctlr,
 				    struct spi_transfer *tfr)
 {
 	struct bcm2835_spi *bs = spi_controller_get_devdata(ctlr);
-	unsigned long spi_hz, clk_hz, cdiv, spi_used_hz;
+	unsigned long spi_hz, cdiv, spi_used_hz;
 	unsigned long hz_per_byte, byte_limit;
 	u32 cs = bs->prepare_cs[spi->chip_select];
 


### PR DESCRIPTION
Remove unused variable clk_hz.

Fixes: 095c8ca0d6f5 ("spi: spi-bcm2835: Fix deadlock")
Signed-off-by: Alexandru Tachici <alexandru.tachici@analog.com>