### PR TITLE
arch:arm:overlays: rpi-adxl355 overlay

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -185,6 +185,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	rpi-adar1000.dtbo \
 	rpi-adgs1408.dtbo \
 	rpi-adxl345.dtbo \
+	rpi-adxl355.dtbo \
 	rpi-adxl372.dtbo \
 	rpi-adxl375.dtbo \
 	rpi-adxrs290.dtbo \

--- a/arch/arm/boot/dts/overlays/rpi-adxl355-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-adxl355-overlay.dts
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+
+/ {
+
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target = <&spidev0>;
+
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@1 {
+		target = <&gpio>;
+		__overlay__ {
+			adxl355_pins: adxl355_pins {
+				brcm,pins = <25>; // interrupt
+				brcm,function = <0>; // in
+			};
+		};
+	};
+
+	fragment@2 {
+		target = <&spi0>;
+		__overlay__ {
+			#address-cells = <1>;
+			status = "okay";
+			#size-cells = <0>;
+
+			adxl355@0 {
+				compatible = "adi,adxl355";
+				reg = <0>;
+				pinctrl-names = "default";
+				pinctrl-0 = <&adxl355_pins>;
+				spi-max-frequency = <1000000>;
+				interrupt-parent = <&gpio>;
+				interrupts = <25 IRQ_TYPE_EDGE_RISING>;
+				interrupt-names = "DRDY";
+			};
+		};
+	};
+};


### PR DESCRIPTION
Add SPI dt overlay for the ADXL355 driver.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>