### PR TITLE
drivers: iio: addac: one-bit-adc-dac: Set device name from dt child.

### DIFF
--- a/drivers/iio/addac/one-bit-adc-dac.c
+++ b/drivers/iio/addac/one-bit-adc-dac.c
@@ -167,7 +167,7 @@ static int one_bit_adc_dac_probe(struct platform_device *pdev)
 	st = iio_priv(indio_dev);
 	st->pdev = pdev;
 	indio_dev->dev.parent = &pdev->dev;
-	indio_dev->name = "one-bit-adc-dac";
+	indio_dev->name = pdev->dev.of_node->name;
 	indio_dev->modes = INDIO_DIRECT_MODE;
 	indio_dev->info = &one_bit_adc_dac_info;
 


### PR DESCRIPTION
In case of multiple instances, this will fix confusion between devices.

Signed-off-by: Cristian Pop <cristian.pop@analog.com>