### PR TITLE
arm64: dts: zcu102-adrv9002: Move EEPROM to HPC0

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9002-rx2tx2.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9002-rx2tx2.dts
@@ -13,11 +13,11 @@
 
 &i2c1 {
 	i2c-mux@75 {
-		i2c@1 { /* HPC1 */
+		i2c@0 { /* HPC0 */
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <1>;
-
+			reg = <0>;
+			/* HPC0_IIC */
 			eeprom@50 {
 				compatible = "at24,24c02";
 				reg = <0x50>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9002.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9002.dts
@@ -13,16 +13,15 @@
 
 &i2c1 {
 	i2c-mux@75 {
-		i2c@1 { /* HPC1 */
+		i2c@0 { /* HPC0 */
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <1>;
-
+			reg = <0>;
+			/* HPC0_IIC */
 			eeprom@50 {
 				compatible = "at24,24c02";
 				reg = <0x50>;
 			};
-
 		};
 	};
 };


### PR DESCRIPTION
In accordance with the HDL the EEPROM is expected to be available on
HPC0 not HPC1.

See: https://github.com/analogdevicesinc/hdl/blob/master/projects/adrv9001/zcu102/system_constr.xdc