### PR TITLE
JESD204 dyn dt support

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9081-m8-l4-overlay.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9081-m8-l4-overlay.dts
@@ -1,0 +1,536 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD9081-FMC-EBZ
+ * https://wiki.analog.com/resources/eval/user-guides/quadmxfe/quick-start
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-mxfe/ad9081
+ *
+ * hdl_project: <ad9081_fmca_ebz/zcu102>
+ * board_revision: <>
+ *
+ * Copyright (C) 2021 Analog Devices Inc.
+ */
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/interrupt-controller/irq.h>
+#include <dt-bindings/iio/adc/adi,ad9081.h>
+#include <dt-bindings/jesd204/adxcvr.h>
+#include <dt-bindings/iio/frequency/hmc7044.h>
+
+/ {
+
+	fragment@0 {
+
+		target = <&fpga_full>;
+		#address-cells = <2>;
+		#size-cells = <2>;
+
+		__overlay__ {
+			#address-cells = <2>;
+			#size-cells = <2>;
+			firmware-name = "system_top.bit";
+		};
+	};
+
+	fragment@1 {
+		target = <&spi1>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			hmc7044: hmc7044@0 {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				#clock-cells = <1>;
+				compatible = "adi,hmc7044";
+				reg = <0>;
+				spi-max-frequency = <1000000>;
+
+				jesd204-device;
+				#jesd204-cells = <2>;
+				jesd204-sysref-provider;
+				adi,hmc-two-level-tree-sync-en;
+
+				adi,jesd204-max-sysref-frequency-hz = <2000000>; /* 2 MHz */
+
+				/*
+				* There are different versions of the AD9081-FMCA-EBZ & AD9082-FMCA-EBZ
+				* VCXO = 122.880 MHz, XO = 122.880MHz (AD9081-FMC-EBZ & AD9082-FMC-EBZ)
+				* VCXO = 100.000 MHz, XO = 100.000MHz (AD9081-FMC-EBZ-A2 & AD9082-FMC-EBZ-A2)
+				* To determine which board is which, read the freqency printed on the VCXO
+				* or use the fru-dump utility:
+				* #fru-dump -b /sys/bus/i2c/devices/15-0050/eeprom
+				*/
+
+				//adi,pll1-clkin-frequencies = <122880000 30720000 0 0>;
+				//adi,vcxo-frequency = <122880000>;
+
+				adi,pll1-clkin-frequencies = <100000000 10000000 0 0>;
+				adi,vcxo-frequency = <100000000>;
+
+				adi,pll1-loop-bandwidth-hz = <200>;
+
+				adi,pll2-output-frequency = <2880000000>;
+
+				adi,sysref-timer-divider = <1024>;
+				adi,pulse-generator-mode = <0>;
+
+				adi,clkin0-buffer-mode  = <0x07>;
+				adi,clkin1-buffer-mode  = <0x07>;
+				adi,oscin-buffer-mode = <0x15>;
+
+				adi,gpi-controls = <0x00 0x00 0x00 0x00>;
+				adi,gpo-controls = <0x37 0x33 0x00 0x00>;
+
+				clock-output-names =
+				"hmc7044_out0", "hmc7044_out1", "hmc7044_out2",
+				"hmc7044_out3", "hmc7044_out4", "hmc7044_out5",
+				"hmc7044_out6", "hmc7044_out7", "hmc7044_out8",
+				"hmc7044_out9", "hmc7044_out10", "hmc7044_out11",
+				"hmc7044_out12", "hmc7044_out13";
+
+				hmc7044_c0: channel@0 {
+					reg = <0>;
+					adi,extended-name = "CORE_CLK_RX";
+					adi,divider = <20>;
+					adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
+
+				};
+				hmc7044_c2: channel@2 {
+					reg = <2>;
+					adi,extended-name = "DEV_REFCLK";
+					adi,divider = <10>;
+					adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
+				};
+				hmc7044_c3: channel@3 {
+					reg = <3>;
+					adi,extended-name = "DEV_SYSREF";
+					adi,divider = <1536>;
+					adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
+					adi,jesd204-sysref-chan;
+				};
+
+				hmc7044_c6: channel@6 {
+					reg = <6>;
+					adi,extended-name = "CORE_CLK_TX";
+					adi,divider = <20>;
+					adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
+				};
+
+				hmc7044_c8: channel@8 {
+					reg = <8>;
+					adi,extended-name = "FPGA_REFCLK1";
+					adi,divider = <10>;
+					adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
+				};
+				hmc7044_c10: channel@10 {
+					reg = <10>;
+					adi,extended-name = "CORE_CLK_RX_ALT";
+					adi,divider = <20>;
+					adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
+				};
+
+				hmc7044_c12: channel@12 {
+					reg = <12>;
+					adi,extended-name = "FPGA_REFCLK2";
+					adi,divider = <10>;
+					adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
+				};
+				hmc7044_c13: channel@13 {
+					reg = <13>;
+					adi,extended-name = "FPGA_SYSREF";
+					adi,divider = <1536>;
+					adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
+					adi,jesd204-sysref-chan;
+				};
+			};
+
+		};
+	};
+
+	fragment@2 {
+		target = <&spi0>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			trx0_ad9081: ad9081@0 {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				compatible = "adi,ad9081";
+				reg = <0>;
+				spi-max-frequency = <5000000>;
+
+				/* Clocks */
+				clocks = <&hmc7044 2>;
+				clock-names = "dev_clk";
+
+				clock-output-names = "rx_sampl_clk", "tx_sampl_clk";
+				#clock-cells = <1>;
+
+				jesd204-device;
+				#jesd204-cells = <2>;
+				jesd204-top-device = <0>; /* This is the TOP device */
+				jesd204-link-ids = <FRAMER_LINK0_RX DEFRAMER_LINK0_TX>;
+				//jesd204-ignore-errors;
+
+				jesd204-inputs =
+					<&axi_ad9081_core_rx 0 FRAMER_LINK0_RX>,
+					<&axi_ad9081_core_tx 0 DEFRAMER_LINK0_TX>;
+
+				reset-gpios = <&gpio 133 0>;
+				sysref-req-gpios = <&gpio 121 0>;
+				rx2-enable-gpios = <&gpio 135 0>;
+				rx1-enable-gpios = <&gpio 134 0>;
+				tx2-enable-gpios = <&gpio 137 0>;
+				tx1-enable-gpios = <&gpio 136 0>;
+
+				adi,tx-dacs {
+					#size-cells = <0>;
+					#address-cells = <1>;
+
+					adi,dac-frequency-hz = /bits/ 64 <6912000000>;
+
+					adi,main-data-paths {
+						#address-cells = <1>;
+						#size-cells = <0>;
+
+						adi,interpolation = <8>;
+
+						ad9081_dac0: dac@0 {
+							reg = <0>;
+							adi,crossbar-select = <&ad9081_tx_fddc_chan0>;
+							adi,nco-frequency-shift-hz = /bits/ 64 <1000000000>; /* 100 MHz */
+						};
+						ad9081_dac1: dac@1 {
+							reg = <1>;
+							adi,crossbar-select = <&ad9081_tx_fddc_chan1>;
+							adi,nco-frequency-shift-hz = /bits/ 64 <1100000000>; /* 200 MHz */
+						};
+						ad9081_dac2: dac@2 {
+							reg = <2>;
+							adi,crossbar-select = <&ad9081_tx_fddc_chan2>; /* All 4 channels @ dac2 */
+							adi,nco-frequency-shift-hz = /bits/ 64 <1200000000>;  /* 300 MHz */
+						};
+						ad9081_dac3: dac@3 {
+							reg = <3>;
+							adi,crossbar-select = <&ad9081_tx_fddc_chan3>; /* All 4 channels @ dac2 */
+							adi,nco-frequency-shift-hz = /bits/ 64 <1300000000>; /* 400 MHz */
+						};
+					};
+
+					adi,channelizer-paths {
+						#address-cells = <1>;
+						#size-cells = <0>;
+						adi,interpolation = <6>;
+
+						ad9081_tx_fddc_chan0: channel@0 {
+							reg = <0>;
+							adi,gain = <2048>; /* 2048 * 10^(gain_dB/20) */
+							adi,nco-frequency-shift-hz =  /bits/ 64 <0>;
+
+						};
+						ad9081_tx_fddc_chan1: channel@1 {
+							reg = <1>;
+							adi,gain = <2048>; /* 2048 * 10^(gain_dB/20) */
+							adi,nco-frequency-shift-hz =  /bits/ 64 <0>;
+
+						};
+						ad9081_tx_fddc_chan2: channel@2 {
+							reg = <2>;
+							adi,gain = <2048>; /* 2048 * 10^(gain_dB/20) */
+							adi,nco-frequency-shift-hz =  /bits/ 64 <0>;
+
+						};
+						ad9081_tx_fddc_chan3: channel@3 {
+							reg = <3>;
+							adi,gain = <2048>; /* 2048 * 10^(gain_dB/20) */
+							adi,nco-frequency-shift-hz =  /bits/ 64 <0>;
+
+						};
+					};
+
+					adi,jesd-links {
+						#size-cells = <0>;
+						#address-cells = <1>;
+
+						ad9081_tx_jesd_l0: link@0 {
+							#address-cells = <1>;
+							#size-cells = <0>;
+							reg = <0>;
+
+							adi,logical-lane-mapping = /bits/ 8 <0 2 7 7 1 7 7 3>;
+
+							adi,link-mode = <9>;			/* JESD Quick Configuration Mode */
+							adi,subclass = <1>;			/* JESD SUBCLASS 0,1,2 */
+							adi,version = <1>;			/* JESD VERSION 0=204A,1=204B,2=204C */
+							adi,dual-link = <0>;			/* JESD Dual Link Mode */
+
+							adi,converters-per-device = <8>;	/* JESD M */
+							adi,octets-per-frame = <4>;		/* JESD F */
+
+							adi,frames-per-multiframe = <32>;	/* JESD K */
+							adi,converter-resolution = <16>;	/* JESD N */
+							adi,bits-per-sample = <16>;		/* JESD NP' */
+							adi,control-bits-per-sample = <0>;	/* JESD CS */
+							adi,lanes-per-device = <4>;		/* JESD L */
+							adi,samples-per-converter-per-frame = <1>; /* JESD S */
+							adi,high-density = <0>;			/* JESD HD */
+						};
+					};
+				};
+
+				adi,rx-adcs {
+					#size-cells = <0>;
+					#address-cells = <1>;
+
+					adi,adc-frequency-hz = /bits/ 64 <3456000000>;
+
+					adi,main-data-paths {
+						#address-cells = <1>;
+						#size-cells = <0>;
+
+
+						ad9081_adc0: adc@0 {
+							reg = <0>;
+							adi,decimation = <3>;
+							adi,nco-frequency-shift-hz =  /bits/ 64 <400000000>;
+							adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+							//adi,crossbar-select = <&ad9081_rx_fddc_chan0>, <&ad9081_rx_fddc_chan2>; /* Static for now */
+						};
+						ad9081_adc1: adc@1 {
+							reg = <1>;
+							adi,decimation = <3>;
+							adi,nco-frequency-shift-hz =  /bits/ 64 <(-400000000)>;
+							adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+							//adi,crossbar-select = <&ad9081_rx_fddc_chan1>, <&ad9081_rx_fddc_chan3>; /* Static for now */
+						};
+						ad9081_adc2: adc@2 {
+							reg = <2>;
+							adi,decimation = <3>;
+							adi,nco-frequency-shift-hz =  /bits/ 64 <100000000>;
+							adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+							//adi,crossbar-select = <&ad9081_rx_fddc_chan4>, <&ad9081_rx_fddc_chan6>; /* Static for now */
+						};
+						ad9081_adc3: adc@3 {
+							reg = <3>;
+							adi,decimation = <3>;
+							adi,nco-frequency-shift-hz =  /bits/ 64 <100000000>;
+							adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+							//adi,crossbar-select = <&ad9081_rx_fddc_chan5>, <&ad9081_rx_fddc_chan7>; /* Static for now */
+						};
+					};
+
+					adi,channelizer-paths {
+						#address-cells = <1>;
+						#size-cells = <0>;
+
+
+						ad9081_rx_fddc_chan0: channel@0 {
+							reg = <0>;
+							adi,decimation = <8>;
+							adi,gain = <2048>; /* 2048 * 10^(gain_dB/20) */
+							adi,nco-frequency-shift-hz =  /bits/ 64 <0>;
+
+						};
+						ad9081_rx_fddc_chan1: channel@1 {
+							reg = <1>;
+							adi,decimation = <8>;
+							adi,gain = <2048>; /* 2048 * 10^(gain_dB/20) */
+							adi,nco-frequency-shift-hz =  /bits/ 64 <0>;
+
+						};
+						ad9081_rx_fddc_chan4: channel@4 {
+							reg = <4>;
+							adi,decimation = <8>;
+							adi,gain = <2048>; /* 2048 * 10^(gain_dB/20) */
+							adi,nco-frequency-shift-hz =  /bits/ 64 <0>;
+
+						};
+						ad9081_rx_fddc_chan5: channel@5 {
+							reg = <5>;
+							adi,decimation = <8>;
+							adi,gain = <2048>; /* 2048 * 10^(gain_dB/20) */
+							adi,nco-frequency-shift-hz =  /bits/ 64 <0>;
+
+						};
+					};
+
+					adi,jesd-links {
+						#size-cells = <0>;
+						#address-cells = <1>;
+
+						ad9081_rx_jesd_l0: link@0 {
+							reg = <0>;
+							adi,converter-select =
+								<&ad9081_rx_fddc_chan0 FDDC_I>, <&ad9081_rx_fddc_chan0 FDDC_Q>,
+								<&ad9081_rx_fddc_chan1 FDDC_I>, <&ad9081_rx_fddc_chan1 FDDC_Q>,
+								<&ad9081_rx_fddc_chan4 FDDC_I>, <&ad9081_rx_fddc_chan4 FDDC_Q>,
+								<&ad9081_rx_fddc_chan5 FDDC_I>, <&ad9081_rx_fddc_chan5 FDDC_Q>;
+
+							adi,logical-lane-mapping = /bits/ 8 <2 0 7 7 7 7 3 1>;
+
+							adi,link-mode = <10>;			/* JESD Quick Configuration Mode */
+							adi,subclass = <1>;			/* JESD SUBCLASS 0,1,2 */
+							adi,version = <1>;			/* JESD VERSION 0=204A,1=204B,2=204C */
+							adi,dual-link = <0>;			/* JESD Dual Link Mode */
+
+							adi,converters-per-device = <8>;	/* JESD M */
+							adi,octets-per-frame = <4>;		/* JESD F */
+
+							adi,frames-per-multiframe = <32>;	/* JESD K */
+							adi,converter-resolution = <16>;	/* JESD N */
+							adi,bits-per-sample = <16>;		/* JESD NP' */
+							adi,control-bits-per-sample = <0>;	/* JESD CS */
+							adi,lanes-per-device = <4>;		/* JESD L */
+							adi,samples-per-converter-per-frame = <1>; /* JESD S */
+							adi,high-density = <0>;			/* JESD HD */
+						};
+					};
+				};
+			};
+		};
+	};
+
+	fragment@3 {
+		target = <&amba>;
+		__overlay__ {
+			interrupt-parent = <&gic>;
+			status = "okay";
+			#address-cells = <2>;
+			#size-cells = <2>;
+
+			axi_sysid_0: axi-sysid-0@85000000 {
+				status = "okay";
+				compatible = "adi,axi-sysid-1.00.a";
+				reg = <0x0 0x85000000 0x0 0x10000>;
+			};
+
+			rx_dma: dma@9c420000 {
+				compatible = "adi,axi-dmac-1.00.a";
+				reg = <0x0 0x9c420000 0x0 0x10000>;
+				#dma-cells = <1>;
+				#clock-cells = <0>;
+				interrupts = <0 109 IRQ_TYPE_LEVEL_HIGH>;
+				clocks = <&zynqmp_clk 73>;
+			};
+
+			tx_dma: dma@9c430000  {
+				compatible = "adi,axi-dmac-1.00.a";
+				reg = <0x0 0x9c430000  0x0 0x10000>;
+				#dma-cells = <1>;
+				#clock-cells = <0>;
+				interrupts = <0 108 IRQ_TYPE_LEVEL_HIGH>;
+				clocks = <&zynqmp_clk 73>;
+			};
+
+			axi_ad9081_adxcvr_rx: axi-adxcvr-rx@84a60000 {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				compatible = "adi,axi-adxcvr-1.0";
+				reg = <0x0 0x84a60000 0x0 0x1000>;
+
+				clocks = <&hmc7044 12>;
+				clock-names = "conv";
+
+				#clock-cells = <1>;
+				clock-output-names = "rx_gt_clk", "rx_out_clk";
+
+				adi,sys-clk-select = <XCVR_QPLL>;
+				adi,out-clk-select = <XCVR_REFCLK_DIV2>;
+				adi,use-lpm-enable;
+
+				jesd204-device;
+				#jesd204-cells = <2>;
+				jesd204-inputs =  <&hmc7044 0 FRAMER_LINK0_RX>;
+			};
+
+			axi_ad9081_adxcvr_tx: axi-adxcvr-tx@84b60000 {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				compatible = "adi,axi-adxcvr-1.0";
+				reg = <0x0 0x84b60000 0x0 0x1000>;
+
+				clocks = <&hmc7044 12>;
+				clock-names = "conv";
+
+				#clock-cells = <1>;
+				clock-output-names = "tx_gt_clk", "tx_out_clk";
+
+				adi,sys-clk-select = <XCVR_QPLL>;
+				adi,out-clk-select = <XCVR_REFCLK_DIV2>;
+
+				jesd204-device;
+				#jesd204-cells = <2>;
+				jesd204-inputs =  <&hmc7044 0 DEFRAMER_LINK0_TX>;
+			};
+
+
+
+			axi_ad9081_rx_jesd: axi-jesd204-rx@84a90000 {
+				compatible = "adi,axi-jesd204-rx-1.0";
+				reg = <0x0 0x84a90000 0x0 0x1000>;
+
+				interrupts = <0 107 IRQ_TYPE_LEVEL_HIGH>;
+
+				clocks = <&zynqmp_clk 71>, <&hmc7044 10>, <&axi_ad9081_adxcvr_rx 0>;
+				clock-names = "s_axi_aclk", "device_clk", "lane_clk";
+
+				#clock-cells = <0>;
+				clock-output-names = "jesd_rx_lane_clk";
+
+				jesd204-device;
+				#jesd204-cells = <2>;
+				jesd204-inputs = <&axi_ad9081_adxcvr_rx 0 FRAMER_LINK0_RX>;
+			};
+
+			axi_ad9081_tx_jesd: axi-jesd204-tx@84b90000 {
+				compatible = "adi,axi-jesd204-tx-1.0";
+				reg = <0x0 0x84b90000 0x0 0x1000>;
+
+				interrupts = <0 106 IRQ_TYPE_LEVEL_HIGH>;
+
+				clocks = <&zynqmp_clk 71>, <&hmc7044 6>, <&axi_ad9081_adxcvr_tx 0>;
+				clock-names = "s_axi_aclk", "device_clk", "lane_clk";
+
+				#clock-cells = <0>;
+				clock-output-names = "jesd_tx_lane_clk";
+
+				jesd204-device;
+				#jesd204-cells = <2>;
+				jesd204-inputs = <&axi_ad9081_adxcvr_tx 0 DEFRAMER_LINK0_TX>;
+			};
+
+			axi_ad9081_core_rx: axi-ad9081-rx-hpc@84a10000 {
+				compatible = "adi,axi-ad9081-rx-1.0";
+				reg = <0x0 0x84a10000  0x0 0x8000>;
+				dmas = <&rx_dma 0>;
+				dma-names = "rx";
+				spibus-connected = <&trx0_ad9081>;
+
+				jesd204-device;
+				#jesd204-cells = <2>;
+				jesd204-inputs = <&axi_ad9081_rx_jesd 0 FRAMER_LINK0_RX>;
+			};
+
+			axi_ad9081_core_tx: axi-ad9081-tx-hpc@84b10000 {
+				compatible = "adi,axi-ad9081-tx-1.0";
+				reg = <0x0 0x84b10000 0x0 0x4000>;
+				dmas = <&tx_dma 0>;
+				dma-names = "tx";
+				clocks = <&trx0_ad9081 1>;
+				clock-names = "sampl_clk";
+				spibus-connected = <&trx0_ad9081>;
+				//adi,axi-pl-fifo-enable;
+
+				jesd204-device;
+				#jesd204-cells = <2>;
+				jesd204-inputs = <&axi_ad9081_tx_jesd 0 DEFRAMER_LINK0_TX>;
+			};
+		};
+	};
+
+};
+

