### PR TITLE
Some typo fixes for maxim drivers and adp5520

### DIFF
--- a/drivers/mfd/Kconfig
+++ b/drivers/mfd/Kconfig
@@ -93,7 +93,7 @@ config PMIC_ADP5520
 	bool "Analog Devices ADP5520/01 MFD PMIC Core Support"
 	depends on I2C=y
 	help
-	  Say yes here to add support for Analog Devices AD5520 and ADP5501,
+	  Say yes here to add support for Analog Devices ADP5520 and ADP5501,
 	  Multifunction Power Management IC. This includes
 	  the I2C driver and the core APIs _only_, you have to select
 	  individual components like LCD backlight, LEDs, GPIOs and Kepad

--- a/drivers/power/supply/Kconfig
+++ b/drivers/power/supply/Kconfig
@@ -442,7 +442,7 @@ config CHARGER_ISP1704
 	  ISP1707/ISP1704 USB transceivers.
 
 config CHARGER_MAX8903
-	tristate "MAX8903 Battery DC-DC Charger for USB and Adapter Power"
+	tristate "MAX8903A/B/C/D/E/G/H/J/N/Y Battery DC-DC Charger for USB and Adapter Power"
 	help
 	  Say Y to enable support for the MAX8903 DC-DC charger and sysfs.
 	  The driver supports controlling charger-enable and current-limit

--- a/drivers/power/supply/max8903_charger.c
+++ b/drivers/power/supply/max8903_charger.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 /*
- * max8903_charger.c - Maxim 8903 USB/Adapter Charger Driver
+ * max8903_charger.c - Maxim 8903A/B/C/D/E/G/H/J/N/Y USB/Adapter Charger Driver
  *
  * Copyright (C) 2011 Samsung Electronics
  * MyungJoo Ham <myungjoo.ham@samsung.com>

--- a/drivers/regulator/Kconfig
+++ b/drivers/regulator/Kconfig
@@ -518,12 +518,12 @@ config REGULATOR_MAX8952
 	  modes ranging from 0.77V to 1.40V by 0.01V steps.
 
 config REGULATOR_MAX8973
-	tristate "Maxim MAX8973 voltage regulator "
+	tristate "Maxim MAX8973A voltage regulator"
 	depends on I2C
 	depends on THERMAL && THERMAL_OF
 	select REGMAP_I2C
 	help
-	  The MAXIM MAX8973 high-efficiency. three phase, DC-DC step-down
+	  The MAXIM MAX8973A high-efficiency. three phase, DC-DC step-down
 	  switching regulator delivers up to 9A of output current. Each
 	  phase operates at a 2MHz fixed frequency with a 120 deg shift
 	  from the adjacent phase, allowing the use of small magnetic component.

--- a/drivers/regulator/max8973-regulator.c
+++ b/drivers/regulator/max8973-regulator.c
@@ -1,7 +1,7 @@
 /*
- * max8973-regulator.c -- Maxim max8973
+ * max8973-regulator.c -- Maxim max8973A
  *
- * Regulator driver for MAXIM 8973 DC-DC step-down switching regulator.
+ * Regulator driver for MAXIM 8973A DC-DC step-down switching regulator.
  *
  * Copyright (c) 2012, NVIDIA Corporation.
  *

--- a/drivers/rtc/Kconfig
+++ b/drivers/rtc/Kconfig
@@ -966,7 +966,7 @@ config RTC_DRV_VRTC
 	updates are done via IPC calls to the system controller FW.
 
 config RTC_DRV_DS1216
-	tristate "Dallas DS1216"
+	tristate "Dallas DS1216B/C/D/E/F/H"
 	depends on SNI_RM
 	help
 	  If you say yes here you get support for the Dallas DS1216 RTC chips.

--- a/drivers/rtc/rtc-ds1216.c
+++ b/drivers/rtc/rtc-ds1216.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
 /*
- * Dallas DS1216 RTC driver
+ * Dallas DS1216B/C/D/E/F/H RTC driver
  *
  * Copyright (c) 2007 Thomas Bogendoerfer
  *

--- a/drivers/usb/host/Kconfig
+++ b/drivers/usb/host/Kconfig
@@ -372,7 +372,7 @@ config USB_FOTG210_HCD
 	  module will be called fotg210-hcd.
 
 config USB_MAX3421_HCD
-	tristate "MAX3421 HCD (USB-over-SPI) support"
+	tristate "MAX3421E HCD (USB-over-SPI) support"
 	depends on USB && SPI
 	---help---
 	  The Maxim MAX3421E chip supports standard USB 2.0-compliant

--- a/drivers/w1/masters/Kconfig
+++ b/drivers/w1/masters/Kconfig
@@ -26,10 +26,10 @@ config W1_MASTER_DS2490
 	  will be called ds2490.
 
 config W1_MASTER_DS2482
-	tristate "Maxim DS2482 I2C to 1-Wire bridge"
+	tristate "Maxim DS2482-100 and DS2482-800 I2C to 1-Wire bridge"
 	depends on I2C
 	help
-	  If you say yes here you get support for the Maxim DS2482
+	  If you say yes here you get support for the Maxim DS2482-100 and DS2482-800
 	  I2C to 1-Wire bridge.
 
 	  This driver can also be built as a module.  If so, the module

--- a/drivers/w1/slaves/w1_ds28e04.c
+++ b/drivers/w1/slaves/w1_ds28e04.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
 /*
- *	w1_ds28e04.c - w1 family 1C (DS28E04) driver
+ *	w1_ds28e04.c - w1 family 1C (DS28E04-100) driver
  *
  * Copyright (c) 2012 Markus Franke <franke.m@sebakmt.com>
  */


### PR DESCRIPTION
After adding the maxim projects on wiki we noticed some typos in the Kconfig files and some driver files which failed to specify existing variants of the product. This pull request aims to fix those