### PR TITLE
ci: add --strict option for checkpatch

### DIFF
--- a/ci/travis/run-build.sh
+++ b/ci/travis/run-build.sh
@@ -234,6 +234,7 @@ build_checkpatch() {
 	__update_git_ref "${ref_branch}" "${ref_branch}"
 
 	scripts/checkpatch.pl --git "${ref_branch}.." \
+		--strict \
 		--ignore FILE_PATH_CHANGES \
 		--ignore LONG_LINE \
 		--ignore LONG_LINE_STRING \

--- a/ci/travis/run-build.sh
+++ b/ci/travis/run-build.sh
@@ -238,7 +238,8 @@ build_checkpatch() {
 		--ignore FILE_PATH_CHANGES \
 		--ignore LONG_LINE \
 		--ignore LONG_LINE_STRING \
-		--ignore LONG_LINE_COMMENT
+		--ignore LONG_LINE_COMMENT \
+		--ignore PARENTHESIS_ALIGNMENT
 }
 
 build_dtb_build_test() {


### PR DESCRIPTION
The `--strict` option is mandatory when sending a patch upstream.

This patch aims to minimize the number of upstream resubmissions due to
styling issues.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>