### PR TITLE
Add documentation generation for devicetree nodes

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,0 +1,29 @@
+name: Documentation
+
+on: [push, pull_request]
+
+jobs:
+  BuildDocs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install dependencies
+        run: |
+          pip install -r docs/requirements.txt
+      - name: Check doc build
+        run: |
+          mkdocs build -v -s
+
+      - name: Publish master doc
+        if: github.ref == 'refs/heads/master'
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site
+          destination_dir: master

--- a/docs/_templates/temp.yml
+++ b/docs/_templates/temp.yml
@@ -1,0 +1,41 @@
+site_name: linux
+site_description: ADI Linux Kernel
+site_author: Analog Devices, Inc.
+
+theme:
+  name: material
+  features:
+    - content.tabs.link
+  palette:
+    - scheme: default
+      primary: deep orange
+      toggle:
+        icon: material/toggle-switch-off-outline
+        name: Switch to dark mode
+    - scheme: slate
+      primary: deep orange
+      toggle:
+        icon: material/toggle-switch
+        name: Switch to light mode
+
+nav:
+    - Home: index.md
+    - Devs:
+        {% block content -%}
+        {% for dev in devs -%}
+              - devs/{{ dev }}
+        {% endfor %}
+        {% endblock %}
+
+repo_url: https://github.com/analogdevicesinc/linux
+
+markdown_extensions:
+    - pymdownx.superfences
+    - pymdownx.tabbed
+
+plugins:
+  - search
+  - dt-plugin
+
+extra_css:
+  - stylesheets/style.css

--- a/docs/devs/ADI_AD5766.md
+++ b/docs/devs/ADI_AD5766.md
@@ -1,0 +1,3 @@
+
+
+::: linux:Documentation/devicetree/bindings/iio/dac/adi,ad5766.yaml

--- a/docs/devs/ADI_AD5770R.md
+++ b/docs/devs/ADI_AD5770R.md
@@ -1,0 +1,3 @@
+
+
+::: linux:Documentation/devicetree/bindings/iio/dac/adi,ad5770r.yaml

--- a/docs/devs/ADI_AD7091R5.md
+++ b/docs/devs/ADI_AD7091R5.md
@@ -1,0 +1,3 @@
+
+
+::: linux:Documentation/devicetree/bindings/iio/adc/adi,ad7091r5.yaml

--- a/docs/devs/ADI_AD7124.md
+++ b/docs/devs/ADI_AD7124.md
@@ -1,0 +1,3 @@
+
+
+::: linux:Documentation/devicetree/bindings/iio/adc/adi,ad7124.yaml

--- a/docs/devs/ADI_AD7192.md
+++ b/docs/devs/ADI_AD7192.md
@@ -1,0 +1,3 @@
+
+
+::: linux:Documentation/devicetree/bindings/iio/adc/adi,ad7192.yaml

--- a/docs/devs/ADI_AD7291.md
+++ b/docs/devs/ADI_AD7291.md
@@ -1,0 +1,3 @@
+
+
+::: linux:Documentation/devicetree/bindings/iio/adc/adi,ad7291.yaml

--- a/docs/devs/ADI_AD7292.md
+++ b/docs/devs/ADI_AD7292.md
@@ -1,0 +1,3 @@
+
+
+::: linux:Documentation/devicetree/bindings/iio/adc/adi,ad7292.yaml

