### PR TITLE
iio: adc: ad9361_conv: Skip digital tune on AXI slave cores

### DIFF
--- a/drivers/iio/adc/ad9361_conv.c
+++ b/drivers/iio/adc/ad9361_conv.c
@@ -694,14 +694,16 @@ static int ad9361_post_setup(struct iio_dev *indio_dev)
 
 	flags = 0;
 
-	ret = ad9361_dig_tune(phy, (axiadc_read(st, ADI_AXI_REG_ID)) ?
-		0 : 61440000, flags);
+	ret = ad9361_dig_tune(phy, 61440000, axiadc_read(st, ADI_AXI_REG_ID) ?
+		flags | RESTORE_DEFAULT : flags);
 	if (ret < 0)
 		goto error;
 
 	if (flags & (DO_IDELAY | DO_ODELAY)) {
-		ret = ad9361_dig_tune(phy, (axiadc_read(st, ADI_AXI_REG_ID)) ?
-			0 : 61440000, flags & BE_VERBOSE);
+		ret = ad9361_dig_tune(phy, 61440000,
+			axiadc_read(st, ADI_AXI_REG_ID) ?
+			flags | RESTORE_DEFAULT | BE_VERBOSE :
+			flags | BE_VERBOSE);
 		if (ret < 0)
 			goto error;
 	}


### PR DESCRIPTION
In MCS setups, the secondary AD936x won't reliably work unless the
complete MCS sequence has been performed. So we skip tuning on the
secondary device. It's up to the user responsibility to run the MCS
sequence and rerun the digital tuning afterwards. The libad9361
has all the required logic and can handle this.

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>