### PR TITLE
arm64: dts: xilinx: Move gpio-poweroff from kernel to ATF

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-pluto-ng.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-pluto-ng.dts
@@ -585,11 +585,6 @@
 			gpio-key,wakeup;
 		};
 	};
-
-	gpio-poweroff {
-		compatible = "gpio-poweroff";
-		gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
-	};
 };
 
 #define fmc_spi spi0


### PR DESCRIPTION
Since drivers/firmware/psci/psci.c registers a pm_power_off, GPIO
poweroff signals should be enabled by the PSCI firmware.

Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>