### PR TITLE
dt-bindings:admv1014: misc fixes

### DIFF
--- a/Documentation/devicetree/bindings/iio/frequency/adi,admv1014.yaml
+++ b/Documentation/devicetree/bindings/iio/frequency/adi,admv1014.yaml
@@ -106,9 +106,9 @@ properties:
     description:
       Digital Rx Detector Program.
     $ref: /schemas/types.yaml#/definitions/uint32
-    enum: [1, 2, 4, 8, 16, 32, 64]
+    enum: [0, 1, 2, 4, 8, 16, 32, 64]
 
-  adi,adi,bb-amp-gain-ctrl:
+  adi,bb-amp-gain-ctrl:
     description:
       Baseband Amp Gain control.
     $ref: /schemas/types.yaml#/definitions/uint32


### PR DESCRIPTION
Add 0 to the det-prog enum since it is a valid value.
Fix typo in the bb-amp-gain-ctrl property.

Fixes: 77dd8d6b42da2c3be0f1ad6ec9acd0b9c66816c8
(dt:bindings:iio:frequency:add admv1014 doc)
Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>