--- a/docs/devs/ADI_AD7606.md
+++ b/docs/devs/ADI_AD7606.md
@@ -1,0 +1,1006 @@
+
+
+::: linux:Documentation/devicetree/bindings/iio/adc/adi,ad7606.yaml
+
+
+=== "sysfs"
+
+    ```bash
+    root:/> cd /sys/bus/iio/devices/
+    root:/sys/bus/iio/devices> ls
+    iio:device4  iio:trigger0
+
+    root:/sys/bus/iio/devices> cd iio:device4
+
+    root:/sys/bus/iio/devices/iio:device4> ls -l
+    drwxr-xr-x    2 root     root             0 Jan  1 00:00 buffer
+    -r--r--r--    1 root     root          4096 Jan  1 00:00 dev
+    -rw-r--r--    1 root     root          4096 Jan  1 00:00 in_voltage0_calibbias
+    -rw-r--r--    1 root     root          4096 Jan  1 00:00 in_voltage0_calibphase
+    -rw-r--r--    1 root     root          4096 Jan  1 00:00 in_voltage0_calibscale
+    -rw-r--r--    1 root     root          4096 Jan  1 00:00 in_voltage0_filter_high_pass_3db_frequency
+    -rw-r--r--    1 root     root          4096 Jan  1 00:00 in_voltage0_test_mode
+    -rw-r--r--    1 root     root          4096 Jan  1 00:00 in_voltage1_calibbias
+    -rw-r--r--    1 root     root          4096 Jan  1 00:00 in_voltage1_calibphase
+    -rw-r--r--    1 root     root          4096 Jan  1 00:00 in_voltage1_calibscale
+    -rw-r--r--    1 root     root          4096 Jan  1 00:00 in_voltage1_filter_high_pass_3db_frequency
+    -rw-r--r--    1 root     root          4096 Jan  1 00:00 in_voltage1_test_mode
+    -rw-r--r--    1 root     root          4096 Jan  1 00:00 in_voltage_sampling_frequency
+    -rw-r--r--    1 root     root          4096 Jan  1 00:00 in_voltage_scale
+    -r--r--r--    1 root     root          4096 Jan  1 00:00 in_voltage_scale_available
+    -r--r--r--    1 root     root          4096 Jan  1 00:00 in_voltage_test_mode_available
+    -r--r--r--    1 root     root          4096 Jan  1 00:00 name
+    drwxr-xr-x    2 root     root             0 Jan  1 00:00 scan_elements
+    lrwxrwxrwx    1 root     root             0 Jan  1 00:00 subsystem -> ../../../../bus/iio
+    -rw-r--r--    1 root     root          4096 Jan  1 00:00 uevent
+    root:/sys/bus/iio/devices/iio:device4>
+    ```
+
+=== "libiio API "
+
+	<div class="iio-context">
+	
+	<p><img src='https://analogdevicesinc.github.io/libiio/img/iio_logo.png' alt='libiio' style='height:40px;vertical-align: middle;'> <span style='vertical-align: middle;'><b>ad9361-phy</b></span></p>
+	<p>This is a device</p>
+	<p class="devattr-header"><i>DEVICE ATTRIBUTES</i>: <b>ad9361-phy</b></p>
+	<!-- <hr class="devattr-table-hr"> -->
+	<table class="devattr-table">
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">calib_mode</td>
+	<td class="devattr-type-col">str</td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">Set calibration mode</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">calib_mode_available</td>
+	<td class="devattr-type-col">str</td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">dcxo_tune_coarse</td>
+	<td class="devattr-type-col">str</td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">dcxo_tune_coarse_available</td>
+	<td class="devattr-type-col">str</td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">dcxo_tune_fine</td>
+	<td class="devattr-type-col">str</td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">dcxo_tune_fine_available</td>
+	<td class="devattr-type-col">str</td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">ensm_mode</td>
+	<td class="devattr-type-col">str</td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">ensm_mode_available</td>
+	<td class="devattr-type-col">str</td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">filter_fir_config</td>
+	<td class="devattr-type-col">str</td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">gain_table_config</td>
+	<td class="devattr-type-col">str</td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">multichip_sync</td>
+	<td class="devattr-type-col">str</td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">rssi_gain_step_error</td>
+	<td class="devattr-type-col">str</td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">rx_path_rates</td>
+	<td class="devattr-type-col">str</td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">trx_rate_governor</td>
+	<td class="devattr-type-col">str</td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">trx_rate_governor_available</td>
+	<td class="devattr-type-col">str</td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">tx_path_rates</td>
+	<td class="devattr-type-col">str</td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">xo_correction</td>
+	<td class="devattr-type-col">str</td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">xo_correction_available</td>
+	<td class="devattr-type-col">str</td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+
+	</table>
+
+	<br>
+	<!-- <hr> -->
+	<br>
+	<p class="devattr-header"><i>CHANNEL ATTRIBUTES</i>: <b>ad9361-phy</b></p>
+	<table class="devattr-table">
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">external</td>
+	<td class="devattr-type-col">str</td>
+	<!-- <span>altvoltage1, altvoltage0</span></td> -->
+	</tr>
+	<tr>
+	<td></td>
+	<td></td>
+	<td class="devattr-type-col"><span>altvoltage1, altvoltage0</span></td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">fastlock_load</td>
+	<td class="devattr-type-col">str</td>
+	<!-- <span>altvoltage1, altvoltage0</span></td> -->
+	</tr>
+	<tr>
+	<td></td>
+	<td></td>
+	<td class="devattr-type-col"><span>altvoltage1, altvoltage0</span></td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">fastlock_recall</td>
+	<td class="devattr-type-col">str</td>
+	<!-- <span>altvoltage1, altvoltage0</span></td> -->
+	</tr>
+	<tr>
+	<td></td>
+	<td></td>
+	<td class="devattr-type-col"><span>altvoltage1, altvoltage0</span></td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">fastlock_save</td>
+	<td class="devattr-type-col">str</td>
+	<!-- <span>altvoltage1, altvoltage0</span></td> -->
+	</tr>
+	<tr>
+	<td></td>
+	<td></td>
+	<td class="devattr-type-col"><span>altvoltage1, altvoltage0</span></td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">fastlock_store</td>
+	<td class="devattr-type-col">str</td>
+	<!-- <span>altvoltage1, altvoltage0</span></td> -->
+	</tr>
+	<tr>
+	<td></td>
+	<td></td>
+	<td class="devattr-type-col"><span>altvoltage1, altvoltage0</span></td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">frequency</td>
+	<td class="devattr-type-col">str</td>
+	<!-- <span>altvoltage1, altvoltage0</span></td> -->
+	</tr>
+	<tr>
+	<td></td>
+	<td></td>
+	<td class="devattr-type-col"><span>altvoltage1, altvoltage0</span></td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">frequency_available</td>
+	<td class="devattr-type-col">str</td>
+	<!-- <span>altvoltage1, altvoltage0</span></td> -->
+	</tr>
+	<tr>
+	<td></td>
+	<td></td>
+	<td class="devattr-type-col"><span>altvoltage1, altvoltage0</span></td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">powerdown</td>
+	<td class="devattr-type-col">str</td>
+	<!-- <span>altvoltage1, altvoltage0</span></td> -->
+	</tr>
+	<tr>
+	<td></td>
+	<td></td>
+	<td class="devattr-type-col"><span>altvoltage1, altvoltage0</span></td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">bb_dc_offset_tracking_en</td>
+	<td class="devattr-type-col">str</td>
+	<!-- <span>voltage0, voltage2</span></td> -->
+	</tr>
+	<tr>
+	<td></td>
+	<td></td>
+	<td class="devattr-type-col"><span>voltage0, voltage2</span></td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">filter_fir_en</td>
+	<td class="devattr-type-col">str</td>
+	<!-- <span>voltage0, voltage3, voltage2, voltage0, voltage2</span></td> -->
+	</tr>
+	<tr>
+	<td></td>
+	<td></td>
+	<td class="devattr-type-col"><span>voltage0, voltage3, voltage2, voltage0, voltage2</span></td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">gain_control_mode</td>
+	<td class="devattr-type-col">str</td>
+	<!-- <span>voltage0</span></td> -->
+	</tr>
+	<tr>
+	<td></td>
+	<td></td>
+	<td class="devattr-type-col"><span>voltage0</span></td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">gain_control_mode_available</td>
+	<td class="devattr-type-col">str</td>
+	<!-- <span>voltage0, voltage2</span></td> -->
+	</tr>
+	<tr>
+	<td></td>
+	<td></td>
+	<td class="devattr-type-col"><span>voltage0, voltage2</span></td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">hardwaregain</td>
+	<td class="devattr-type-col">str</td>
+	<!-- <span>voltage0, voltage0</span></td> -->
+	</tr>
+	<tr>
+	<td></td>
+	<td></td>
+	<td class="devattr-type-col"><span>voltage0, voltage0</span></td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">hardwaregain_available</td>
+	<td class="devattr-type-col">str</td>
+	<!-- <span>voltage0, voltage0</span></td> -->
+	</tr>
+	<tr>
+	<td></td>
+	<td></td>
+	<td class="devattr-type-col"><span>voltage0, voltage0</span></td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">quadrature_tracking_en</td>
+	<td class="devattr-type-col">str</td>
+	<!-- <span>voltage0, voltage2</span></td> -->
+	</tr>
+	<tr>
+	<td></td>
+	<td></td>
+	<td class="devattr-type-col"><span>voltage0, voltage2</span></td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">rf_bandwidth</td>
+	<td class="devattr-type-col">str</td>
+	<!-- <span>voltage0, voltage3, voltage2, voltage0, voltage2</span></td> -->
+	</tr>
+	<tr>
+	<td></td>
+	<td></td>
+	<td class="devattr-type-col"><span>voltage0, voltage3, voltage2, voltage0, voltage2</span></td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">rf_bandwidth_available</td>
+	<td class="devattr-type-col">str</td>
+	<!-- <span>voltage0, voltage3, voltage2, voltage0, voltage2</span></td> -->
+	</tr>
+	<tr>
+	<td></td>
+	<td></td>
+	<td class="devattr-type-col"><span>voltage0, voltage3, voltage2, voltage0, voltage2</span></td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">rf_dc_offset_tracking_en</td>
+	<td class="devattr-type-col">str</td>
+	<!-- <span>voltage0, voltage2</span></td> -->
+	</tr>
+	<tr>
+	<td></td>
+	<td></td>
+	<td class="devattr-type-col"><span>voltage0, voltage2</span></td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">rf_port_select</td>
+	<td class="devattr-type-col">str</td>
+	<!-- <span>voltage0, voltage0</span></td> -->
+	</tr>
+	<tr>
+	<td></td>
+	<td></td>
+	<td class="devattr-type-col"><span>voltage0, voltage0</span></td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">rf_port_select_available</td>
+	<td class="devattr-type-col">str</td>
+	<!-- <span>voltage0, voltage3, voltage2, voltage0, voltage2</span></td> -->
+	</tr>
+	<tr>
+	<td></td>
+	<td></td>
+	<td class="devattr-type-col"><span>voltage0, voltage3, voltage2, voltage0, voltage2</span></td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">rssi</td>
+	<td class="devattr-type-col">str</td>
+	<!-- <span>voltage0, voltage0</span></td> -->
+	</tr>
+	<tr>
+	<td></td>
+	<td></td>
+	<td class="devattr-type-col"><span>voltage0, voltage0</span></td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">sampling_frequency</td>
+	<td class="devattr-type-col">str</td>
+	<!-- <span>voltage0, voltage3, voltage2, voltage0, voltage2</span></td> -->
+	</tr>
+	<tr>
+	<td></td>
+	<td></td>
+	<td class="devattr-type-col"><span>voltage0, voltage3, voltage2, voltage0, voltage2</span></td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">sampling_frequency_available</td>
+	<td class="devattr-type-col">str</td>
+	<!-- <span>voltage0, voltage3, voltage2, voltage0, voltage2</span></td> -->
+	</tr>
+	<tr>
+	<td></td>
+	<td></td>
+	<td class="devattr-type-col"><span>voltage0, voltage3, voltage2, voltage0, voltage2</span></td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">raw</td>
+	<td class="devattr-type-col">str</td>
+	<!-- <span>voltage3, voltage2, voltage2</span></td> -->
+	</tr>
+	<tr>
+	<td></td>
+	<td></td>
+	<td class="devattr-type-col"><span>voltage3, voltage2, voltage2</span></td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">scale</td>
+	<td class="devattr-type-col">str</td>
+	<!-- <span>voltage3, voltage2, voltage2</span></td> -->
+	</tr>
+	<tr>
+	<td></td>
+	<td></td>
+	<td class="devattr-type-col"><span>voltage3, voltage2, voltage2</span></td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">input</td>
+	<td class="devattr-type-col">str</td>
+	<!-- <span>temp0</span></td> -->
+	</tr>
+	<tr>
+	<td></td>
+	<td></td>
+	<td class="devattr-type-col"><span>temp0</span></td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">offset</td>
+	<td class="devattr-type-col">str</td>
+	<!-- <span>voltage2</span></td> -->
+	</tr>
+	<tr>
+	<td></td>
+	<td></td>
+	<td class="devattr-type-col"><span>voltage2</span></td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">voltage_filter_fir_en</td>
+	<td class="devattr-type-col">str</td>
+	<!-- <span>out</span></td> -->
+	</tr>
+	<tr>
+	<td></td>
+	<td></td>
+	<td class="devattr-type-col"><span>out</span></td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+
+	</table>    
+
+
+	<p><b>xadc</b></p>
+	<p>This is a device</p>
+	<p class="devattr-header"><i>DEVICE ATTRIBUTES</i>: <b>xadc</b></p>
+	<!-- <hr class="devattr-table-hr"> -->
+	<table class="devattr-table">
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">sampling_frequency</td>
+	<td class="devattr-type-col">str</td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+
+	</table>
+
+	<br>
+	<!-- <hr> -->
+	<br>
+	<p class="devattr-header"><i>CHANNEL ATTRIBUTES</i>: <b>xadc</b></p>
+	<table class="devattr-table">
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">raw</td>
+	<td class="devattr-type-col">str</td>
+	<!-- <span>voltage5, voltage0, voltage4, temp0, voltage7, voltage1, voltage2, voltage3, voltage8, voltage6</span></td> -->
+	</tr>
+	<tr>
+	<td></td>
+	<td></td>
+	<td class="devattr-type-col"><span>voltage5, voltage0, voltage4, temp0, voltage7, voltage1, voltage2, voltage3, voltage8, voltage6</span></td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">scale</td>
+	<td class="devattr-type-col">str</td>
+	<!-- <span>voltage5, voltage0, voltage4, temp0, voltage7, voltage1, voltage2, voltage3, voltage8, voltage6</span></td> -->
+	</tr>
+	<tr>
+	<td></td>
+	<td></td>
+	<td class="devattr-type-col"><span>voltage5, voltage0, voltage4, temp0, voltage7, voltage1, voltage2, voltage3, voltage8, voltage6</span></td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">offset</td>
+	<td class="devattr-type-col">str</td>
+	<!-- <span>temp0</span></td> -->
+	</tr>
+	<tr>
+	<td></td>
+	<td></td>
+	<td class="devattr-type-col"><span>temp0</span></td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+
+	</table>    
+
+
+	<br>
+	<!-- <hr> -->
+	<br>
+	<p class="devattr-header"><i>CHANNEL ATTRIBUTES</i>: <b>cf-ad9361-dds-core-lpc</b></p>
+	<table class="devattr-table">
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">calibphase</td>
+	<td class="devattr-type-col">str</td>
+	<!-- <span>voltage0, voltage1</span></td> -->
+	</tr>
+	<tr>
+	<td></td>
+	<td></td>
+	<td class="devattr-type-col"><span>voltage0, voltage1</span></td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">calibscale</td>
+	<td class="devattr-type-col">str</td>
+	<!-- <span>voltage0, voltage1</span></td> -->
+	</tr>
+	<tr>
+	<td></td>
+	<td></td>
+	<td class="devattr-type-col"><span>voltage0, voltage1</span></td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">sampling_frequency</td>
+	<td class="devattr-type-col">str</td>
+	<!-- <span>voltage0, voltage1, altvoltage3, altvoltage1, altvoltage0, altvoltage2</span></td> -->
+	</tr>
+	<tr>
+	<td></td>
+	<td></td>
+	<td class="devattr-type-col"><span>voltage0, voltage1, altvoltage3, altvoltage1, altvoltage0, altvoltage2</span></td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">sampling_frequency_available</td>
+	<td class="devattr-type-col">str</td>
+	<!-- <span>voltage0, voltage1</span></td> -->
+	</tr>
+	<tr>
+	<td></td>
+	<td></td>
+	<td class="devattr-type-col"><span>voltage0, voltage1</span></td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">frequency</td>
+	<td class="devattr-type-col">str</td>
+	<!-- <span>altvoltage3, altvoltage1, altvoltage0, altvoltage2</span></td> -->
+	</tr>
+	<tr>
+	<td></td>
+	<td></td>
+	<td class="devattr-type-col"><span>altvoltage3, altvoltage1, altvoltage0, altvoltage2</span></td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">phase</td>
+	<td class="devattr-type-col">str</td>
+	<!-- <span>altvoltage3, altvoltage1, altvoltage0, altvoltage2</span></td> -->
+	</tr>
+	<tr>
+	<td></td>
+	<td></td>
+	<td class="devattr-type-col"><span>altvoltage3, altvoltage1, altvoltage0, altvoltage2</span></td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">raw</td>
+	<td class="devattr-type-col">str</td>
+	<!-- <span>altvoltage3, altvoltage1, altvoltage0, altvoltage2</span></td> -->
+	</tr>
+	<tr>
+	<td></td>
+	<td></td>
+	<td class="devattr-type-col"><span>altvoltage3, altvoltage1, altvoltage0, altvoltage2</span></td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">scale</td>
+	<td class="devattr-type-col">str</td>
+	<!-- <span>altvoltage3, altvoltage1, altvoltage0, altvoltage2</span></td> -->
+	</tr>
+	<tr>
+	<td></td>
+	<td></td>
+	<td class="devattr-type-col"><span>altvoltage3, altvoltage1, altvoltage0, altvoltage2</span></td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+
+	</table>    
+
+
+	<br>
+	<!-- <hr> -->
+	<br>
+	<p class="devattr-header"><i>CHANNEL ATTRIBUTES</i>: <b>cf-ad9361-lpc</b></p>
+	<table class="devattr-table">
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">calibbias</td>
+	<td class="devattr-type-col">str</td>
+	<!-- <span>voltage0, voltage1</span></td> -->
+	</tr>
+	<tr>
+	<td></td>
+	<td></td>
+	<td class="devattr-type-col"><span>voltage0, voltage1</span></td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">calibphase</td>
+	<td class="devattr-type-col">str</td>
+	<!-- <span>voltage0, voltage1</span></td> -->
+	</tr>
+	<tr>
+	<td></td>
+	<td></td>
+	<td class="devattr-type-col"><span>voltage0, voltage1</span></td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">calibscale</td>
+	<td class="devattr-type-col">str</td>
+	<!-- <span>voltage0, voltage1</span></td> -->
+	</tr>
+	<tr>
+	<td></td>
+	<td></td>
+	<td class="devattr-type-col"><span>voltage0, voltage1</span></td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">samples_pps</td>
+	<td class="devattr-type-col">str</td>
+	<!-- <span>voltage0, voltage1</span></td> -->
+	</tr>
+	<tr>
+	<td></td>
+	<td></td>
+	<td class="devattr-type-col"><span>voltage0, voltage1</span></td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">sampling_frequency</td>
+	<td class="devattr-type-col">str</td>
+	<!-- <span>voltage0, voltage1</span></td> -->
+	</tr>
+	<tr>
+	<td></td>
+	<td></td>
+	<td class="devattr-type-col"><span>voltage0, voltage1</span></td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+	<tr>
+	<td class="devattr-topleft-col"></td>
+	<td class="devattr-name-col">sampling_frequency_available</td>
+	<td class="devattr-type-col">str</td>
+	<!-- <span>voltage0, voltage1</span></td> -->
+	</tr>
+	<tr>
+	<td></td>
+	<td></td>
+	<td class="devattr-type-col"><span>voltage0, voltage1</span></td>
+	</tr>
+	<tr>
+	<td class="devattr-bottomleft-col"></td>
+	<td class="devattr-spacer-col"></td>
+	<td class="devattr-about">NA</td>
+	</tr>
+
+	</table>    
+
+
+
+	</div>

