### PR TITLE
CI: update rpi branch

### DIFF
--- a/azure-pipelines-rpi.yml
+++ b/azure-pipelines-rpi.yml
@@ -9,38 +9,40 @@ pr:
 - rpi-5.4.y
 - rpi-5.10.y
 
-pool:
-  vmImage: 'ubuntu-latest'
+stages:
+- stage: Builds
+  jobs:
+  - job: checkpatch
+    condition: eq(variables['Build.Reason'], 'PullRequest')
+    variables:
+      BUILD_TYPE: checkpatch
+      TARGET_BRANCH: $[ variables['System.PullRequest.TargetBranch'] ]
+    pool:
+      vmImage: 'ubuntu-latest'
+    steps:
+    - checkout: self
+      fetchDepth: 50
+      clean: true
+    - script: ./ci/travis/run-build.sh
+      displayName: 'Checkpatch Script'
 
-jobs:
-
-- job: checkpatch
-  condition: eq(variables['Build.Reason'], 'PullRequest')
-  variables:
-    BUILD_TYPE: checkpatch
-    TARGET_BRANCH: $[ variables['System.PullRequest.TargetBranch'] ]
-  steps:
-  - checkout: self
-    fetchDepth: 50
-    clean: true
-  - script: ./ci/travis/run-build.sh
-    displayName: 'Checkpatch Script'
-
-- job: BuildDockerized
-  strategy:
-    matrix:
-      bcm2709_arm_adi:
-        DEFCONFIG: adi_bcm2709_defconfig
-        ARCH: arm
-      bcm2711_arm_adi:
-        DEFCONFIG: adi_bcm2711_defconfig
-        ARCH: arm
-      bcmrpi_arm_adi:
-        DEFCONFIG: adi_bcmrpi_defconfig
-        ARCH: arm
-  steps:
-  - checkout: self
-    fetchDepth: 1
-    clean: true
-  - script: ./ci/travis/run-build-docker.sh
-    displayName: "Build test for '$(DEFCONFIG)'"
+  - job: BuildDockerized
+    strategy:
+      matrix:
+        bcm2709_arm_adi:
+          DEFCONFIG: adi_bcm2709_defconfig
+          ARCH: arm
+        bcm2711_arm_adi:
+          DEFCONFIG: adi_bcm2711_defconfig
+          ARCH: arm
+        bcmrpi_arm_adi:
+          DEFCONFIG: adi_bcmrpi_defconfig
+          ARCH: arm
+    pool:
+      vmImage: 'ubuntu-latest'
+    steps:
+    - checkout: self
+      fetchDepth: 1
+      clean: true
+    - script: ./ci/travis/run-build-docker.sh
+      displayName: "Build test for '$(DEFCONFIG)'"

--- a/azure-pipelines-rpi.yml
+++ b/azure-pipelines-rpi.yml
@@ -32,12 +32,15 @@ stages:
         bcm2709_arm_adi:
           DEFCONFIG: adi_bcm2709_defconfig
           ARCH: arm
+          artifactName: 'adi_bcm2709_defconfig'
         bcm2711_arm_adi:
           DEFCONFIG: adi_bcm2711_defconfig
           ARCH: arm
+          artifactName: 'adi_bcm2711_defconfig'
         bcmrpi_arm_adi:
           DEFCONFIG: adi_bcmrpi_defconfig
           ARCH: arm
+          artifactName: 'adi_bcmrpi_defconfig'
     pool:
       vmImage: 'ubuntu-latest'
     steps:
@@ -46,3 +49,12 @@ stages:
       clean: true
     - script: ./ci/travis/run-build-docker.sh
       displayName: "Build test for '$(DEFCONFIG)'"
+    - task: CopyFiles@2
+      inputs:
+        sourceFolder: '$(Agent.BuildDirectory)/s/arch/arm/boot/dts/overlays'
+        contents: '$(Agent.BuildDirectory)/s/arch/arm/boot/dts/overlays/?(*.dtbo)'
+        targetFolder: '$(Build.ArtifactStagingDirectory)'
+    - task: PublishPipelineArtifact@1
+      inputs:
+        targetPath: '$(Build.ArtifactStagingDirectory)'
+        artifactName: '$(artifactName)'

--- a/azure-pipelines-rpi.yml
+++ b/azure-pipelines-rpi.yml
@@ -54,7 +54,60 @@ stages:
         sourceFolder: '$(Agent.BuildDirectory)/s/arch/arm/boot/dts/overlays'
         contents: '$(Agent.BuildDirectory)/s/arch/arm/boot/dts/overlays/?(*.dtbo)'
         targetFolder: '$(Build.ArtifactStagingDirectory)'
