### PR TITLE
arch: arm: overlays: rpi-adt7420 support

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -168,6 +168,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	rpi-adxrs290.dtbo \
 	rpi-ad5770r.dtbo \
 	rpi-ad5791.dtbo \
+	rpi-adt7420.dtbo \
 	rpi-backlight.dtbo \
 	rpi-cirrus-wm5102.dtbo \
 	rpi-cn0504.dtbo \

--- a/arch/arm/boot/dts/overlays/rpi-adt7420-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-adt7420-overlay.dts
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709", "brcm,bcm2711";
+
+	fragment@1 {
+		target = <&i2c1>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			adt7420@4b {
+				compatible = "adt7420";
+				reg = <0x4b>;
+			};
+		};
+	};
+};


### PR DESCRIPTION
The ADT7420 is connected on the I2C1 bus and
configured to use slave address 0x4b.

Signed-off-by: Cosmin Tanislav <demonsingur@gmail.com>