### PR TITLE
versal-vck190-reva-ad9081.dts: add hdl tag

### DIFF
--- a/arch/arm64/boot/dts/xilinx/versal-vck190-reva-ad9081.dts
+++ b/arch/arm64/boot/dts/xilinx/versal-vck190-reva-ad9081.dts
@@ -4,7 +4,7 @@
  * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-mxfe/ad9081
  * https://wiki.analog.com/resources/eval/user-guides/ad9081_fmca_ebz/ad9081_fmca_ebz_hdl
  *
- * hdl_project: <>
+ * hdl_project: <ad9081_fmca_ebz/vck190>
  * board_revision: <>
  *
  * Copyright (C) 2019-2020 Analog Devices Inc.


### PR DESCRIPTION
Add hdl tag ad9081_fmca_ebz/vck190 in versal-vck190-reva-ad9081.dts.

Signed-off-by: stefan.raus <stefan.raus@analog.com>