### PR TITLE
[dev] add adrv9002 gpio debugfs

### DIFF
--- a/drivers/iio/adc/navassa/devices/adrv9001/public/include/adi_adrv9001_gpio.h
+++ b/drivers/iio/adc/navassa/devices/adrv9001/public/include/adi_adrv9001_gpio.h
@@ -120,7 +120,7 @@ int32_t adi_adrv9001_gpio_GpIntStatus_Get(adi_adrv9001_Device_t *adrv9001, uint3
  * \returns A code indicating success (ADI_COMMON_ACT_NO_ACTION) or the required action to recover
  */
 int32_t adi_adrv9001_gpio_OutputPinLevel_Set(adi_adrv9001_Device_t *adrv9001,
-                                             adi_adrv9001_GpioPin_e pin, 
+                                             adi_adrv9001_GpioPin_e pin,
                                              adi_adrv9001_GpioPinLevel_e level);
 
 /**
@@ -158,58 +158,75 @@ int32_t adi_adrv9001_gpio_OutputPinLevel_Get(adi_adrv9001_Device_t *adrv9001,
  *
  * \returns A code indicating success (ADI_COMMON_ACT_NO_ACTION) or the required action to recover
  */
-int32_t adi_adrv9001_gpio_InputPinLevel_Get(adi_adrv9001_Device_t *adrv9001, 
+int32_t adi_adrv9001_gpio_InputPinLevel_Get(adi_adrv9001_Device_t *adrv9001,
                                             adi_adrv9001_GpioPin_e pin,
                                             adi_adrv9001_GpioPinLevel_e *gpioInPinLevels);
-    
+
+/**
+ * \brief Reads the ADRV9001 GPIO pin direction for BITBANG mode
+ *
+ *  This function allows reading the direction of the GPIO
+ *
+ * \note Message type: \ref timing_direct "Direct register access"
+ *
+ * \param[in]  adrv9001	        Context variable - Pointer to the ADRV9001 device settings data structure
+ * \param[in]  pin              The pin for which to get the direction
+ * \param[out] direction        Current direction of the pin
+ *
+ * \returns A code indicating success (ADI_COMMON_ACT_NO_ACTION) or the required action to recover
+ */
+int32_t adi_adrv9001_gpio_PinDirection_Get(adi_adrv9001_Device_t *device,
+					   adi_adrv9001_GpioPin_e pin,
+					   adi_adrv9001_GpioPinDirection_e *direction);
+
 /**
  * \brief Configure specified pin as manual input
- * 
+ *
  * \note Message type: \ref timing_direct "Direct register access"
  *
  * \param[in] adrv9001	Context variable - Pointer to the ADRV9001 device settings data structure
  * \param[in] pin       The GPIO pin to configure
- * 
+ *
  * \returns A code indicating success (ADI_COMMON_ACT_NO_ACTION) or the required action to recover
  */
 int32_t adi_adrv9001_gpio_ManualInput_Configure(adi_adrv9001_Device_t *adrv9001, adi_adrv9001_GpioPin_e pin);
-    
+
 /**
  * \brief Configure specified pin crumb as manual output
- * 
+ *
  * \note Message type: \ref timing_direct "Direct register access"
  *
  * \param[in] adrv9001	Context variable - Pointer to the ADRV9001 device settings data structure
  * \param[in] crumb     The GPIO pin crumb to configure
- * 
+ *
  * \returns A code indicating success (ADI_COMMON_ACT_NO_ACTION) or the required action to recover
  */
 int32_t adi_adrv9001_gpio_ManualOutput_Configure(adi_adrv9001_Device_t *adrv9001, adi_adrv9001_GpioPinCrumbSel_e crumb);
 
 /**
  * \brief Configure specified analog GPIO pin as manual input
- * 
+ *
  * \note Message type: \ref timing_direct "Direct register access"
  *
  * \param[in] adrv9001	Context variable - Pointer to the ADRV9001 device settings data structure
  * \param[in] pin       The analog GPIO pin to configure
- * 
+ *
  * \returns A code indicating success (ADI_COMMON_ACT_NO_ACTION) or the required action to recover
  */
-int32_t adi_adrv9001_gpio_ManualAnalogInput_Configure(adi_adrv9001_Device_t *adrv9001, 
+int32_t adi_adrv9001_gpio_ManualAnalogInput_Configure(adi_adrv9001_Device_t *adrv9001,
                                                       adi_adrv9001_GpioPin_e pin);
 /**
  * \brief Configure specified analog GPIO pin nibble as manual output
- * 
+ *
  * \note Message type: \ref timing_direct "Direct register access"
  *
  * \param[in] adrv9001	Context variable - Pointer to the ADRV9001 device settings data structure
  * \param[in] nibble    The analog GPIO pin nibble to configure
  * \param[in] source    The source signal to be output on the pins
- * 
+ *
  * \returns A code indicating success (ADI_COMMON_ACT_NO_ACTION) or the required action to recover
  */
-int32_t adi_adrv9001_gpio_ManualAnalogOutput_Configure(adi_adrv9001_Device_t *adrv9001, 
+int32_t adi_adrv9001_gpio_ManualAnalogOutput_Configure(adi_adrv9001_Device_t *adrv9001,
                                                        adi_adrv9001_GpioAnalogPinNibbleSel_e nibble);
 
 /**
@@ -224,7 +241,7 @@ int32_t adi_adrv9001_gpio_ManualAnalogOutput_Configure(adi_adrv9001_Device_t *ad
  */
 int32_t adi_adrv9001_gpio_ControlInit_Configure(adi_adrv9001_Device_t *adrv9001,
                                                 adi_adrv9001_GpioCtrlInitCfg_t *gpioCtrlInitCfg);
-    
+
 /**
  * \brief Configure the ADRV9001 GPIO for the specified signal
  *
@@ -241,7 +258,7 @@ int32_t adi_adrv9001_gpio_ControlInit_Configure(adi_adrv9001_Device_t *adrv9001,
 int32_t adi_adrv9001_gpio_Configure(adi_adrv9001_Device_t *adrv9001,
                                     adi_adrv9001_GpioSignal_e signal,
                                     adi_adrv9001_GpioCfg_t *gpioConfig);
-    
+
 /**
  * \brief Retrieve the ADRV9001 GPIO configuration for the requested signal
  *

--- a/drivers/iio/adc/navassa/devices/adrv9001/public/src/adi_adrv9001_gpio.c
+++ b/drivers/iio/adc/navassa/devices/adrv9001/public/src/adi_adrv9001_gpio.c
@@ -213,6 +213,38 @@ static __maybe_unused int32_t __maybe_unused adi_adrv9001_gpio_ManualAnalogInput
     ADI_API_RETURN(device);
 }
 
+static __maybe_unused int32_t adi_adrv9001_gpio_PinDirection_Get_Validate(adi_adrv9001_Device_t *device,
+									  adi_adrv9001_GpioPin_e pin)
+{
+    ADI_API_RETURN(device);
+    ADI_RANGE_CHECK(device, pin, ADI_ADRV9001_GPIO_DIGITAL_00, ADI_ADRV9001_GPIO_ANALOG_11);
+}
+
+int32_t adi_adrv9001_gpio_PinDirection_Get(adi_adrv9001_Device_t *device,
+					   adi_adrv9001_GpioPin_e pin,
+					   adi_adrv9001_GpioPinDirection_e *direction)
+{
+    uint16_t gpioOutEn = 0;
+
+    ADI_PERFORM_VALIDATION(adi_adrv9001_gpio_PinDirection_Get_Validate, device, pin);
+    if (ADI_ADRV9001_GPIO_DIGITAL_00 <= pin && pin <= ADI_ADRV9001_GPIO_DIGITAL_15)
+    {
+        ADI_EXPECT(adrv9001_NvsRegmapCore_NvsGpioDirectionControlOe_Get, device, &gpioOutEn);
+	*direction = (gpioOutEn & (1 << (pin - 1))) >> (pin - 1);
+    }
+    else if (ADI_ADRV9001_GPIO_ANALOG_00 <= pin && pin <= ADI_ADRV9001_GPIO_ANALOG_11)
+    {
+        ADI_EXPECT(adrv9001_NvsRegmapCore1_NvsGpioAnalogDirectionControlOe_Get, device, &gpioOutEn);
+	*direction = (gpioOutEn & (1 << (pin - ADI_ADRV9001_GPIO_ANALOG_00))) >> (pin - ADI_ADRV9001_GPIO_ANALOG_00);
+    }
+    else
+    {
+        ADI_SHOULD_NOT_EXECUTE(device);
+    }
+
+    ADI_API_RETURN(device);
+}
+
 int32_t adi_adrv9001_gpio_ManualAnalogInput_Configure(adi_adrv9001_Device_t *device,
                                                       adi_adrv9001_GpioPin_e pin)
 {


### PR DESCRIPTION
Add support for manually controlling the device gpios through debugfs. The first commit adds a a new API to the device driver API so that we can get the gpio direction. Checkpatch stuff is to be ignored on that commit.