### PR TITLE
iio: beamformer: adar1000: Reuse local variables

### DIFF
--- a/drivers/iio/beamformer/adar1000.c
+++ b/drivers/iio/beamformer/adar1000.c
@@ -2557,7 +2557,6 @@ static int adar1000_probe(struct spi_device *spi)
 			return -ENOMEM;
 
 		st = iio_priv(indio_dev);
-		spi_set_drvdata(spi, indio_dev);
 		st->spi = spi;
 		st->regmap = regmap;
 


### PR DESCRIPTION
For better visual loock, remove memory allocation also.

Signed-off-by: Cristian Pop <cristian.pop@analog.com>