--- a/docs/devs/ADI_AD7768-1.md
+++ b/docs/devs/ADI_AD7768-1.md
@@ -1,0 +1,3 @@
+
+
+::: linux:Documentation/devicetree/bindings/iio/adc/adi,ad7768-1.yaml

--- a/docs/devs/ADI_AD7780.md
+++ b/docs/devs/ADI_AD7780.md
@@ -1,0 +1,3 @@
+
+
+::: linux:Documentation/devicetree/bindings/iio/adc/adi,ad7780.yaml

--- a/docs/devs/ADI_AD7923.md
+++ b/docs/devs/ADI_AD7923.md
@@ -1,0 +1,3 @@
+
+
+::: linux:Documentation/devicetree/bindings/iio/adc/adi,ad7923.yaml

--- a/docs/devs/ADI_AD7949.md
+++ b/docs/devs/ADI_AD7949.md
@@ -1,0 +1,3 @@
+
+
+::: linux:Documentation/devicetree/bindings/iio/adc/adi,ad7949.yaml

--- a/docs/devs/ADI_AD9083.md
+++ b/docs/devs/ADI_AD9083.md
@@ -1,0 +1,3 @@
+
+
+::: linux:Documentation/devicetree/bindings/iio/adc/adi,ad9083.yaml

--- a/docs/devs/ADI_AD9467.md
+++ b/docs/devs/ADI_AD9467.md
@@ -1,0 +1,3 @@
+
+
+::: linux:Documentation/devicetree/bindings/iio/adc/adi,ad9467.yaml

