### PR TITLE
checkpatch fixes and improvements

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,11 +36,17 @@ jobs:
   variables:
     BUILD_TYPE: checkpatch
     TARGET_BRANCH: $[ variables['System.PullRequest.TargetBranch'] ]
+    COMMIT: $[ variables['Build.SourceVersion'] ]
+    REPO_URL: $[ variables['Build.Repository.Uri'] ]
   steps:
-  - checkout: self
-    fetchDepth: 50
-    clean: true
-  - script: ./ci/travis/run-build.sh
+  - checkout: none
+  - script: |
+      set -ex
+      git init
+      git remote add origin ${REPO_URL}
+      git fetch --filter=tree:0 --no-tags origin ${COMMIT}
+      git checkout --progress --force ${COMMIT}
+      ./ci/travis/run-build.sh
     displayName: 'Checkpatch Script'
 
 - job: check_is_new_adi_driver_dual_licensed

--- a/ci/travis/run-build.sh
+++ b/ci/travis/run-build.sh
@@ -215,13 +215,6 @@ build_allmodconfig() {
 }
 
 build_checkpatch() {
-	# TODO: Re-visit periodically:
-	# https://github.com/torvalds/linux/blob/master/Documentation/devicetree/writing-schema.rst
-	# This seems to change every now-n-then
-	apt_install python3-ply python-git-doc libyaml-dev python3-pip python3-setuptools
-	pip3 install wheel
-	pip3 install git+https://github.com/devicetree-org/dt-schema.git@master
-
 	local ref_branch="$(get_ref_branch)"
 
 	echo_green "Running checkpatch for commit range '$ref_branch..'"


### PR DESCRIPTION
The main goal of this PR is to fix a false positive checkpatch report... The problem is that whenever a not so old commit is referenced in a new commit (eg: on Fixes tag), checkpatch will report that the commit is not known even though the commit exists. The problem is that a shallow clone with depth=50 (to speed up `git fetch`) is being done in the job and hence checkpatch won't know about the commit because we don't have the whole history.
    
This all means that we need to fetch the whole git history. To do that while minimizing fetch times, we'll do a partial clone.  What this means is that only the tree and blobs respective to HEAD will be fetched instead of all trees and blobs for all existing commits. This considerably speeds up the fetch time when compared to a full fetch (more than 50% is some tests). As treeless clones are not supported in azure, we need to tell it to not do any checkout and manually handle things before calling run-build.sh.