### PR TITLE
iio: adc: adrv9009: Support for digital baseband DC offset tracking

### DIFF
--- a/drivers/iio/adc/adrv9009.h
+++ b/drivers/iio/adc/adrv9009.h
@@ -53,6 +53,7 @@ enum adrv9009_bist_mode {
 enum adrv9009_rx_ext_info {
 	RSSI,
 	RX_QEC,
+	RX_BBDC,
 	RX_HD2,
 	RX_RF_BANDWIDTH,
 	RX_POWERDOWN,


### PR DESCRIPTION
This patch add support to control the BBDC offset tracking.

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>