--- a/docs/devs/ADI_ADA4250.md
+++ b/docs/devs/ADI_ADA4250.md
@@ -1,0 +1,3 @@
+
+
+::: linux:Documentation/devicetree/bindings/iio/amplifiers/adi,ada4250.yaml

--- a/docs/devs/ADI_ADAR1000.md
+++ b/docs/devs/ADI_ADAR1000.md
@@ -1,0 +1,3 @@
+
+
+::: linux:Documentation/devicetree/bindings/iio/adc/adi,adar1000.yaml

--- a/docs/devs/ADI_ADAR300X.md
+++ b/docs/devs/ADI_ADAR300X.md
@@ -1,0 +1,3 @@
+
+
+::: linux:Documentation/devicetree/bindings/iio/beamformer/adi,adar300x.yaml

--- a/docs/devs/ADI_ADIS16240.md
+++ b/docs/devs/ADI_ADIS16240.md
@@ -1,0 +1,3 @@
+
+
+::: linux:Documentation/devicetree/bindings/iio/accel/adi,adis16240.yaml

--- a/docs/devs/ADI_ADIS16460.md
+++ b/docs/devs/ADI_ADIS16460.md
@@ -1,0 +1,3 @@
+
+
+::: linux:Documentation/devicetree/bindings/iio/imu/adi,adis16460.yaml