+    - task: CopyFiles@2
+      inputs:
+        sourceFolder: '$(Agent.BuildDirectory)/s/arch/arm/boot'
+        contents: '$(Agent.BuildDirectory)/s/arch/arm/boot/zImage'
+        targetFolder: '$(Build.ArtifactStagingDirectory)'
+    - task: CopyFiles@2
+      inputs:
+        sourceFolder: '$(Agent.BuildDirectory)/s/arch/arm/boot/dts'
+        contents: '$(Agent.BuildDirectory)/s/arch/arm/boot/dts/?(*.dtb)'
+        targetFolder: '$(Build.ArtifactStagingDirectory)'
     - task: PublishPipelineArtifact@1
       inputs:
         targetPath: '$(Build.ArtifactStagingDirectory)'
         artifactName: '$(artifactName)'
+
+- stage: PushArtifacts
+  dependsOn: Builds
+  variables:
+    SOURCE_DIRECTORY: $(Build.SourcesDirectory)/bin
+    KEY_FILE: $(key.secureFilePath)
+  jobs:
+  - job: Push_to_SWDownloads
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/rpi-5.10.y'))
+    pool:
+      vmImage: 'ubuntu-latest'
+    steps:
+      - task: DownloadPipelineArtifact@2
+        inputs:
+          path: $(Build.SourcesDirectory)/bin
+      - bash: ./ci/travis/prepare_artifacts.sh structure
+        displayName: 'Prepare the folder structure'
+      - task: DownloadSecureFile@1
+        name: key
+        displayName: 'Download rsa key'
+        inputs:
+          secureFile: 'id_rsa'
+      - bash: ./ci/travis/prepare_artifacts.sh swdownloads
+        env:
+          DEST_SERVER: $(SERVER_ADDRESS)
+        displayName: "Push to SWDownloads"
+  - job: Push_to_Artifactory
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/rpi-5.10.y'))
+    pool:
+      name: Default
+      demands:
+        - agent.name -equals lab2_b5
+    steps:
+      - task: DownloadPipelineArtifact@2
+        inputs:
+          path: $(Build.SourcesDirectory)/bin
+      - bash: ./ci/travis/prepare_artifacts.sh structure
+        displayName: 'Prepare the folder structure'
+      - bash: ./ci/travis/prepare_artifacts.sh artifactory
+        env:
+          ARTIFACTORY_PATH: $(PATH)
+          ARTIFACTORY_TOKEN: $(TOKEN)
+        displayName: "Push to Artifactory"

