### PR TITLE
adis overlays

### DIFF
--- a/arch/arm/boot/dts/overlays/adis16475-overlay.dts
+++ b/arch/arm/boot/dts/overlays/adis16475-overlay.dts
@@ -59,8 +59,16 @@
 	};
 
 	__overrides__ {
-		interrupt = <&adis16475_pins>,"brcm,pins:0",
-				<&adis16475>,"interrupts:0";
+		/*
+		 * This gives an option to use the gpio25 as the data ready pin. This
+		 * must be used for the adis16465/7 families as these devices use the
+		 * 14 pin connector where DR is using gpio25. Note that this should
+		 * not be used for the other devices as the gpio25 is both connected to
+		 * the sync selector and to the sync pin (because the sync and DR pins
+		 * are swapped in the 16 pin connector).
+		 */
+		drdy_gpio25 = <&adis16475_pins>,"brcm,pins:0=25",
+				<&adis16475>,"interrupts:0=25";
 		device = <&adis16475>,"compatible";
 	};
 };

--- a/arch/arm/boot/dts/overlays/adis16475-overlay.dts
+++ b/arch/arm/boot/dts/overlays/adis16475-overlay.dts
@@ -45,7 +45,6 @@
 			#size-cells = <0>;
 
 			adis16475: adis16475@0 {
-				compatible = "adi,adis16477-1";
 				reg = <0>;
 				pinctrl-names = "default";
 				pinctrl-0 = <&adis16475_pins>;
@@ -62,5 +61,6 @@
 	__overrides__ {
 		interrupt = <&adis16475_pins>,"brcm,pins:0",
 				<&adis16475>,"interrupts:0";
+		device = <&adis16475>,"compatible";
 	};
 };

--- a/arch/arm/boot/dts/overlays/adis16475-overlay.dts
+++ b/arch/arm/boot/dts/overlays/adis16475-overlay.dts
@@ -62,7 +62,5 @@
 	__overrides__ {
 		interrupt = <&adis16475_pins>,"brcm,pins:0",
 				<&adis16475>,"interrupts:0";
-		reset = <&adis16475_pins>,"brcm,pins:4",
-				<&adis16475>,"reset-gpios:4";
 	};
 };

--- a/arch/arm/boot/dts/overlays/adis16480-overlay.dts
+++ b/arch/arm/boot/dts/overlays/adis16480-overlay.dts
@@ -59,11 +59,4 @@
 			};
 		};
 	};
-
-	__overrides__ {
-		interrupt = <&adis16480_pins>,"brcm,pins:0",
-				<&adis16480>,"interrupts:0";
-		reset = <&adis16480_pins>,"brcm,pins:4",
-				<&adis16480>,"reset-gpios:4";
-	};
 };

--- a/arch/arm/boot/dts/overlays/adis16480-overlay.dts
+++ b/arch/arm/boot/dts/overlays/adis16480-overlay.dts
@@ -61,5 +61,14 @@
 
 	__overrides__ {
 		device = <&adis16480>,"compatible";
+		drdy_dio2 = <&adis16480_pins>,"brcm,pins:0=25",
+				<&adis16480>,"interrupts:0=25",
+				<&adis16480>,"interrupt-names=DIO2";
+		drdy_dio3 = <&adis16480_pins>,"brcm,pins:0=4",
+				<&adis16480>,"interrupts:0=4",
+				<&adis16480>,"interrupt-names=DIO3";
+		drdy_dio4 = <&adis16480_pins>,"brcm,pins:0=5",
+				<&adis16480>,"interrupts:0=5",
+				<&adis16480>,"interrupt-names=DIO4";
 	};
 };

--- a/arch/arm/boot/dts/overlays/adis16480-overlay.dts
+++ b/arch/arm/boot/dts/overlays/adis16480-overlay.dts
@@ -45,7 +45,6 @@
 			#size-cells = <0>;
 
 			adis16480: adis16480@0 {
-				compatible = "adi,adis16495-3";
 				reg = <0>;
 				pinctrl-names = "default";
 				pinctrl-0 = <&adis16480_pins>;
@@ -58,5 +57,9 @@
 				interrupt-parent = <&gpio>;
 			};
 		};
+	};
+
+	__overrides__ {
+		device = <&adis16480>,"compatible";
 	};
 };


### PR DESCRIPTION
Do some cleanup and refactoring on IMUs overlays. The biggest change is that, now, the compatible property has to be given as an overlay parameter so that we can support more devices without having to recompile the overlay.