--- a/docs/devs/ADI_ADIS16475.md
+++ b/docs/devs/ADI_ADIS16475.md
@@ -1,0 +1,3 @@
+
+
+::: linux:Documentation/devicetree/bindings/iio/imu/adi,adis16475.yaml

--- a/docs/devs/ADI_ADL5960.md
+++ b/docs/devs/ADI_ADL5960.md
@@ -1,0 +1,3 @@
+
+
+::: linux:Documentation/devicetree/bindings/iio/frequency/adi,adl5960.yaml

--- a/docs/devs/ADI_ADMV1013.md
+++ b/docs/devs/ADI_ADMV1013.md
@@ -1,0 +1,3 @@
+
+
+::: linux:Documentation/devicetree/bindings/iio/frequency/adi,admv1013.yaml

--- a/docs/devs/ADI_ADMV1014.md
+++ b/docs/devs/ADI_ADMV1014.md
@@ -1,0 +1,3 @@
+
+
+::: linux:Documentation/devicetree/bindings/iio/frequency/adi,admv1014.yaml

--- a/docs/devs/ADI_ADMV8818.md
+++ b/docs/devs/ADI_ADMV8818.md
@@ -1,0 +1,3 @@
+
+
+::: linux:Documentation/devicetree/bindings/iio/filter/adi,admv8818.yaml

