### PR TITLE
ci: Fix failures and add script for long bash command lines

### DIFF
--- a/azure-pipelines-rpi.yml
+++ b/azure-pipelines-rpi.yml
@@ -30,12 +30,15 @@ stages:
         bcm2709_arm_adi:
           DEFCONFIG: adi_bcm2709_defconfig
           ARCH: arm
+          artifactName: 'adi_bcm2709_defconfig'
         bcm2711_arm_adi:
           DEFCONFIG: adi_bcm2711_defconfig
           ARCH: arm
+          artifactName: 'adi_bcm2711_defconfig'
         bcmrpi_arm_adi:
           DEFCONFIG: adi_bcmrpi_defconfig
           ARCH: arm
+          artifactName: 'adi_bcmrpi_defconfig'
     pool:
       vmImage: 'ubuntu-latest'
     steps:
@@ -65,7 +68,7 @@ stages:
       - task: DownloadPipelineArtifact@2
         inputs:
           path: $(Build.SourcesDirectory)/bin
-      - bash: tar -zcvf $(Build.SourcesDirectory)/bin/adi_bcm2709_defconfig.tar $(Build.SourcesDirectory)/bin/adi_bcm2709_defconfig/ ; tar -zcvf $(Build.SourcesDirectory)/bin/adi_bcm2711_defconfig.tar $(Build.SourcesDirectory)/bin/adi_bcm2711_defconfig/ ; tar -zcvf $(Build.SourcesDirectory)/bin/adi_bcmrpi_defconfig.tar $(Build.SourcesDirectory)/bin/adi_bcmrpi_defconfig/
+      - bash: cd $(Build.SourcesDirectory)/bin ; tar -zcvf adi_bcm2709_defconfig.tar adi_bcm2709_defconfig ; tar -zcvf adi_bcm2711_defconfig.tar adi_bcm2711_defconfig ; tar -zcvf adi_bcmrpi_defconfig.tar adi_bcmrpi_defconfig
         displayName: 'Archive artifacts'
       - task: DownloadSecureFile@1
         name: key
@@ -87,7 +90,7 @@ stages:
       - task: DownloadPipelineArtifact@2
         inputs:
           path: $(Build.SourcesDirectory)/bin
-      - bash: tar -zcvf $(Build.SourcesDirectory)/bin/adi_bcm2709_defconfig.tar $(Build.SourcesDirectory)/bin/adi_bcm2709_defconfig/ ; tar -zcvf $(Build.SourcesDirectory)/bin/adi_bcm2711_defconfig.tar $(Build.SourcesDirectory)/bin/adi_bcm2711_defconfig/ ; tar -zcvf $(Build.SourcesDirectory)/bin/adi_bcmrpi_defconfig.tar $(Build.SourcesDirectory)/bin/adi_bcmrpi_defconfig/
+      - bash: cd $(Build.SourcesDirectory)/bin ; tar -zcvf adi_bcm2709_defconfig.tar adi_bcm2709_defconfig ; tar -zcvf adi_bcm2711_defconfig.tar adi_bcm2711_defconfig ; tar -zcvf adi_bcmrpi_defconfig.tar adi_bcmrpi_defconfig
         displayName: 'Archive artifacts'
       - bash: curl -u$USERNAME:$PASSWORD -T $(Build.SourcesDirectory)/bin/adi_bcm2709_defconfig.tar $ARTIFACTORY_PATH1 ; curl -u$USERNAME:$PASSWORD -T $(Build.SourcesDirectory)/bin/adi_bcm2711_defconfig.tar $ARTIFACTORY_PATH2 ; curl -u$USERNAME:$PASSWORD -T $(Build.SourcesDirectory)/bin/adi_bcmrpi_defconfig.tar $ARTIFACTORY_PATH3
         env:

--- a/azure-pipelines-rpi.yml
+++ b/azure-pipelines-rpi.yml
@@ -59,6 +59,9 @@ stages:
 
 - stage: PushArtifacts
   dependsOn: Builds
+  variables:
+    SOURCE_DIRECTORY: $(Build.SourcesDirectory)/bin
+    KEY_FILE: $(key.secureFilePath)
   jobs:
   - job: SWDownloads
     condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/rpi-5.4.y'))
@@ -68,14 +71,14 @@ stages:
       - task: DownloadPipelineArtifact@2
         inputs:
           path: $(Build.SourcesDirectory)/bin
