### PR TITLE
arm64: dts: adi-ad9172-fmc-ebz.dtsi: Use exact DAC rate

### DIFF
--- a/arch/arm64/boot/dts/xilinx/adi-ad9172-fmc-ebz.dtsi
+++ b/arch/arm64/boot/dts/xilinx/adi-ad9172-fmc-ebz.dtsi
@@ -72,7 +72,7 @@
 		clocks = <&axi_ad9172_jesd>, <&hmc7044 2>, <&hmc7044 3>;
 		clock-names = "jesd_dac_clk", "dac_clk", "dac_sysref";
 
-		adi,dac-rate-khz = <3000000>;
+		adi,dac-rate-khz = <2949120>;
 		adi,jesd-link-mode = <10>;
 
 		adi,jesd-subclass = <0>;


### PR DESCRIPTION
In this example the DAC REF_CLK is 368640000 Hz.
So we need to set a DAC rate which can be supported by the PLL.
Right now 3.000GHz works due to rounding effects.

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>