### PR TITLE
arch: arm64: dts: Add new zcu102/ad9081 dt with tdd engine

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9081-m8-l4-do.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9081-m8-l4-do.dts
@@ -22,6 +22,11 @@
 		// adi,sync-config = <2>;
 		// adi,transfer-length = /bits/ 64 <0x10000>; // 2**16 bytes
 	};
+
+	axi_data_offload_rx: axi-data-offload-1@9c450000 {
+		compatible = "adi,axi-data-offload-1.0.a";
+		reg = <0x9c450000 0x10000>;
+	};
 };
 
 &axi_ad9081_core_tx {

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9081-m8-l4-tdd.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9081-m8-l4-tdd.dts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD9081-FMC-EBZ
+ * https://wiki.analog.com/resources/eval/user-guides/quadmxfe/quick-start
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-mxfe/ad9081
+ *
+ * hdl_project: <ad9081_fmca_ebz/zcu102>
+ * board_revision: <>
+ *
+ * Copyright (C) 2021 Analog Devices Inc.
+ */
+
+#include "zynqmp-zcu102-rev10-ad9081-m8-l4-do.dts"
+
+&axi_data_offload_tx {
+	adi,oneshot;
+	adi,sync-config = <1>;
+};
+
+&axi_data_offload_rx {
+	adi,oneshot;
+	adi,sync-config = <1>;
+};
+
+&fpga_axi {
+	axi_tdd_0: axi-tdd-0@9c460000 {
+		compatible = "adi,axi-tdd-1.00";
+		reg = <0x9c460000 0x10000>;
+		clocks = <&zynqmp_clk PL0_REF>, <&hmc7044 6>;
+		clock-names = "s_axi_aclk", "intf_clk";
+	};
+};
+
+&axi_ad9081_core_tx {
+	adi,axi-pl-fifo-enable;
+};
+


### PR DESCRIPTION
This commit adds a new device tree that extends the previously available
zynqmp-zcu102-rev10-ad9081-m8-l4-do.dts by the TDD engine which may
optionally be enabled in the HDL during synthesis.

Additionally, the rx data offload is added to the device tree. This
device isn't new, and has been available in all HDL that contains the tx
data offload - it just didn't have to be exposed before.