### PR TITLE
arch:arm:overlays: add several rpi dt overlays

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -172,6 +172,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	rpi-addi9036.dtbo \
 	rpi-adf4159.dtbo \
 	rpi-adf4371.dtbo \
+	rpi-adrf6780.dtbo \
 	rpi-ad5677r.dtbo \
 	rpi-ad5686.dtbo \
 	rpi-ad5679r.dtbo \

--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -173,6 +173,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	rpi-adf4159.dtbo \
 	rpi-adf4371.dtbo \
 	rpi-admv1013.dtbo \
+	rpi-admv1014.dtbo \
 	rpi-adrf6780.dtbo \
 	rpi-ad5677r.dtbo \
 	rpi-ad5686.dtbo \

--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -174,6 +174,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	rpi-adf4371.dtbo \
 	rpi-admv1013.dtbo \
 	rpi-admv1014.dtbo \
+	rpi-admv8818.dtbo \
 	rpi-adrf6780.dtbo \
 	rpi-ad5677r.dtbo \
 	rpi-ad5686.dtbo \

--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -172,6 +172,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	rpi-addi9036.dtbo \
 	rpi-adf4159.dtbo \
 	rpi-adf4371.dtbo \
+	rpi-admv1013.dtbo \
 	rpi-adrf6780.dtbo \
 	rpi-ad5677r.dtbo \
 	rpi-ad5686.dtbo \

--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -166,6 +166,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	qca7000.dtbo \
 	qca7000-uart0.dtbo \
 	rotary-encoder.dtbo \
+	rpi-ada4250.dtbo \
 	rpi-adau1761.dtbo \
 	rpi-adau1472.dtbo \
 	rpi-addi9036.dtbo \

--- a/arch/arm/boot/dts/overlays/rpi-ada4250-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ada4250-overlay.dts
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target = <&spidev0>;
+
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@1 {
+		target-path = "/";
+		__overlay__ {
+			avdd: fixedregulator@0 {
+				compatible = "regulator-fixed";
+				regulator-name = "avdd";
+				regulator-min-microvolt = <5000000>;
+				regulator-max-microvolt = <5000000>;
+				regulator-boot-on;
+			};
+		};
+	};
+
+	fragment@2 {
+		target = <&spi0>;
+
+		__overlay__{
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			ada4250@0{
+				compatible = "adi,ada4250";
+				reg = <0>;
+				spi-max-frequency = <1000000>;
+				avdd-supply = <&avdd>;
+			};
+		};
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-admv1013-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-admv1013-overlay.dts
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target = <&spidev0>;
+
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@1 {
+		target-path = "/";
+		__overlay__ {
+			clocks {
+				admv1013_lo: clock@0 {
+					compatible = "fixed-clock";
+
+					clock-frequency = <100000000>;
+					clock-output-names = "lo_in";
+					#clock-cells = <0>;
+				};
+			};
+		};
+	};
+
+	fragment@2 {
+		target-path = "/";
+		__overlay__ {
+			vcm: fixedregulator@0 {
+				compatible = "regulator-fixed";
+				regulator-name = "vcm";
+				regulator-min-microvolt = <0>;
+				regulator-max-microvolt = <0>;
+				regulator-boot-on;
+			};
+		};
+	};
+
+	fragment@3 {
+		target = <&spi0>;
+
+		__overlay__{
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			admv1013@0{
+				compatible = "adi,admv1013";
+				reg = <0>;
+				spi-max-frequency = <1000000>;
+				clocks = <&admv1013_lo>;
+				clock-names = "lo_in";
+				clock-scales = <1 5>;
+				vcm-supply = <&vcm>;
+				adi,quad-se-mode = <12>;
+				adi,parity-en;
+			};
+		};
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-admv1014-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-admv1014-overlay.dts
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target = <&spidev0>;
+
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@1 {
+		target-path = "/";
+		__overlay__ {
+			clocks {
+				admv1014_lo: clock@0 {
+					compatible = "fixed-clock";
+
+					clock-frequency = <1000000000>;
+					clock-output-names = "lo_in";
+					#clock-cells = <0>;
+				};
+			};
+		};
+	};
+
+	fragment@2 {
+		target-path = "/";
+		__overlay__ {
+			vcm: fixedregulator@0 {
+				compatible = "regulator-fixed";
+				regulator-name = "vcm";
+				regulator-min-microvolt = <1500000>;
+				regulator-max-microvolt = <1500000>;
+				regulator-boot-on;
+			};
+		};
+	};
+
+	fragment@3 {
+		target = <&spi0>;
+
+		__overlay__{
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			admv1014@0{
+				compatible = "adi,admv1014";
+				reg = <0>;
+				spi-max-frequency = <1000000>;
+				clocks = <&admv1014_lo>;
+				clock-names = "lo_in";
+				clock-scales = <1 8>;
+				vcm-supply = <&vcm>;
+				adi,quad-se-mode = <0>;
+				adi,parity-en;
+				adi,p1db-comp = <3>;
+				adi,det-prog = <4>;
+				adi,bb-amp-gain-ctrl = <0>;
+			};
+		};
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-admv8818-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-admv8818-overlay.dts
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target = <&spidev0>;
+
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@1 {
+		target-path = "/";
+		__overlay__ {
+			clocks {
+				admv8818_rfin: clock@0 {
+					compatible = "fixed-clock";
+
+					clock-frequency = <100000000>;
+					clock-output-names = "rf_in";
+					#clock-cells = <0>;
+				};
+			};
+		};
+	};
+
+	fragment@2 {
+		target = <&spi0>;
+
+		__overlay__{
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			admv8818@0{
+				compatible = "adi,admv8818";
+				reg = <0>;
+				spi-max-frequency = <10000000>;
+				clocks = <&admv8818_rfin>;
+				clock-scales = <1 50>;
+				clock-names = "rf_in";
+				adi,bw-hz = /bits/ 64 <600000000>;
+			};
+		};
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-adrf6780-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-adrf6780-overlay.dts
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target = <&spidev0>;
+
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@1 {
+		target-path = "/";
+		__overlay__ {
+			clocks {
+				adrf6780_lo: clock@0 {
+					compatible = "fixed-clock";
+
+					clock-frequency = <100000000>;
+					clock-output-names = "lo_in";
+					#clock-cells = <0>;
+				};
+			};
+		};
+	};
+
+	fragment@2 {
+		target = <&spi0>;
+
+		__overlay__{
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			adrf6780@0{
+				compatible = "adi,adrf6780";
+				reg = <0>;
+				spi-max-frequency = <1000000>;
+				clocks = <&adrf6780_lo>;
+				clock-names = "lo_in";
+				adi,parity-en;
+			};
+		};
+	};
+};


### PR DESCRIPTION
Add dt overlays for several drivers that were merged into the master branch:
- ada4250
- admv1013
- admv1014
- adrf6780
- admv8818

Note: these overlays were used in the driver development, and updated during the review process, therefore tested.

