### PR TITLE
iio:frequency:admv1013 vcm range fix

### DIFF
--- a/drivers/iio/frequency/admv1013.c
+++ b/drivers/iio/frequency/admv1013.c
@@ -309,9 +309,9 @@ static int admv1013_update_mixer_vgate(struct admv1013_dev *dev)
 
 	vcm = regulator_get_voltage(dev->reg);
 
-	if (vcm >= 0 && vcm < 1800000)
+	if (vcm >= 0 && vcm <= 1800000)
 		mixer_vgate = (2389 * vcm / 1000000 + 8100) / 100;
-	else if (vcm > 1800000 && vcm < 2600000)
+	else if (vcm > 1800000 && vcm <= 2600000)
 		mixer_vgate = (2375 * vcm / 1000000 + 125) / 100;
 	else
 		return -EINVAL;


### PR DESCRIPTION
Make sure that the margins for the two common-mode voltage ranges are
included in the checks.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>