### PR TITLE
dt-bindings: admv8818: fix example

### DIFF
--- a/Documentation/devicetree/bindings/iio/filter/adi,admv8818.yaml
+++ b/Documentation/devicetree/bindings/iio/filter/adi,admv8818.yaml
@@ -81,7 +81,7 @@ examples:
         clocks = <&admv8818_rfin>;
         clock-scales = <1 5>;
         clock-names = "rf_in";
-        adi,tolerance-percent = <3>;
+        adi,bw-hz = /bits/ 64 <600000000>;
       };
     };
 ...


### PR DESCRIPTION
With 13b575b492b5a311c68cb26398455d729974403d the tolerance property was
replaced with bandwidth.

Adjust the device tree example accordingly.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>