### PR TITLE
arch:arm:overlays: add ad5592r overlay

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -176,6 +176,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	rpi-admv1014.dtbo \
 	rpi-admv8818.dtbo \
 	rpi-adrf6780.dtbo \
+	rpi-ad5592r.dtbo \
 	rpi-ad5593r.dtbo \
 	rpi-ad5677r.dtbo \
 	rpi-ad5686.dtbo \

--- a/arch/arm/boot/dts/overlays/rpi-ad5592r-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ad5592r-overlay.dts
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/iio/adi,ad5592r.h>
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target = <&spidev0>;
+
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@1 {
+		target = <&spi0>;
+		__overlay__ {
+			#size-cells = <0>;
+			#address-cells = <1>;
+			status = "okay";
+
+			ad5592r: ad5592r@0 {
+				compatible = "adi,ad5592r";
+				reg = <0>;
+
+				spi-max-frequency = <1000000>;
+				spi-cpol;
+
+				channel@0 {
+					reg = <0>;
+					adi,mode = <CH_MODE_DAC>;
+				};
+				channel@1 {
+					reg = <1>;
+					adi,mode = <CH_MODE_ADC>;
+				};
+				channel@2 {
+					reg = <2>;
+					adi,mode = <CH_MODE_DAC_AND_ADC>;
+				};
+				channel@3 {
+					reg = <3>;
+					adi,mode = <CH_MODE_DAC_AND_ADC>;
+					adi,off-state = <CH_OFFSTATE_PULLDOWN>;
+				};
+				channel@4 {
+					reg = <4>;
+					adi,mode = <CH_MODE_UNUSED>;
+					adi,off-state = <CH_OFFSTATE_PULLDOWN>;
+				};
+				channel@5 {
+					reg = <5>;
+					adi,mode = <CH_MODE_GPIO>;
+					adi,off-state = <CH_OFFSTATE_PULLDOWN>;
+				};
+				channel@6 {
+					reg = <6>;
+					adi,mode = <CH_MODE_GPIO>;
+					adi,off-state = <CH_OFFSTATE_PULLDOWN>;
+				};
+				channel@7 {
+					reg = <7>;
+					adi,mode = <CH_MODE_GPIO>;
+					adi,off-state = <CH_OFFSTATE_PULLDOWN>;
+				};
+			};
+		};
+	};
+	__overrides__ {
+		cs_pin = <&ad5592r>,"reg:0";
+	};
+};


### PR DESCRIPTION
Add rpi SPI overlay for ad5592r device.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>