### PR TITLE
azure-pipelines: allow custom rpi build trigger

### DIFF
--- a/azure-pipelines-rpi.yml
+++ b/azure-pipelines-rpi.yml
@@ -1,6 +1,7 @@
 trigger:
 - rpi-4.19.y
 - rpi-5.4.y
+- staging-rpi/*
 
 pr:
 - rpi-4.19.y


### PR DESCRIPTION
Similar to the azure-pipelines master branch related builds, allow
custom staging branches to trigger the rpi related builds.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>