### PR TITLE
[No functional changes] Microblaze DTS: add missing hdl_project tags

### DIFF
--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcjesdadc1.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcjesdadc1.dts
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: GPL-2.0
 /*
- * Analog Devices AD-FMCOMMS11-EBZ
+ * Analog Devices AD-FMCJESDADC1 FMC
  * https://wiki.analog.com/resources/eval/user-guides/ad-fmcjesdadc1-ebz
  *
  * hdl_project: <fmcjesdadc1/zc706>
  * board_revision: <>
  *
- * Copyright (C) 2014-2020 Analog Devices Inc.
+ * Copyright (C) 2014-2021 Analog Devices Inc.
 */
 /dts-v1/;
 

--- a/arch/microblaze/boot/dts/kc705_fmcjesdadc1.dts
+++ b/arch/microblaze/boot/dts/kc705_fmcjesdadc1.dts
@@ -1,4 +1,14 @@
-
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD-FMCJESDADC1 FMC
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-adc/axi-adc-hdl
+ * https://wiki.analog.com/resources/eval/user-guides/ad-fmcjesdadc1-ebz
+ *
+ * hdl_project: <fmcjesdadc1/kc705>
+ * board_revision: <>
+ *
+ * Copyright (C) 2016-2021 Analog Devices Inc.
+ */
 /dts-v1/;
 
 #include "kc705.dtsi"

--- a/arch/microblaze/boot/dts/kc705_fmcomms2-3.dts
+++ b/arch/microblaze/boot/dts/kc705_fmcomms2-3.dts
@@ -1,4 +1,14 @@
-
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD-FMCOMMS2-EBZ/AD-FMCOMMS3-EBZ
+ * https://wiki.analog.com/resources/eval/user-guides/ad-fmcomms2-ebz
+ * https://wiki.analog.com/resources/eval/user-guides/ad-fmcomms3-ebz
+ *
+ * hdl_project: <fmcomms2/kc705>
+ * board_revision: <>
+ *
+ * Copyright (C) 2014-2021 Analog Devices Inc.
+ */
 /dts-v1/;
 #include "kc705.dtsi"
 

--- a/arch/microblaze/boot/dts/kc705_fmcomms4.dts
+++ b/arch/microblaze/boot/dts/kc705_fmcomms4.dts
@@ -1,4 +1,14 @@
-
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices EVAL-AD-FMCOMMS4-EBZ
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/ad9361
+ * https://wiki.analog.com/eval/user-guides/ad-fmcomms4-ebz
+ *
+ * hdl_project: <fmcomms2/kc705>
+ * board_revision: <>
+ *
+ * Copyright (C) 2014-2021 Analog Devices Inc.
+ */
 /dts-v1/;
 #include "kc705.dtsi"
 

--- a/arch/microblaze/boot/dts/kcu105_fmcdaq3.dts
+++ b/arch/microblaze/boot/dts/kcu105_fmcdaq3.dts
@@ -1,4 +1,13 @@
-
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD-FMCDAQ3-EBZ
+ * https://wiki.analog.com/resources/eval/user-guides/ad-fmcdaq3-ebz
+ *
+ * hdl_project: <daq3/kcu105>
+ * board_revision: <>
+ *
+ * Copyright (C) 2015-2021 Analog Devices Inc.
+ */
 /dts-v1/;
 
 #include "kcu105.dtsi"

--- a/arch/microblaze/boot/dts/kcu105_fmcomms2-3.dts
+++ b/arch/microblaze/boot/dts/kcu105_fmcomms2-3.dts
@@ -1,4 +1,14 @@
-
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD-FMCOMMS2-EBZ/AD-FMCOMMS3-EBZ
+ * https://wiki.analog.com/resources/eval/user-guides/ad-fmcomms2-ebz
+ * https://wiki.analog.com/resources/eval/user-guides/ad-fmcomms3-ebz
+ *
+ * hdl_project: <fmcomms2/kcu105>
+ * board_revision: <>
+ *
+ * Copyright (C) 2014-2021 Analog Devices Inc.
+ */
 /dts-v1/;
 #include "kcu105.dtsi"
 

--- a/arch/microblaze/boot/dts/kcu105_fmcomms4.dts
+++ b/arch/microblaze/boot/dts/kcu105_fmcomms4.dts
@@ -1,4 +1,14 @@
-
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices EVAL-AD-FMCOMMS4-EBZ
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/ad9361
+ * https://wiki.analog.com/eval/user-guides/ad-fmcomms4-ebz
+ *
+ * hdl_project: <fmcomms2/kcu105>
+ * board_revision: <>
+ *
+ * Copyright (C) 2014-2021 Analog Devices Inc.
+ */
 /dts-v1/;
 #include "kcu105.dtsi"
 