--- a/docs/devs/ADI_ADRF6780.md
+++ b/docs/devs/ADI_ADRF6780.md
@@ -1,0 +1,3 @@
+
+
+::: linux:Documentation/devicetree/bindings/iio/frequency/adi,adrf6780.yaml

--- a/docs/devs/ADI_ADXL345.md
+++ b/docs/devs/ADI_ADXL345.md
@@ -1,0 +1,3 @@
+
+
+::: linux:Documentation/devicetree/bindings/iio/accel/adi,adxl345.yaml

--- a/docs/devs/ADI_ADXL355.md
+++ b/docs/devs/ADI_ADXL355.md
@@ -1,0 +1,3 @@
+
+
+::: linux:Documentation/devicetree/bindings/iio/accel/adi,adxl355.yaml

--- a/docs/devs/ADI_ADXL372.md
+++ b/docs/devs/ADI_ADXL372.md
@@ -1,0 +1,3 @@
+
+
+::: linux:Documentation/devicetree/bindings/iio/accel/adi,adxl372.yaml

--- a/docs/devs/ADI_ADXRS290.md
+++ b/docs/devs/ADI_ADXRS290.md
@@ -1,0 +1,3 @@
+
+
+::: linux:Documentation/devicetree/bindings/iio/gyroscope/adi,adxrs290.yaml

