### PR TITLE
iio: adc: max1363: probe: Distinguish multiple devices

### DIFF
--- a/drivers/iio/adc/max1363.c
+++ b/drivers/iio/adc/max1363.c
@@ -1648,7 +1648,7 @@ static int max1363_probe(struct i2c_client *client,
 	if (ret)
 		goto error_disable_reg;
 
-	indio_dev->name = id->name;
+	indio_dev->name = client->dev.of_node ? client->dev.of_node->name : id->name;
 	indio_dev->channels = st->chip_info->channels;
 	indio_dev->num_channels = st->chip_info->num_channels;
 	indio_dev->info = st->chip_info->info;


### PR DESCRIPTION
Setting IIO name using node name facilitates differentiation among multiple devices
using this driver. This name can be used to locate device using libiio in userspace.

Signed-off-by: Edward Kigwana <ekigwana@gmail.com>