### PR TITLE
arch:arm64:dts: add xmicrowave support

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-revb-adrv2crr-fmc-revb-jesd204-fsm-xmicrowave.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-revb-adrv2crr-fmc-revb-jesd204-fsm-xmicrowave.dts
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * ADRV2CRR-FMC using ADRV9009-ZU11EG Rev.B System on Module
+ *
+ * https://wiki.analog.com/resources/eval/user-guides/adrv9009
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9009
+ * https://wiki.analog.com/resources/tools-software/linux-software/adrv9009_advanced_plugin
+ * https://wiki.analog.com/resources/eval/user-guides/adrv9009-zu11eg/adrv2crr-fmc_carrier_board
+ *
+ * hdl_project: <adrv9009zu11eg/adrv2crr_fmc>
+ * board_revision: <B>
+ *
+ * Copyright (C) 2021 Analog Devices Inc.
+ */
+
+#include "zynqmp-adrv9009-zu11eg-revb-adrv2crr-fmc-revb-jesd204-fsm.dts"
+
+/ {
+	adf5356_clkin: clock@0 {
+		compatible = "fixed-clock";
+
+		clock-frequency = <100000000>;
+		clock-output-names = "refclk";
+		#clock-cells = <0>;
+	};
+
+	vcm: fixedregulator@0 {
+		compatible = "regulator-fixed";
+		regulator-name = "vcm";
+		regulator-min-microvolt = <1500000>;
+		regulator-max-microvolt = <1500000>;
+		regulator-boot-on;
+	};
+};
+
+&fpga_axi {
+	axi_spi_1: spi@84000000 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		bits-per-word = <8>;
+		compatible = "xlnx,xps-spi-2.00.a";
+		reg = <0x0 0x84000000 0x1000>;
+		fifo-size = <16>;
+		interrupts = <0 92 IRQ_TYPE_EDGE_RISING>;
+		num-cs = <0x8>;
+		xlnx,num-ss-bits = <0x8>;
+		xlnx,spi-mode = <0>;
+	};
+};
+
+&axi_spi_1 {
+	admv1013_a@0 {
+		compatible = "adi,admv1013";
+		reg = <0>;
+		spi-max-frequency = <5000000>;
+		clocks = <&lo_adf5356>;
+		clock-names = "lo_in";
+		clock-scales = <1 8>;
+		vcm-supply = <&vcm>;
+		adi,parity-en;
+		adi,quad-se-mode = <9>;
+		adi,mixer-if-en;
+		adi,det-en;
+	};
+
+	admv1013_b@1 {
+		compatible = "adi,admv1013";
+		reg = <1>;
+		spi-max-frequency = <5000000>;
+		clocks = <&lo_adf5356>;
+		clock-names = "lo_in";
+		clock-scales = <1 8>;
+		vcm-supply = <&vcm>;
+		adi,quad-se-mode = <9>;
+		adi,parity-en;
+		adi,mixer-if-en;
+		adi,det-en;
+	};
+
+	admv1014_a@2 {
+		compatible = "adi,admv1014";
+		reg = <2>;
+		spi-max-frequency = <5000000>;
+		clocks = <&lo_adf5356>;
+		clock-names = "lo_in";
+		clock-scales = <1 8>;
+		vcm-supply = <&vcm>;
+		adi,quad-se-mode = <6>;
+		adi,p1db-comp = <3>;
+		adi,det-prog = <4>;
+		adi,parity-en;
+		adi,bb-amp-gain-ctrl = <0>;
+	};
+
+	admv1014_b@3 {
+		compatible = "adi,admv1014";
+		reg = <3>;
+		spi-max-frequency = <5000000>;
+		clocks = <&lo_adf5356>;
+		clock-names = "lo_in";
+		clock-scales = <1 8>;
+		vcm-supply = <&vcm>;
+		adi,quad-se-mode = <6>;
+		adi,p1db-comp = <3>;
+		adi,det-prog = <4>;
+		adi,parity-en;
+		adi,bb-amp-gain-ctrl = <0>;
+	};
+
+	lo_adf5356: adf5356@4 {
+		#clock-cells = <0>;
+		compatible = "adi,adf5356";
+		reg = <4>;
+		spi-max-frequency = <5000000>;
+		clocks = <&adf5356_clkin>;
+		clock-names = "clkin";
+		clock-output-names = "ADF5356";
+		adi,charge-pump-current = <900>;
+		adi,muxout-select = <6>;
+		adi,muxout-level-3v3-enable;
+		adi,mute-till-lock-enable;
+		adi,output-a-power = <3>;
+		adi,output-b-power = <3>;
+		adi,charge-pump-negative-bleed-enable;
+		adi,power-up-frequency = /bits/ 64 <6800000000>;
+		adi,output-b-enable;
+		adi,reference-doubler-enable;
+	};
+};


### PR DESCRIPTION
Add dts support for xmicrowave project in conjunction with
adrv9009-zu11eg-revb-jesd204-fsm.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>