### PR TITLE
arch:arm:overlays: add ad5593r rpi overlay

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -176,6 +176,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	rpi-admv1014.dtbo \
 	rpi-admv8818.dtbo \
 	rpi-adrf6780.dtbo \
+	rpi-ad5593r.dtbo \
 	rpi-ad5677r.dtbo \
 	rpi-ad5686.dtbo \
 	rpi-ad5679r.dtbo \

--- a/arch/arm/boot/dts/overlays/rpi-ad5593r-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ad5593r-overlay.dts
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/iio/adi,ad5592r.h>
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@1 {
+		target = <&i2c1>;
+		__overlay__ {
+			#size-cells = <0>;
+			#address-cells = <1>;
+			status = "okay";
+
+			clock-frequency = <400000>;
+
+			ad5593r: ad5593r@10 {
+				compatible = "adi,ad5593r";
+				reg = <0x10>;
+
+				channel@0 {
+					reg = <0>;
+					adi,mode = <CH_MODE_DAC>;
+					adi,off-state = <CH_OFFSTATE_PULLDOWN>;
+				};
+				channel@1 {
+					reg = <1>;
+					adi,mode = <CH_MODE_ADC>;
+					adi,off-state = <CH_OFFSTATE_PULLDOWN>;
+				};
+				channel@2 {
+					reg = <2>;
+					adi,mode = <CH_MODE_DAC_AND_ADC>;
+					adi,off-state = <CH_OFFSTATE_PULLDOWN>;
+				};
+				channel@6 {
+					reg = <6>;
+					adi,mode = <CH_MODE_GPIO>;
+					adi,off-state = <CH_OFFSTATE_PULLDOWN>;
+				};
+			};
+		};
+	};
+	__overrides__ {
+		addr = <&ad5593r>,"reg:0";
+	};
+};


### PR DESCRIPTION
Add i2c overlay for the AD5593r device.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>