### PR TITLE
dts: zynqmp-adrv9009-zu11eg-reva-adrv2crr-fmc-reva: Add FRU at 0x52

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-reva-adrv2crr-fmc-reva.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-reva-adrv2crr-fmc-reva.dts
@@ -428,7 +428,7 @@
 			};
 
 		};
-		i2c@5 { /* FMC HPC */
+		i2c_fmc: i2c@5 { /* FMC HPC */
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <5>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-revb-adrv2crr-fmc-revb-sync-fmcomms8.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-revb-adrv2crr-fmc-revb-sync-fmcomms8.dts
@@ -13,6 +13,13 @@
  */
 #include "zynqmp-adrv9009-zu11eg-revb-adrv2crr-fmc-revb.dts"
 
+&i2c_fmc { /* FMC */
+	eeprom@52 {
+		compatible = "at24,24c02";
+		reg = <0x52>;
+	};
+};
+
 &trx0_adrv9009 {
 	compatible = "adrv9009-x4";
 };


### PR DESCRIPTION
This adds the FRU eeprom found on the FMCOMMS8

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>