### PR TITLE
ci: use latest ubuntu stable image for docker builds

### DIFF
--- a/ci/travis/run-build-docker.sh
+++ b/ci/travis/run-build-docker.sh
@@ -18,7 +18,7 @@ else
 		fi
 	done
 	export OS_TYPE=ubuntu
-	export OS_VERSION=rolling
+	export OS_VERSION=latest
 	prepare_docker_image
 	run_docker_script run-build.sh
 fi


### PR DESCRIPTION
When building inside docker, the rolling ubuntu tag was being used. As
that brings the latest tools/packages, it might bring issues when
building. That just started to happen with the latest updates on the
docker image that introduced gcc 11 support. With that toolchain, arm
builds are failing with:

  /tmp/ccrHfZPj.s: Assembler messages:
  /tmp/ccrHfZPj.s:116: Error: selected processor does not support `dmb ish'
in ARM mode
  /tmp/ccrHfZPj.s:150: Error: selected processor does not support `isb '
in ARM mode
  /tmp/ccrHfZPj.s:160: Error: selected processor does not support
`mrrc p15,1,r4,r5,c14' in ARM mode
  /tmp/ccrHfZPj.s:245: Error: selected processor does not support `dmb ish'
in ARM mode
  /tmp/ccrHfZPj.s:503: Error: selected processor does not support `dmb ish'
in ARM mode
  /tmp/ccrHfZPj.s:527: Error: selected processor does not support `dmb ish'
in ARM mode
  /tmp/ccrHfZPj.s:698: Error: selected processor does not support `dmb ish'
in ARM mode
  /tmp/ccrHfZPj.s:731: Error: selected processor does not support `isb '
in ARM mode

There's a patch for linux [1] that is still not applied and building
with gcc 11.2 seems to work again which might indicate that the issue
was fixed on the compiler.

Anyways, this is the sort of things we get when trying to have a stable CI
build using rolling images. Hence, let's just use the latest stable
image.

[1]: https://x-lore.kernel.org/all/20210810061350.754134-1-juergh@canonical.com/
Signed-off-by: Nuno Sá <nuno.sa@analog.com>