### PR TITLE
iio: beamformer: adar1000: Scratchpad test

### DIFF
--- a/drivers/iio/beamformer/adar1000.c
+++ b/drivers/iio/beamformer/adar1000.c
@@ -2610,18 +2610,17 @@ static int adar1000_probe(struct spi_device *spi)
 
 		ret = adar1000_setup(indio_dev);
 		if (ret < 0) {
-			dev_err(&spi->dev, "Setup failed (%d)\n", ret);
-			return ret;
+			dev_warn(&spi->dev, "Setup failed (%d), dev: %d, cnt: %d\n", ret, tmp, cnt);
+		} else {
+			ret = devm_iio_device_register(&spi->dev, indio_dev);
+			if (ret < 0)
+				return ret;
+
+			ret = sysfs_create_bin_file(&indio_dev->dev.kobj,
+						    &st->bin_pt);
+			if (ret < 0)
+				return ret;
 		}
-
-		ret = devm_iio_device_register(&spi->dev, indio_dev);
-		if (ret < 0)
-			return ret;
-
-		ret = sysfs_create_bin_file(&indio_dev->dev.kobj,
-					    &st->bin_pt);
-		if (ret < 0)
-			return ret;
 
 		cnt++;
 	}


### PR DESCRIPTION
Test read/write scratchpad register so that we are sure that the device is
present. This will prevent  the driver to probe successfully, with no
device attached to the board.

Signed-off-by: Cristian Pop <cristian.pop@analog.com>