### PR TITLE
Sync ad5766 with latest upstream changes

### DIFF
--- a/Documentation/devicetree/bindings/iio/dac/adi,ad5766.yaml
+++ b/Documentation/devicetree/bindings/iio/dac/adi,ad5766.yaml
@@ -54,7 +54,7 @@ examples:
 
           ad5766@0 {
               compatible = "adi,ad5766";
-              output-range-microvolts = <(-5000) 5000>;
+              output-range-microvolts = <(-5000000) 5000000>;
               reg = <0>;
               spi-cpol;
               spi-max-frequency = <1000000>;

--- a/drivers/iio/dac/ad5766.c
+++ b/drivers/iio/dac/ad5766.c
@@ -503,13 +503,13 @@ static int ad5766_get_output_range(struct ad5766_state *st)
 	int i, ret, min, max, tmp[2];
 
 	ret = device_property_read_u32_array(&st->spi->dev,
-					     "output-range-voltage",
+					     "output-range-microvolts",
 					     tmp, 2);
 	if (ret)
 		return ret;
 
-	min = tmp[0] / 1000;
-	max = tmp[1] / 1000;
+	min = tmp[0] / 1000000;
+	max = tmp[1] / 1000000;
 	for (i = 0; i < ARRAY_SIZE(ad5766_span_tbl); i++) {
 		if (ad5766_span_tbl[i].min != min ||
 		    ad5766_span_tbl[i].max != max)


### PR DESCRIPTION
- https://github.com/torvalds/linux/commit/8fc4f038fa832ec3543907fdcbe1334e1b0a8950#diff-12a23def815fdcc56cbeacb20b51db9bedb16de1ddd71abfc0b8047d47557e0b
- https://github.com/torvalds/linux/commit/d9de0fbdeb0103a204055efb69cb5cc8f5f12a6a#diff-e684de5029dac3b27852954551adcd240d276a92036eb747f4cd05d88a8c42d9
- https://github.com/torvalds/linux/commit/885b9790c25a5fb8b253971c107744b17d8c29e7#diff-e684de5029dac3b27852954551adcd240d276a92036eb747f4cd05d88a8c42d9

Changes to adapt to the ADI linux output buffer have been made