### PR TITLE
zynqmp-zcu102-rev10-ad9083-fmc-ebz.dts: update hdl_project tag

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9083-fmc-ebz.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9083-fmc-ebz.dts
@@ -4,7 +4,7 @@
  * https://wiki.analog.com/resources/eval/dpg/ad9083-fmc-ebz
  * https://wiki.analog.com/resources/eval/dpg/eval-ad9083
  *
- * hdl_project: <adc_fmc_ebz/zcu102>
+ * hdl_project: <ad9083_evb/zcu102>
  * board_revision: <>
  *
  * Copyright (C) 2021 Analog Devices Inc.


### PR DESCRIPTION
Update hdl_project tag in zynqmp-zcu102-rev10-ad9083-fmc-ebz.dts
to correspond with hdl project ad9083_evb/zcu102.

Signed-off-by: stefan.raus <stefan.raus@analog.com>