-      - bash: cd $(Build.SourcesDirectory)/bin ; tar -zcvf adi_bcm2709_defconfig.tar adi_bcm2709_defconfig ; tar -zcvf adi_bcm2711_defconfig.tar adi_bcm2711_defconfig ; tar -zcvf adi_bcmrpi_defconfig.tar adi_bcmrpi_defconfig
+      - bash: ./ci/travis/artifacts.sh archive
         displayName: 'Archive artifacts'
       - task: DownloadSecureFile@1
         name: key
         displayName: 'Download rsa key'
         inputs:
           secureFile: 'id_rsa'
-      - bash: chmod 600 $(key.secureFilePath) ; scp -2 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o HostKeyAlgorithms=+ssh-dss -vv -i $(key.secureFilePath) -r $(Build.SourcesDirectory)/bin/adi_bcm2709_defconfig.tar $(Build.SourcesDirectory)/bin/adi_bcm2711_defconfig.tar $(Build.SourcesDirectory)/bin/adi_bcmrpi_defconfig.tar $DEST_SERVER
+      - bash: ./ci/travis/artifacts.sh swdownloads
         env:
           DEST_SERVER: $(SERVER_ADDRESS)
         displayName: "PushToSWDownloads"
@@ -90,9 +93,9 @@ stages:
       - task: DownloadPipelineArtifact@2
         inputs:
           path: $(Build.SourcesDirectory)/bin
-      - bash: cd $(Build.SourcesDirectory)/bin ; tar -zcvf adi_bcm2709_defconfig.tar adi_bcm2709_defconfig ; tar -zcvf adi_bcm2711_defconfig.tar adi_bcm2711_defconfig ; tar -zcvf adi_bcmrpi_defconfig.tar adi_bcmrpi_defconfig
+      - bash: ./ci/travis/artifacts.sh archive
         displayName: 'Archive artifacts'
-      - bash: curl -u$USERNAME:$PASSWORD -T $(Build.SourcesDirectory)/bin/adi_bcm2709_defconfig.tar $ARTIFACTORY_PATH1 ; curl -u$USERNAME:$PASSWORD -T $(Build.SourcesDirectory)/bin/adi_bcm2711_defconfig.tar $ARTIFACTORY_PATH2 ; curl -u$USERNAME:$PASSWORD -T $(Build.SourcesDirectory)/bin/adi_bcmrpi_defconfig.tar $ARTIFACTORY_PATH3
+      - bash: ./ci/travis/artifacts.sh artifactory
         env:
           USERNAME: $(USER)
           PASSWORD: $(PASS)

--- a/ci/travis/artifacts.sh
+++ b/ci/travis/artifacts.sh
@@ -1,0 +1,30 @@
+#!/bin/bash -e
+# SPDX-License-Identifier: (GPL-1.0-only OR BSD-2-Clause)
+
+bcm_types='bcm2709 bcm2711 bcmrpi'
+
+artifacts_to_archive() {
+	cd ${SOURCE_DIRECTORY}
+	for bcm in $bcm_types; do
+		tar -zcvf adi_${bcm}_defconfig.tar adi_${bcm}_defconfig
+	done
+}
+
+artifacts_to_swdownloads() {
+	chmod 600 ${KEY_FILE}
+	for bcm in $bcm_type; do
+		scp -2 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o HostKeyAlgorithms=+ssh-dss \
+		    -i ${KEY_FILE} -r ${SOURCE_DIRECTORY}/adi_${bcm}_defconfig.tar ${DEST_SERVER}
+	done
+}
+
+artifacts_to_artifactory() {
+	local path=($ARTIFACTORY_PATH1 $ARTIFACTORY_PATH2 $ARTIFACTORY_PATH3)
+	local index=1
+	for bcm in $bcm_type; do
+		curl -u$USERNAME:$PASSWORD -T ${SOURCE_DIRECTORY}/adi_${bcm}_defconfig.tar ${path[index]}
+		((index++))
+	done
+}
+
+artifacts_to_${1}


### PR DESCRIPTION
The first commit fix Azure failures, by adding 'artifactName' variable and fixing a 'tar' warning.

The second commit add a script, artifacts.sh in ci/travis, that contains three functions that will be called in azure-pipelines-rpi.yml files instead of long bash command lines.