--- a/arch/microblaze/boot/dts/vc707_fmcadc2.dts
+++ b/arch/microblaze/boot/dts/vc707_fmcadc2.dts
@@ -1,4 +1,13 @@
-
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD-FMCADC2-EBZ
+ * https://wiki.analog.com/resources/eval/user-guides/ad-fmcadc2-ebz
+ *
+ * hdl_project: <fmcadc2/vc707>
+ * board_revision: <>
+ *
+ * Copyright (C) 2014-2021 Analog Devices Inc.
+ */
 /dts-v1/;
 
 #include "vc707.dtsi"

--- a/arch/microblaze/boot/dts/vc707_fmcadc5.dts
+++ b/arch/microblaze/boot/dts/vc707_fmcadc5.dts
@@ -1,4 +1,13 @@
-
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD-FMCADC5-EBZ
+ * https://wiki.analog.com/resources/eval/user-guides/ad-fmcadc5-ebz
+ *
+ * hdl_project: <fmcadc5/vc707>
+ * board_revision: <>
+ *
+ * Copyright (C) 2014-2021 Analog Devices Inc.
+ */
 /dts-v1/;
 
 #include "vc707.dtsi"

--- a/arch/microblaze/boot/dts/vc707_fmcdaq2.dts
+++ b/arch/microblaze/boot/dts/vc707_fmcdaq2.dts
@@ -1,4 +1,13 @@
-
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD-FMCDAQ2-EBZ
+ * https://wiki.analog.com/resources/eval/user-guides/ad-fmcdaq2-ebz
+ *
+ * hdl_project: <daq2/vc707>
+ * board_revision: <>
+ *
+ * Copyright (C) 2014-2021 Analog Devices Inc.
+ */
 /dts-v1/;
 
 #include "vc707.dtsi"

--- a/arch/microblaze/boot/dts/vc707_fmcjesdadc1.dts
+++ b/arch/microblaze/boot/dts/vc707_fmcjesdadc1.dts
@@ -1,4 +1,14 @@
-
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD-FMCJESDADC1 FMC
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-adc/axi-adc-hdl
+ * https://wiki.analog.com/resources/eval/user-guides/ad-fmcjesdadc1-ebz
+ *
+ * hdl_project: <fmcjesdadc1/vc707>
+ * board_revision: <>
+ *
+ * Copyright (C) 2016-2021 Analog Devices Inc.
+ */
 /dts-v1/;
 
 #include "vc707.dtsi"

--- a/arch/microblaze/boot/dts/vc707_fmcomms2-3.dts
+++ b/arch/microblaze/boot/dts/vc707_fmcomms2-3.dts
@@ -1,4 +1,14 @@
-
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD-FMCOMMS2-EBZ/AD-FMCOMMS3-EBZ
+ * https://wiki.analog.com/resources/eval/user-guides/ad-fmcomms2-ebz
+ * https://wiki.analog.com/resources/eval/user-guides/ad-fmcomms3-ebz
+ *
+ * hdl_project: <fmcomms2/vc707>
+ * board_revision: <>
+ *
+ * Copyright (C) 2014-2021 Analog Devices Inc.
+ */
 /dts-v1/;
 #include "vc707.dtsi"
 

--- a/arch/microblaze/boot/dts/vc707_fmcomms4.dts
+++ b/arch/microblaze/boot/dts/vc707_fmcomms4.dts
@@ -1,4 +1,14 @@
-
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices EVAL-AD-FMCOMMS4-EBZ
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/ad9361
+ * https://wiki.analog.com/eval/user-guides/ad-fmcomms4-ebz
+ *
+ * hdl_project: <fmcomms2/vc707>
+ * board_revision: <>
+ *
+ * Copyright (C) 2014-2021 Analog Devices Inc.
+ */
 /dts-v1/;
 #include "vc707.dtsi"
 

--- a/arch/microblaze/boot/dts/vcu118_dual_ad9208.dts
+++ b/arch/microblaze/boot/dts/vcu118_dual_ad9208.dts
@@ -1,4 +1,15 @@
 // SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD9208 / AD9689 ANALOG-TO-DIGITAL CONVERTER
+ * https://wiki.analog.com/resources/eval/ad9208-3000ebz
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-adc/ad9208
+ *
+ * hdl_project: <ad9208_dual_ebz/vcu118>
+ * board_revision: <>
+ *
+ * Copyright (C) 2021 Analog Devices Inc.
+ */
+
 /dts-v1/;
 
 #include "vcu118.dtsi"

--- a/arch/microblaze/boot/dts/vcu118_fmcdaq3.dts
+++ b/arch/microblaze/boot/dts/vcu118_fmcdaq3.dts
@@ -1,4 +1,13 @@
-
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD-FMCDAQ3-EBZ
+ * https://wiki.analog.com/resources/eval/user-guides/ad-fmcdaq3-ebz
+ *
+ * hdl_project: <daq3/vcu118>
+ * board_revision: <>
+ *
+ * Copyright (C) 2015-2021 Analog Devices Inc.
+ */
 /dts-v1/;
 
 #include "vcu118.dtsi"


### PR DESCRIPTION
Add missing hdl_project tags in comment section of DTS.
Fix also some typos.

Signed-off-by: stefan.raus <stefan.raus@analog.com>