### PR TITLE
hwmon: adt7410: support adt7422 chip

### DIFF
--- a/Documentation/hwmon/adt7410.rst
+++ b/Documentation/hwmon/adt7410.rst
@@ -22,6 +22,16 @@ Supported chips:
 
 	       http://www.analog.com/static/imported-files/data_sheets/ADT7420.pdf
 
+  * Analog Devices ADT7422
+
+    Prefix: 'adt7422'
+
+    Addresses scanned: None
+
+    Datasheet: Publicly available at the Analog Devices website
+
+	       http://www.analog.com/static/imported-files/data_sheets/ADT7422.pdf
+
   * Analog Devices ADT7310
 
     Prefix: 'adt7310'
@@ -47,26 +57,26 @@ Author: Hartmut Knaack <knaack.h@gmx.de>
 Description
 -----------
 
-The ADT7310/ADT7410 is a temperature sensor with rated temperature range of
--55°C to +150°C. It has a high accuracy of +/-0.5°C and can be operated at a
-resolution of 13 bits (0.0625°C) or 16 bits (0.0078°C). The sensor provides an
-INT pin to indicate that a minimum or maximum temperature set point has been
-exceeded, as well as a critical temperature (CT) pin to indicate that the
-critical temperature set point has been exceeded. Both pins can be set up with a
-common hysteresis of 0°C - 15°C and a fault queue, ranging from 1 to 4 events.
-Both pins can individually set to be active-low or active-high, while the whole
-device can either run in comparator mode or interrupt mode. The ADT7410 supports
-continuous temperature sampling, as well as sampling one temperature value per
-second or even just get one sample on demand for power saving. Besides, it can
-completely power down its ADC, if power management is required.
+The ADT7310, AD7320, ADT7410, ADT7420, and ADT7422 are register-compatible
+temperature sensors.
 
-The ADT7320/ADT7420 is register compatible, the only differences being the
-package, a slightly narrower operating temperature range (-40°C to +150°C), and
-a better accuracy (0.25°C instead of 0.50°C.)
+The ADT7310 and ADT7320 use SPI, while the ADT7410, ADT7420 and ADT7422 use I2C.
 
-The difference between the ADT7310/ADT7320 and ADT7410/ADT7420 is the control
-interface, the ADT7310 and ADT7320 use SPI while the ADT7410 and ADT7420 use
-I2C.
+They have a rated temperature range of -55°C to +150°C, a high accuracy
+(+/-0.5°C for the ADT7310 and ADT7410, +/-0.2°C for the ADT7320 and ADT7420,
++/-0.1°C for the ADT7422), and can be operated at a resolution of 13 bits
+(0.0625°C) or 16 bits (0.0078°C).
+
+The sensors provide an INT pin to indicate that a minimum or maximum temperature
+set point has been exceeded, as well as a critical temperature (CT) pin to
+indicate that the critical temperature set point has been exceeded.
+Both pins can be set up with a common hysteresis of 0°C - 15°C and a fault
+queue, ranging from 1 to 4 events. Both pins can individually set to be
+active-low or active-high, while the whole device can either run in comparator
+mode or interrupt mode. The sensors support continuous temperature sampling, as
+well as sampling one temperature value per second or even just get one sample on
+demand for power saving. Besides, they can completely power down their ADC,
+if power management is required.
 
 Configuration Notes
 -------------------

--- a/drivers/hwmon/Kconfig
+++ b/drivers/hwmon/Kconfig
@@ -197,7 +197,7 @@ config SENSORS_ADT7X10
 	tristate
 	help
 	  This module contains common code shared by the ADT7310/ADT7320 and
-	  ADT7410/ADT7420 temperature monitoring chip drivers.
+	  ADT7410/ADT7420/ADT7422 temperature monitoring chip drivers.
 
 	  If built as a module, the module will be called adt7x10.
 
@@ -213,12 +213,12 @@ config SENSORS_ADT7310
 	  will be called adt7310.
 
 config SENSORS_ADT7410
-	tristate "Analog Devices ADT7410/ADT7420"
+	tristate "Analog Devices ADT7410/ADT7420/ADT7422"
 	depends on I2C
 	select SENSORS_ADT7X10
 	help
 	  If you say yes here you get support for the Analog Devices
-	  ADT7410 and ADT7420 temperature monitoring chips.
+	  ADT7410, ADT7420 and ADT7422 temperature monitoring chips.
 
 	  This driver can also be built as a module. If so, the module
 	  will be called adt7410.

--- a/drivers/hwmon/adt7410.c
+++ b/drivers/hwmon/adt7410.c
@@ -57,6 +57,7 @@ static int adt7410_i2c_remove(struct i2c_client *client)
 static const struct i2c_device_id adt7410_ids[] = {
 	{ "adt7410", 0 },
 	{ "adt7420", 0 },
+	{ "adt7422", 0 },
 	{}
 };
 MODULE_DEVICE_TABLE(i2c, adt7410_ids);


### PR DESCRIPTION
Uses the same register map as the adt7420 chip.

Signed-off-by: Cosmin Tanislav <demonsingur@gmail.com>