### PR TITLE
ci: add more things to ignore on checkpatch

### DIFF
--- a/ci/travis/run-build.sh
+++ b/ci/travis/run-build.sh
@@ -239,7 +239,9 @@ build_checkpatch() {
 		--ignore LONG_LINE \
 		--ignore LONG_LINE_STRING \
 		--ignore LONG_LINE_COMMENT \
-		--ignore PARENTHESIS_ALIGNMENT
+		--ignore PARENTHESIS_ALIGNMENT \
+		--ignore CAMELCASE \
+		--ignore UNDOCUMENTED_DT_STRING
 }
 
 build_dtb_build_test() {


### PR DESCRIPTION
With this commit, the following checkpatch warnings are ignored:

* UNDOCUMENTED_DT_STRING: We have a significant amount of "active"
drivers and dts with no bindings. Often this adds noise to CI. Ideally,
we would add all the missing bindings so that we could stop ignoring
this.
* CAMELCASE: All the "external" APIs generate a lot of warnings because
of this. And this is something that we can't really change. I'm also
fairly sure that everyone is mostly used to not do CAMELCASE in the
kernel so ignoring this should not be a big problem.

Signed-off-by: Nuno Sá <nuno.sa@analog.com>