### PR TITLE
adrv9009-zu11eg-revb-adrv2crr-fmc-revb-sync-jesd204-fsm: Fix HDL tags

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-revb-adrv2crr-fmc-revb-sync-jesd204-fsm-multisom-primary.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-revb-adrv2crr-fmc-revb-sync-jesd204-fsm-multisom-primary.dts
@@ -8,7 +8,7 @@
  * https://wiki.analog.com/resources/tools-software/linux-software/adrv9009_advanced_plugin
  * https://wiki.analog.com/resources/tools-software/linux-drivers/jesd204/jesd204-fsm-framework
  *
- * hdl_project: <adrv9009zu11eg/adrv2crr_fmc/>
+ * hdl_project: <adrv9009zu11eg/adrv2crr_fmc>
  * board_revision: <>
  *
  * Copyright (C) 2021 Analog Devices Inc.

--- a/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-revb-adrv2crr-fmc-revb-sync-jesd204-fsm-multisom-secondary.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-revb-adrv2crr-fmc-revb-sync-jesd204-fsm-multisom-secondary.dts
@@ -8,7 +8,7 @@
  * https://wiki.analog.com/resources/tools-software/linux-software/adrv9009_advanced_plugin
  * https://wiki.analog.com/resources/tools-software/linux-drivers/jesd204/jesd204-fsm-framework
  *
- * hdl_project: <adrv9009zu11eg/adrv2crr_fmc/>
+ * hdl_project: <adrv9009zu11eg/adrv2crr_fmc>
  * board_revision: <>
  *
  * Copyright (C) 2021 Analog Devices Inc.


### PR DESCRIPTION

Fix hdl project tags in zynqmp-adrv9009-zu11eg-revb-adrv2crr-fmc-revb-sync-jesd204-fsm-multisom-primary.dts
and zynqmp-adrv9009-zu11eg-revb-adrv2crr-fmc-revb-sync-jesd204-fsm-multisom-secondary.dts by removing the
extra '/' from the end.

Signed-off-by: stefan.raus <stefan.raus@analog.com>