### PR TITLE
arch:arm:overlays:adrf6780: sync overlay

### DIFF
--- a/arch/arm/boot/dts/overlays/rpi-adrf6780-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-adrf6780-overlay.dts
@@ -42,7 +42,6 @@
 				spi-max-frequency = <1000000>;
 				clocks = <&adrf6780_lo>;
 				clock-names = "lo_in";
-				adi,parity-en;
 			};
 		};
 	};


### PR DESCRIPTION
Sync with upstream version where the parity-en dt property was removed.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>