--- a/docs/devs/ADI_AXI-ADC.md
+++ b/docs/devs/ADI_AXI-ADC.md
@@ -1,0 +1,3 @@
+
+
+::: linux:Documentation/devicetree/bindings/iio/adc/adi,axi-adc.yaml

--- a/docs/devs/ADI_AXI-PULSE-CAPTURE.md
+++ b/docs/devs/ADI_AXI-PULSE-CAPTURE.md
@@ -1,0 +1,3 @@
+
+
+::: linux:Documentation/devicetree/bindings/iio/adc/adi,axi-pulse-capture.yaml

--- a/docs/devs/ADI_HMC425A.md
+++ b/docs/devs/ADI_HMC425A.md
@@ -1,0 +1,3 @@
+
+
+::: linux:Documentation/devicetree/bindings/iio/amplifiers/adi,hmc425a.yaml

--- a/docs/devs/ADI_LTC2308.md
+++ b/docs/devs/ADI_LTC2308.md
@@ -1,0 +1,3 @@
+
+
+::: linux:Documentation/devicetree/bindings/iio/adc/adi,ltc2308.yaml

--- a/docs/devs/ADI_LTC2471.md
+++ b/docs/devs/ADI_LTC2471.md
@@ -1,0 +1,3 @@
+
+
+::: linux:Documentation/devicetree/bindings/iio/adc/adi,ltc2471.yaml

--- a/docs/devs/ADI_LTC2983.md
+++ b/docs/devs/ADI_LTC2983.md
@@ -1,0 +1,3 @@
+
+
+::: linux:Documentation/devicetree/bindings/iio/temperature/adi,ltc2983.yaml

--- a/docs/devs/ADI_LTC6952.md
+++ b/docs/devs/ADI_LTC6952.md
@@ -1,0 +1,3 @@
+
+
+::: linux:Documentation/devicetree/bindings/iio/frequency/adi,ltc6952.yaml

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,3 @@
+# Linux
+
+Documentation for the ADI Linux Kernel

--- a/docs/process_kernel.py
+++ b/docs/process_kernel.py
@@ -1,0 +1,71 @@
+"""Generate MD pages for DT yaml files and create mkdocs.yml"""
+import glob
+from jinja2 import Environment, FileSystemLoader
+import yaml
+import os
+
+
+def test_yaml(filename):
+    try:
+        with open(filename, "r") as stream:
+            data = yaml.safe_load(stream)
+        return True
+    except:
+        return False
+
+
+def generate_md_files(kernel_root_dir, stop_bad_yaml=False, limit_to_adi=True):
+    """Generate MD files for all DT yaml files"""
+
+    if not os.path.isdir(kernel_root_dir):
+        raise Exception(f"{kernel_root_dir} not a directory")
+
+    path = os.path.join(
+        kernel_root_dir, "Documentation/devicetree/bindings/iio/**/*.yaml"
+    )
+    print(path)
+    files = glob.glob(path)
+    filenames = []
+
+    for file in files:
+        if not limit_to_adi or "adi," in file:
+            if not test_yaml(file):
+                if stop_bad_yaml:
+                    raise Exception(f"Invalid yaml file found: {file}")
+                print(f"BAD YAML: {file}")
+                continue
+            filename = file.split("/")[-1]
+            filename = filename.replace(",", "_").replace("yaml", "md")
+            filename = filename.upper()
+            filename = filename.replace(".MD", ".md")
+            with open(f"docs/devs/{filename}", "w") as f:
+                cmd = f"\n\n::: linux:{file}"
+                f.write(cmd)
+            filenames.append(filename)
+
+    return filenames
+
+
+def create_mkdocs_yml(filenames: list):
+    """Gernerate mkdocs.yml file based on generated md files"""
+
+    file_loader = FileSystemLoader("templates")
+    env = Environment(loader=file_loader)
+
+    template = env.get_template("temp.yml")
+
+    output = template.render(devs=filenames)
+
+    with open("mkdocs.yml", "w") as f:
+        f.write(output)
+
+
+def default():
+    loc = os.path.dirname(__file__)
+    kernel_root_dir = os.path.abspath(os.path.join(loc, "../"))
+    fns = generate_md_files(kernel_root_dir)
+    create_mkdocs_yml(fns)
+
+
+if __name__ == "__main__":
+    default()

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,6 @@
+git+https://github.com/tfcollins/mkdocs-devicetree-plugin.git#egg=mkdocs-devicetree-plugin
+mkdocs
+mkdocs-material==7.1
+pymdown-extensions
+mkdocstrings
+mike