--- a/drivers/base/dd.c
+++ b/drivers/base/dd.c
@@ -162,7 +162,7 @@ static bool driver_deferred_probe_enable = false;
  * changes in the midst of a probe, then deferred processing should be triggered
  * again.
  */
-static void driver_deferred_probe_trigger(void)
+void driver_deferred_probe_trigger(void)
 {
 	if (!driver_deferred_probe_enable)
 		return;
@@ -184,7 +184,7 @@ static void driver_deferred_probe_trigger(void)
 	 */
 	schedule_work(&deferred_probe_work);
 }
-
+EXPORT_SYMBOL_GPL(driver_deferred_probe_trigger);
 /**
  * device_block_probing() - Block/defer device's probes
  *

--- a/drivers/jesd204/jesd204-core.c
+++ b/drivers/jesd204/jesd204-core.c
@@ -30,6 +30,7 @@ static unsigned int jesd204_device_count;
 static unsigned int jesd204_topologies_count;
 
 static unsigned int jesd204_con_id_counter;
+static bool jesd204_dyn_dt_change;
 
 static void jesd204_dev_unregister(struct jesd204_dev *jdev);
 
@@ -934,9 +935,11 @@ static struct jesd204_dev *jesd204_dev_register(struct device *dev,
 	}
 
 	jdev = jesd204_dev_find_by_of_node(dev->of_node);
-	if (!jdev) {
+	if (!jdev && !jesd204_dyn_dt_change) {
 		dev_err(dev, "Device has no configuration node\n");
 		return ERR_PTR(-ENODEV);
+	} else if (!jdev) {
+		return ERR_PTR(-EPROBE_DEFER);
 	}
 
 	ret = jesd204_dev_init_links_data(dev, jdev, init);
@@ -1068,6 +1071,84 @@ struct jesd204_dev *devm_jesd204_dev_register(struct device *dev,
 }
 EXPORT_SYMBOL_GPL(devm_jesd204_dev_register);
 
+
+static int jesd204_overlay_has_device(struct device_node *node)
+{
+	struct device_node *dn;
+	int i = 0;
+
+	for (dn = of_find_node_with_property(node, "jesd204-device"); dn;
+		dn = of_find_node_with_property(dn, "jesd204-device"))
+		i++;
+
+	return i;
+}
+
+/**
+ * of_jesd204_notify - reconfig notifier for dynamic DT changes
+ * @nb:		notifier block
+ * @action:	notifier action
+ * @arg:	reconfig data
+ *
+ */
+static int of_jesd204_notify(struct notifier_block *nb,
+				 unsigned long action, void *arg)
+{
+	struct of_overlay_notify_data *nd = arg;
+	int devs, ret =  0;
+
+	switch (action) {
+	case OF_OVERLAY_PRE_APPLY:
+		pr_debug("%s OF_OVERLAY_PRE_APPLY\n", __func__);
+
+		devs = jesd204_overlay_has_device(nd->overlay);
+		if (!devs)
+			return NOTIFY_OK;
+
+		if (devs && (jesd204_device_count || jesd204_topologies_count)) {
+			pr_err("%s Failed: base devicetree must not any jesd204-devices",
+				__func__);
+			return notifier_from_errno(-EOPNOTSUPP);
+		}
+
+		jesd204_dyn_dt_change = true;
+
+		return NOTIFY_OK;
+	case OF_OVERLAY_POST_APPLY:
+		pr_debug("%s OF_OVERLAY_POST_APPLY\n", __func__);
+
+		if (jesd204_dyn_dt_change) {
+			ret = jesd204_of_create_devices();
+
+			pr_info("found %u devices and %u topologies\n",
+				jesd204_device_count, jesd204_topologies_count);
+
+			jesd204_dyn_dt_change = false;
+			driver_deferred_probe_trigger();
+
+			return notifier_from_errno(ret);
+		}
+
+		return NOTIFY_OK;
+	case OF_OVERLAY_PRE_REMOVE:
+		pr_debug("%s OF_OVERLAY_PRE_REMOVE\n", __func__);
+
+		if (jesd204_device_count)
+			return notifier_from_errno(-EOPNOTSUPP);
+
+		return NOTIFY_OK;
+	case OF_OVERLAY_POST_REMOVE:
+		pr_debug("%s OF_OVERLAY_POST_REMOVE\n", __func__);
+		return NOTIFY_OK;
+	default:	/* should not happen */
+		return NOTIFY_OK;
+	}
+}
+
+static struct notifier_block jesd204_of_nb = {
+	.notifier_call = of_jesd204_notify,
+};
+
 static int __init jesd204_init(void)
 {
 	int ret;
@@ -1084,6 +1165,10 @@ static int __init jesd204_init(void)
 	if (ret < 0)
 		goto error_unreg_devices;
 
+	ret = of_overlay_notifier_register(&jesd204_of_nb);
+	if (ret)
+		return ret;
+
 	pr_info("found %u devices and %u topologies\n",
 		jesd204_device_count, jesd204_topologies_count);
 
@@ -1099,6 +1184,7 @@ static void __exit jesd204_exit(void)
 {
 	jesd204_of_unregister_devices();
 	bus_unregister(&jesd204_bus_type);
+	of_overlay_notifier_unregister(&jesd204_of_nb);
 }
 
 subsys_initcall(jesd204_init);

--- a/include/linux/device/driver.h
+++ b/include/linux/device/driver.h
@@ -240,6 +240,7 @@ extern int driver_deferred_probe_timeout;
 void driver_deferred_probe_add(struct device *dev);
 int driver_deferred_probe_check_state(struct device *dev);
 void driver_init(void);
+void driver_deferred_probe_trigger(void);
 
 /**
  * module_driver() - Helper macro for drivers that don't do anything


### PR DESCRIPTION
This adds support for loading dt overlays including jesd204-devices.
The requirement for this to work is that the base device tree doesn't
define any jesd204-devices. Also overlay removals are currently not supported.

This PR is likely not upstream-able. We had to export  driver_deferred_probe_trigger()
Which has been on the lkml several times: https://lkml.org/lkml/2021/8/17/802

I tried to parse the devices in the OF_OVERLAY_PRE_APPLY callback. 
However there are issues with the phandles at this stage.
In the long run I think we would need to change our connector mechanism to use of_graph.

The reason we return EPROBE_DEFER, is that in the OF_OVERLAY_POST_APPLY
callback the devices are already being probed, without connections and devices in
the jesd204 framework. So they return with error.
The solution is to defer probing until the jesd204 connections and devices are 
established.

Maybe @commodo also has some ideas.

