### PR TITLE
AD9081 dev

### DIFF
--- a/drivers/iio/adc/Makefile
+++ b/drivers/iio/adc/Makefile
@@ -52,6 +52,7 @@ ad9081_drv-y := ad9081.o \
 	ad9081/adi_ad9081_device.o \
 	ad9081/adi_ad9081_jesd.o \
 	ad9081/adi_ad9081_hal.o \
+	ad9081/adi_ad9081_sync.o \
 	ad9081/adi_ad9081_dac.o
 
 obj-$(CONFIG_AD9081) += ad9081_drv.o

--- a/drivers/iio/adc/ad9081/adi_ad9081.h
+++ b/drivers/iio/adc/ad9081/adi_ad9081.h
@@ -291,21 +291,6 @@
 /*============= ENUMS ==============*/
 
 /*!
- * @brief Enumerates Chip Output Resolution
- */
-typedef enum {
-	AD9081_CHIP_OUT_RES_16BIT = 0x0, /*!< 16Bit */
-	AD9081_CHIP_OUT_RES_15BIT = 0x1, /*!< 15Bit */
-	AD9081_CHIP_OUT_RES_14BIT = 0x2, /*!< 14Bit */
-	AD9081_CHIP_OUT_RES_13BIT = 0x3, /*!< 13Bit */
-	AD9081_CHIP_OUT_RES_12BIT = 0x4, /*!< 12Bit */
-	AD9081_CHIP_OUT_RES_11BIT = 0x5, /*!< 11Bit */
-	AD9081_CHIP_OUT_RES_10BIT = 0x6, /*!< 10Bit */
-	AD9081_CHIP_OUT_RES_09BIT = 0x7, /*!<  9Bit */
-	AD9081_CHIP_OUT_RES_08BIT = 0x8 /*!<  8Bit */
-} adi_ad9081_chip_output_res_e;
-
-/*!
  * @brief Enumerates DAC Select
  */
 typedef enum {
@@ -318,7 +303,7 @@ typedef enum {
 } adi_ad9081_dac_select_e;
 
 /*!
- * @brief Enumerates DAC Channel Select
+ * @brief Enumerates DAC Channel / Fine DUC Datapath Select
  */
 typedef enum {
 	AD9081_DAC_CH_NONE = 0x00, /*!< No Channel */
@@ -334,27 +319,40 @@ typedef enum {
 } adi_ad9081_dac_channel_select_e;
 
 /*!
- * @brief Enumerates DAC Mode Switch Group Select
+ * @brief Enumerates Main DAC Datapth / Coarse DUC Datapath Select
  */
 typedef enum {
-	AD9081_DAC_MODE_SWITCH_GROUP_NONE = 0x00, /*!< No Group */
-	AD9081_DAC_MODE_SWITCH_GROUP_0 = 0x01, /*!< Group 0 (DAC0 & DAC1) */
-	AD9081_DAC_MODE_SWITCH_GROUP_1 = 0x02, /*!< Group 1 (DAC2 & DAC3) */
-	AD9081_DAC_MODE_SWITCH_GROUP_ALL = 0x03, /*!< All Groups */
-} adi_ad9081_dac_mode_switch_group_select_e;
+	AD9081_DAC_DP_NONE = 0x0, /*!< No Coarse DUC /No Main DAC Datapath */
+	AD9081_DAC_DP_0 = 0x1, /*!< Coarse DUC 0/ Main DAC0 Datapath */
+	AD9081_DAC_DP_1 = 0x2, /*!< Coarse DUC 1/ Main DAC1 Datapath */
+	AD9081_DAC_DP_2 = 0x4, /*!< Coarse DUC 2/ Main DAC2 Datapath */
+	AD9081_DAC_DP_3 = 0x8, /*!< Coarse DUC 3/ Main DAC3 Datapath */
+	AD9081_DAC_DP_ALL = 0x0F /*!< ALL Coarse DUC /ALL Main DAC Datapths */
+} adi_ad9081_dac_dp_select_e;
 
 /*!
- * @brief Enumerates DAC Mode Select
+ * @brief Enumerates DAC PAIRING for DAC mode Configuration
  */
 typedef enum {
-	AD9081_DAC_MODE_0 = 0x00, /*!< I0.Q0 -> DAC0, I1.Q1 -> DAC1 */
-	AD9081_DAC_MODE_1 =
+	AD9081_DAC_PAIR_NONE = 0x00, /*!< No Group */
+	AD9081_DAC_PAIR_0_1 = 0x01, /*!< Group 0 (DAC0 & DAC1) */
+	AD9081_DAC_PAIR_2_3 = 0x02, /*!< Group 1 (DAC2 & DAC3) */
+	AD9081_DAC_PAIR_ALL = 0x03, /*!< All Groups */
+} adi_ad9081_dac_pair_select_e;
+
+/*!
+ * @brief Enumerates DAC PAIR CDUC I/Q Data to DAC Core Modulation Mux Routing modes
+ */
+typedef enum {
+	AD9081_DAC_MUX_MODE_0 =
+		0x00, /*!<  I0.Q0 -> DAC0, Complex I1.Q1 -> DAC1 */
+	AD9081_DAC_MUX_MODE_1 =
 		0x01, /*!< (I0 + I1) / 2 -> DAC0, (Q0 + Q1) / 2 -> DAC1, Data Path NCOs Bypassed */
-	AD9081_DAC_MODE_2 =
+	AD9081_DAC_MUX_MODE_2 =
 		0x02, /*!< I0 -> DAC0, Q0 -> DAC1, Datapath0 NCO Bypassed, Datapath1 Unused */
-	AD9081_DAC_MODE_3 =
+	AD9081_DAC_MUX_MODE_3 =
 		0x03, /*!< (I0 + I1) / 2 -> DAC0, DAC1 Output Tied To Midscale */
-} adi_ad9081_dac_mode_e;
+} adi_ad9081_dac_mod_mux_mode_e;
 
 /*!
  * @brief Enumerates ADC Select
@@ -767,7 +765,9 @@ typedef struct {
 typedef struct {
 	adi_ad9081_ser_lane_settings_t lane_settings[8];
 	uint8_t invert_mask;
-	uint8_t lane_mapping[2][8];
+	uint8_t lane_mapping
+		[2]
+		[8]; /*Deserialise Lane Mapping, Map Virtual Converter to Physical Lane, index is physical, value is logical lane*/
 } adi_ad9081_ser_settings_t;
 
 /*!
@@ -780,7 +780,7 @@ typedef struct {
 		[8]; /*Equaliser CTLE Filter Selection, Range 0 - 4, based on Jesd IL, Pick lower setting for Higher Insertion loss*/
 	uint8_t lane_mapping
 		[2]
-		[8]; /*Deserialise Lane Mapping, Map Virtual Converter to Physical Lane*/
+		[8]; /*Deserialise Lane Mapping, Map Virtual Converter to Physical Lane, index is logical lane, value is physical lane*/
 } adi_ad9081_des_settings_t;
 
 /*!
@@ -840,8 +840,6 @@ typedef struct {
 		tx_en_pin_ctrl; /*!< Function pointer to hal tx_enable pin control function */
 	adi_reset_pin_ctrl_t
 		reset_pin_ctrl; /*!< Function pointer to hal reset# pin control function */
-	adi_sysref_ctrl_t
-		sysref_ctrl; /*!< Function pointer to hal sysref control function */
 } adi_ad9081_hal_t;
 
 /*!
@@ -1132,7 +1130,7 @@ int32_t adi_ad9081_device_main_auto_clk_gen_enable(adi_ad9081_device_t *device,
 
 /*===== 2 . 0   T R A N S M I T  P A T H  S E T U P =====*/
 /**
- * @ingroup tx_setup
+ * @ingroup tx_data_path_setup
  * @brief  System Top Level API. \n Startup Tx As NCO Test Mode
  *         This API will be called after adi_ad9081_device_clk_config_set().
  *
@@ -1154,7 +1152,7 @@ adi_ad9081_device_startup_nco_test(adi_ad9081_device_t *device,
 				   int64_t chan_shift[8], uint16_t dc_offset);
 
 /**
- * @ingroup tx_setup
+ * @ingroup tx_data_path_setup
  * @brief  System Top Level API. \n Startup Tx
  *         This API will be called after adi_ad9081_device_clk_config_set().
  *
@@ -1176,7 +1174,7 @@ int32_t adi_ad9081_device_startup_tx(adi_ad9081_device_t *device,
 				     adi_cms_jesd_param_t *jesd_param);
 
 /**
- * @ingroup tx_setup
+ * @ingroup tx_data_path_setup
  * @brief  System Top Level API. \n Set Fine DUC gain
  *         Call after adi_ad9081_device_startup_tx().
  *
@@ -1190,25 +1188,42 @@ int32_t adi_ad9081_dac_duc_nco_gains_set(adi_ad9081_device_t *device,
 					 uint16_t gains[8]);
 
 /**
- * @ingroup tx_setup
- * @brief  System Top Level API. \n Set DAC working mode
+ * @ingroup tx_data_path_setup
+ * @brief  System Top Level API. \n
+ *         Set DAC Data source Mux mode.
  *         Call after adi_ad9081_device_startup_tx()
  *
  * @param  device   Pointer to the device structure
- * @param  groups   Mode switch groups, @see adi_ad9081_dac_mode_switch_group_select_e
+ * @param  dac_pair DAC Pair Select for mode configuration @see adi_ad9081_dac_pair_select_e
  * @param  mode     Working mode, @see adi_ad9081_dac_mode_e
  *
  * @return API_CMS_ERROR_OK                     API Completed Successfully
  * @return <0                                   Failed. @see adi_cms_error_e for details.
  */
 int32_t
-adi_ad9081_dac_mode_set(adi_ad9081_device_t *device,
-			adi_ad9081_dac_mode_switch_group_select_e groups,
-			adi_ad9081_dac_mode_e mode);
+adi_ad9081_dac_modulation_mux_mode_set(adi_ad9081_device_t *device,
+				       adi_ad9081_dac_pair_select_e dac_pair,
+				       adi_ad9081_dac_mod_mux_mode_e mode);
+
+/**
+ * @ingroup tx_data_path_setup
+ * @brief  Set DAC complex modulation enable
+ *         Call after adi_ad9081_device_startup_tx()
+ *
+ * @param  device   Pointer to the device structure
+ * @param  groups   Mode switch groups, @see adi_ad9081_dac_pair_select_e
+ * @param  enable   1 to enable complex modulation
+ *
+ * @return API_CMS_ERROR_OK                     API Completed Successfully
+ * @return <0                                   Failed. @see adi_cms_error_e for details.
+ */
+int32_t adi_ad9081_dac_complex_modulation_enable_set(
+	adi_ad9081_device_t *device, adi_ad9081_dac_pair_select_e dac_pair,
+	uint8_t enable);
 
 /*===== 2 . 1   T R A N S M I T  T X E N =====*/
 /**
- * @ingroup tx_txen_setup
+ * @ingroup tx_transmit_en_setup
  * @brief  Set TXEN State Machine Enable
  *
  * @param  device  Pointer to the device structure
@@ -1223,7 +1238,7 @@ adi_ad9081_dac_tx_enable_state_machine_enable_set(adi_ad9081_device_t *device,
 						  uint8_t dacs, uint8_t enable);
 
 /**
- * @ingroup tx_txen_setup
+ * @ingroup tx_transmit_en_setup
  * @brief  Enable SPI as TXEN Control
  *
  * @param  device  Pointer to the device structure
@@ -1237,7 +1252,7 @@ int32_t adi_ad9081_dac_spi_as_tx_en_set(adi_ad9081_device_t *device,
 					uint8_t dacs, uint8_t enable);
 
 /**
- * @ingroup tx_txen_setup
+ * @ingroup tx_transmit_en_setup
  * @brief  Block Top Level API. \n Set Enable on DAC outputs
  *         Call after adi_ad9081_device_startup_tx().
  *
@@ -1252,7 +1267,7 @@ int32_t adi_ad9081_dac_tx_enable_set(adi_ad9081_device_t *device, uint8_t dacs,
 				     uint8_t enable);
 
 /**
- * @ingroup tx_txen_setup
+ * @ingroup tx_transmit_en_setup
  * @brief  Enable/Disable GPIOs Input For Tx Enable Control
  *
  * @param  device     Pointer to the device structure
@@ -1289,12 +1304,13 @@ int32_t adi_ad9081_dac_power_up_set(adi_ad9081_device_t *device, uint8_t dacs,
  * @param  device  Pointer to the device structure
  * @param  dacs    Target DAC Channel to enable data output
  * @param  uA      Desired current value in uA
+ * @param  rerun_cal Paramter to rerun dac cals after fsc change (recommended)
  *
  * @return API_CMS_ERROR_OK                     API Completed Successfully
  * @return <0                                   Failed. @see adi_cms_error_e for details.
  */
 int32_t adi_ad9081_dac_fsc_set(adi_ad9081_device_t *device, uint8_t dacs,
-			       uint32_t uA);
+			       uint32_t uA, uint8_t rerun_cal);
 
 /*===== 2 . 3   T R A N S M I T  C H A N N E L I Z E R  G A I N =====*/
 /**
@@ -1331,8 +1347,14 @@ int32_t adi_ad9081_dac_interpolation_set(adi_ad9081_device_t *device,
 
 /**
  * @ingroup tx_dp_setup
- * @brief  Block Top Level API. \n Set Main DAC to Channel Xbar
- *         Call after adi_ad9081_device_startup_tx().
+ * @brief  Block Top Level API. \n
+ *         Manually Set Main DAC to Channel Xbar
+ *         adi_ad9081_device_startup_tx(), Sets the DAC to Channel xbar based on channel interpolation
+ *         For Channel Bypass Modes where CH interpolation is 1, use this
+ *         API to mux IQ data pairs to the DACs
+ *         Refer to 4X4 Cross Bar in SDUG
+ *         Note This mux as a dependancy on channel interpolation, Call this API after
+ *         adi_ad9081_device_startup_tx or adi_ad9081_dac_interpolation_set
  *
  * @param  device     Pointer to the device structure
  * @param  dacs       Target DAC Channel Output
@@ -1409,22 +1431,6 @@ int32_t adi_ad9081_dac_nco_set(adi_ad9081_device_t *device, uint8_t dacs,
 int32_t adi_ad9081_dac_duc_nco_enable_set(adi_ad9081_device_t *device,
 					  uint8_t dacs, uint8_t channels,
 					  uint8_t enable);
-
-/**
- * @ingroup tx_nco_setup
- * @brief  Set DAC complex modulation enable
- *         Call after adi_ad9081_device_startup_tx()
- *
- * @param  device   Pointer to the device structure
- * @param  groups   Mode switch groups, @see adi_ad9081_dac_mode_switch_group_select_e
- * @param  enable   1 to enable complex modulation
- *
- * @return API_CMS_ERROR_OK                     API Completed Successfully
- * @return <0                                   Failed. @see adi_cms_error_e for details.
- */
-int32_t adi_ad9081_dac_complex_modulation_enable_set(
-	adi_ad9081_device_t *device,
-	adi_ad9081_dac_mode_switch_group_select_e groups, uint8_t enable);
 
 /**
  * @ingroup tx_nco_setup
@@ -2005,16 +2011,24 @@ int32_t adi_ad9081_jesd_tx_fbw_sel_set(adi_ad9081_device_t *device,
 
 /**
  * @ingroup rx_setup
- * @brief  System Top Level API. \n Set ADC Nyquist Zone
+ * @brief  System Top Level API. \n Set Nyquist Zone operation for each ADC
+ *         Required for correct ADC background Cal operation. See SDUG for more information
+ *         Nyquist Zone = ROUNDDOWN�(fIN/(fADC/2)) + 1
  *         Call after adi_ad9081_device_startup_rx().
  *
+ *
  * @param  device         Pointer to the device structure
- * @param  zone           AD9081_ADC_NYQUIST_ZONE_ODD / AD9081_ADC_NYQUIST_ZONE_EVEN
+ * @param  adc_sel        Masked list of ADC, as defined by adi_ad9081_adc_sel_e to be assign nyquist zone as described by zone parameter
+ * @param  zone           Desired nyquist zone operation for the adcs specified by adc_sel parameter.
+ *                        AD9081_ADC_NYQUIST_ZONE_ODD
+ *                        AD9081_ADC_NYQUIST_ZONE_EVEN
+ *
  *
  * @return API_CMS_ERROR_OK                     API Completed Successfully
  * @return <0                                   Failed. @see adi_cms_error_e for details.
  */
 int32_t adi_ad9081_adc_nyquist_zone_set(adi_ad9081_device_t *device,
+					adi_ad9081_adc_select_e adc_sel,
 					adi_ad9081_adc_nyquist_zone_e zone);
 
 /**
@@ -3455,6 +3469,25 @@ int32_t adi_ad9081_adc_clk_out_enable_set(adi_ad9081_device_t *device,
 
 /**
  * @ingroup rx_helper_api
+ * @brief  Set voltage swing level of ADC Clock Output Driver.
+ *
+ * @param  device     	Pointer to the device structure
+ * @param  code       	Input Value ranging -1000 to 1000 mV to estimate voltage swing as:
+ *                      code = (993mV - voltage_swing) / 99mV
+ *						(code -> Swing)
+ *						0 -> 993mV;		1 -> 894mV;		2 -> 795mV;		3 -> 696mV;		4 -> 597mV;		5 -> 498mV;		6 -> 399mV;
+ *						7 -> 300mV;		8 -> 201mV;		9 -> 102mV;		10 -> 3mV;		11 -> -96mV;	12 -> -195mV;	13 -> -294mV;
+ *						14 -> -393mV;	15 -> -492mV;	16 -> -591mV;	17 -> -690mV;	18 -> -789mV;	19 -> -888mV;	20 -> -987mV;
+ *
+ *
+ * @return API_CMS_ERROR_OK                     API Completed Successfully
+ * @return <0                                   Failed. @see adi_cms_error_e for details.
+ */
+int32_t adi_ad9081_adc_clk_out_voltage_swing_set(adi_ad9081_device_t *device,
+						 int16_t swing_mv);
+
+/**
+ * @ingroup rx_helper_api
  * @brief  Configure mapping between fast detection enable to GPIO
  *
  * @param  device     Pointer to the device structure
@@ -3801,18 +3834,6 @@ int32_t adi_ad9081_jesd_rx_power_down_des(adi_ad9081_device_t *device);
 
 /**
  * @ingroup dac_link_setup
- * @brief  Block Top Level API. \n Start onshot sync
- *         Call after adi_ad9081_device_startup_rx().
- *
- * @param  device       Pointer to the device structure
- *
- * @return API_CMS_ERROR_OK                     API Completed Successfully
- * @return <0                                   Failed. @see adi_cms_error_e for details.
- */
-int32_t adi_ad9081_jesd_oneshot_sync(adi_ad9081_device_t *device);
-
-/**
- * @ingroup dac_link_setup
  * @brief  Read jesd jrx link configuration status
  *
  * @param  device        Pointer to the device structure
@@ -3887,12 +3908,13 @@ int32_t adi_ad9081_jesd_rx_link_select_set(adi_ad9081_device_t *device,
 
 /**
  * @ingroup dac_link_setup
- * @brief  Configure the JESD Rx lanes cross bar between physical lane and logic lane
+ * @brief  Configure the JESD Rx lanes cross bar between physical lane and logic lane per link
  *         Call after adi_ad9081_device_startup_tx().
  *
  * @param  device          Pointer to the device structure
  * @param  links           Target link
- * @param  logical_lanes   Logical lane index (0~7 for each value)
+ * @param  logical_lanes   Logical lane to physical lane mapping array (0~7)
+ *                          Where the index is logical lane, value is physical lane
  *
  * @return API_CMS_ERROR_OK                     API Completed Successfully
  * @return <0                                   Failed. @see adi_cms_error_e for details.
@@ -4349,7 +4371,7 @@ int32_t adi_ad9081_jesd_tx_format_sel_set(adi_ad9081_device_t *device,
  *
  * @param  device          Pointer to the device structure
  * @param  links           Target link select
- * @param  resolution      Chip output resolution, @see adi_ad9081_chip_output_res_e
+ * @param  resolution      Chip output resolution, Valid Range 8-16
  *
  * @return API_CMS_ERROR_OK                     API Completed Successfully
  * @return <0                                   Failed. @see adi_cms_error_e for details.
@@ -4463,6 +4485,22 @@ int32_t adi_ad9081_jesd_tx_synca_onchip_term_enable(adi_ad9081_device_t *device,
  */
 int32_t adi_ad9081_jesd_tx_syncb_onchip_term_enable(adi_ad9081_device_t *device,
 						    uint8_t enable);
