### PR TITLE
drivers:iio:adc:mykonos: fix ARM state check routine

### DIFF
--- a/drivers/iio/adc/mykonos/mykonos.c
+++ b/drivers/iio/adc/mykonos/mykonos.c
@@ -13548,7 +13548,7 @@ mykonosErr_t MYKONOS_checkArmState(mykonosDevice_t *device, mykonosArmState_t ar
                 break;
         }
 
-        if (armStateCheck && armStatusMapped)
+        if ((armStateCheck & armStatusMapped) || !(armStateCheck || armStatusMapped))
         {
             retVal = MYKONOS_ERR_OK;
             break;


### PR DESCRIPTION
Correctly use a bitwise operation to check for the desired ARM state
instead of logical operation.

Signed-off-by: Andrei Drimbarean <andrei.drimbarean@analog.com>