### PR TITLE
drivers:iio:filter:admv8818: add missing ret check

### DIFF
--- a/drivers/iio/filter/admv8818.c
+++ b/drivers/iio/filter/admv8818.c
@@ -482,6 +482,8 @@ static int admv8818_clk_setup(struct admv8818_dev *dev)
 	dev->tolerance = clamp(dev->tolerance, 0U, 50U);
 
 	ret = clk_prepare_enable(dev->clkin);
+	if (ret)
+		return ret;
 
 	ret = devm_add_action_or_reset(&spi->dev, admv8818_clk_disable, dev->clkin);
 	if (ret)


### PR DESCRIPTION
Add missing return check in the clk_setup function.

Fixes: bd10500885159c88fc7b0fcd97e55154a14dca18 (iio:filter:admv8818: add support for ADMV8818)

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>