### PR TITLE
nvmem: adi_axi_sysid: Fix custom info stack corruption

### DIFF
--- a/drivers/nvmem/adi_axi_sysid.c
+++ b/drivers/nvmem/adi_axi_sysid.c
@@ -116,7 +116,7 @@ static int axi_sysid_validate_v1_1(struct platform_device *pdev,
 				   struct build_info_header_v1_1 *build)
 {
 	struct sysid_header_v1 *header;
-	char custom_info[48];
+	char custom_info[128];
 	struct tm tm;
 	time64_t t = 0;
 
@@ -131,7 +131,8 @@ static int axi_sysid_validate_v1_1(struct platform_device *pdev,
 	time64_to_tm(t, 0, &tm);
 
 	if (axi_sysid_get_str(st, header->custom_info_offs))
-		sprintf(custom_info, "%s%s%s", " [", axi_sysid_get_str(st, header->custom_info_offs), "]");
+		snprintf(custom_info, sizeof(custom_info), "%s%s%s",
+			" [", axi_sysid_get_str(st, header->custom_info_offs), "]");
 	else
 		custom_info[0] = 0;
 
@@ -154,7 +155,7 @@ static int axi_sysid_validate_v1(struct platform_device *pdev,
 				 struct build_info_header_v1 *build)
 {
 	struct sysid_header_v1 *header;
-	char custom_info[48];
+	char custom_info[128];
 	struct tm tm;
 	time64_t t = 0;
 
@@ -169,7 +170,8 @@ static int axi_sysid_validate_v1(struct platform_device *pdev,
 	time64_to_tm(t, 0, &tm);
 
 	if (axi_sysid_get_str(st, header->custom_info_offs))
-		sprintf(custom_info, "%s%s%s", " [", axi_sysid_get_str(st, header->custom_info_offs), "]");
+		snprintf(custom_info, sizeof(custom_info), "%s%s%s",
+			" [", axi_sysid_get_str(st, header->custom_info_offs), "]");
 	else
 		custom_info[0] = 0;
 


### PR DESCRIPTION
This fixes following kernel panic seen with the sysid on the
ad40xx_fmc project:

Kernel panic - not syncing: stack-protector: Kernel stack is corrupted
in: axi_sysid_probe+0x704/0x71c

Increase custom_info buffer and use snprintf() to truncate in case
the string doesn't fit the reserved buffer space.

Fixes 64ea0d3503ee ("nvmem: adi_axi_sysid: Print System Custom String")

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>