--- a/ci/travis/prepare_artifacts.sh
+++ b/ci/travis/prepare_artifacts.sh
@@ -1,0 +1,50 @@
+#!/bin/bash -e
+# SPDX-License-Identifier: (GPL-1.0-only OR BSD-2-Clause)
+
+timestamp=$(date +%Y_%m_%d-%H_%M)
+bcm_types='bcm2709 bcm2711 bcmrpi'
+
+#prepare the structure of the folder containing artifacts
+artifacts_structure() {
+	cd ${SOURCE_DIRECTORY}
+	mkdir ${timestamp}
+
+	GIT_SHA=$(git rev-parse --short HEAD)
+	GIT_SHA_DATE=$(git show -s --format="%ci" ${GIT_SHA} | sed -e "s/ \|\:/-/g")
+	echo "git_sha=${GIT_SHA}" >> ${timestamp}/properties.txt
+	echo "git_sha_date=${GIT_SHA_DATE}" >> ${timestamp}/properties.txt
+
+	for bcm in $bcm_types; do
+		cd adi_${bcm}_defconfig
+		mkdir overlays
+		mv ./*.dtbo ./overlays
+		if [ "${bcm}" = "bcm2709" ]; then
+			mv ./zImage ./kernel7.img
+		elif [ "${bcm}" = "bcm2711" ]; then
+			mv ./zImage ./kernel7l.img
+		elif [ "${bcm}" = "bcmrpi" ]; then
+			mv ./zImage ./kernel.img
+		fi
+		cd ../
+		mv ./adi_${bcm}_defconfig ./${timestamp}/adi_${bcm}_defconfig
+	done
+}
+
+#upload artifacts to Artifactory
+artifacts_artifactory() {
+	cd ${SOURCE_DIRECTORY}
+	python /root/myagent/_work/1/s/ci/travis/upload_to_artifactory.py --base_path="${ARTIFACTORY_PATH}" --server_path="linux_rpi/${BUILD_SOURCEBRANCHNAME}" --local_path="./${timestamp}" --token="${ARTIFACTORY_TOKEN}"
+}
+
+#archive artifacts and upload to SWDownloads
+artifacts_swdownloads() {
+	cd ${SOURCE_DIRECTORY}/${timestamp}
+	chmod 600 ${KEY_FILE}
+	for bcm in $bcm_types; do
+		tar -zcvf adi_${bcm}_defconfig.tar adi_${bcm}_defconfig
+		scp -2 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o HostKeyAlgorithms=+ssh-dss \
+		    -i ${KEY_FILE} -r ${SOURCE_DIRECTORY}/${timestamp}/adi_${bcm}_defconfig.tar ${DEST_SERVER}
+	done
+}
+
+artifacts_${1}

--- a/ci/travis/upload_to_artifactory.py
+++ b/ci/travis/upload_to_artifactory.py
@@ -1,0 +1,138 @@
+# SPDX-License-Identifier: (GPL-1.0-only OR BSD-2-Clause)
+
+########################################################################
+#
+# File name: upload_to_artifactory.py
+# Author: Raus Stefan
+#
+# This script is used to upload files to ADI internal artifactory server
+#
+# Copyright (C) 2019-2022 Analog Devices Inc.
+#
+#######################################################################
+
+#!/usr/bin/python3.6
+
+import os
+import argparse
+import glob
+import shutil
+import sys
+from glob import glob
+
+LOCAL_PATHS_LIST = []
+# If you try to upload files in a different folder than the ones in below list, there will be printed a message and files won't be uploaded
+SERVER_FOLDERS_LIST = [ "hdl", "linux", "linux_rpi", "arm_trusted_firmware", "boot_partition", "rootfs", "u-boot", "HighSpeedConverterToolbox", "TransceiverToolbox", "SD_card_image"]
+
+########### Define arguments and help section #################
+
+parser = argparse.ArgumentParser(
+   description='This script is uploading files or folders to artifactory server.Parameter order doesn\'t matter.', \
+   formatter_class=argparse.RawDescriptionHelpFormatter,
+   epilog='Examples: '\
+                + '\n-> "./upload_to_artifactory.py --server_path="hdl/master/2020_12_12/pluto" --local_path="../projects/pluto/log_file.txt"'\
+                + ' --properties="git_sha=928ggraf;git_commmit_date=2020_12_12" --no_rel_path" will upload file "log_file.txt" to '\
+                + ' <UPLOAD_BASE_PATH>/hdl/master/2020_12_12/pluto/log_file.txt and add properties git_sha=928ggraf and git_commit_date=2010_12_12 on it.'\
+                + '\n-> "./upload_to_artifactory.py --server_path="linux" --local_path="master/2020_11_25/arm/zynq_zed_adv7511.dtb"" will upload dtb'\
+                + ' file to <UPLOAD_BASE_PATH>/linux/master/2020_11_25/arm/zynq_zed_adv7511.dtb')
+parser.add_argument("--base_path",   help="Artifactory Base Path - Internal ADI Artifactory server and development folder")
+parser.add_argument("--server_path", help="Artifactory folder where the files/folders will be saved, for example 'hdl' or 'linux'.")
+parser.add_argument("--local_path",  help="Local path to file/folder to upload. It can be relative or absolute.")
+parser.add_argument("--properties",  help="Properties to be added to file/folder. If multiple ones, split them by ';'.")
+parser.add_argument("--no_rel_path", help="If this exists, the relative path until local file will be appended to artifactory path", action="store_true")
+parser.add_argument("--props_level", help="Set for how many levels of folders to set specified properties, by default just on file.")
+parser.add_argument("--token",       help="Artifactory authentication token. Otherwise you can export API_TOKEN in terminal before calling this script.")
+args = parser.parse_args()
+parser.parse_args()
+
+########## Check if required and optional arguments are set  #################
+if args.token:
+   API_TOKEN = args.token
+else:
+   if "API_TOKEN" in os.environ:
+      API_TOKEN = os.environ['API_TOKEN']
+   else:
+      print('\nParameter "--token" is not set. This is Artifactory Authentication Token and can be set even using parameter "--token" on upload command, even by exporting API_TOKEN variable in terminal, before calling upload script.')
+      quit()
+
+if args.base_path:
+   UPLOAD_BASE_PATH = args.base_path
+else:
+   if "UPLOAD_BASE_PATH" in os.environ:
+      UPLOAD_BASE_PATH = os.environ['UPLOAD_BASE_PATH']
+   else:
+      print('\nParameter "--base_path" is not set. This is ADI Internal Artifactory Server plus first level of folders. It can be set even using parameter "--base_path" on upload command, even by exporting UPLOAD_BASE_PATH variable in terminal, before calling upload script.')
+      quit()
+
+
+if args.server_path:
+   # take first folder from server path and check if matches with folders from artifactory server (hdl, linux, SD_card_image etc)
+   SERVER_PATH = args.server_path
+   SERVER_PATH = SERVER_PATH[1:] if SERVER_PATH.startswith('/') else SERVER_PATH
+   SERVER_FOLDER = SERVER_PATH.split("/", 1)[0]
+   if SERVER_FOLDER not in SERVER_FOLDERS_LIST:
+     print('\nParameter "--server_path" must contain an already existing folder, for example "hdl", "linux", "SD_card_image" etc.' +
+     'If you want to add new folders, please edit "upload_to_artifactory.py" or contact script owner.')
+     quit()
+else:
+   print('\nParameter "--server_path" is required. It should be set to server location where the files/folder will be uploaded. Check help section.')
+   quit()
+
+if args.local_path:
+   LOCAL_PATH = os.path.abspath(args.local_path) if '../' in args.local_path else args.local_path
+   # if there was given a dir as local_path parameter, get all the files inside it in a list
+   if os.path.isdir(LOCAL_PATH):
+      for dpath, dnames, fnames in os.walk(LOCAL_PATH):
+         for i, FILE_NAME in enumerate([os.path.join(dpath, fname) for fname in fnames]):
+            LOCAL_PATHS_LIST.append(str(FILE_NAME))
+   elif os.path.isfile(LOCAL_PATH):
+      LOCAL_PATHS_LIST = [LOCAL_PATH]
+   else:
+      print('\nIt looks that parameter "--LOCAL_PATH" is wrong defined/does not exists. Plese check: ' + local_path)
+      quit()
+else:
+   print('\nParameter "--local_path" is required. It should point to local file/folder to upload.')
+   quit()
+
+if args.properties:
+   PROPS = args.properties
+else:
+   PROPS = ''
+
+if args.no_rel_path:
+   NO_REL_PATH = True
+else:
+   NO_REL_PATH = False
+
+if args.props_level:
+   PROP_LEVEL = int(args.props_level)
+else:
+   PROP_LEVEL = 0
+
+########## Upload files ##########
+# If files with same name already exists at specified server path, they will be overwritten
+
+for FILE in LOCAL_PATHS_LIST:
+   if NO_REL_PATH:
+        FILE_NAME = os.path.basename(FILE)
+        ART_PATH = UPLOAD_BASE_PATH + "/" + SERVER_PATH + "/" + FILE_NAME
+   else:
+        ART_PATH = UPLOAD_BASE_PATH + "/" + SERVER_PATH + "/" + FILE
+   upload_cmd = "curl -H \"X-JFrog-Art-Api:" + API_TOKEN + "\" -X PUT \"" + ART_PATH + ";" + PROPS + "\" -T \"" + FILE + "\""
+   os.system(upload_cmd)
+
+########## Upload properties on folders #########
+
+if NO_REL_PATH:
+   ART_PATH = UPLOAD_BASE_PATH + "/" + SERVER_PATH
+else:
+   ART_PATH = UPLOAD_BASE_PATH + "/" + SERVER_PATH + "/" + os.path.split(LOCAL_PATHS_LIST[0])[0]
+
+i = 0
+while ( i < int(PROP_LEVEL)):
+   set_folder_props_cmd = "curl -H \"X-JFrog-Art-Api:" + API_TOKEN + "\" -X PUT \"" + ART_PATH + "/;" + PROPS + "\""
+   os.system(set_folder_props_cmd)
+   i = i + 1
+   ART_PATH = os.path.split(ART_PATH)[0]
+
+#################################################


### PR DESCRIPTION
In this pull request:  
    - Azure Pipelines builds for rpi-5.10.y branch was updated similar with previous used branch (rpi-5.4.y)
    - At the request of the test team the structure of uploaded folder on Artifactory was changed.  The folder follow the 
       structure: <build_date>/
            -properties.txt - contains git_sha and git_sha_date
	    -<bcm_type>/ and inside are the next subfolders
		    -kernel image  file - kernel7.img for bcm2709, kernel7l.img for bcm2711, and kernel.img for bcmrpi
		    -.dtb files
		    -overlays - contains .dtbo files

Signed-off-by: Raluca Chis raluca.chis@analog.com