+
+/**
+ * @ingroup adc_link_setup
+ * @brief  Digital reset links
+ *
+ * @param  device     Pointer to the device structure
+ * @param  links      Target link
+ * @param  reset      Enable or disable link reset
+ *
+ * @return API_CMS_ERROR_OK                     API Completed Successfully
+ * @return <0                                   Failed. @see adi_cms_error_e for details.
+ */
+int32_t
+adi_ad9081_jesd_tx_force_digital_reset_set(adi_ad9081_device_t *device,
+					   adi_ad9081_jesd_link_select_e links,
+					   uint8_t reset);
 
 /*=====    A P P E N D I X  =====*/
 /**
@@ -4774,6 +4812,23 @@ adi_ad9081_jesd_tx_jtspat_enable_set(adi_ad9081_device_t *device,
 /*===== A 2 . 0   M U L T I C H I P  S Y N C  &  S U B C L A S S  1   =====*/
 /**
  * @ingroup appdx_mcs
+ * @brief  Block Top Level API. \n Start onshot sync
+ *         Call after adi_ad9081_device_startup_rx() & adi_ad9081_device_startup_tx()
+ *         And Prior to links enable
+ *
+ * @param  device       Pointer to the device structure
+ * @param  subclass     System JESD Synchronization as per application requirements
+ *                      JESD_SUBCLASS_0,
+ *                      JESD_SUBCLASS_1
+ * @return API_CMS_ERROR_OK                     api completed successfully
+ * @return API_CMS_ERROR_JESD_SYNC_NOT_DONE     synchronization did not complete
+ * @return <0                                   Failed. @see adi_cms_error_e for details.
+ */
+int32_t adi_ad9081_jesd_oneshot_sync(adi_ad9081_device_t *device,
+				     adi_cms_jesd_subclass_e subclass);
+
+/**
+ * @ingroup appdx_mcs
  * @brief  Set SYSREF Phase
  *
  * @param  device  Pointer to the device structure
@@ -4951,29 +5006,20 @@ int32_t adi_ad9081_jesd_sysref_enable_set(adi_ad9081_device_t *device,
 
 /**
  * @ingroup appdx_mcs
- * @brief  Set sysref capture enable
+ * @brief  Block Top Level API. \n Set sysref input receiver mode
  *
- * @param  device     Pointer to the device structure
- * @param  enable     1:Enable, 0:Disable
- *
- * @return API_CMS_ERROR_OK                     API Completed Successfully
- * @return <0                                   Failed. @see adi_cms_error_e for details.
- */
-int32_t adi_ad9081_jesd_sysref_spi_enable_set(adi_ad9081_device_t *device,
-					      uint8_t enable);
-
-/**
- * @ingroup appdx_mcs
- * @brief  Set sysref input mode
- *
- * @param  device     Pointer to the device structure
- * @param  input_mode 0:AC couple, 1:DC couple
+ * @param  device                                   Pointer to the device structure
+ * @param  enable_receiver                          1:Enable, 0:Disable
+ * @param  enable_capture                           1:Enable, 0:Disable
+ * @param adi_cms_signal_coupling_e input_mode      Parameter of type adi_cms_signal_coupling_e to set the desired sysref signal type
+ *                                                  COUPLING_AC or COUPLING_DC
  *
  * @return API_CMS_ERROR_OK                     API Completed Successfully
  * @return <0                                   Failed. @see adi_cms_error_e for details.
  */
-int32_t adi_ad9081_jesd_sysref_input_mode_set(adi_ad9081_device_t *device,
-					      uint8_t input_mode);
+int32_t adi_ad9081_jesd_sysref_input_mode_set(
+	adi_ad9081_device_t *device, uint8_t enable_receiver,
+	uint8_t enable_capture, adi_cms_signal_coupling_e input_mode);
 
 /**
  * @ingroup appdx_mcs
@@ -5000,6 +5046,117 @@ int32_t adi_ad9081_adc_sysref_resync_mode_set(adi_ad9081_device_t *device,
  */
 int32_t adi_ad9081_adc_sysref_rise_edge_enable_set(adi_ad9081_device_t *device,
 						   uint8_t enable);
+
+/**
+ * @ingroup appdx_mcs
+ * @brief  Check if potential setup time violation exists.
+ *
+ * @param  device                                 Pointer to the device structure
+ * @param  setup_risk_assessment                  Pointer to number of ones in setup time register value
+ * @param  hold_risk_assessment                   Pointer to number of ones in hold time register value
+ *
+ * @return API_CMS_ERROR_OK                     API Completed Successfully
+ * @return <0                                   Failed. @see adi_cms_error_e for details.
+ */
+int32_t adi_ad9081_jesd_sysref_setup_hold_get(adi_ad9081_device_t *device,
+					      uint8_t *setup_risk_assessment,
+					      uint8_t *hold_risk_assessment);
+
+/**
+ * @ingroup appdx_mcs
+ * @brief  Enable and set fine and superfine delay on the SYSREF input.
+ *
+ * @param  device                Pointer to the device structure
+ * @param  enable                00:delay is disabled, 01:fine delay enabled, 10:superfine delay enabled, 11:both enabled
+ * @param  fine_delay            Fine delay adjustment of the SYSREF input in 1.1 ps steps with max of 56 ps
+ * @param  superfine_delay       Super fine delay adjustment of the SYSREF input in ~16 fs steps with max of 4 ps
+ *
+ * @return API_CMS_ERROR_OK                     API Completed Successfully
+ * @return <0                                   Failed. @see adi_cms_error_e for details.
+ */
+int32_t adi_ad9081_jesd_sysref_fine_superfine_delay_set(
+	adi_ad9081_device_t *device, uint8_t enable, uint8_t fine_delay,
+	uint8_t superfine_delay);
+
+/**
+ * @ingroup appdx_mcs
+ * @brief  Set Sysref edge count to delay enabling one-shot mode.
+ *
+ * @param  device                      Pointer to the device structure
+ * @param  edges                       Number of rising edges to ignore before sync
+ *
+ * @return API_CMS_ERROR_OK                     API Completed Successfully
+ * @return <0                                   Failed. @see adi_cms_error_e for details.
+ */
+int32_t adi_ad9081_jesd_sysref_count_set(adi_ad9081_device_t *device,
+					 uint8_t edges);
+
+/**
+ * @ingroup appdx_mcs
+ * @brief  Set number of Sysref pulses that are averaged before one-shot mode.
+ *
+ * @param  device                      Pointer to the device structure
+ * @param  pulses                      Number of pulses to be averaged calculated by 2^n
+ *
+ * @return API_CMS_ERROR_OK                     API Completed Successfully
+ * @return <0                                   Failed. @see adi_cms_error_e for details.
+ */
+int32_t adi_ad9081_jesd_sysref_average_set(adi_ad9081_device_t *device,
+					   uint8_t pulses);
+
+/**
+ * @ingroup appdx_mcs
+ * @brief  Get Sysref phase in monitor mode
+ *
+ * @param  device               Pointer to the device structure
+ * @param  sysref_phase         Pointer to the sysref phase register
+ *
+ * @return API_CMS_ERROR_OK                     API Completed Successfully
+ * @return <0                                   Failed. @see adi_cms_error_e for details.
+ */
+int32_t adi_ad9081_jesd_sysref_monitor_phase_get(adi_ad9081_device_t *device,
+						 uint16_t *sysref_phase);
+
+/**
+ * @ingroup appdx_mcs
+ * @brief  Get Sysref to lmfc align error in monitor mode
+ *
+ * @param  device                     Pointer to the device structure
+ * @param  lmfc_align_err_get         Pointer to the lmfc align error value
+ *
+ * @return API_CMS_ERROR_OK                     API Completed Successfully
+ * @return <0                                   Failed. @see adi_cms_error_e for details.
+ */
+int32_t
+adi_ad9081_jesd_sysref_monitor_lmfc_align_error_get(adi_ad9081_device_t *device,
+						    uint8_t *lmfc_align_err);
+
+/**
+ * @ingroup appdx_mcs
+ * @brief  Set Sysref lmfc align threshold in monitor mode
+ *
+ * @param  device                      Pointer to the device structure
+ * @param  sysref_error_window         Sysref error window value
+ *
+ * @return API_CMS_ERROR_OK                     API Completed Successfully
+ * @return <0                                   Failed. @see adi_cms_error_e for details.
+ */
+int32_t adi_ad9081_jesd_sysref_monitor_lmfc_align_threshold_set(
+	adi_ad9081_device_t *device, uint8_t sysref_error_window);
+
+/**
+ * @ingroup appdx_mcs
+ * @brief  Check oneshot sync mode flag if sync is done.
+ *
+ * @param  device                      Pointer to the device structure
+ * @param  sync_done                   Pointer to value of oneshot sync done flag
+ *
+ * @return API_CMS_ERROR_OK                     API Completed Successfully
+ * @return <0                                   Failed. @see adi_cms_error_e for details.
+ */
+int32_t
+adi_ad9081_jesd_sysref_oneshot_sync_done_get(adi_ad9081_device_t *device,
+					     uint8_t *sync_done);
 
 /*===== A 3 . 0   I R Q S   =====*/
 

--- a/drivers/iio/adc/ad9081/adi_ad9081_adc.c
+++ b/drivers/iio/adc/ad9081/adi_ad9081_adc.c
@@ -66,6 +66,70 @@ int32_t adi_ad9081_adc_core_analog_regs_enable_set(adi_ad9081_device_t *device,
 	return API_CMS_ERROR_OK;
 }
 
