### PR TITLE
arm: dts: zynq-zed-adv7511: Adds FMC I2C  bus and FRU EEPROM

### DIFF
--- a/arch/arm/boot/dts/zynq-zed-adv7511.dtsi
+++ b/arch/arm/boot/dts/zynq-zed-adv7511.dtsi
@@ -58,6 +58,24 @@
 			};
 		};
 
+		i2c@41620000 {
+			compatible = "xlnx,axi-iic-1.01.b", "xlnx,xps-iic-2.00.a";
+			reg = <0x41620000 0x10000>;
+			interrupt-parent = <&intc>;
+			interrupts = <0 55 IRQ_TYPE_LEVEL_HIGH>;
+			clocks = <&clkc 15>;
+			clock-names = "pclk";
+
+			#size-cells = <0>;
+			#address-cells = <1>;
+
+			eeprom@50 {
+				compatible = "at24,24c02";
+				reg = <0x50>;
+			};
+
+		};
+
 		hdmi_dma: dma@43000000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x43000000 0x10000>;


### PR DESCRIPTION
This adds the FMC i2c controller that is in the HDL design to the devicetree.
The FMC FRU EEPROM device is also included to allow its contents to be accessed.

Signed-off-by: Michael Bradley <michael.bradley@analog.com>