### PR TITLE
iio:admv1013: fix comparison for quad filters

### DIFF
--- a/drivers/iio/frequency/admv1013.c
+++ b/drivers/iio/frequency/admv1013.c
@@ -289,11 +289,11 @@ static int admv1013_update_quad_filters(struct admv1013_dev *dev)
 {
 	unsigned int filt_raw;
 
-	if (dev->clkin_freq <= 5400000000 && dev->clkin_freq <= 7000000000)
+	if (dev->clkin_freq >= 5400000000 && dev->clkin_freq <= 7000000000)
 		filt_raw = 15;
-	else if (dev->clkin_freq <= 5400000000 && dev->clkin_freq <= 8000000000)
+	else if (dev->clkin_freq >= 5400000000 && dev->clkin_freq <= 8000000000)
 		filt_raw = 10;
-	else if (dev->clkin_freq <= 6600000000 && dev->clkin_freq <= 9200000000)
+	else if (dev->clkin_freq >= 6600000000 && dev->clkin_freq <= 9200000000)
 		filt_raw = 5;
 	else
 		filt_raw = 0;


### PR DESCRIPTION
Fix comparison when applying quad filters based on the input clock.

Fixes: 0538776f05eeb32902f122013868fdd662d3763c(iio:frequency:admv1013: add support for ADMV1013)
Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>