### PR TITLE
hwmon: adt7410: support adt7422 chip

### DIFF
--- a/drivers/hwmon/adt7410.c
+++ b/drivers/hwmon/adt7410.c
@@ -57,6 +57,7 @@ static int adt7410_i2c_remove(struct i2c_client *client)
 static const struct i2c_device_id adt7410_ids[] = {
 	{ "adt7410", 0 },
 	{ "adt7420", 0 },
+	{ "adt7422", 0 },
 	{}
 };
 MODULE_DEVICE_TABLE(i2c, adt7410_ids);


### PR DESCRIPTION
Uses the same register map as the adt7420 chip.

Signed-off-by: Cosmin Tanislav <demonsingur@gmail.com>