### PR TITLE
Ad9545 zero delay mode

### DIFF
--- a/Documentation/devicetree/bindings/clock/clk-ad9545.yaml
+++ b/Documentation/devicetree/bindings/clock/clk-ad9545.yaml
@@ -283,6 +283,13 @@ patternProperties:
         $ref: /schemas/types.yaml#/definitions/uint32
         enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 
+      adi,pll-slew-rate-limit-ps:
+        description: |
+          DPLL0 phase slew limit rate (in picoseconds/second).
+        $ref: /schemas/types.yaml#/definitions/uint32
+        minimum: 1
+        maximum: 4000000000
+
       adi,fast-acq-trigger-mode:
         description: |
           If this is not specified Fast Acquisition will be used every time. See reg 0x2106

--- a/Documentation/devicetree/bindings/clock/clk-ad9545.yaml
+++ b/Documentation/devicetree/bindings/clock/clk-ad9545.yaml
@@ -267,6 +267,22 @@ patternProperties:
       '#size-cells':
          const: 0
 
+      adi,pll-internal-zero-delay:
+        description: |
+          Rate of the output that will be used as a feedback path for this PLL bloc.
+        $ref: /schemas/types.yaml#/definitions/uint32
+        minimum: 1
+        maximum: 200000000
+
+      adi,pll-internal-zero-delay-feedback:
+        description: |
+          Internal zero delay feedback path. Choose one from the possible outputs depending
+          on the parent PLL. If parrent PLL is PLL0 choose from [0, 5] otherweise [6, 9].
+          Mentioning an output for the feedback path here, will cause the respective clock's
+          rate to become imutable.
+        $ref: /schemas/types.yaml#/definitions/uint32
+        enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+
       adi,fast-acq-trigger-mode:
         description: |
           If this is not specified Fast Acquisition will be used every time. See reg 0x2106

--- a/drivers/clk/adi/clk-ad9545.c
+++ b/drivers/clk/adi/clk-ad9545.c
@@ -1617,7 +1617,7 @@ static int ad9545_outputs_setup(struct ad9545_state *st)
 
 		for (j = 0; j < ARRAY_SIZE(ad9545_out_source_ua); j++)
 			if (ad9545_out_source_ua[j] == st->out_clks[out_i].source_ua)
-				reg |= FIELD_PREP(GENMASK(2, 1), i);
+				reg |= FIELD_PREP(GENMASK(2, 1), j);
 
 		reg |= FIELD_PREP(GENMASK(4, 3), st->out_clks[out_i].output_mode);
 

--- a/drivers/clk/adi/clk-ad9545.c
+++ b/drivers/clk/adi/clk-ad9545.c
@@ -2141,7 +2141,7 @@ static unsigned long ad9545_pll_clk_recalc_rate(struct clk_hw *hw, unsigned long
 	 */
 	i = ad9545_pll_get_parent(hw);
 	if (i == clk->num_parents)
-		return div_u64(clk->free_run_freq * m, 2);
+		return DIV_ROUND_UP(clk->free_run_freq, 2) * m;
 
 	parent_rate = clk_hw_get_rate(clk->parents[i]);
 

--- a/drivers/clk/adi/clk-ad9545.c
+++ b/drivers/clk/adi/clk-ad9545.c
@@ -41,6 +41,7 @@
 #define AD9545_REF_A_PERIOD		0x0404
 #define AD9545_REF_A_OFFSET_LIMIT	0x040C
 #define AD9545_REF_A_MONITOR_HYST	0x040F
+#define AD9545_REF_A_VALID_TIMER	0x0410
 #define AD9545_PHASE_LOCK_THRESH	0x0800
 #define AD9545_PHASE_LOCK_FILL_RATE	0x0803
 #define AD9545_PHASE_LOCK_DRAIN_RATE	0x0804
@@ -116,6 +117,7 @@
 #define AD9545_REF_X_PERIOD(x)			(AD9545_REF_A_PERIOD + ((x) * 0x20))
 #define AD9545_REF_X_OFFSET_LIMIT(x)		(AD9545_REF_A_OFFSET_LIMIT + ((x) * 0x20))
 #define AD9545_REF_X_MONITOR_HYST(x)		(AD9545_REF_A_MONITOR_HYST + ((x) * 0x20))
+#define AD9545_REF_X_VALID_TIMER(x)		(AD9545_REF_A_VALID_TIMER + ((x) * 0x20))
 #define AD9545_REF_X_PHASE_LOCK_FILL(x)		(AD9545_PHASE_LOCK_FILL_RATE + ((x) * 0x20))
 #define AD9545_REF_X_PHASE_LOCK_DRAIN(x)	(AD9545_PHASE_LOCK_DRAIN_RATE + ((x) * 0x20))
 #define AD9545_REF_X_FREQ_LOCK_FILL(x)		(AD9545_FREQ_LOCK_FILL_RATE + ((x) * 0x20))
@@ -1815,6 +1817,12 @@ static int ad9545_input_refs_setup(struct ad9545_state *st)
 
 		regval = cpu_to_le32(st->ref_in_clks[i].freq_thresh_ps);
 		ret = regmap_bulk_write(st->regmap, AD9545_SOURCEX_FREQ_THRESH(i),
+					&regval, 3);
+		if (ret < 0)
+			return ret;
+
+		regval = cpu_to_le32(st->ref_in_clks[i].valid_t_ms);
+		ret = regmap_bulk_write(st->regmap, AD9545_REF_X_VALID_TIMER(i),
 					&regval, 3);
 		if (ret < 0)
 			return ret;

--- a/drivers/clk/clk-conf.c
+++ b/drivers/clk/clk-conf.c
@@ -116,6 +116,55 @@ static int __set_clk_rates(struct device_node *node, bool clk_supplier)
 	return 0;
 }
 
