### PR TITLE
arch:arm64:dts: add fmc eeprom device

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-revb-adrv2crr-fmc-revb-jesd204-fsm-fmcbridge.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-revb-adrv2crr-fmc-revb-jesd204-fsm-fmcbridge.dts
@@ -126,3 +126,10 @@
 		spi-max-frequency = <500000>;
 	};
 };
+
+&i2c_fmc {
+	eeprom@52 {
+		compatible = "at24,24c02";
+		reg = <0x52>;
+	};
+};


### PR DESCRIPTION
Add eeprom device inside the fmcbridge dts.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>