### PR TITLE
iio: adrv9002: add support for BBDC loop gain

### DIFF
--- a/drivers/iio/adc/navassa/adrv9002.h
+++ b/drivers/iio/adc/navassa/adrv9002.h
@@ -81,6 +81,7 @@ enum adrv9002_rx_ext_info {
 	RX_NCO_FREQUENCY,
 	RX_ADC_SWITCH,
 	RX_BBDC,
+	RX_BBDC_LOOP_GAIN,
 };
 
 enum adrv9002_tx_ext_info {


### PR DESCRIPTION
This adds support for manipulating RX BBDC loop gain. Note that this is
being supported with raw values because the loop gain is represented as
a fractional value with 31bits representing the fractional part. This
means that the resolution is pretty low and thus making it very hard to
handle in the kernel. Hence, support this as raw and defer the floating
point handling to userspace.

Signed-off-by: Nuno Sá <nuno.sa@analog.com>