### PR TITLE
iio: altera_adxcvr: Prevent clock already disabled/unprepared warnings

### DIFF
--- a/drivers/iio/jesd204/altera_adxcvr.c
+++ b/drivers/iio/jesd204/altera_adxcvr.c
@@ -431,7 +431,8 @@ static void adxcvr_link_clk_work(struct work_struct *work)
 
 	link_rate = READ_ONCE(st->lane_rate) * (1000 / 40);
 
-	clk_disable_unprepare(st->link_clk);
+	if (__clk_is_enabled(st->link_clk))
+		clk_disable_unprepare(st->link_clk);
 
 	/*
 	 * Due to rounding errors link_rate might not contain the exact rate.


### PR DESCRIPTION
In case st->link_clk is disabled/unprepared without being
prepared/enabled previously, a warning and the backtrace will
be displayed.

Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>