### PR TITLE
iio: ad_adc: fix NULL pointer dereference in direct_reg_access

### DIFF
--- a/drivers/iio/adc/ad_adc.c
+++ b/drivers/iio/adc/ad_adc.c
@@ -566,7 +566,7 @@ static int adc_reg_access(struct iio_dev *indio_dev,
 	struct axiadc_state *st = iio_priv(indio_dev);
 
 	mutex_lock(&indio_dev->mlock);
-	if (reg & 0x80000000) {
+	if (st->slave_regs && reg & 0x80000000) {
 		if (readval == NULL)
 			axiadc_slave_write(st, (reg & 0xffff), writeval);
 		else


### PR DESCRIPTION
When doing direct register access, bit 31 in the register value is
being used to distinguish between accessing the main register map or the
slave register map. Hence, we need to make sure a slave register map
exists before trying to access it in case the bit 31 is set.

Fixes: ca3d2c2de1b48 ("iio: ad_adc: Merge m2k branch")
Signed-off-by: Nuno Sá <nuno.sa@analog.com>

@ronagyl can you give this a quick test?