### PR TITLE
dts: zynq pluto|m2k: Update ADM1177 compatible to adi,adm1177-iio

### DIFF
--- a/arch/arm/boot/dts/zynq-m2k-reva.dts
+++ b/arch/arm/boot/dts/zynq-m2k-reva.dts
@@ -201,7 +201,7 @@
 			};
 
 			current_limiter: current_limiter@5a {
-				compatible = "adi,adm1177";
+				compatible = "adi,adm1177-iio";
 				reg = <0x5a>;
 				adi,r-sense-mohm = <50>; /* 50 mOhm */
 				adi,shutdown-threshold-ma = <1200>; /* 1.200 A */

--- a/arch/arm/boot/dts/zynq-pluto-sdr-revb.dts
+++ b/arch/arm/boot/dts/zynq-pluto-sdr-revb.dts
@@ -19,7 +19,7 @@
 
 &axi_i2c0 {
 	current_limiter@5a {
-		compatible = "adi,adm1177";
+		compatible = "adi,adm1177-iio";
 		reg = <0x5a>;
 		adi,r-sense-mohm = <50>; /* 50 mOhm */
 		adi,shutdown-threshold-ma = <1059>; /* 1.059 A */

--- a/arch/arm/boot/dts/zynq-pluto-sdr.dts
+++ b/arch/arm/boot/dts/zynq-pluto-sdr.dts
@@ -17,7 +17,7 @@
 
 &axi_i2c0 {
 	current_limiter@5a {
-		compatible = "adi,adm1177";
+		compatible = "adi,adm1177-iio";
 		reg = <0x5a>;
 		adi,r-sense-mohm = <50>; /* 50 mOhm */
 		adi,shutdown-threshold-ma = <1059>; /* 1.059 A */

--- a/arch/arm/boot/dts/zynq-zed-adv7511-m2k-revb.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-m2k-revb.dts
@@ -135,7 +135,7 @@
 		};
 
 		current_limiter@5a {
-			compatible = "adi,adm1177";
+			compatible = "adi,adm1177-iio";
 			reg = <0x5a>;
 			adi,r-sense-mohm = <100>; /* 100 mOhm */
 			adi,shutdown-threshold-ma = <1059>; /* 1.059 A */

--- a/arch/arm/boot/dts/zynq-zed-adv7511-m2k-revc.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-m2k-revc.dts
@@ -153,7 +153,7 @@
 		};
 
 		current_limiter@5a {
-			compatible = "adi,adm1177";
+			compatible = "adi,adm1177-iio";
 			reg = <0x5a>;
 			adi,r-sense-mohm = <100>; /* 100 mOhm */
 			adi,shutdown-threshold-ma = <1059>; /* 1.059 A */


### PR DESCRIPTION
This will make sure we use the ADM1177 IIO and not the HWMON driver.

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>