--- a/docs/stylesheets/style.css
+++ b/docs/stylesheets/style.css
@@ -1,0 +1,50 @@
+:root {
+  --left-col-min-width: 50px;
+}
+
+
+.devattr-header {
+  box-sizing: border-box;
+  border-bottom: 1px solid rgba(38, 50, 56, 0.3);
+  padding-bottom: 5px;
+}
+
+.devattr-table {
+  border-bottom-width: 10px;
+  background-color: rgb(102, 102, 102, 0.01);
+}
+
+.devattr-topleft-col {
+  color: green;
+  width: 400px;
+  white-space: nowrap;
+  min-width: var(--left-col-min-width);
+}
+
+.devattr-bottomleft-col {
+  border-bottom: 1px solid rgba(0, 0, 0, 0);
+  /*Transparent*/
+  padding-bottom: 10px;
+  width: 400px;
+  white-space: nowrap;
+  min-width: var(--left-col-min-width);
+}
+
+.devattr-name-col {
+  padding-right: 10px;
+}
+
+.devattr-type-col {
+  color: rgb(102, 102, 102);
+}
+
+.devattr-about {
+  border-bottom: 1px solid rgb(159, 180, 190);
+  width: 100%;
+  padding-bottom: 10px;
+}
+
+.enum-dt {
+  background-color: rgb(126, 126, 126, 0.2);
+  border: 3px solid rgb(126, 126, 126, 0.2);
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,73 @@
+site_name: linux
+site_description: ADI Linux Kernel
+site_author: Analog Devices, Inc.
+
+theme:
+  name: material
+  features:
+    - content.tabs.link
+  palette:
+    - scheme: default
+      primary: deep orange
+      toggle:
+        icon: material/toggle-switch-off-outline
+        name: Switch to dark mode
+    - scheme: slate
+      primary: deep orange
+      toggle:
+        icon: material/toggle-switch
+        name: Switch to light mode
+
+nav:
+    - Home: index.md
+    - Devs:
+        - devs/ADI_AD5766.md
+        - devs/ADI_AD5770R.md
+        - devs/ADI_LTC2983.md
+        - devs/ADI_ADXL355.md
+        - devs/ADI_ADXL345.md
+        - devs/ADI_ADXL372.md
+        - devs/ADI_ADIS16240.md
+        - devs/ADI_ADMV8818.md
+        - devs/ADI_LTC2308.md
+        - devs/ADI_AD7606.md
+        - devs/ADI_AD7949.md
+        - devs/ADI_AD7768-1.md
+        - devs/ADI_AXI-ADC.md
+        - devs/ADI_AXI-PULSE-CAPTURE.md
+        - devs/ADI_LTC2471.md
+        - devs/ADI_AD7780.md
+        - devs/ADI_AD9467.md
+        - devs/ADI_AD7124.md
+        - devs/ADI_AD7923.md
+        - devs/ADI_ADAR1000.md
+        - devs/ADI_AD9083.md
+        - devs/ADI_AD7091R5.md
+        - devs/ADI_AD7291.md
+        - devs/ADI_AD7292.md
+        - devs/ADI_AD7192.md
+        - devs/ADI_ADRF6780.md
+        - devs/ADI_ADMV1014.md
+        - devs/ADI_ADL5960.md
+        - devs/ADI_ADMV1013.md
+        - devs/ADI_LTC6952.md
+        - devs/ADI_HMC425A.md
+        - devs/ADI_ADA4250.md
+        - devs/ADI_ADIS16475.md
+        - devs/ADI_ADIS16460.md
+        - devs/ADI_ADAR300X.md
+        - devs/ADI_ADXRS290.md
+        
+
+repo_url: https://github.com/analogdevicesinc/linux
+
+markdown_extensions:
+    - pymdownx.superfences
+    - pymdownx.tabbed
+
+plugins:
+  - search
+  - dt-plugin
+
+extra_css:
+  - stylesheets/style.css


### PR DESCRIPTION
This PR adds documentation generation targeted at GitHub Pages primarily for devicetree definitions, similar to the Zephyr project. This should be considered WIP right now so we can mold the doc into the exact form we want. So please comment on styling, features, presentation, ...

- The currently built doc generated from this PR can be [seen here](https://tfcollins.github.io/linux/master/)
- The core piece that makes this function is a [custom plugin for mkdocs](https://github.com/tfcollins/mkdocs-devicetree-plugin) designed to process devicetree yaml doc and generate the necessary HTML. This reduces a lot of custom code to be put in this repo and would allow other to use it as well.

We will likely want to add CI checks for all future drivers to validate their yaml (there are existing bugs found) and that they are up to any standard desired (similar to Zephyr)

Theoretically, this does not have to live inside the Linux repo as well. For example, if we wanted to merge APIs across Linux and No-OS it might make sense to have a doc-specific repo that merges domains.

Signed-off-by: Travis F. Collins <travis.collins@analog.com>