+static int __set_clk_nshot(struct device_node *node, bool clk_supplier)
+{
+	struct of_phandle_args clkspec;
+	struct property	*prop;
+	const __be32 *cur;
+	int rc, index = 0;
+	struct clk *clk;
+	u32 nshot;
+
+	of_property_for_each_u32(node, "assigned-clock-nshot", prop, cur, nshot) {
+		if (nshot) {
+			rc = of_parse_phandle_with_args(node, "assigned-clocks",
+							"#clock-cells",	index, &clkspec);
+			if (rc < 0) {
+				/* skip empty (null) phandles */
+				if (rc == -ENOENT)
+					continue;
+
+				return rc;
+			}
+
+			if (clkspec.np == node && !clk_supplier) {
+				of_node_put(clkspec.np);
+				return 0;
+			}
+
+			clk = of_clk_get_from_provider(&clkspec);
+			if (IS_ERR(clk)) {
+				if (PTR_ERR(clk) != -EPROBE_DEFER)
+					pr_err("clk: couldn't get clock %d for %pOF\n", index,
+					       node);
+				of_node_put(clkspec.np);
+				return PTR_ERR(clk);
+			}
+
+			rc = clk_set_nshot(clk, nshot);
+			if (rc < 0)
+				pr_warn("clk: couldn't set %s clk nshot to %u (%d), current nshot: %u\n",
+					__clk_get_name(clk), nshot, rc, clk_get_nshot(clk));
+
+			clk_put(clk);
+			of_node_put(clkspec.np);
+		}
+		index++;
+	}
+
+	return 0;
+}
+
 /**
  * of_clk_set_defaults() - parse and set assigned clocks configuration
  * @node: device node to apply clock settings for
@@ -139,6 +188,10 @@ int of_clk_set_defaults(struct device_node *node, bool clk_supplier)
 	if (rc < 0)
 		return rc;
 
-	return __set_clk_rates(node, clk_supplier);
+	rc = __set_clk_rates(node, clk_supplier);
+	if (rc < 0)
+		return rc;
+
+	return __set_clk_nshot(node, clk_supplier);
 }
 EXPORT_SYMBOL_GPL(of_clk_set_defaults);

--- a/drivers/iio/frequency/hmc7044.c
+++ b/drivers/iio/frequency/hmc7044.c
@@ -598,6 +598,7 @@ static ssize_t hmc7044_sync_pin_mode_store(struct device *dev,
 {
 	struct iio_dev *indio_dev = dev_to_iio_dev(dev);
 	struct hmc7044 *hmc = iio_priv(indio_dev);
+	struct clk *sync_clk;
 	int i, ret = -EINVAL;
 
 	i = sysfs_match_string(sync_pin_modes, buf);
@@ -605,6 +606,40 @@ static ssize_t hmc7044_sync_pin_mode_store(struct device *dev,
 		mutex_lock(&hmc->lock);
 		ret = hmc7044_sync_pin_set(indio_dev, i);
 		mutex_unlock(&hmc->lock);
+	}
+
+	if (ret)
+		return ret;
+
+	sync_clk = clk_get(dev, "sync_clk");
+	if (!IS_ERR(sync_clk)) {
+		/*
+		 * Setup sync_clk to generate 1 pulse on clk_enable,
+		 * if it is not configured to do that already.
+		 */
+		i = clk_get_nshot(sync_clk);
+		if (i < 0) {
+			clk_put(sync_clk);
+			return ret;
+		}
+
+		if (i != 1) {
+			ret = clk_set_nshot(sync_clk, 1);
+			if (ret < 0) {
+				clk_put(sync_clk);
+				return ret;
+			}
+		}
+
+		/*
+		 * Above we setup the n-shot to only one pulse.
+		 * Enable the clock to physically send the pulse.
+		 * Disable the clock to prevent to a future error caused
+		 * by enabling the same clock twice.
+		 */
+		clk_prepare_enable(sync_clk);
+		clk_disable_unprepare(sync_clk);
+		clk_put(sync_clk);
 	}
 
 	return ret ? ret : len;


### PR DESCRIPTION
e32665df9179 - clk: ad9545: Fix free run rate recalc
Rate recalculation for the free run mode was wrong.

38eb3f601d05 - clk: ad9545: Fix validation timer write
Validation timer would be read from DT but not programmed.

9476bfe5ed52 - clk: ad9545: fix output current selection
Current selection was using the wrong iterator.

60229f6746b6 - iio: hmc7044: add n-shot trigger
Allow user to trigger a sync pulse from a clock mentioned in DT.

19cb9b4bb19d - clk: ad9545: add zero delay support
Mode in which AD9545 aligns the output phase to the input phase.

c7858a6aa38b - blindings: clock: ad9545: document use of slew rate
Allow the user to program the slew rate from DT. Application depended as some ICs are sensible to high output slew-rates.

6994adbf4c02 - clk: clk-conf: allow user to setup an n-shot from DT
e89531db498c - bindings: clock: ad9545: document use of zero delay