+int32_t
+adi_ad9081_adc_analog_input_buffer_set(adi_ad9081_device_t *device,
+				       uint8_t adc_cores,
+				       adi_cms_signal_coupling_e coupling)
+{
+	int32_t err;
+	uint8_t enable_adc_core = 3, enable_cmbuf, cmin_input, cmin_out,
+		cmin_out_pulldown;
+	AD9081_NULL_POINTER_RETURN(device);
+	AD9081_LOG_FUNC();
+
+	if (adc_cores == 1 && coupling == COUPLING_AC) {
+		enable_cmbuf = 3;
+		cmin_input = 14;
+		cmin_out = 14;
+		cmin_out_pulldown = 4;
+	} else if (adc_cores == 1 && coupling == COUPLING_DC) {
+		enable_cmbuf = 0;
+		cmin_input = 14;
+		cmin_out = 4;
+		cmin_out_pulldown = 7;
+	} else if (adc_cores == 2 && coupling == COUPLING_AC) {
+		enable_cmbuf = 2;
+		cmin_input = 0;
+		cmin_out = 0;
+		cmin_out_pulldown = 3;
+	} else if (adc_cores == 2 && coupling == COUPLING_DC) {
+		enable_cmbuf = 0;
+		cmin_input = 0;
+		cmin_out = 4;
+		cmin_out_pulldown = 7;
+	} else {
+		return API_CMS_ERROR_INVALID_PARAM;
+	}
+	err = adi_ad9081_hal_bf_set(
+		device, 0x2112, 0x0,
+		1); /* CAL_FREEZE_GLOBAL freeze calibration for reconfig of common-mode loop*/
+	AD9081_ERROR_RETURN(err);
+	err = adi_ad9081_adc_core_analog_regs_enable_set(
+		device, adc_cores,
+		enable_adc_core); /*Global enable of ADC0 and ADC1 SPI access */
+	AD9081_ERROR_RETURN(err);
+	err = adi_ad9081_hal_bf_set(device, 0x1721, 0x206,
+				    enable_cmbuf); /* Power down CMBUF_PD */
+	AD9081_ERROR_RETURN(err);
+	err = adi_ad9081_hal_bf_set(
+		device, 0x1732, 0x400,
+		cmin_input); /* SPI_CMIN_INPUT_SEL select common mode loop for TxFE or MxFE*/
+	AD9081_ERROR_RETURN(err);
+	err = adi_ad9081_hal_bf_set(
+		device, 0x1733, 0X403,
+		cmin_out); /* SPI_CMIN_OUT_SEL select common mode loop for TxFE or MxFE*/
+	AD9081_ERROR_RETURN(err);
+	err = adi_ad9081_hal_bf_set(
+		device, 0x1733, 0x300,
+		cmin_out_pulldown); /* SPI_CMIN_OUT_PULDWN pulls VCMx pin low when common mode buffer is disabled*/
+	AD9081_ERROR_RETURN(err);
+	err = adi_ad9081_hal_bf_set(device, 0x2112, 0x0,
+				    0); /* CAL_FREEZE_GLOBAL */
+	AD9081_ERROR_RETURN(err);
+
+	return API_CMS_ERROR_OK;
+}
+
 int32_t adi_ad9081_adc_power_up_set(adi_ad9081_device_t *device, uint8_t adcs,
 				    uint8_t enable)
 {
@@ -209,6 +273,32 @@ int32_t adi_ad9081_adc_clk_out_enable_set(adi_ad9081_device_t *device,
 
 	err = adi_ad9081_hal_bf_set(device, REG_CLK_CTRL1_ADDR,
 				    BF_PD_ADC_DRIVER_INFO, !enable);
+	AD9081_ERROR_RETURN(err);
+
+	return API_CMS_ERROR_OK;
+}
+
+int32_t adi_ad9081_adc_clk_out_voltage_swing_set(adi_ad9081_device_t *device,
+						 int16_t swing_mv)
+{
+	int32_t err;
+	uint8_t code;
+	AD9081_NULL_POINTER_RETURN(device);
+	AD9081_LOG_FUNC();
+
+	if (swing_mv > 1000 || swing_mv < -1000) {
+		return API_CMS_ERROR_INVALID_PARAM;
+	}
+
+	code = (993 - swing_mv + (99 / 2)) / 99;
+
+	/* Voltage Swing = 993mV - (code * 99mV).
+	0 -> 993mV;		1 -> 894mV;		2 -> 795mV;		3 -> 696mV;		4 -> 597mV;		5 -> 498mV;		6 -> 399mV;
+	7 -> 300mV;		8 -> 201mV;		9 -> 102mV;		10 -> 3mV;		11 -> -96mV;	12 -> -195mV;	13 -> -294mV;
+	14 -> -393mV;	15 -> -492mV;	16 -> -591mV;	17 -> -690mV;	18 -> -789mV;	19 -> -888mV;	20 -> -987mV;
+	*/
+	err = adi_ad9081_hal_bf_set(device, REG_ADC_CLK_CTRL0_ADDR,
+				    BF_ADC_DRIVER_DATA_CTRL_INFO, code);
 	AD9081_ERROR_RETURN(err);
 
 	return API_CMS_ERROR_OK;
@@ -2454,10 +2544,13 @@ int32_t adi_ad9081_adc_config(adi_ad9081_device_t *device, uint8_t cddcs,
 }
 
 int32_t adi_ad9081_adc_nyquist_zone_set(adi_ad9081_device_t *device,
+					adi_ad9081_adc_select_e adc_sel,
 					adi_ad9081_adc_nyquist_zone_e zone)
 {
 	int32_t err;
 	uint32_t reg_nyquist_zone_addr = 0x2110;
+	uint8_t nyquist_setting = 0x0;
+	int i = 0;
 	AD9081_NULL_POINTER_RETURN(device);
 	AD9081_LOG_FUNC();
 
@@ -2468,19 +2561,28 @@ int32_t adi_ad9081_adc_nyquist_zone_set(adi_ad9081_device_t *device,
 	    device->dev_info.dev_rev == 3) { /* r1r/r2 */
 		reg_nyquist_zone_addr = 0x2110;
 	}
+	err = adi_ad9081_hal_reg_get(device, reg_nyquist_zone_addr,
+				     &nyquist_setting);
 
+	nyquist_setting |= 0x1; /*enable default override*/
 	if (zone == AD9081_ADC_NYQUIST_ZONE_ODD) {
-		err = adi_ad9081_hal_reg_set(device, reg_nyquist_zone_addr,
-					     0x01);
-		AD9081_ERROR_RETURN(err);
+		for (i = 0; i < 4; i++) {
+			if ((1 << i) & adc_sel) {
+				nyquist_setting &= ~(0x2 << i);
+			}
+		}
 	}
 	if (zone == AD9081_ADC_NYQUIST_ZONE_EVEN) {
-		err = adi_ad9081_hal_reg_set(device, reg_nyquist_zone_addr,
-					     0x1f);
-		AD9081_ERROR_RETURN(err);
+		for (i = 0; i < 4; i++) {
+			if ((1 << i) & adc_sel) {
+				nyquist_setting |= (0x2 << i);
+			}
+		}
 	}
+	err = adi_ad9081_hal_reg_set(device, reg_nyquist_zone_addr,
+				     nyquist_setting);
 	err = adi_ad9081_hal_reg_set(device, 0x2100,
-				     1); /* @user_ctrl_transfer */
+				     1); /* Trigger Data Transfer */
 	AD9081_ERROR_RETURN(err);
 
 	return API_CMS_ERROR_OK;
@@ -2526,16 +2628,12 @@ int32_t adi_ad9081_adc_test_mode_config_set(adi_ad9081_device_t *device,
 	AD9081_LOG_FUNC();
 
 	/* set test mode on all converters */
-	adi_ad9081_jesd_tx_conv_test_mode_enable_set(
+	err = adi_ad9081_jesd_tx_conv_test_mode_enable_set(
 		device, links,
 		((i_mode == AD9081_TMODE_OFF) && (q_mode == AD9081_TMODE_OFF)) ?
 			0x0000 :
 			0xffff);
-
-	/* set output as 16bit resolution */
-	adi_ad9081_jesd_tx_res_sel_set(device, links,
-				       AD9081_CHIP_OUT_RES_16BIT);
-
+	AD9081_ERROR_RETURN(err);
 	/* set test mode type */
 	err = adi_ad9081_hal_bf_set(device, REG_TMODE_I_CTRL1_ADDR,
 				    BF_TMODE_I_TYPE_SEL_INFO,

--- a/drivers/iio/adc/ad9081/adi_ad9081_config.h
+++ b/drivers/iio/adc/ad9081/adi_ad9081_config.h
@@ -40,7 +40,10 @@
 #define __FUNCTION_NAME__ __FUNCTION__
 #endif
 
-#define AD9081_API_REV 0x00010101
+#define AD9081_API_REV 0x00010200
+#define AD9081_API_HW_RESET_LOW 600000
+#define AD9081_API_RESET_WAIT 500000
+#define AD9081_PLL_LOCK_TRY 75
 #define AD9081_PLL_LOCK_WAIT 20000
 #define AD9081_JESD_CAL_BOOT_WAIT 250000
 #define AD9081_JESD_MAN_CAL_WAIT 200000
@@ -126,119 +129,834 @@
 extern "C" {
 #endif
 
+/**
+ * \brief Enables or disables on-chip PLL.
+ *
+ *  If set, the device clocks will be generated from the PLL. Otherwise
+ *  the device clocks will be generated from the reference clock supplied.
+ *
+ * \param[in]  device	         Pointer to device handler structure.
+ * \param[in]  pll_en            Enable signal for PLL
+ *                                  0 – Disable PLL
+ *                                  1 – Enable PLL
+ *
+ * \returns API_CMS_ERROR_OK returned upon success. Otherwise, a failure code.
+ */
 int32_t adi_ad9081_device_clk_pll_enable_set(adi_ad9081_device_t *device,
 					     uint8_t pll_en);
+
+/**
+ * \brief Configures PLL divider settings.
+ *
+ *   Set up the on-chip pll dividers which can generate the device
+ *   clocks for dac and adc cores from a provided reference clock.
+ *
+ * \param[in]  device	         Pointer to device handler structure.
+ * \param[in]  ref_div           Input reference clock divider. Valid range 0-0x3.
+ * \param[in]  m_div             PLL M-Divider.
+ * \param[in]  pll_div           PLL output divider. Valid range 0-0x3.
+ * \param[in]  fb_div            PLL Feedback divider. Valid range 0-0x3F.
+ *
+ * \returns API_CMS_ERROR_OK is returned upon success. Otherwise, a failure code.
+ */
 int32_t adi_ad9081_device_clk_pll_div_set(adi_ad9081_device_t *device,
 					  uint8_t ref_div, uint8_t m_div,
 					  uint8_t pll_div, uint8_t fb_div);
+
+/**
+ * \brief Configures PLL input and output frequencies.
+ *
+ *  Configure the PLL as per the desired DAC and ADC clock based on the
+ *  supplied reference clock set by ref_clk_hz parameter.
+ *
+ * \param[in]  device	         Pointer to device handler structure.
+ * \param[in]  dac_clk_hz        Desired DAC Clock Frequency in Hz. Valid Range 1.5GHz to 12GHz.
+ * \param[in]  adc_clk_hz        Desired ADC Clock Frequency in Hz. Valid Range 2GHz to 6GHz.
+ * \param[in]  ref_clk_hz        Reference Clock Frequecny provided in Hz. Valid Range 100 MHz to 2GHz.
+ *
+ * \returns API_CMS_ERROR_OK is returned upon success. Otherwise, a failure code.
+ */
 int32_t adi_ad9081_device_clk_pll_startup(adi_ad9081_device_t *device,
 					  uint64_t dac_clk_hz,
 					  uint64_t adc_clk_hz,
 					  uint64_t ref_clk_hz);
+
+/**
+ * \brief Configures up dividers.
+ *
+ *
+ * \param[in]  device	         Pointer to device handler structure.
+ * \param[in]  dac_clk_hz        Desired DAC Clock Frequency in Hz. Valid Range 1.5GHz to 12GHz.
+ *
+ * \returns API_CMS_ERROR_OK is returned upon success. Otherwise, a failure code.
+ */
 int32_t adi_ad9081_device_clk_up_div_set(adi_ad9081_device_t *device,
 					 uint64_t dac_clk_hz);
+
+/**
+ * \brief Gets laminate ID.
+ *
+ * Gets laminate ID from register 0x1e0d and puts it where input parameter 'id' points.
+ *
+ * \param[in]  device	         Pointer to device handler structure.
+ * \param[in]  id                Pointer to where you want to store laminate ID.
+ *
+ * \returns API_CMS_ERROR_OK is returned upon success. Otherwise, a failure code.
+ */
 int32_t adi_ad9081_device_laminate_id_get(adi_ad9081_device_t *device,
 					  uint8_t *id);
+
+/**
+ * \brief Gets die ID.
+ *
+ *  Gets die ID from register 0x1e0e and puts it where input parameter 'id' points.
+ *
+ * \param[in]  device	         Pointer to device handler structure.
+ * \param[in]  id                Pointer to where you want to store die ID.
+ *
+ * \returns API_CMS_ERROR_OK is returned upon success. Otherwise, a failure code.
+ */
 int32_t adi_ad9081_device_die_id_get(adi_ad9081_device_t *device, uint8_t *id);
+
+/**
+ * \brief Checks status of power supplies.
+ *
+ *  Checks power supply status for: DAC, Clock, ADC0, and ADC1.
+ *
+ * \param[in]  device	Pointer to device handler structure.
+ *
+ * \returns API_CMS_ERROR_OK is returned if all power supplies are on. Otherwise, a failure code.
+ */
 int32_t adi_ad9081_device_power_status_check(adi_ad9081_device_t *device);
+
+/**
+ * \brief Performs 8-bit register read/write test.
+ *
+ * Tries writing/reading register REG_PAGEINDX_DAC_CHAN_ADDR (0x0000001C).
+ *
+ * \param[in]  device	         Pointer to device handler structure.
+ *
+ * \returns API_CMS_ERROR_OK is returned upon success. Otherwise, a failure code.
+ */
 int32_t adi_ad9081_device_reg8_access_check(adi_ad9081_device_t *device);
+
+/**
+ * \brief Performs 32-bit register read/write test.
+ *
+ * Tries writing/reading register 0x01001300.
+ *
+ * \param[in]  device	         Pointer to device handler structure.
+ *
+ * \returns API_CMS_ERROR_OK is returned upon success. Otherwise, a failure code.
+ */
 int32_t adi_ad9081_device_reg32_access_check(adi_ad9081_device_t *device);
+
+/**
+ * \brief Verifies and logs pre-clock boot activity.
+ *
+ * Tracks core status through register 0x3472 to ensure boot reaches expected spot in boot_pre_clock().
+ * Next, checks that device revision is supported and logs chip ID, laminate ID, and die ID.
+ *
+ * \param[in]  device	         Pointer to device handler structure.
+ *
+ * \returns API_CMS_ERROR_OK is returned upon success. Otherwise, a failure code.
+ */
 int32_t adi_ad9081_device_boot_pre_clock(adi_ad9081_device_t *device);
+
+/**
+ * \brief Verifies and logs post-clock boot activity.
+ *
+ * Checks device revision to determine if the boot loader power up sequence should be bypassed.
+ * Verifies up_spi_edge_interrupt bit is cleared. Checks that boot is complete.
+ * Checks that core is waiting to run application code. Verifies that clock switch is done.
+ * Completes additional writes to ADC SPI enable registers. Finally, logs firmware revision.
+ *
+ * \param[in]  device	         Pointer to device handler structure.
+ *
+ * \returns API_CMS_ERROR_OK is returned upon success. Otherwise, a failure code.
+ */
 int32_t adi_ad9081_device_boot_post_clock(adi_ad9081_device_t *device);
+
+/**
+ * \brief Control master-slave mode for NCO sync.
+ *
+ * \param[in]  device	         Pointer to device handler structure.
+ * \param[in]  mode              0: disable, 1: set as master, 2: set as slave, 3: disable.
+ *
+ * \returns API_CMS_ERROR_OK is returned upon success. Otherwise, a failure code.
+ */
 int32_t adi_ad9081_device_nco_sync_mode_set(adi_ad9081_device_t *device,
 					    uint8_t mode);
+
+/**
+ * \brief Select which source triggers Master-slave mode for the master device.
+ *
+ * \param[in]  device	         Pointer to device handler structure.
+ * \param[in]  source            0: sysref, 1: lmfc rising edge, 2: lmfc falling edge.
+ *
+ * \returns API_CMS_ERROR_OK is returned upon success. Otherwise, a failure code.
+ */
 int32_t
 adi_ad9081_device_nco_sync_trigger_source_set(adi_ad9081_device_t *device,
 					      uint8_t source);
+
+/**
+ * \brief Set GPIOs related to NCO sync.
+ *
+ * \param[in]  device	         Pointer to device handler structure.
+ * \param[in]  gpio_index        GPIO identifier.
+ * \param[in]  output            (output > 0): 10 written to bitfield (output < 0): 11 written to bitfield.
+ *
+ * \returns API_CMS_ERROR_OK is returned upon success. Otherwise, a failure code.
+ */
 int32_t adi_ad9081_device_nco_sync_gpio_set(adi_ad9081_device_t *device,
 					    uint8_t gpio_index, uint8_t output);
+
+/**
+ * \brief In NCO Master-Slave sync mode, set how many extra lmfc cycles to delay before an NCO reset is issued.
+ *
+ *  Only valid when 'nco_sync_ms_mode'==1 & 'nco_sync_ms_trig_source'!=0.
+ *
+ * \param[in]  device	         Pointer to device handler structure.
+ * \param[in]  num               Number of extra lmfc.
+ *
+ * \returns API_CMS_ERROR_OK is returned upon success. Otherwise, a failure code.
+ */
 int32_t
 adi_ad9081_device_nco_sync_extra_lmfc_num_set(adi_ad9081_device_t *device,
 					      uint8_t num);
+
+/**
+ * \brief Control how RX & TX NCOs are synced by sysref.
+ *
+ * \param[in]  device	         Pointer to device handler structure.
+ * \param[in]  mode              0: immediately by sysref, 1: by next lmfc rising edge, 2: by next lmfc falling edge.
+ *
+ * \returns API_CMS_ERROR_OK is returned upon success. Otherwise, a failure code.
+ */
 int32_t adi_ad9081_device_nco_sync_sysref_mode_set(adi_ad9081_device_t *device,
 						   uint8_t mode);
+
+/**
+ * \brief Resets NCO
+ *
+ * Transition low to high triggers an internal NCO reset signal, on the next received SYSREF pulse.
+ *
+ * \param[in]  device	         Pointer to device handler structure.
+ * \param[in]  enable            1: reset NCO, 0: clear reset bit.
+ *
+ * \returns API_CMS_ERROR_OK is returned upon success. Otherwise, a failure code.
+ */
 int32_t
 adi_ad9081_device_nco_sync_reset_via_sysref_set(adi_ad9081_device_t *device,
 						uint8_t enable);
+
+/**
+ * \brief Triggers master-slave NCO synchronization.
+ *
+ * Self-clearing.
+ *
+ * \param[in]  device	         Pointer to device handler structure.
+ *
+ * \returns API_CMS_ERROR_OK is returned upon success. Otherwise, a failure code.
+ */
 int32_t adi_ad9081_device_nco_sync_trigger_set(adi_ad9081_device_t *device);
 
+/**
+ * \brief  Enable dual SPI mode
+ *
+ * Selecting dual0 will enable access to control registers in ranges 0x180-0x194, 0x60-0x7E, and 0x140-0x178.
+ * This will only access these registers for DAC0, DAC1, ADC0, and ADC2. Select dual1 for the same ranges on
+ * the DAC2, DAC3, ADC1, ADC3 side of the device.
+ *
+ * \param[in]  device	         Pointer to device handler structure.
+ * \param[in]  duals             0x1: select dual0, 0x2: select dual1, 0x3: select both.
+ * \param[in]  enable            1: enable, 0: disable.
+ *
+ * \returns API_CMS_ERROR_OK is returned upon success. Otherwise, a failure code.
+ */
 int32_t adi_ad9081_dac_d2a_dual_spi_enable_set(adi_ad9081_device_t *device,
 					       uint8_t duals, uint8_t enable);
+
+/**
+ * \brief Starts up specified DACs
+ *
+ * Enables DLL clock control, SWD clock control, and mushi decoder/control for each
+ * specified DAC. Overrides manual DCC code.
+ *
+ *
+ * \param[in]  device	         Pointer to device handler structure.
+ * \param[in]  dacs              0bXXXX, set X==1 to start-up corresponding DAC :
+ *                                  Bit 3: DAC 3  (MSB)
+ *                                  Bit 2: DAC 2
+ *                                  Bit 1: DAC 1
+ *                                  Bit 0: DAC 0  (LSB)
+ *
+ * \returns API_CMS_ERROR_OK is returned upon success. Otherwise, a failure code.
+ */
 int32_t adi_ad9081_dac_dll_startup(adi_ad9081_device_t *device, uint8_t dacs);
+
+/**
+ * \brief Enables digital logic.
+ *
+ * This includes JESD digital, digital clock gen., digital data path.
+ *
+ *
+ * \param[in]  device	         Pointer to device handler structure.
+ * \param[in]  enable            1: enable digital logic.
+ *
+ * \returns API_CMS_ERROR_OK is returned upon success. Otherwise, a failure code.
+ */
 int32_t adi_ad9081_dac_digital_logic_enable_set(adi_ad9081_device_t *device,
 						uint8_t enable);
+
+/**
+ * \brief Sets frequency tuning word for specified DACs and channels.
+ *
+ * If DDSM modulus disabled, main datapath NCO frequency =  FDAC * (FTW/2^48).
+ * If DDSM modulus enabled, main datapath NCO frequency = FDAC * (FTW + REG_DDSM_ACC_DELTA/REG_DDSM_ACC_MODULUS) / 2^48.
+ *
+ *      Note: ACC_DELTA and ACC_MODULUS are set via adi_ad9081_dac_duc_nco_ftw_set call.
+ *
+ *
+ * \param[in]  device	         Pointer to device handler structure.
+ * \param[in]  dacs              0bXXXX, set X==1 to specify DACs you wish to affect:
+ *                                  Bit 3: DAC 3  (MSB)
+ *                                  Bit 2: DAC 2
+ *                                  Bit 1: DAC 1
+ *                                  Bit 0: DAC 0  (LSB)
+ * \param[in]  channels         0bXXXXXXXX, (8 bits) set X==1 to specifiy channels you wish to affect:
+ *                                  Bit 7: Channel 7 (MSB)
+ *                                  Bit 6: Channel 6
+ *                                  .....
+ *                                  Bit 0: Channel 0 (LSB)
+ * \param[in]  ftw              Frequency tuning word.
+ *
+ * \returns API_CMS_ERROR_OK is returned upon success. Otherwise, a failure code.
+ */
 int32_t adi_ad9081_dac_duc_nco_ftw0_set(adi_ad9081_device_t *device,
 					uint8_t dacs, uint8_t channels,
 					uint64_t ftw);
+
+/**
+ * \brief Enables soft off gain block for specified DACs.
+ *
+ * The ramp up/down process is achieved by data * gain which controls gain up
+ * and down, so soft off gain block must be enabled to use soft off/on.
+ *
+ *
+ * \param[in]  device	         Pointer to device handler structure.
+ * \param[in]  dacs              0bXXXX, set X==1 to specify DACs you wish to affect:
+ *                                  Bit 3: DAC 3  (MSB)
+ *                                  Bit 2: DAC 2
+ *                                  Bit 1: DAC 1
+ *                                  Bit 0: DAC 0  (LSB)
+ * \param[in] enable             1: enable, 0: disable.
+ *
+ * \returns API_CMS_ERROR_OK is returned upon success. Otherwise, a failure code.
+ */
 int32_t adi_ad9081_dac_soft_off_gain_enable_set(adi_ad9081_device_t *device,
 						uint8_t dacs, uint8_t enable);
+
+/**
+ * \brief Enables MSB and ISB shuffling.
+ *
+ * Enable shuffling (randomly selecting) active MSB & ISB segments for each new DAC sampling cycle.
+ *
+ *
+ * \param[in]  device	         Pointer to device handler structure.
+ * \param[in]  dacs              0bXXXX, set X==1 to specify DACs you wish to affect:
+ *                                  Bit 3: DAC 3  (MSB)
+ *                                  Bit 2: DAC 2
+ *                                  Bit 1: DAC 1
+ *                                  Bit 0: DAC 0  (LSB)
+ * \param[in] enable             1: enable, 0: disable.
+ *
+ * \returns API_CMS_ERROR_OK is returned upon success. Otherwise, a failure code.
+ */
 int32_t adi_ad9081_dac_shuffle_enable_set(adi_ad9081_device_t *device,
 					  uint8_t dacs, uint8_t enable);
+
+/**
+ * \brief Enables both:
+ *           - DAC data scrambling in sync and re-timer block (xor)
+ *           - DAC data de-scramble in decoder (de-xor)
+ *
+ *
+ * \param[in]  device	         Pointer to device handler structure.
+ * \param[in]  dacs              0bXXXX, set X==1 to specify DACs you wish to affect:
+ *                                  Bit 3: DAC 3  (MSB)
+ *                                  Bit 2: DAC 2
+ *                                  Bit 1: DAC 1
+ *                                  Bit 0: DAC 0  (LSB)
+ * \param[in] enable             1: enable, 0: disable.
+ *
+ * \returns API_CMS_ERROR_OK is returned upon success. Otherwise, a failure code.
+ */
 int32_t adi_ad9081_dac_data_xor_set(adi_ad9081_device_t *device, uint8_t dacs,
 				    uint8_t enable);
 
+/**
+ * \brief Selects ADCs to affect with next ADC setting change by updating coarse paging register.
+ *
+ *
+ * \param[in]  device	         Pointer to device handler structure.
+ * \param[in]  adcs              0bXXXX, set X==1 to specify ADCs you wish to affect:
+ *                                  Bit 3: ADC 3  (MSB)
+ *                                  Bit 2: ADC 2
+ *                                  Bit 1: ADC 1
+ *                                  Bit 0: ADC 0  (LSB)
+ *
+ * \returns API_CMS_ERROR_OK is returned upon success. Otherwise, a failure code.
+ */
 int32_t adi_ad9081_adc_select_set(adi_ad9081_device_t *device, uint8_t adcs);
+
+/**
+ * \brief Enables ADC0 and ADC1 analog register SPI access through the 8bit and 32bit SPI registers.
+ *
+ *
+ * \param[in]  device	         Pointer to device handler structure.
+ * \param[in]  adc_cores         0x01: ADC0 enable, 0x02: ADC1 enable, 0x03: both enable.
+ *
+ * \returns API_CMS_ERROR_OK is returned upon success. Otherwise, a failure code.
+ */
 int32_t adi_ad9081_adc_core_analog_regs_enable_set(adi_ad9081_device_t *device,
 						   uint8_t adc_cores,
 						   uint8_t enable);
+
+/**
+ * \brief Boots up specified ADC cores.
+ *
+ *
+ * \param[in]  device	         Pointer to device handler structure.
+ * \param[in]  adc_cores         0x01: boot ADC0, 0x02: boot ADC1, 0x03: boot both.
+ *
+ * \returns API_CMS_ERROR_OK is returned upon success. Otherwise, a failure code.
+ */
 int32_t adi_ad9081_adc_core_setup(adi_ad9081_device_t *device,
 				  uint8_t adc_cores);
+
+/**
+ * \brief Configures SPI registers for ADC Buffer
+ *
+ * \param[in]  device               Pointer to device handler structure.
+ * \param[in]  adc_cores            0x01: boot ADC0, 0x02: boot ADC1, 0x03: boot both.
+ * \param[in]  coupling             AC_COUPLED or DC_COUPLED
+ *
+ * \returns API_CMS_ERROR_OK is returned upon success. Otherwise, a failure code.
+ */
+int32_t
+adi_ad9081_adc_analog_input_buffer_set(adi_ad9081_device_t *device,
+				       uint8_t adc_cores,
+				       adi_cms_signal_coupling_e coupling);
+
+/**
+ * \brief Powers up selected ADCs by booting up their respective cores.
+ *
+ *  Essentially a wrapper for adi_ad9081_adc_core_setup.
+ *
+ *
+ * \param[in]  device	         Pointer to device handler structure.
+ * \param[in]  adcs              0bXXXX, set X==1 to specify ADCs you wish to power up:
+ *                                  Bit 3: ADC 3  (MSB)
+ *                                  Bit 2: ADC 2
+ *                                  Bit 1: ADC 1
+ *                                  Bit 0: ADC 0  (LSB)
+ *
+ * \returns API_CMS_ERROR_OK is returned upon success. Otherwise, a failure code.
+ */
 int32_t adi_ad9081_adc_power_up_set(adi_ad9081_device_t *device, uint8_t adcs,
 				    uint8_t enable);
+
+/**
+ * \brief Decodes ADC coarse DDC decimation values.
+ *
+ *
+ * \param[in]  cddc_dcm	         Value to be decoded.
+ *
+ * \param[out] cddc_dcm_value    Decoded value.
+ *
+ * \returns cddc_dcm_value - Decoded decimation value.
+ */
 uint8_t
 adi_ad9081_adc_ddc_coarse_dcm_decode(adi_ad9081_adc_coarse_ddc_dcm_e cddc_dcm);
+
+/**
+ * \brief Decodes ADC fine DDC decimation values.
+ *
+ *
+ * \param[in]  fddc_dcm	         Value to be decoded.
+ *
+ * \param[out] fddc_dcm_value    Decoded value.
+ *
+ * \returns fddc_dcm_value - Decoded decimation value.
+ */
 uint8_t
 adi_ad9081_adc_ddc_fine_dcm_decode(adi_ad9081_adc_fine_ddc_dcm_e fddc_dcm);
+
+/**
+ * \brief Selects the GPIOs to which PERI_I_SEL21/22 are connected.
+ *
+ * PERI_I_SEL21/22 are drive bits 0 and 1, respectively, of a 2-bit selector which
+ * chooses among four profiles of Programmable Filter/Fractional Delay/Cycle Delay
+ * (see datasheet).
+ *
+ *
+ * \param[in]  device	         Pointer to device handler structure.
+ * \param[in]  sel0              Map a GPIO to PERI_I_SEL21.
+ *
+ *                               Pin selection:
+ *
+ *                                  TxFE GPIO[6] 	 0x02
+ *                                  TxFE GPIO[7] 	 0x03
+ *                                  TxFE GPIO[8] 	 0x04
+ *                                  TxFE GPIO[9] 	 0x05
+ *                                  TxFE GPIO[10]    0x06
+ *                                  TxFE SYNCINB1_P	 0x07
+ *                                  TxFE SYNCINB1_N  0x08
+ *
+ * \param[in]  sel1             Map a GPIO to PERI_I_SEL22. Same pin selection as sel0.
+ *
+ * \returns API_CMS_ERROR_OK is returned upon success. Otherwise, a failure code.
+ */
 int32_t adi_ad9081_adc_fdelay_cdelay_pfir_sel_to_gpio_mapping_set(
 	adi_ad9081_device_t *device, uint8_t sel0, uint8_t sel1);
+
+/**
+ * \brief Enables common, GPIO based frequency hopping for all coarse DDC NCOs.
+ *
+ * When enabled while GPIO based hopping is selected, freq. hopping is done at the same time for all the Coarse DDC NCOs, bypassing the profile_pins[5:4].
+ * When disabled while GPIO based hopping is selected, freq. hopping is done for the Coarse DDC NCO selected by profile_pins[5:4].
+ *
+ * \param[in]  device	         Pointer to device handler structure.
+ * \param[in]  enable            1: enable, 0: disable.
+ *
+ * \returns API_CMS_ERROR_OK is returned upon success. Otherwise, a failure code.
+ */
 int32_t adi_ad9081_adc_common_hop_en_set(adi_ad9081_device_t *device,
 					 uint8_t enable);
+
+/**
+ * \brief Enables trig NCO reset for specified coarse DDCs.
+ *
+ *
+ * \param[in]  device	         Pointer to device handler structure.
+ * \param[in]  cddcs             0bXXXX, set X==1 to specify cddcs you wish to affect:
+ *                                  Bit 3: cddc 3  (MSB)
+ *                                  Bit 2: cddc 2
+ *                                  Bit 1: cddc 1
+ *                                  Bit 0: cddc 0  (LSB)
+ * \param[in]  enable            1: enable, 0: disable.
+ *
+ * \returns API_CMS_ERROR_OK is returned upon success. Otherwise, a failure code.
+ */
 int32_t adi_ad9081_adc_ddc_coarse_trig_nco_reset_enable_set(
 	adi_ad9081_device_t *device, uint8_t cddcs, uint8_t enable);
+
+/**
+ * \brief Changes Profile Update Mode/ Phase Update Mode for specified coarse DDCs.
+ *
+ *
+ * \param[in]  device	         Pointer to device handler structure.
+ * \param[in]  cddcs             0bXXXX, set X==1 to specify cddcs you wish to affect:
+ *                                  Bit 3: cddc 3  (MSB)
+ *                                  Bit 2: cddc 2
+ *                                  Bit 1: cddc 1
+ *                                  Bit 0: cddc 0  (LSB)
+ * \param[in]  mode              0: Instantaneous/Continuous Update. Phase increment and phase offset values are updated immediately.
+ *                               1: Phase increment and phase offset values are updated synchronously either when the chip_transfer
+ *                                  bit is set high or based on the GPIO (pin ddc_chip_gpio_transfer at nova_dig_dp_top hierarchy)
+ *                                  pin low to high transition. The chip transfer bit will be cleared once the transfer is complete.
+ *
+ * \returns API_CMS_ERROR_OK is returned upon success. Otherwise, a failure code.
+ */
 int32_t adi_ad9081_adc_ddc_coarse_nco_channel_update_mode_set(
 	adi_ad9081_device_t *device, uint8_t cddcs, uint8_t mode);
+
+/**
+ * \brief Changes GPIO Chip Transfer Mode for specified coarse DDCs.
+ *
+ * Used when ddc0_phase_update_mode is '1'.
+ *
+ * \param[in]  device	         Pointer to device handler structure.
+ * \param[in]  cddcs             0bXXXX, set X==1 to specify cddcs you wish to affect:
+ *                                  Bit 3: cddc 3  (MSB)
+ *                                  Bit 2: cddc 2
+ *                                  Bit 1: cddc 1
+ *                                  Bit 0: cddc 0  (LSB)
+ * \param[in]  mode              0: Phase increment and phase offset values are updated synchronously when the chip_transfer bit is set
+ *                                  high. The chip transfer bit will be cleared once the transfer is complete.
+ *                               1: Phase increment and phase offset values are updated based on the GPIO (pin ddc_chip_gpio_transfer
+ *                                  at nova_dig_dp_top hierarchy) pin low to high transition.
+ *
+ * \returns API_CMS_ERROR_OK is returned upon success. Otherwise, a failure code.
+ */
 int32_t
 adi_ad9081_adc_ddc_coarse_gpio_chip_xfer_mode_set(adi_ad9081_device_t *device,
 						  uint8_t cddcs, uint8_t mode);
+
+/**
+ * \brief Enable trig signal frequency hopping for specified coarse DDCs.
+ *
+ *
+ * \param[in]  device	         Pointer to device handler structure.
+ * \param[in]  cddcs             0bXXXX, set X==1 to specify cddcs you wish to affect:
+ *                                  Bit 3: cddc 3  (MSB)
+ *                                  Bit 2: cddc 2
+ *                                  Bit 1: cddc 1
+ *                                  Bit 0: cddc 0  (LSB)
+ * \param[in]  enable            0: Frequency hopping is independent of trig signal.
+ *                               1: Trig signal is used for frequency hopping.
+ *
+ * \returns API_CMS_ERROR_OK is returned upon success. Otherwise, a failure code.
+ */
 int32_t adi_ad9081_adc_ddc_coarse_trig_hop_en_set(adi_ad9081_device_t *device,
 						  uint8_t cddcs,
 						  uint8_t enable);
+
+/**
+ * \brief Enables amplitude dither and phase dither for specified coarse DDCs.
+ *
+ *
+ * \param[in]  device	         Pointer to device handler structure.
+ * \param[in]  cddcs             0bXXXX, set X==1 to specify cddcs you wish to affect:
+ *                                  Bit 3: cddc 3  (MSB)
+ *                                  Bit 2: cddc 2
+ *                                  Bit 1: cddc 1
+ *                                  Bit 0: cddc 0  (LSB)
+ * \param[in]  amp_dither_en     0: enable, 1: disable
+ * \param[in]  phase_dither_en   0: enable, 1: disable
+ *
+ * \returns API_CMS_ERROR_OK is returned upon success. Otherwise, a failure code.
+ */
 int32_t adi_ad9081_adc_ddc_coarse_dither_en_set(adi_ad9081_device_t *device,
 						uint8_t cddcs,
 						uint8_t amp_dither_en,
 						uint8_t phase_dither_en);
+
+/**
+ * \brief Sets Profile Select Word (PSW) for specified coarse DDCs.
+ *
+ * The PSW specifies the rollover point (in encode samples) for the Profile Select Timer (PST).  Whenever the Profile Select Timer
+ * rolls over to zero, channel selection counter increments when channel selection is through Profile Select Timer.
+ *
+ * \param[in]  device	         Pointer to device handler structure.
+ * \param[in]  cddcs             0bXXXX, set X==1 to specify cddcs you wish to affect:
+ *                                  Bit 3: cddc 3  (MSB)
+ *                                  Bit 2: cddc 2
+ *                                  Bit 1: cddc 1
+ *                                  Bit 0: cddc 0  (LSB)
+ * \param[in]  psw               Profile Select Word.
+ *
+ * \returns API_CMS_ERROR_OK is returned upon success. Otherwise, a failure code.
+ */
 int32_t adi_ad9081_adc_ddc_coarse_psw_set(adi_ad9081_device_t *device,
 					  uint8_t cddcs, uint64_t psw);
+
+/**
+ * \brief Enables trig NCO reset for specified fine DDCs.
+ *
+ *
+ * \param[in]  device	         Pointer to device handler structure.
+ * \param[in]  fddcs             0bXXXXXXXX, (8 bits) set X==1 to specify fddcs you wish to affect:
+ *                                  Bit 7: fddc 7  (MSB)
+ *                                  Bit 6: fddc 6
+ *                                  .....
+ *                                  Bit 0: fddc 0  (LSB)
+ * \param[in]  enable            1: enable, 0: disable.
+ *
+ * \returns API_CMS_ERROR_OK is returned upon success. Otherwise, a failure code.
+ */
 int32_t adi_ad9081_adc_ddc_fine_trig_nco_reset_enable_set(
 	adi_ad9081_device_t *device, uint8_t fddcs, uint8_t enable);
+
+/**
+ * \brief Changes Profile Update Mode/ Phase Update Mode for specified fine DDCs.
+ *
+ *
+ * \param[in]  device	         Pointer to device handler structure.
+ * \param[in]  fddcs             0bXXXXXXXX, (8 bits) set X==1 to specify fddcs you wish to affect:
+ *                                  Bit 7: fddc 7  (MSB)
+ *                                  Bit 6: fddc 6
+ *                                  .....
+ *                                  Bit 0: fddc 0  (LSB)
+ * \param[in]  mode              0: Instantaneous/Continuous Update. Phase increment and phase offset values are updated immediately.
+ *                               1: Phase increment and phase offset values are updated synchronously either when the chip_transfer
+ *                                  bit is set high or based on the GPIO (pin ddc_chip_gpio_transfer at nova_dig_dp_top hierarchy)
+ *                                  pin low to high transition. The chip transfer bit will be cleared once the transfer is complete.
+ *
+ * \returns API_CMS_ERROR_OK is returned upon success. Otherwise, a failure code.
+ */
 int32_t adi_ad9081_adc_ddc_fine_nco_channel_update_mode_set(
 	adi_ad9081_device_t *device, uint8_t fddcs, uint8_t mode);
+
+/**
+ * \brief Changes GPIO Chip Transfer Mode for specified fine DDCs.
+ *
+ * Used when ddc0_phase_update_mode is '1'.
+ *
+ * \param[in]  device	         Pointer to device handler structure.
+ * \param[in]  fddcs             0bXXXXXXXX, (8 bits) set X==1 to specify fddcs you wish to affect:
+ *                                  Bit 7: fddc 7  (MSB)
+ *                                  Bit 6: fddc 6
+ *                                  .....
+ *                                  Bit 0: fddc 0  (LSB)
+ * \param[in]  mode              0: Phase increment and phase offset values are updated synchronously when the chip_transfer bit is set
+ *                                  high. The chip transfer bit will be cleared once the transfer is complete.
+ *                               1: Phase increment and phase offset values are updated based on the GPIO (pin ddc_chip_gpio_transfer
+ *                                  at nova_dig_dp_top hierarchy) pin low to high transition.
+ *
+ * \returns API_CMS_ERROR_OK is returned upon success. Otherwise, a failure code.
+ */
 int32_t
 adi_ad9081_adc_ddc_fine_gpio_chip_xfer_mode_set(adi_ad9081_device_t *device,
 						uint8_t fddcs, uint8_t mode);
+
+/**
+ * \brief Enable trig signal frequency hopping for specified fine DDCs.
+ *
+ *
+ * \param[in]  device	         Pointer to device handler structure.
+ * \param[in]  fddcs             0bXXXXXXXX, (8 bits) set X==1 to specify fddcs you wish to affect:
+ *                                  Bit 7: fddc 7  (MSB)
+ *                                  Bit 6: fddc 6
+ *                                  .....
+ *                                  Bit 0: fddc 0  (LSB)
+ * \param[in]  enable            0: Frequency hopping is independent of trig signal.
+ *                               1: Trig signal is used for frequency hopping.
+ *
+ * \returns API_CMS_ERROR_OK is returned upon success. Otherwise, a failure code.
+ */
 int32_t adi_ad9081_adc_ddc_fine_trig_hop_en_set(adi_ad9081_device_t *device,
 						uint8_t fddcs, uint8_t enable);
+
+/**
+ * \brief Enables amplitude dither and phase dither for specified fine DDCs.
+ *
+ *
+ * \param[in]  device	         Pointer to device handler structure.
+ * \param[in]  fddcs             0bXXXXXXXX, (8 bits) set X==1 to specify fddcs you wish to affect:
+ *                                  Bit 7: fddc 7  (MSB)
+ *                                  Bit 6: fddc 6
+ *                                  .....
+ *                                  Bit 0: fddc 0  (LSB)
+ * \param[in]  amp_dither_en     0: enable, 1: disable
+ * \param[in]  phase_dither_en   0: enable, 1: disable
+ *
+ * \returns API_CMS_ERROR_OK is returned upon success. Otherwise, a failure code.
+ */
 int32_t adi_ad9081_adc_ddc_fine_dither_en_set(adi_ad9081_device_t *device,
 					      uint8_t fddcs,
 					      uint8_t amp_dither_en,
 					      uint8_t phase_dither_en);
 
+/**
+ * \brief  Sets masking for unused channels.
+ *
+ *
+ * \param[in]  device	         Pointer to device handler structure.
+ * \param[in]  links             Choose AD9081 link(s) to set mask for:
+ *                                  0x1 - AD9081_LINK_0
+ *                                  0x2 - AD9081_LINK_1
+ *                                  0x3 - Both
+ * \param[in]  conv_index        Choose converter to set mask for:
+ *                                  0x0 - CONV0
+ *                                  0x1 - CONV1
+ *                                  0x2 - CONV2
+ *                                  .....
+ *                                  0xF - CONV15
+ * \param[in]  val               0: unmask, 1: mask.
+ *
+ * \returns API_CMS_ERROR_OK is returned upon success. Otherwise, a failure code.
+ */
 int32_t adi_ad9081_jesd_tx_conv_mask_set(adi_ad9081_device_t *device,
 					 adi_ad9081_jesd_link_select_e links,
 					 uint8_t conv_index, uint8_t val);
+
+/**
+ * \brief Sets virtual converters for specified links.
+ *
+ * \param[in]  device	         Pointer to device handler structure.
+ * \param[in]  links             Choose AD9081 link(s) to set mask for:
+ *                                  0x1 - AD9081_LINK_0
+ *                                  0x2 - AD9081_LINK_1
+ *                                  0x3 - Both
+ * \param[in]  jesd_conv_sel     jesd_conv_sel[0] - Virtual converter selection struct for AD9081_LINK_0.
+ *                               jesd_conv_sel[1] - Virtual converter selection struct for AD9081_LINK_1.
+ * \param[in]  jesd_m            jesd_m[0] - Number of used virtual converters for AD9081_LINK_0.
+ *                               jesd_m[1] - Number of used virtual converters for AD9081_LINK_1.
+ *
+ * \returns API_CMS_ERROR_OK is returned upon success. Otherwise, a failure code.
+ */
 int32_t adi_ad9081_jesd_tx_link_conv_sel_set(
 	adi_ad9081_device_t *device, adi_ad9081_jesd_link_select_e links,
 	adi_ad9081_jtx_conv_sel_t jesd_conv_sel[2], uint8_t jesd_m[2]);
+
+/**
+ * \brief Get status of PLL.
+ *
+ * \param[in]  device	         Pointer to device handler structure.
+ * \param[in]  pll_locked        Pointer to location for storing pll locked status.
+ *
+ * \returns API_CMS_ERROR_OK is returned upon success. Otherwise, a failure code.
+ */
 int32_t adi_ad9081_jesd_tx_pll_status_get(adi_ad9081_device_t *device,
 					  uint8_t *pll_locked);
+
+/**
+ * \brief Startup JESD deserializers.
+ *
+ * \param[in]  device	         Pointer to device handler structure.
+ * \param[in]  deser_mode        0: Full rate operation, 1: Half rate operation, 2: Quarter rate operation.
+ *
+ * \returns API_CMS_ERROR_OK is returned upon success. Otherwise, a failure code.
+ */
 int32_t adi_ad9081_jesd_rx_startup_des(adi_ad9081_device_t *device,
 				       adi_ad9081_deser_mode_e deser_mode);
+
+/**
+ * \brief Finds unused DFormat output to assign to unused virtual converters.
+ *
+ * \param[in]  jesd_conv_sel     Pointer to virtual converter selection struct.
+ * \param[in]  jesd_m            Number of used virtual converters.
+ *
+ * \param[out] df_out            Unused DFormat output.
+ *
+ * \returns df_out: Unused DFormat output.
+ */
 uint16_t adi_ad9081_jesd_find_dformat_out_nc(
 	adi_ad9081_jtx_conv_sel_t const *jesd_conv_sel, uint8_t jesd_m);
+
+/**
+ * \brief Finds the highest common unused DFormat output between both AD9081 links.
+ *
+ * \param[in]  links             0x1 - Outputs first unused DFormat output for AD9081_LINK_0.
+ *                               0x2 - Outputs first unused DFormat output for AD9081_LINK_1.
+ *                               0x3 - Outputs highest common unused DFormat output between both.
+ * \param[in]  jesd_conv_sel     jesd_conv_sel[0] - Virtual converter selection struct for AD9081_LINK_0.
+ *                               jesd_conv_sel[1] - Virtual converter selection struct for AD9081_LINK_1.
+ * \param[in]  jesd_m            jesd_m[0] - Number of used virtual converters for AD9081_LINK_0.
+ *                               jesd_m[1] - Number of used virtual converters for AD9081_LINK_1.
+ *
+ * \param[out] nc                DFormat output.
+ *
+ * \returns nc - DFormat output.
+ */
 uint8_t
 adi_ad9081_jesd_determine_common_nc(adi_ad9081_jesd_link_select_e links,
 				    adi_ad9081_jtx_conv_sel_t jesd_conv_sel[2],
 				    uint8_t jesd_m[2]);
+
+/**
+ * \brief  Set d2acenter enable
+ *
+ * \param[in]  device     Pointer to the device structure
+ * \param[in]  enable     1:Enable, 0:Disable
+ *
+ * \return API_CMS_ERROR_OK is returned upon success. Otherwise, a failure code.
+ */
+int32_t adi_ad9081_jesd_sysref_d2acenter_enable_set(adi_ad9081_device_t *device,
+						    uint8_t enable);
 
 #if AD9081_USE_FLOATING_TYPE > 0
 int32_t adi_ad9081_hal_calc_nco_ftw_f(adi_ad9081_device_t *device, double freq,

--- a/drivers/iio/adc/ad9081/adi_ad9081_dac.c
+++ b/drivers/iio/adc/ad9081/adi_ad9081_dac.c
@@ -16,6 +16,37 @@
 /*============= I N C L U D E S ============*/
 #include "adi_ad9081_config.h"
 #include "adi_ad9081_hal.h"
+/*============= M A C R O S ====================*/
+#define AD9081_R2R_DAC_CAL_ADDR 0x17
+#define AD9081_R2R_DAC_CAL_CFG 0x4F
+#define AD9081_DAC_CAL_RUN_CFG 0x22
+#define AD9081_DAC_CAL_COMP_SPEED 0x1
+#define AD9081_DAC_CAL_THROWAWAY_CURR_CFG 0x11
+/*============= H E L P E R ====================*/
+/**
+ * @brief  Run Startup DAC Cals
+ *         Run After Startup, during startup
+ * @param  device    Pointer to the device structure.
+ * @param  dacs      Mask of Target DACs, refer to enum adi_ad9081_dac_select_e
+
+ * @return API_CMS_ERROR_OK                     API Completed Successfully
+ * @return <0                                   Failed. @see adi_cms_error_e for details.
+ */
+int32_t adi_ad9081_dac_run_startup_cal(adi_ad9081_device_t *device,
+				       uint8_t dacs);
+
+/**
+ * @brief  Run Startup DAC Cals
+ *         Run After Startup, during startup
+ * @param  device    Pointer to the device structure.
+ * @param  config    Config Setting for R2R Cals, Do Not Modify. Use ADI recommended Setting (0x79)
+ * @param  dacs      Mask of Target DACs, refer to enum adi_ad9081_dac_select_e
+
+ * @return API_CMS_ERROR_OK                     API Completed Successfully
+ * @return <0                                   Failed. @see adi_cms_error_e for details.
+ */
+int32_t adi_ad9081_dac_r2r_cal_config_set(adi_ad9081_device_t *device,
+					  uint8_t config, uint8_t dacs);
 
 /*============= C O D E ====================*/
 int32_t adi_ad9081_dac_select_set(adi_ad9081_device_t *device, uint8_t dacs)
@@ -69,73 +100,82 @@ int32_t adi_ad9081_dac_d2a_dual_spi_enable_set(adi_ad9081_device_t *device,
 }
 
 int32_t adi_ad9081_dac_mode_switch_group_select_set(
-	adi_ad9081_device_t *device,
-	adi_ad9081_dac_mode_switch_group_select_e group)
+	adi_ad9081_device_t *device, adi_ad9081_dac_pair_select_e dac_pair)
 {
 	AD9081_NULL_POINTER_RETURN(device);
 	AD9081_LOG_FUNC();
 	return adi_ad9081_hal_bf_set(device, REG_PAGEINDX_DAC_JRX_ADDR,
-				     BF_MODS_MSK_INFO, group);
+				     BF_MODS_MSK_INFO, dac_pair);
 }
 
 int32_t
-adi_ad9081_dac_mode_set(adi_ad9081_device_t *device,
-			adi_ad9081_dac_mode_switch_group_select_e groups,
-			adi_ad9081_dac_mode_e mode)
+adi_ad9081_dac_modulation_mux_mode_set(adi_ad9081_device_t *device,
+				       adi_ad9081_dac_pair_select_e dac_pair,
+				       adi_ad9081_dac_mod_mux_mode_e mode)
 {
 	int32_t err;
 	AD9081_NULL_POINTER_RETURN(device);
 	AD9081_LOG_FUNC();
-
-	if ((groups & AD9081_DAC_MODE_SWITCH_GROUP_0) > 0) {
-		err = adi_ad9081_dac_mode_switch_group_select_set(
-			device, AD9081_DAC_MODE_SWITCH_GROUP_0);
-		AD9081_ERROR_RETURN(err);
-		err = adi_ad9081_hal_bf_set(device, REG_DDSM_DATAPATH_CFG_ADDR,
-					    BF_DDSM_MODE_INFO,
-					    mode); /* paged */
-		AD9081_ERROR_RETURN(err);
-	}
-	if ((groups & AD9081_DAC_MODE_SWITCH_GROUP_1) > 0) {
-		err = adi_ad9081_dac_mode_switch_group_select_set(
-			device, AD9081_DAC_MODE_SWITCH_GROUP_1);
-		AD9081_ERROR_RETURN(err);
-		err = adi_ad9081_hal_bf_set(device, REG_DDSM_DATAPATH_CFG_ADDR,
-					    BF_DDSM_MODE_INFO,
-					    mode); /* paged */
-		AD9081_ERROR_RETURN(err);
-	}
-
+	if (((mode > 0x3) || (mode < 0) || (dac_pair == 0))) {
+		AD9081_INVALID_PARAM_RETURN(1);
+	};
+	err = adi_ad9081_dac_mode_switch_group_select_set(device, dac_pair);
+	AD9081_ERROR_RETURN(err);
+	err = adi_ad9081_hal_bf_set(device, REG_DDSM_DATAPATH_CFG_ADDR,
+				    BF_DDSM_MODE_INFO, mode); /* paged */
+	err = adi_ad9081_dac_mode_switch_group_select_set(device,
+							  AD9081_DAC_PAIR_NONE);
+	AD9081_ERROR_RETURN(err);
+#if 0
+    if ((dac_pair & AD9081_DAC_PAIR_0_1) > 0) {
+        err = adi_ad9081_dac_mode_switch_group_select_set(device, AD9081_DAC_MODE_SWITCH_GROUP_0);
+        AD9081_ERROR_RETURN(err);
+        err = adi_ad9081_hal_bf_set(device, REG_DDSM_DATAPATH_CFG_ADDR, BF_DDSM_MODE_INFO, mode); /* paged */
+        AD9081_ERROR_RETURN(err);
+    }
+    if ((dac_pair & AD9081_DAC_PAIR_2_3) > 0) {
+        err = adi_ad9081_dac_mode_switch_group_select_set(device, AD9081_DAC_MODE_SWITCH_GROUP_1);
+        AD9081_ERROR_RETURN(err);
+        err = adi_ad9081_hal_bf_set(device, REG_DDSM_DATAPATH_CFG_ADDR, BF_DDSM_MODE_INFO, mode); /* paged */
+        AD9081_ERROR_RETURN(err);
+    }
+#endif
 	return API_CMS_ERROR_OK;
 }
 
 int32_t adi_ad9081_dac_complex_modulation_enable_set(
-	adi_ad9081_device_t *device,
-	adi_ad9081_dac_mode_switch_group_select_e groups, uint8_t enable)
+	adi_ad9081_device_t *device, adi_ad9081_dac_pair_select_e dac_pair,
+	uint8_t enable)
 {
 	int32_t err;
 	AD9081_NULL_POINTER_RETURN(device);
 	AD9081_LOG_FUNC();
-
-	if ((groups & AD9081_DAC_MODE_SWITCH_GROUP_0) > 0) {
-		err = adi_ad9081_dac_mode_switch_group_select_set(
-			device, AD9081_DAC_MODE_SWITCH_GROUP_0);
-		AD9081_ERROR_RETURN(err);
-		err = adi_ad9081_hal_bf_set(device, REG_DDSM_DATAPATH_CFG_ADDR,
-					    BF_EN_CMPLX_MODULATION_INFO,
-					    enable); /* paged */
-		AD9081_ERROR_RETURN(err);
-	}
-	if ((groups & AD9081_DAC_MODE_SWITCH_GROUP_1) > 0) {
-		err = adi_ad9081_dac_mode_switch_group_select_set(
-			device, AD9081_DAC_MODE_SWITCH_GROUP_1);
-		AD9081_ERROR_RETURN(err);
-		err = adi_ad9081_hal_bf_set(device, REG_DDSM_DATAPATH_CFG_ADDR,
-					    BF_EN_CMPLX_MODULATION_INFO,
-					    enable); /* paged */
-		AD9081_ERROR_RETURN(err);
-	}
-
+	if (((enable > 1) || (dac_pair == 0x0))) {
+		AD9081_INVALID_PARAM_RETURN(1);
+	};
+	err = adi_ad9081_dac_mode_switch_group_select_set(device, dac_pair);
+	AD9081_ERROR_RETURN(err);
+	err = adi_ad9081_hal_bf_set(device, REG_DDSM_DATAPATH_CFG_ADDR,
+				    BF_EN_CMPLX_MODULATION_INFO,
+				    enable); /* paged */
+	AD9081_ERROR_RETURN(err);
+	err = adi_ad9081_dac_mode_switch_group_select_set(device,
+							  AD9081_DAC_PAIR_NONE);
+	AD9081_ERROR_RETURN(err);
+#if 0
+    if ((dac_pair & AD9081_DAC_MODE_SWITCH_GROUP_0) > 0) {
+        err = adi_ad9081_dac_mode_switch_group_select_set(device, AD9081_DAC_MODE_SWITCH_GROUP_0);
+        AD9081_ERROR_RETURN(err);
+        err = adi_ad9081_hal_bf_set(device, REG_DDSM_DATAPATH_CFG_ADDR, BF_EN_CMPLX_MODULATION_INFO, enable); /* paged */
+        AD9081_ERROR_RETURN(err);
+    }
+    if ((dac_pair & AD9081_DAC_MODE_SWITCH_GROUP_1) > 0) {
+        err = adi_ad9081_dac_mode_switch_group_select_set(device, AD9081_DAC_MODE_SWITCH_GROUP_1);
+        AD9081_ERROR_RETURN(err);
+        err = adi_ad9081_hal_bf_set(device, REG_DDSM_DATAPATH_CFG_ADDR, BF_EN_CMPLX_MODULATION_INFO, enable); /* paged */
+        AD9081_ERROR_RETURN(err);
+    }
+#endif
 	return API_CMS_ERROR_OK;
 }
 
@@ -1713,7 +1753,7 @@ int32_t adi_ad9081_dac_duc_main_dsa_set(adi_ad9081_device_t *device,
 }
 
 int32_t adi_ad9081_dac_fsc_set(adi_ad9081_device_t *device, uint8_t dacs,
-			       uint32_t uA)
+			       uint32_t uA, uint8_t rerun_cal)
 {
 	int32_t err;
 	uint8_t i, dac, min_code;
@@ -1721,12 +1761,15 @@ int32_t adi_ad9081_dac_fsc_set(adi_ad9081_device_t *device, uint8_t dacs,
 	uint32_t min_fsc, cf, ff;
 	AD9081_NULL_POINTER_RETURN(device);
 	AD9081_LOG_FUNC();
-	if (uA > 40000)
+	if (uA > 40000) {
 		AD9081_LOG_WARN(
 			"full-scale current beyond design recommendation (7mA - 40mA)");
+	}
 	if (uA < 7000)
 		AD9081_LOG_WARN(
 			"full-scale current beyond design recommendation (7mA - 40mA)");
+	if (rerun_cal > 1)
+		AD9081_INVALID_PARAM_RETURN(device);
 
 	for (i = 0; i < 4; i++) {
 		dac = dacs & (AD9081_DAC_0 << i);
@@ -1778,6 +1821,10 @@ int32_t adi_ad9081_dac_fsc_set(adi_ad9081_device_t *device, uint8_t dacs,
 			AD9081_ERROR_RETURN(err);
 		}
 	}
+	if (rerun_cal) {
+		err = adi_ad9081_dac_run_startup_cal(device, dacs);
+	}
+	AD9081_ERROR_RETURN(err);
 	return API_CMS_ERROR_OK;
 }
 
@@ -1883,8 +1930,8 @@ int32_t adi_ad9081_dac_nco_sync_set(adi_ad9081_device_t *device,
 	AD9081_INVALID_PARAM_RETURN(align_source > 4);
 
 	if (align_source == 0) { /* oneshot */
-		err = adi_ad9081_jesd_oneshot_sync(device);
-		AD9081_ERROR_RETURN(err);
+		/*err = adi_ad9081_jesd_oneshot_sync(device);
+        AD9081_ERROR_RETURN(err);*/
 	} else if (align_source == 1) { /* spi */
 		err = adi_ad9081_dac_nco_reset_set(device);
 		AD9081_ERROR_RETURN(err);
@@ -1948,4 +1995,142 @@ int32_t adi_ad9081_dac_nco_master_slave_sync(adi_ad9081_device_t *device,
 	return API_CMS_ERROR_OK;
 }
 
+int32_t adi_ad9081_dac_r2r_cal_config_set(adi_ad9081_device_t *device,
+					  uint8_t config, uint8_t dacs)
+{
+	int32_t err;
+	uint8_t i = 0;
+	AD9081_NULL_POINTER_RETURN(device);
+	AD9081_LOG_FUNC();
+
+	/*Page Target Dacs*/
+	err = adi_ad9081_dac_select_set(device, dacs);
+	AD9081_ERROR_RETURN(err);
+
+	/*set cal config*/
+	err = adi_ad9081_hal_bf_set(device, REG_CAL_DEBUG0_ADDR, 0x00000103, 0);
+	AD9081_ERROR_RETURN(err);
+	err = adi_ad9081_hal_bf_set(device, REG_CAL_DEBUG0_ADDR, 0x00000102, 1);
+	AD9081_ERROR_RETURN(err);
+
+	/*Set R2R Cal Config*/
+	for (i = 0; i < 8; i++) {
+		err = adi_ad9081_hal_bf_set(device, (0x00000111), 0x00000600,
+					    AD9081_R2R_DAC_CAL_ADDR + i);
+		AD9081_ERROR_RETURN(err);
+		err = adi_ad9081_hal_bf_set(device, (0x00000112), 0x00000700,
+					    config);
+		AD9081_ERROR_RETURN(err);
+		err = adi_ad9081_hal_bf_set(device, (REG_CAL_CTRL_ADDR),
+					    0x00000103, 1);
+		AD9081_ERROR_RETURN(err);
+		err = adi_ad9081_hal_delay_us(device, 1000);
+		err = adi_ad9081_hal_bf_set(device, (REG_CAL_CTRL_ADDR),
+					    0x00000103, 0);
+		AD9081_ERROR_RETURN(err);
+	}
+
+	/*set cal config*/
+	err = adi_ad9081_hal_bf_set(device, REG_CAL_DEBUG0_ADDR, 0x00000103, 1);
+	AD9081_ERROR_RETURN(err);
+	err = adi_ad9081_hal_bf_set(device, REG_CAL_DEBUG0_ADDR, 0x00000102, 0);
+	AD9081_ERROR_RETURN(err);
+	return API_CMS_ERROR_OK;
+}
+int32_t adi_ad9081_dac_run_startup_cal(adi_ad9081_device_t *device,
+				       uint8_t dacs)
+{
+	int32_t err;
+	uint8_t i = 0, reg_val = 0x00, dac = 0;
+	AD9081_NULL_POINTER_RETURN(device);
+	AD9081_LOG_FUNC();
+	/*Page Target Dacs*/
+	err = adi_ad9081_dac_select_set(device, dacs);
+
+	/*Setup Calibration Clocks*/
+	/*Power Up CAL CLKS for target DACs*/
+	err = adi_ad9081_hal_reg_get(device, REG_CLK_CTRL2_ADDR, &reg_val);
+	AD9081_ERROR_RETURN(err);
+	reg_val &= ~0x0F;
+	reg_val |= dacs;
+	err = adi_ad9081_hal_reg_set(device, REG_CLK_CTRL2_ADDR, reg_val);
+
+	/*Set Cal Div*/
+	err = adi_ad9081_hal_bf_set(device, 0x0000010E, 0x00000400, 0x8);
+	AD9081_ERROR_RETURN(err);
+
+	/*Disable Ring Osc Set CAL CLK source to be DAC CLK*/
+	err = adi_ad9081_hal_bf_set(device, REG_RING_OSC_ADDR,
+				    BF_RINGOSC_EN_INFO, 0);
+	AD9081_ERROR_RETURN(err);
+
+	err = adi_ad9081_hal_reg_get(device, 0x0000019C, &reg_val);
+	AD9081_ERROR_RETURN(err);
+	reg_val &= ~0x0F;
+	for (i = 0; i < 4; i++) {
+		dac = dacs & (AD9081_DAC_0 << i);
+		if (dac > 0) {
+			reg_val |= ~(AD9081_DAC_0 << i);
+		}
+	}
+	err = adi_ad9081_hal_reg_set(device, 0x0000019C, reg_val);
+	AD9081_ERROR_RETURN(err);
+
+	/*Reset CAL Status*/
+	err = adi_ad9081_hal_bf_set(device, REG_CAL_CTRL_ADDR,
+				    BF_CAL_RESETB_INFO, 0);
+	AD9081_ERROR_RETURN(err);
+	err = adi_ad9081_hal_bf_set(device, REG_CAL_CTRL_ADDR,
+				    BF_CAL_RESETB_INFO, 1);
+	AD9081_ERROR_RETURN(err);
+
+	/*Set Calibration Config: cal settings*/
+	err = adi_ad9081_hal_bf_set(device, REG_CAL_DEBUG0_ADDR, 0x00000106, 1);
+	AD9081_ERROR_RETURN(err);
+	err = adi_ad9081_hal_bf_set(device, REG_CAL_DEBUG0_ADDR, 0x00000103, 1);
+	AD9081_ERROR_RETURN(err);
+	err = adi_ad9081_hal_bf_set(device, REG_CAL_DEBUG0_ADDR,
+				    BF_CAL_EN_G_INFO, 1);
+	AD9081_ERROR_RETURN(err);
+	/*CAL_MODE to GMode(0x1)*/
+	err = adi_ad9081_hal_bf_set(device, REG_CAL_CTRL_ADDR, BF_CAL_MODE_INFO,
+				    1);
+	AD9081_ERROR_RETURN(err);
+
+	/*Set Calibration Config: cal run settings  with ADI Recommended Settings*/
+	err = adi_ad9081_hal_reg_set(device, 0x0000011D,
+				     AD9081_DAC_CAL_RUN_CFG);
+	AD9081_ERROR_RETURN(err);
+	err = adi_ad9081_hal_bf_set(device, 0x00000127, 0x00000200,
+				    AD9081_DAC_CAL_COMP_SPEED);
+	AD9081_ERROR_RETURN(err);
+
+	/*Set Throwaway Currents*/
+	for (i = 0; i < 7; i++) {
+		err = adi_ad9081_hal_reg_set(device, 0x00000128 + i,
+					     AD9081_DAC_CAL_THROWAWAY_CURR_CFG);
+		AD9081_ERROR_RETURN(err);
+	}
+	err = adi_ad9081_hal_reg_set(device, 0x00000128 + i, 0x01);
+	AD9081_ERROR_RETURN(err);
+
+	/*Trigger Cal Start*/
+	err = adi_ad9081_hal_bf_set(device, REG_CAL_CTRL_ADDR,
+				    BF_CAL_START_INFO, 0x1);
+	AD9081_ERROR_RETURN(err);
+
+	/*Delay*/
+	err = adi_ad9081_hal_delay_us(device, 1000);
+	AD9081_ERROR_RETURN(err);
+
+	for (i = 0; i < 4; i++) {
+		dac = dacs & (AD9081_DAC_0 << i);
+		if (dac > 0) {
+			err = adi_ad9081_dac_r2r_cal_config_set(device, 79,
+								dac);
+			AD9081_ERROR_RETURN(err);
+		}
+	}
+	return API_CMS_ERROR_OK;
+}
 /*! @} */

--- a/drivers/iio/adc/ad9081/adi_ad9081_hal.c
+++ b/drivers/iio/adc/ad9081/adi_ad9081_hal.c
@@ -66,23 +66,6 @@ int32_t adi_ad9081_hal_reset_pin_ctrl(adi_ad9081_device_t *device,
 	return API_CMS_ERROR_OK;
 }
 
-int32_t adi_ad9081_hal_sysref_ctrl(adi_ad9081_device_t *device,
-				      uint8_t enable)
-{
-	AD9081_NULL_POINTER_RETURN(device);
-
-	/* Optional callback */
-	if (!device->hal_info.sysref_ctrl)
-		return API_CMS_ERROR_OK;
-
-	if (device->hal_info.sysref_ctrl(device->hal_info.user_data, enable)
-		!= API_CMS_ERROR_OK) {
-		return API_CMS_ERROR_ERROR;
-	}
-
-	return API_CMS_ERROR_OK;
-}
-
 int32_t adi_ad9081_hal_log_write(adi_ad9081_device_t *device,
 				 adi_cms_log_type_e log_type,
 				 const char *comment, ...)

--- a/drivers/iio/adc/ad9081/adi_ad9081_hal.h
+++ b/drivers/iio/adc/ad9081/adi_ad9081_hal.h
@@ -26,13 +26,45 @@
 extern "C" {
 #endif
 
+/**
+ * \brief Open and initialize resources and peripherals required for the TxFE device.
+ *
+ * \param[in]  device	         Pointer to device handler structure.
+ *
+ * \returns API_CMS_ERROR_OK is returned upon success. Otherwise, API_CMS_ERROR_HW_OPEN failure code.
+ */
 int32_t adi_ad9081_hal_hw_open(adi_ad9081_device_t *device);
+
+/**
+ * \brief Shutdown and close any resources opened by adi_aegir_hal_hw_open.
+ *
+ * \param[in]  device	         Pointer to device handler structure.
+ *
+ * \returns API_CMS_ERROR_OK is returned upon success. Otherwise, API_CMS_ERROR_HW_CLOSE failure code.
+ */
 int32_t adi_ad9081_hal_hw_close(adi_ad9081_device_t *device);
+
+/**
+ * \brief Perform a wait/thread sleep in units of microseconds.
+ *
+ * \param[in]  device	         Pointer to device handler structure.
+ * \param[in]  us                Delay duration in microseconds.
+ *
+ * \returns API_CMS_ERROR_OK is returned upon success. Otherwise, API_CMS_ERROR_DELAY_US failure code.
+ */
 int32_t adi_ad9081_hal_delay_us(adi_ad9081_device_t *device, uint32_t us);
+
+/**
+ * \brief Set ADI device RESETB pin high or low.
+ *
+ * \param[in]  device	         Pointer to device handler structure.
+ * \param[in]  enable            0: set RESETB pin low, 1: set RESETB pin high.
+ *
+ * \returns API_CMS_ERROR_OK is returned upon success. Otherwise, API_CMS_ERROR_RESET_PIN_CTRL failure code.
+ */
 int32_t adi_ad9081_hal_reset_pin_ctrl(adi_ad9081_device_t *device,
 				      uint8_t enable);
-int32_t adi_ad9081_hal_sysref_ctrl(adi_ad9081_device_t *device,
-				      uint8_t enable);
+
 int32_t adi_ad9081_hal_log_write(adi_ad9081_device_t *device,
 				 adi_cms_log_type_e type, const char *comment,
 				 ...);

--- a/drivers/iio/adc/ad9081/adi_ad9081_sync.c
+++ b/drivers/iio/adc/ad9081/adi_ad9081_sync.c
@@ -1,0 +1,401 @@
+// SPDX-License-Identifier: GPL-2.0
+/*!
+ * @brief     APIs for SYSREF configuration and control
+ *
+ * @copyright copyright(c) 2018 analog devices, inc. all rights reserved.
+ *            This software is proprietary to Analog Devices, Inc. and its
+ *            licensor. By using this software you agree to the terms of the
+ *            associated analog devices software license agreement.
+ */
+
+/*!
+ * @addtogroup AD9081_SYSREF_API
+ * @{
+ */
+
+/*============= I N C L U D E S ============*/
+#include "adi_ad9081_config.h"
+#include "adi_ad9081_hal.h"
+
+/*============= C O D E ====================*/
+
+int32_t adi_ad9081_jesd_sysref_enable_set(adi_ad9081_device_t *device,
+					  uint8_t enable)
+{
+	int32_t err;
+	AD9081_NULL_POINTER_RETURN(device);
+	AD9081_LOG_FUNC();
+
+	/* Power down the sysref receiver and sync circuitry. */
+	err = adi_ad9081_hal_bf_set(device, REG_SYSREF_CTRL_ADDR,
+				    BF_SYSREF_PD_INFO, !enable); /* not paged */
+	AD9081_ERROR_RETURN(err);
+
+	return API_CMS_ERROR_OK;
+}
+
+int32_t adi_ad9081_jesd_sysref_d2acenter_enable_set(adi_ad9081_device_t *device,
+						    uint8_t enable)
+{
+	int32_t err;
+	AD9081_NULL_POINTER_RETURN(device);
+	AD9081_LOG_FUNC();
+
+	err = adi_ad9081_hal_bf_set(device, REG_SPI_ENABLE_DAC_ADDR,
+				    BF_SPI_EN_D2ACENTER_INFO, enable);
+	AD9081_ERROR_RETURN(err);
+
+	return API_CMS_ERROR_OK;
+}
+
+int32_t adi_ad9081_jesd_sysref_input_mode_set(
+	adi_ad9081_device_t *device, uint8_t enable_receiver,
+	uint8_t enable_capture, adi_cms_signal_coupling_e input_mode)
+{
+	int32_t err;
+	AD9081_LOG_FUNC();
+	AD9081_NULL_POINTER_RETURN(device);
+	if ((input_mode >= COUPLING_UNKNOWN) || (input_mode < 0)) {
+		return API_CMS_ERROR_INVALID_PARAM;
+	}
+
+	adi_ad9081_jesd_sysref_d2acenter_enable_set(device, 1);
+
+	/* 1: AC couple, 0: DC couple */
+	err = adi_ad9081_hal_bf_set(
+		device, REG_SYSREF_CTRL_ADDR, BF_SYSREF_INPUTMODE_INFO,
+		((input_mode == COUPLING_AC) ? 1 : 0)); /* not paged */
+	AD9081_ERROR_RETURN(err);
+
+	/* Power down the sysref receiver and sync circuitry. */
+	err = adi_ad9081_hal_bf_set(device, REG_SYSREF_CTRL_ADDR,
+				    BF_SYSREF_PD_INFO,
+				    !enable_receiver); /* not paged */
+	AD9081_ERROR_RETURN(err);
+
+	/* enables sysref capture */
+	err = adi_ad9081_hal_bf_set(
+		device, 0x0fb0, 0x0103,
+		enable_capture); /* not paged, spi_sysref_en@sysref_control */
+	AD9081_ERROR_RETURN(err);
+
+	adi_ad9081_jesd_sysref_d2acenter_enable_set(device, 0);
+
+	return API_CMS_ERROR_OK;
+}
+
+int32_t adi_ad9081_jesd_oneshot_sync(adi_ad9081_device_t *device,
+				     adi_cms_jesd_subclass_e subclass)
+{
+	int32_t err;
+	uint8_t pd_fdacby4, sync_done;
+	AD9081_NULL_POINTER_RETURN(device);
+	AD9081_LOG_FUNC();
+
+	if (subclass == JESD_SUBCLASS_0) {
+		adi_ad9081_jesd_tx_force_digital_reset_set(
+			device, AD9081_LINK_ALL,
+			1); /* FORCE_LINK_RESET if subclass 0 */
+	}
+
+	err = adi_ad9081_hal_bf_get(device, REG_CLK_CTRL1_ADDR, 0x00000102,
+				    &pd_fdacby4, 1); /* not paged */
+	AD9081_ERROR_RETURN(err);
+	err = adi_ad9081_hal_bf_set(device, REG_CLK_CTRL1_ADDR, 0x00000102,
+				    0); /* not paged */
+	AD9081_ERROR_RETURN(err);
+	err = adi_ad9081_hal_bf_set(device, REG_ROTATION_MODE_ADDR,
+				    BF_ROTATION_MODE_INFO, 1); /* not paged */
+	AD9081_ERROR_RETURN(err);
+
+	//d2a0, d2a1, anacenter
+	err = adi_ad9081_dac_d2a_dual_spi_enable_set(device, AD9081_LINK_ALL,
+						     1);
+	AD9081_ERROR_RETURN(err);
+	err = adi_ad9081_hal_bf_set(device, REG_SPI_ENABLE_DAC_ADDR,
+				    BF_SPI_EN_ANACENTER_INFO, 1);
+	AD9081_ERROR_RETURN(err);
+
+	if (device->dev_info.dev_rev == 3) { /* r2 */
+		err = adi_ad9081_hal_bf_set(device, REG_ACLK_CTRL_ADDR,
+					    BF_PD_TXDIGCLK_INFO,
+					    1); /* not paged */
+		AD9081_ERROR_RETURN(err);
+		err = adi_ad9081_hal_bf_set(device, REG_ADC_DIVIDER_CTRL_ADDR,
+					    0x00000107, 0); /* not paged */
+		AD9081_ERROR_RETURN(err);
+	}
+
+	err = adi_ad9081_hal_bf_set(device, REG_SYSREF_MODE_ADDR,
+				    BF_SYSREF_MODE_ONESHOT_INFO,
+				    0); /* not paged */
+	AD9081_ERROR_RETURN(err);
+	err = adi_ad9081_hal_bf_set(device, REG_SYSREF_MODE_ADDR,
+				    BF_SYSREF_MODE_ONESHOT_INFO,
+				    1); /* not paged */
+	AD9081_ERROR_RETURN(err);
+	if (err = adi_ad9081_hal_bf_wait_to_clear(
+		    device, REG_SYSREF_MODE_ADDR,
+		    BF_SYSREF_MODE_ONESHOT_INFO), /* not paged */
+	    err != API_CMS_ERROR_OK) {
+		AD9081_LOG_WARN("sysref_mode_oneshot bit never cleared.");
+	}
+	err = adi_ad9081_hal_bf_get(device, REG_SYSREF_MODE_ADDR,
+				    BF_ONESHOT_SYNC_DONE_INFO, &sync_done,
+				    1); /* not paged */
+	AD9081_ERROR_RETURN(err);
+	if (sync_done != 1) {
+		AD9081_LOG_WARN("oneshot sync not finished.");
+	}
+
+	if (device->dev_info.dev_rev == 3) { /* r2 */
+		err = adi_ad9081_hal_bf_set(device, REG_ADC_DIVIDER_CTRL_ADDR,
+					    0x00000107, 1); /* not paged */
+		AD9081_ERROR_RETURN(err);
+		err = adi_ad9081_hal_bf_set(device, REG_ACLK_CTRL_ADDR,
+					    BF_PD_TXDIGCLK_INFO,
+					    0); /* not paged */
+		AD9081_ERROR_RETURN(err);
+	}
+	err = adi_ad9081_hal_bf_set(device, REG_CLK_CTRL1_ADDR, 0x00000102,
+				    pd_fdacby4); /* not paged */
+	AD9081_ERROR_RETURN(err);
+
+	if (subclass == JESD_SUBCLASS_0) {
+		adi_ad9081_jesd_tx_force_digital_reset_set(
+			device, AD9081_LINK_ALL,
+			0); /* FORCE_LINK_RESET if subclass 0 */
+		if (sync_done != 1) {
+			return API_CMS_ERROR_JESD_SYNC_NOT_DONE;
+		}
+	}
+
+	return API_CMS_ERROR_OK;
+}
+
+int32_t adi_ad9081_jesd_sysref_setup_hold_get(adi_ad9081_device_t *device,
+					      uint8_t *setup_risk_violation,
+					      uint8_t *hold_risk_violation)
+{
+	int32_t err;
+	uint8_t i = 0;
+	uint8_t scount = 0, snum, hcount = 0, hnum;
+	AD9081_NULL_POINTER_RETURN(device);
+	AD9081_NULL_POINTER_RETURN(setup_risk_violation);
+	AD9081_NULL_POINTER_RETURN(hold_risk_violation);
+	AD9081_LOG_FUNC();
+
+	err = adi_ad9081_hal_bf_get(device, 0x0fb7, 0x800, setup_risk_violation,
+				    sizeof(uint8_t)); /* SYSREF_SETUP */
+	AD9081_ERROR_RETURN(err);
+
+	err = adi_ad9081_hal_bf_get(device, 0x0fb8, 0x800, hold_risk_violation,
+				    sizeof(uint8_t)); /* SYSREF_HOLD */
+	AD9081_ERROR_RETURN(err);
+
+	/* Number of 1s in setup time register */
+	snum = *setup_risk_violation;
+
+	for (i = 0; i < 8; i++) {
+		if (1 & snum) {
+			scount++;
+			snum = snum >> 1;
+		}
+	}
+	*setup_risk_violation = scount;
+
+	/* Number of 1s in hold time register */
+	hnum = *hold_risk_violation;
+
+	for (i = 0; i < 8; i++) {
+		if (1 & hnum) {
+			hcount++;
+			hnum = hnum >> 1;
+		}
+	}
+	*hold_risk_violation = hcount;
+
+	return API_CMS_ERROR_OK;
+}
+
+int32_t adi_ad9081_jesd_sysref_fine_superfine_delay_set(
+	adi_ad9081_device_t *device, uint8_t enable, uint8_t fine_delay,
+	uint8_t superfine_delay)
+{
+	int32_t err;
+	AD9081_NULL_POINTER_RETURN(device);
+	AD9081_LOG_FUNC();
+
+	if (enable > 3) {
+		return API_CMS_ERROR_INVALID_PARAM;
+	}
+
+	/*Enable Fine and Super fine delay on the SYSREF input
+    00: SYSREF delay disabled
+    01: Fine delay
+    10: Super fine delay
+    11: both Fine and Superfine Delay*/
+
+	err = adi_ad9081_hal_bf_set(device, 0x0fb1, 0x200, enable);
+	AD9081_ERROR_RETURN(err);
+	if (enable == 1 || enable == 3) {
+		err = adi_ad9081_hal_bf_set(
+			device, 0x0fb2, 0x800,
+			fine_delay); /* maximum effective setting is 0x2F */
+		AD9081_ERROR_RETURN(err);
+	}
+	if (enable == 2 || enable == 3) {
+		err = adi_ad9081_hal_bf_set(
+			device, 0xfb3, 0x800,
+			superfine_delay); /* maximum is approx. 4ps (255 x 16 fs) */
+		AD9081_ERROR_RETURN(err);
+	}
+
+	return API_CMS_ERROR_OK;
+}
+
+int32_t adi_ad9081_jesd_sysref_count_set(adi_ad9081_device_t *device,
+					 uint8_t edges)
+{
+	int32_t err;
+	AD9081_NULL_POINTER_RETURN(device);
+	AD9081_LOG_FUNC();
+
+	err = adi_ad9081_hal_bf_set(device, REG_SYSREF_COUNT_ADDR,
+				    BF_SYSREF_COUNT_INFO, edges);
+	AD9081_ERROR_RETURN(err);
+
+	return API_CMS_ERROR_OK;
+}
+
+int32_t adi_ad9081_jesd_sysref_average_set(adi_ad9081_device_t *device,
+					   uint8_t pulses)
+{
+	int32_t err;
+	AD9081_NULL_POINTER_RETURN(device);
+	AD9081_LOG_FUNC();
+
+	if (pulses > 0x7) {
+		return API_CMS_ERROR_INVALID_PARAM;
+	}
+
+	err = adi_ad9081_hal_bf_set(device, REG_SYSREF_AVERAGE_ADDR,
+				    BF_SYSREF_AVERAGE_INFO, pulses);
+	AD9081_ERROR_RETURN(err);
+
+	return API_CMS_ERROR_OK;
+}
+
+int32_t adi_ad9081_jesd_sysref_monitor_phase_get(adi_ad9081_device_t *device,
+						 uint16_t *sysref_phase)
+{
+	int32_t err;
+	uint8_t phase0_val;
+	uint8_t phase1_val;
+
+	AD9081_NULL_POINTER_RETURN(device);
+	AD9081_NULL_POINTER_RETURN(sysref_phase);
+	AD9081_LOG_FUNC();
+
+	err = adi_ad9081_hal_bf_get(device, REG_SYSREF_PHASE0_ADDR, 0x800,
+				    &phase0_val, sizeof(uint8_t));
+	err = adi_ad9081_hal_bf_get(device, REG_SYSREF_PHASE1_ADDR, 0x400,
+				    &phase1_val, sizeof(uint8_t));
+
+	*sysref_phase = (phase0_val << 8) + phase1_val;
+
+	AD9081_ERROR_RETURN(err);
+
+	return API_CMS_ERROR_OK;
+}
+
+int32_t
+adi_ad9081_jesd_sysref_monitor_lmfc_align_error_get(adi_ad9081_device_t *device,
+						    uint8_t *lmfc_align_err)
+{
+	int32_t err;
+	AD9081_NULL_POINTER_RETURN(device);
+	AD9081_NULL_POINTER_RETURN(lmfc_align_err);
+	AD9081_LOG_FUNC();
+
+	err = adi_ad9081_hal_bf_get(device, REG_SYSREF_ERR_WINDOW_ADDR,
+				    BF_SYSREF_WITHIN_LMFC_ERRWINDOW_INFO,
+				    lmfc_align_err, sizeof(uint8_t));
+
+	AD9081_ERROR_RETURN(err);
+
+	return API_CMS_ERROR_OK;
+}
+
+int32_t adi_ad9081_jesd_sysref_monitor_lmfc_align_threshold_set(
+	adi_ad9081_device_t *device, uint8_t sysref_error_window)
+{
+	int32_t err;
+	AD9081_NULL_POINTER_RETURN(device);
+	AD9081_LOG_FUNC();
+
+	if (sysref_error_window > 0x7F) {
+		return API_CMS_ERROR_INVALID_PARAM;
+	}
+
+	err = adi_ad9081_hal_bf_set(device, REG_SYSREF_ERR_WINDOW_ADDR,
+				    BF_SYSREF_ERR_WINDOW_INFO,
+				    sysref_error_window);
+
+	AD9081_ERROR_RETURN(err);
+
+	return API_CMS_ERROR_OK;
+}
+
+int32_t adi_ad9081_jesd_sysref_irq_enable_set(adi_ad9081_device_t *device,
+					      uint8_t enable)
+{
+	int32_t err;
+	AD9081_NULL_POINTER_RETURN(device);
+	AD9081_LOG_FUNC();
+
+	err = adi_ad9081_hal_bf_set(device, REG_IRQ_ENABLE_0_ADDR,
+				    BF_EN_SYSREF_IRQ_INFO, enable);
+	AD9081_ERROR_RETURN(err);
+
+	return API_CMS_ERROR_OK;
+}
+
+int32_t adi_ad9081_jesd_sysref_irq_jitter_mux_set(adi_ad9081_device_t *device,
+						  uint8_t pin)
+{
+	int32_t err;
+	AD9081_NULL_POINTER_RETURN(device);
+	AD9081_LOG_FUNC();
+
+	if (pin != 0 || pin != 1) {
+		return API_CMS_ERROR_INVALID_PARAM;
+	}
+
+	err = adi_ad9081_hal_bf_set(device, REG_IRQ_OUTPUT_MUX_0_ADDR,
+				    BF_MUX_SYSREF_JITTER_INFO, pin);
+	AD9081_ERROR_RETURN(err);
+
+	return API_CMS_ERROR_OK;
+}
+
+int32_t
+adi_ad9081_jesd_sysref_oneshot_sync_done_get(adi_ad9081_device_t *device,
+					     uint8_t *sync_done)
+{
+	int32_t err;
+	AD9081_NULL_POINTER_RETURN(device);
+	AD9081_NULL_POINTER_RETURN(sync_done);
+	AD9081_LOG_FUNC();
+
+	err = adi_ad9081_hal_bf_get(device, REG_SYSREF_MODE_ADDR,
+				    BF_ONESHOT_SYNC_DONE_INFO, sync_done,
+				    1); /* not paged */
+	AD9081_ERROR_RETURN(err);
+
+	if (*sync_done != 1) {
+		AD9081_LOG_ERR("oneshot sync not finished.");
+	}
+
+	return API_CMS_ERROR_OK;
+}

--- a/drivers/iio/adc/ad9081/adi_cms_api_common.h
+++ b/drivers/iio/adc/ad9081/adi_cms_api_common.h
@@ -54,6 +54,7 @@ typedef enum {
 	API_CMS_ERROR_DLL_NOT_LOCKED = -22, /*!< DLL is not locked */
 	API_CMS_ERROR_MODE_NOT_IN_TABLE = -23, /*!< JESD Mode not in table */
 	API_CMS_ERROR_JESD_PLL_NOT_LOCKED = -24, /*!< PD STBY function error */
+	API_CMS_ERROR_JESD_SYNC_NOT_DONE = -25, /*!< JESD_SYNC_NOT_DONE */
 	API_CMS_ERROR_FTW_LOAD_ACK = -30, /*!< FTW acknowledge not received */
 	API_CMS_ERROR_NCO_NOT_ENABLED = -31, /*!< The NCO is not enabled */
 	API_CMS_ERROR_INIT_SEQ_FAIL =
@@ -399,22 +400,6 @@ typedef int32_t (*adi_pd_stby_pin_ctrl_t)(void *user_data, uint8_t enable);
  * @return Any non-zero value indicates an error
  */
 typedef int32_t (*adi_reset_pin_ctrl_t)(void *user_data, uint8_t enable);
-
-/**
- * @brief  sysref control function
- *
- * @param  user_data  A void pointer to a client defined structure containing
- *                    any parameters/settings that may be required by the
- *                    function to control the hardware sysref control.
- * @param  enable     A uint8_t value indicating the desired enable/disable
- *                    condition.
- *                    A value of 1 indicates SYSREF n-shot/continuous enable
- *                    A value of 0 disables SYSREF pulses
- *
- * @return 0 for success
- * @return Any non-zero value indicates an error
- */
-typedef int32_t (*adi_sysref_ctrl_t)(void *user_data, uint8_t enable);
 
 /**
  * @brief   Control function for GPIO write.


### PR DESCRIPTION
###  iio: adc: ad9081: Update API to Version 1.2.0

 * Fix DAC Calibration for DAC rates <4GHz to address Noise Floor Issue
 * Address ADC with 12 Bit resolution
 * Enable Background Cal when calling JESD 204C Calibration
 * Allow user to set nyquist Zone per ADC
 * Added controls for sysref input receiver configuration

###  iio: adc: ad9081: Support for direct ADC->DAC loopback mode

This patch adds support for direct ADC->DAC loopback mode.
Note ADC sample rate must be same as DAC sample rate to get this
loopback mode working.
The default mapping: ADC0->DAC0, ADC1->DAC1, ADC0->DAC2, ADC1->DAC3
can either be modified via the adi,direct-loopback-mode-dac-adc-mapping
device tree attribute or during run-time using the
adi,direct-loopback-mode-dac-adc-mapping debugfs attribute.
After writing the debugfs attribute, the new value needs to be latched
by writing the loopback_mode iio attribute again.