### PR TITLE
hwmon: adt7410: fix hwmon sysfs attrs not being created

### DIFF
--- a/drivers/hwmon/adt7410.c
+++ b/drivers/hwmon/adt7410.c
@@ -46,7 +46,7 @@ static int adt7410_i2c_probe(struct i2c_client *client,
 			I2C_FUNC_SMBUS_BYTE_DATA | I2C_FUNC_SMBUS_WORD_DATA))
 		return -ENODEV;
 
-	return adt7x10_probe(&client->dev, NULL, client->irq, &adt7410_i2c_ops);
+	return adt7x10_probe(&client->dev, client->name, client->irq, &adt7410_i2c_ops);
 }
 
 static int adt7410_i2c_remove(struct i2c_client *client)


### PR DESCRIPTION
sysfs attrs for adt7410 are supposed to be created under
the hwmon device, but are being created under the i2c
device.
Switch to hwmon_device_register_with_groups to create
the relevant attrs in the correct directory, and
to also fix the deprecation warning created by
hwmon_device_register.

To achieve this, the following changes are also made.

 * pass client name from adt7410 driver to common
   driver and use it to register hwmon device
 * remove attribute_group declaration and use the
   ATTRIBUTE_GROUPS macro to align with other
   usages of hwmon_device_register_with_groups
 * remove name attribute since it is not needed anymore
   after moving away from hwmon_device_register
 * store bus device into private data and use it to call
   the i2c/spi ops both in hwmon sysfs attr contexts and
   outside of them

Signed-off-by: Cosmin Tanislav <demonsingur@gmail.com>