### PR TITLE
dts: ad9081: Fix adi,high-density settings

### DIFF
--- a/arch/arm/boot/dts/adi-ad9081-fmc-ebz.dtsi
+++ b/arch/arm/boot/dts/adi-ad9081-fmc-ebz.dtsi
@@ -238,7 +238,7 @@
 					adi,control-bits-per-sample = <0>;	/* JESD CS */
 					adi,lanes-per-device = <4>;		/* JESD L */
 					adi,samples-per-converter-per-frame = <1>; /* JESD S */
-					adi,high-density = <1>;			/* JESD HD */
+					adi,high-density = <0>;			/* JESD HD */
 				};
 			};
 		};
@@ -343,7 +343,7 @@
 					adi,control-bits-per-sample = <0>;	/* JESD CS */
 					adi,lanes-per-device = <4>;		/* JESD L */
 					adi,samples-per-converter-per-frame = <1>; /* JESD S */
-					adi,high-density = <1>;			/* JESD HD */
+					adi,high-density = <0>;			/* JESD HD */
 				};
 			};
 		};

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9081-m8-l4-qpllrx.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9081-m8-l4-qpllrx.dts
@@ -327,7 +327,7 @@
 					adi,control-bits-per-sample = <0>;	/* JESD CS */
 					adi,lanes-per-device = <4>;		/* JESD L */
 					adi,samples-per-converter-per-frame = <1>; /* JESD S */
-					adi,high-density = <1>;			/* JESD HD */
+					adi,high-density = <0>;			/* JESD HD */
 				};
 			};
 		};
@@ -436,7 +436,7 @@
 					adi,control-bits-per-sample = <0>;	/* JESD CS */
 					adi,lanes-per-device = <4>;		/* JESD L */
 					adi,samples-per-converter-per-frame = <1>; /* JESD S */
-					adi,high-density = <1>;			/* JESD HD */
+					adi,high-density = <0>;			/* JESD HD */
 				};
 			};
 		};

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9081-m8-l4.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9081-m8-l4.dts
@@ -240,7 +240,7 @@
 					adi,control-bits-per-sample = <0>;	/* JESD CS */
 					adi,lanes-per-device = <4>;		/* JESD L */
 					adi,samples-per-converter-per-frame = <1>; /* JESD S */
-					adi,high-density = <1>;			/* JESD HD */
+					adi,high-density = <0>;			/* JESD HD */
 				};
 			};
 		};
@@ -349,7 +349,7 @@
 					adi,control-bits-per-sample = <0>;	/* JESD CS */
 					adi,lanes-per-device = <4>;		/* JESD L */
 					adi,samples-per-converter-per-frame = <1>; /* JESD S */
-					adi,high-density = <1>;			/* JESD HD */
+					adi,high-density = <0>;			/* JESD HD */
 				};
 			};
 		};

--- a/arch/microblaze/boot/dts/vcu118_ad9081_m8_l4.dts
+++ b/arch/microblaze/boot/dts/vcu118_ad9081_m8_l4.dts
@@ -169,7 +169,7 @@
 				adi,control-bits-per-sample = <0>;	/* JESD CS */
 				adi,lanes-per-device = <4>;		/* JESD L */
 				adi,samples-per-converter-per-frame = <1>; /* JESD S */
-				adi,high-density = <1>;			/* JESD HD */
+				adi,high-density = <0>;			/* JESD HD */
 			};
 		};
 	};
@@ -260,7 +260,7 @@
 				adi,control-bits-per-sample = <0>;	/* JESD CS */
 				adi,lanes-per-device = <4>;		/* JESD L */
 				adi,samples-per-converter-per-frame = <1>; /* JESD S */
-				adi,high-density = <1>;			/* JESD HD */
+				adi,high-density = <0>;			/* JESD HD */
 			};
 		};
 	};

--- a/arch/microblaze/boot/dts/vcu118_quad_ad9081_204b_txmode_9_rxmode_10.dts
+++ b/arch/microblaze/boot/dts/vcu118_quad_ad9081_204b_txmode_9_rxmode_10.dts
@@ -65,7 +65,7 @@
 #define AD9081_TX_JESD_CS			0
 #define AD9081_TX_JESD_L			4
 #define AD9081_TX_JESD_S			1
-#define AD9081_TX_JESD_HD			1
+#define AD9081_TX_JESD_HD			0
 
 /* RX path */
 #define AD9081_RX_MAIN_DECIMATION		4
@@ -93,7 +93,7 @@
 #define AD9081_RX_JESD_CS			0
 #define AD9081_RX_JESD_L			4
 #define AD9081_RX_JESD_S			1
-#define AD9081_RX_JESD_HD			1
+#define AD9081_RX_JESD_HD			0
 
 
 &rx_dma {


### PR DESCRIPTION
UG says HD = 1 for cases where M × S < L. This mode (8x1) !< 4
Fixes issue: AD9081 HD setting from updated UG #1634

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>