### PR TITLE
dts: ad908x: Fix dt property - rename adi,nco-mode -> adi,nco-mixer-mode

### DIFF
--- a/arch/arm/boot/dts/adi-ad9081-fmc-ebz.dtsi
+++ b/arch/arm/boot/dts/adi-ad9081-fmc-ebz.dtsi
@@ -258,25 +258,25 @@
 					reg = <0>;
 					adi,decimation = <4>;
 					adi,nco-frequency-shift-hz =  /bits/ 64 <400000000>;
-					adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+					adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				};
 				ad9081_adc1: adc@1 {
 					reg = <1>;
 					adi,decimation = <4>;
 					adi,nco-frequency-shift-hz =  /bits/ 64 <(-400000000)>;
-					adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+					adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				};
 				ad9081_adc2: adc@2 {
 					reg = <2>;
 					adi,decimation = <4>;
 					adi,nco-frequency-shift-hz =  /bits/ 64 <100000000>;
-					adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+					adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				};
 				ad9081_adc3: adc@3 {
 					reg = <3>;
 					adi,decimation = <4>;
 					adi,nco-frequency-shift-hz =  /bits/ 64 <100000000>;
-					adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+					adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				};
 			};
 

--- a/arch/arm/boot/dts/socfpga_arria10_socdk_ad9081_np12.dts
+++ b/arch/arm/boot/dts/socfpga_arria10_socdk_ad9081_np12.dts
@@ -178,25 +178,25 @@
 					reg = <0>;
 					adi,decimation = <4>;
 					adi,nco-frequency-shift-hz =  /bits/ 64 <400000000>;
-					adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+					adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				};
 				ad9081_adc1: adc@1 {
 					reg = <1>;
 					adi,decimation = <4>;
 					adi,nco-frequency-shift-hz =  /bits/ 64 <(-400000000)>;
-					adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+					adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				};
 				ad9081_adc2: adc@2 {
 					reg = <2>;
 					adi,decimation = <4>;
 					adi,nco-frequency-shift-hz =  /bits/ 64 <100000000>;
-					adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+					adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				};
 				ad9081_adc3: adc@3 {
 					reg = <3>;
 					adi,decimation = <4>;
 					adi,nco-frequency-shift-hz =  /bits/ 64 <100000000>;
-					adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+					adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				};
 			};
 

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad9081-np12.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad9081-np12.dts
@@ -234,25 +234,25 @@
 					reg = <0>;
 					adi,decimation = <4>;
 					adi,nco-frequency-shift-hz =  /bits/ 64 <400000000>;
-					adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+					adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				};
 				ad9081_adc1: adc@1 {
 					reg = <1>;
 					adi,decimation = <4>;
 					adi,nco-frequency-shift-hz =  /bits/ 64 <(-400000000)>;
-					adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+					adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				};
 				ad9081_adc2: adc@2 {
 					reg = <2>;
 					adi,decimation = <4>;
 					adi,nco-frequency-shift-hz =  /bits/ 64 <100000000>;
-					adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+					adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				};
 				ad9081_adc3: adc@3 {
 					reg = <3>;
 					adi,decimation = <4>;
 					adi,nco-frequency-shift-hz =  /bits/ 64 <100000000>;
-					adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+					adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				};
 			};
 

--- a/arch/arm64/boot/dts/xilinx/versal-vck190-reva-ad9081-204c-txmode22-rxmode23.dts
+++ b/arch/arm64/boot/dts/xilinx/versal-vck190-reva-ad9081-204c-txmode22-rxmode23.dts
@@ -284,7 +284,7 @@
 					reg = <0>;
 					adi,decimation = <4>;
 					adi,nco-frequency-shift-hz =  /bits/ 64 <400000000>;
-					adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+					adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				};
 			};
 

--- a/arch/arm64/boot/dts/xilinx/versal-vck190-reva-ad9081.dts
+++ b/arch/arm64/boot/dts/xilinx/versal-vck190-reva-ad9081.dts
@@ -445,13 +445,13 @@
 				reg = <0>;
 				adi,decimation = <2>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <400000000>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 			};
 			ad9081_adc1: adc@1 {
 				reg = <1>;
 				adi,decimation = <2>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <(-400000000)>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 			};
 		};
 		adi,channelizer-paths {

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9081-204b-txmode9-rxmode4.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9081-204b-txmode9-rxmode4.dts
@@ -304,28 +304,28 @@
 					reg = <0>;
 					adi,decimation = <6>;
 					adi,nco-frequency-shift-hz = /bits/ 64 <1000000000>; /* 1000 MHz */
-					adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+					adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 					//adi,crossbar-select = <&ad9081_rx_fddc_chan0>, <&ad9081_rx_fddc_chan2>; /* Static for now */
 				};
 				ad9081_adc1: adc@1 {
 					reg = <1>;
 					adi,decimation = <6>;
 					adi,nco-frequency-shift-hz = /bits/ 64 <1000000000>; /* 1000 MHz */
-					adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+					adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 					//adi,crossbar-select = <&ad9081_rx_fddc_chan1>, <&ad9081_rx_fddc_chan3>; /* Static for now */
 				};
 				ad9081_adc2: adc@2 {
 					reg = <2>;
 					adi,decimation = <6>;
 					adi,nco-frequency-shift-hz = /bits/ 64 <1000000000>; /* 1000 MHz */
-					adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+					adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 					//adi,crossbar-select = <&ad9081_rx_fddc_chan4>, <&ad9081_rx_fddc_chan6>; /* Static for now */
 				};
 				ad9081_adc3: adc@3 {
 					reg = <3>;
 					adi,decimation = <6>;
 					adi,nco-frequency-shift-hz = /bits/ 64 <1000000000>; /* 1000 MHz */
-					adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+					adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 					//adi,crossbar-select = <&ad9081_rx_fddc_chan5>, <&ad9081_rx_fddc_chan7>; /* Static for now */
 				};
 			};

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9081-204c-txmode0-rxmode1.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9081-204c-txmode0-rxmode1.dts
@@ -307,7 +307,7 @@
 					reg = <0>;
 					adi,decimation = <6>;
 					adi,nco-frequency-shift-hz = /bits/ 64 <1000000000>; /* 1000 MHz */
-					adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+					adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 					adi,digital-gain-6db-enable;
 					//adi,crossbar-select = <&ad9081_rx_fddc_chan0>, <&ad9081_rx_fddc_chan2>; /* Static for now */
 				};
@@ -315,7 +315,7 @@
 					reg = <1>;
 					adi,decimation = <6>;
 					adi,nco-frequency-shift-hz = /bits/ 64 <1000000000>; /* 1000 MHz */
-					adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+					adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 					adi,digital-gain-6db-enable;
 					//adi,crossbar-select = <&ad9081_rx_fddc_chan1>, <&ad9081_rx_fddc_chan3>; /* Static for now */
 				};
@@ -323,7 +323,7 @@
 					reg = <2>;
 					adi,decimation = <6>;
 					adi,nco-frequency-shift-hz = /bits/ 64 <1000000000>; /* 1000 MHz */
-					adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+					adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 					adi,digital-gain-6db-enable;
 					//adi,crossbar-select = <&ad9081_rx_fddc_chan4>, <&ad9081_rx_fddc_chan6>; /* Static for now */
 				};
@@ -331,7 +331,7 @@
 					reg = <3>;
 					adi,decimation = <6>;
 					adi,nco-frequency-shift-hz = /bits/ 64 <1000000000>; /* 1000 MHz */
-					adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+					adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 					adi,digital-gain-6db-enable;
 					//adi,crossbar-select = <&ad9081_rx_fddc_chan5>, <&ad9081_rx_fddc_chan7>; /* Static for now */
 				};

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9081-m8-l4-overlay.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9081-m8-l4-overlay.dts
@@ -297,28 +297,28 @@
 							reg = <0>;
 							adi,decimation = <3>;
 							adi,nco-frequency-shift-hz =  /bits/ 64 <400000000>;
-							adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+							adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 							//adi,crossbar-select = <&ad9081_rx_fddc_chan0>, <&ad9081_rx_fddc_chan2>; /* Static for now */
 						};
 						ad9081_adc1: adc@1 {
 							reg = <1>;
 							adi,decimation = <3>;
 							adi,nco-frequency-shift-hz =  /bits/ 64 <(-400000000)>;
-							adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+							adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 							//adi,crossbar-select = <&ad9081_rx_fddc_chan1>, <&ad9081_rx_fddc_chan3>; /* Static for now */
 						};
 						ad9081_adc2: adc@2 {
 							reg = <2>;
 							adi,decimation = <3>;
 							adi,nco-frequency-shift-hz =  /bits/ 64 <100000000>;
-							adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+							adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 							//adi,crossbar-select = <&ad9081_rx_fddc_chan4>, <&ad9081_rx_fddc_chan6>; /* Static for now */
 						};
 						ad9081_adc3: adc@3 {
 							reg = <3>;
 							adi,decimation = <3>;
 							adi,nco-frequency-shift-hz =  /bits/ 64 <100000000>;
-							adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+							adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 							//adi,crossbar-select = <&ad9081_rx_fddc_chan5>, <&ad9081_rx_fddc_chan7>; /* Static for now */
 						};
 					};

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9081-m8-l4-qpllrx.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9081-m8-l4-qpllrx.dts
@@ -347,28 +347,28 @@
 					reg = <0>;
 					adi,decimation = <2>;
 					adi,nco-frequency-shift-hz =  /bits/ 64 <400000000>;
-					adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+					adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 					//adi,crossbar-select = <&ad9081_rx_fddc_chan0>, <&ad9081_rx_fddc_chan2>; /* Static for now */
 				};
 				ad9081_adc1: adc@1 {
 					reg = <1>;
 					adi,decimation = <2>;
 					adi,nco-frequency-shift-hz =  /bits/ 64 <(-400000000)>;
-					adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+					adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 					//adi,crossbar-select = <&ad9081_rx_fddc_chan1>, <&ad9081_rx_fddc_chan3>; /* Static for now */
 				};
 				ad9081_adc2: adc@2 {
 					reg = <2>;
 					adi,decimation = <2>;
 					adi,nco-frequency-shift-hz =  /bits/ 64 <100000000>;
-					adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+					adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 					//adi,crossbar-select = <&ad9081_rx_fddc_chan4>, <&ad9081_rx_fddc_chan6>; /* Static for now */
 				};
 				ad9081_adc3: adc@3 {
 					reg = <3>;
 					adi,decimation = <2>;
 					adi,nco-frequency-shift-hz =  /bits/ 64 <100000000>;
-					adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+					adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 					//adi,crossbar-select = <&ad9081_rx_fddc_chan5>, <&ad9081_rx_fddc_chan7>; /* Static for now */
 				};
 			};

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9081-m8-l4.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9081-m8-l4.dts
@@ -260,28 +260,28 @@
 					reg = <0>;
 					adi,decimation = <4>;
 					adi,nco-frequency-shift-hz =  /bits/ 64 <400000000>;
-					adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+					adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 					//adi,crossbar-select = <&ad9081_rx_fddc_chan0>, <&ad9081_rx_fddc_chan2>; /* Static for now */
 				};
 				ad9081_adc1: adc@1 {
 					reg = <1>;
 					adi,decimation = <4>;
 					adi,nco-frequency-shift-hz =  /bits/ 64 <(-400000000)>;
-					adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+					adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 					//adi,crossbar-select = <&ad9081_rx_fddc_chan1>, <&ad9081_rx_fddc_chan3>; /* Static for now */
 				};
 				ad9081_adc2: adc@2 {
 					reg = <2>;
 					adi,decimation = <4>;
 					adi,nco-frequency-shift-hz =  /bits/ 64 <100000000>;
-					adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+					adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 					//adi,crossbar-select = <&ad9081_rx_fddc_chan4>, <&ad9081_rx_fddc_chan6>; /* Static for now */
 				};
 				ad9081_adc3: adc@3 {
 					reg = <3>;
 					adi,decimation = <4>;
 					adi,nco-frequency-shift-hz =  /bits/ 64 <100000000>;
-					adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+					adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 					//adi,crossbar-select = <&ad9081_rx_fddc_chan5>, <&ad9081_rx_fddc_chan7>; /* Static for now */
 				};
 			};

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9082-204c-txmode22-rxmode23-dual-multi-top.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9082-204c-txmode22-rxmode23-dual-multi-top.dts
@@ -538,14 +538,14 @@
 					reg = <0>;
 					adi,decimation = <4>;
 					adi,nco-frequency-shift-hz =  /bits/ 64 <1000000000>;
-					adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+					adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 					//adi,crossbar-select = <&ad9081_rx_fddc_chan0>, <&ad9081_rx_fddc_chan2>; /* Static for now */
 				};
 				ad9081_adc1: adc@1 {
 					reg = <1>;
 					adi,decimation = <4>;
 					adi,nco-frequency-shift-hz =  /bits/ 64 <(1000000000)>;
-					adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+					adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 					//adi,crossbar-select = <&ad9081_rx_fddc_chan1>, <&ad9081_rx_fddc_chan3>; /* Static for now */
 				};
 

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9082-204c-txmode22-rxmode23-dual.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9082-204c-txmode22-rxmode23-dual.dts
@@ -480,14 +480,14 @@
 					reg = <0>;
 					adi,decimation = <4>;
 					adi,nco-frequency-shift-hz =  /bits/ 64 <1000000000>;
-					adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+					adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 					//adi,crossbar-select = <&ad9081_rx_fddc_chan0>, <&ad9081_rx_fddc_chan2>; /* Static for now */
 				};
 				ad9081_adc1: adc@1 {
 					reg = <1>;
 					adi,decimation = <4>;
 					adi,nco-frequency-shift-hz =  /bits/ 64 <(1000000000)>;
-					adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+					adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 					//adi,crossbar-select = <&ad9081_rx_fddc_chan1>, <&ad9081_rx_fddc_chan3>; /* Static for now */
 				};
 

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9082-204c-txmode22-rxmode23.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9082-204c-txmode22-rxmode23.dts
@@ -283,7 +283,7 @@
 					reg = <0>;
 					adi,decimation = <4>;
 					adi,nco-frequency-shift-hz =  /bits/ 64 <400000000>;
-					adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+					adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				};
 			};
 

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9082-m4-l8.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9082-m4-l8.dts
@@ -245,14 +245,14 @@
 					reg = <0>;
 					adi,decimation = <4>;
 					adi,nco-frequency-shift-hz =  /bits/ 64 <1000000000>;
-					adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+					adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 					//adi,crossbar-select = <&ad9081_rx_fddc_chan0>, <&ad9081_rx_fddc_chan2>; /* Static for now */
 				};
 				ad9081_adc1: adc@1 {
 					reg = <1>;
 					adi,decimation = <4>;
 					adi,nco-frequency-shift-hz =  /bits/ 64 <(1000000000)>;
-					adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+					adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 					//adi,crossbar-select = <&ad9081_rx_fddc_chan1>, <&ad9081_rx_fddc_chan3>; /* Static for now */
 				};
 

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9208.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9208.dts
@@ -167,7 +167,7 @@
 		ad9208_ddc0: channel@0 {
 			reg = <0>;
 			adi,decimation = <2>;
-			adi,nco-mode-select = <AD9208_NCO_MODE_VIF>;
+			adi,nco-mixer-mode-select = <AD9208_NCO_MODE_VIF>;
 			adi,nco-channel-carrier-frequency-hz = /bits/ 64 <70000000>;
 			adi,nco-channel-phase-offset = /bits/ 64 <0>;
 			adi,ddc-gain-6dB-enable;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9988-fmcb-m8-l4.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9988-fmcb-m8-l4.dts
@@ -282,28 +282,28 @@
 					reg = <0>;
 					adi,decimation = <4>;
 					adi,nco-frequency-shift-hz =  /bits/ 64 <250000000>;
-					adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+					adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 					//adi,crossbar-select = <&ad9081_rx_fddc_chan0>, <&ad9081_rx_fddc_chan2>; /* Static for now */
 				};
 				ad9081_adc1: adc@1 {
 					reg = <1>;
 					adi,decimation = <4>;
 					adi,nco-frequency-shift-hz =  /bits/ 64 <500000000>;
-					adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+					adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 					//adi,crossbar-select = <&ad9081_rx_fddc_chan1>, <&ad9081_rx_fddc_chan3>; /* Static for now */
 				};
 				ad9081_adc2: adc@2 {
 					reg = <2>;
 					adi,decimation = <4>;
 					adi,nco-frequency-shift-hz =  /bits/ 64 <1000000000>;
-					adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+					adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 					//adi,crossbar-select = <&ad9081_rx_fddc_chan4>, <&ad9081_rx_fddc_chan6>; /* Static for now */
 				};
 				ad9081_adc3: adc@3 {
 					reg = <3>;
 					adi,decimation = <4>;
 					adi,nco-frequency-shift-hz =  /bits/ 64 <1500000000>;
-					adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+					adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 					//adi,crossbar-select = <&ad9081_rx_fddc_chan5>, <&ad9081_rx_fddc_chan7>; /* Static for now */
 				};
 			};

--- a/arch/microblaze/boot/dts/vcu118_ad9081_204c_txmode_10_rxmode_11.dts
+++ b/arch/microblaze/boot/dts/vcu118_ad9081_204c_txmode_10_rxmode_11.dts
@@ -225,14 +225,14 @@
 				reg = <0>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx0_ad9081_rx_fddc_chan0>, <&trx0_ad9081_rx_fddc_chan2>; /* Static for now */
 			};
 			trx0_ad9081_adc1: adc@1 {
 				reg = <1>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx0_ad9081_rx_fddc_chan1>, <&trx0_ad9081_rx_fddc_chan3>; /* Static for now */
 			};
 		};

--- a/arch/microblaze/boot/dts/vcu118_ad9081_204c_txmode_10_rxmode_11_lr_24_75Gbps.dts
+++ b/arch/microblaze/boot/dts/vcu118_ad9081_204c_txmode_10_rxmode_11_lr_24_75Gbps.dts
@@ -224,14 +224,14 @@
 				reg = <0>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx0_ad9081_rx_fddc_chan0>, <&trx0_ad9081_rx_fddc_chan2>; /* Static for now */
 			};
 			trx0_ad9081_adc1: adc@1 {
 				reg = <1>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx0_ad9081_rx_fddc_chan1>, <&trx0_ad9081_rx_fddc_chan3>; /* Static for now */
 			};
 		};

--- a/arch/microblaze/boot/dts/vcu118_ad9081_204c_txmode_23_rxmode_25.dts
+++ b/arch/microblaze/boot/dts/vcu118_ad9081_204c_txmode_23_rxmode_25.dts
@@ -175,13 +175,13 @@
 				reg = <0>;
 				adi,decimation = <3>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <1000000000>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 			};
 			ad9081_adc1: adc@1 {
 				reg = <1>;
 				adi,decimation = <3>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <(1100000000)>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 			};
 		};
 		adi,channelizer-paths {

--- a/arch/microblaze/boot/dts/vcu118_ad9081_204c_txmode_23_rxmode_25_lr_24_75Gbps.dts
+++ b/arch/microblaze/boot/dts/vcu118_ad9081_204c_txmode_23_rxmode_25_lr_24_75Gbps.dts
@@ -171,13 +171,13 @@
 				reg = <0>;
 				adi,decimation = <2>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <400000000>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 			};
 			ad9081_adc1: adc@1 {
 				reg = <1>;
 				adi,decimation = <2>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <(-400000000)>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 			};
 		};
 		adi,channelizer-paths {

--- a/arch/microblaze/boot/dts/vcu118_ad9081_204c_txmode_24_rxmode_26_lr_24_75Gbps.dts
+++ b/arch/microblaze/boot/dts/vcu118_ad9081_204c_txmode_24_rxmode_26_lr_24_75Gbps.dts
@@ -192,25 +192,25 @@
 				reg = <0>;
 				adi,decimation = <2>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <400000000>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 			};
 			ad9081_adc1: adc@1 {
 				reg = <1>;
 				adi,decimation = <2>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <(-400000000)>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 			};
 			ad9081_adc2: adc@2 {
 				reg = <2>;
 				adi,decimation = <2>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <400000000>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 			};
 			ad9081_adc3: adc@3 {
 				reg = <3>;
 				adi,decimation = <2>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <(-400000000)>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 			};
 		};
 		adi,channelizer-paths {

--- a/arch/microblaze/boot/dts/vcu118_ad9081_m8_l4.dts
+++ b/arch/microblaze/boot/dts/vcu118_ad9081_m8_l4.dts
@@ -184,28 +184,28 @@
 				reg = <0>;
 				adi,decimation = <4>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <400000000>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&ad9081_rx_fddc_chan0>, <&ad9081_rx_fddc_chan2>; /* Static for now */
 			};
 			ad9081_adc1: adc@1 {
 				reg = <1>;
 				adi,decimation = <4>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <(-400000000)>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&ad9081_rx_fddc_chan1>, <&ad9081_rx_fddc_chan3>; /* Static for now */
 			};
 			ad9081_adc2: adc@2 {
 				reg = <2>;
 				adi,decimation = <4>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <100000000>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&ad9081_rx_fddc_chan4>, <&ad9081_rx_fddc_chan6>; /* Static for now */
 			};
 			ad9081_adc3: adc@3 {
 				reg = <3>;
 				adi,decimation = <4>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <100000000>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&ad9081_rx_fddc_chan5>, <&ad9081_rx_fddc_chan7>; /* Static for now */
 			};
 		};

--- a/arch/microblaze/boot/dts/vcu118_quad_ad9081_204b_txmode_9_rxmode_10.dts
+++ b/arch/microblaze/boot/dts/vcu118_quad_ad9081_204b_txmode_9_rxmode_10.dts
@@ -301,28 +301,28 @@
 				reg = <0>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx0_ad9081_rx_fddc_chan0>, <&trx0_ad9081_rx_fddc_chan2>; /* Static for now */
 			};
 			trx0_ad9081_adc1: adc@1 {
 				reg = <1>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <(AD9081_RX_MAIN_NCO_SHIFT)>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx0_ad9081_rx_fddc_chan1>, <&trx0_ad9081_rx_fddc_chan3>; /* Static for now */
 			};
 			trx0_ad9081_adc2: adc@2 {
 				reg = <2>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx0_ad9081_rx_fddc_chan4>, <&trx0_ad9081_rx_fddc_chan6>; /* Static for now */
 			};
 			trx0_ad9081_adc3: adc@3 {
 				reg = <3>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx0_ad9081_rx_fddc_chan5>, <&trx0_ad9081_rx_fddc_chan7>; /* Static for now */
 			};
 		};
@@ -476,28 +476,28 @@
 				reg = <0>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx1_ad9081_rx_fddc_chan0>, <&trx1_ad9081_rx_fddc_chan2>; /* Static for now */
 			};
 			trx1_ad9081_adc1: adc@1 {
 				reg = <1>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx1_ad9081_rx_fddc_chan1>, <&trx1_ad9081_rx_fddc_chan3>; /* Static for now */
 			};
 			trx1_ad9081_adc2: adc@2 {
 				reg = <2>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx1_ad9081_rx_fddc_chan4>, <&trx1_ad9081_rx_fddc_chan6>; /* Static for now */
 			};
 			trx1_ad9081_adc3: adc@3 {
 				reg = <3>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx1_ad9081_rx_fddc_chan5>, <&trx1_ad9081_rx_fddc_chan7>; /* Static for now */
 			};
 		};
@@ -651,28 +651,28 @@
 				reg = <0>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx2_ad9081_rx_fddc_chan0>, <&trx2_ad9081_rx_fddc_chan2>; /* Static for now */
 			};
 			trx2_ad9081_adc1: adc@1 {
 				reg = <1>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx2_ad9081_rx_fddc_chan1>, <&trx2_ad9081_rx_fddc_chan3>; /* Static for now */
 			};
 			trx2_ad9081_adc2: adc@2 {
 				reg = <2>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx2_ad9081_rx_fddc_chan4>, <&trx2_ad9081_rx_fddc_chan6>; /* Static for now */
 			};
 			trx2_ad9081_adc3: adc@3 {
 				reg = <3>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx2_ad9081_rx_fddc_chan5>, <&trx2_ad9081_rx_fddc_chan7>; /* Static for now */
 			};
 		};
@@ -826,28 +826,28 @@
 				reg = <0>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx3_ad9081_rx_fddc_chan0>, <&trx3_ad9081_rx_fddc_chan2>; /* Static for now */
 			};
 			trx3_ad9081_adc1: adc@1 {
 				reg = <1>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx3_ad9081_rx_fddc_chan1>, <&trx3_ad9081_rx_fddc_chan3>; /* Static for now */
 			};
 			trx3_ad9081_adc2: adc@2 {
 				reg = <2>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx3_ad9081_rx_fddc_chan4>, <&trx3_ad9081_rx_fddc_chan6>; /* Static for now */
 			};
 			trx3_ad9081_adc3: adc@3 {
 				reg = <3>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx3_ad9081_rx_fddc_chan5>, <&trx3_ad9081_rx_fddc_chan7>; /* Static for now */
 			};
 		};

--- a/arch/microblaze/boot/dts/vcu118_quad_ad9081_204c_txmode_10_rxmode_11.dts
+++ b/arch/microblaze/boot/dts/vcu118_quad_ad9081_204c_txmode_10_rxmode_11.dts
@@ -313,14 +313,14 @@
 				reg = <0>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx0_ad9081_rx_fddc_chan0>, <&trx0_ad9081_rx_fddc_chan2>; /* Static for now */
 			};
 			trx0_ad9081_adc1: adc@1 {
 				reg = <1>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx0_ad9081_rx_fddc_chan1>, <&trx0_ad9081_rx_fddc_chan3>; /* Static for now */
 			};
 		};
@@ -442,14 +442,14 @@
 				reg = <0>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx1_ad9081_rx_fddc_chan0>, <&trx1_ad9081_rx_fddc_chan2>; /* Static for now */
 			};
 			trx1_ad9081_adc1: adc@1 {
 				reg = <1>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx1_ad9081_rx_fddc_chan1>, <&trx1_ad9081_rx_fddc_chan3>; /* Static for now */
 			};
 		};
@@ -571,14 +571,14 @@
 				reg = <0>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx2_ad9081_rx_fddc_chan0>, <&trx2_ad9081_rx_fddc_chan2>; /* Static for now */
 			};
 			trx2_ad9081_adc1: adc@1 {
 				reg = <1>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx2_ad9081_rx_fddc_chan1>, <&trx2_ad9081_rx_fddc_chan3>; /* Static for now */
 			};
 		};
@@ -700,14 +700,14 @@
 				reg = <0>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx3_ad9081_rx_fddc_chan0>, <&trx3_ad9081_rx_fddc_chan2>; /* Static for now */
 			};
 			trx3_ad9081_adc1: adc@1 {
 				reg = <1>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx3_ad9081_rx_fddc_chan1>, <&trx3_ad9081_rx_fddc_chan3>; /* Static for now */
 			};
 		};

--- a/arch/microblaze/boot/dts/vcu118_quad_ad9081_204c_txmode_11_rxmode_4.dts
+++ b/arch/microblaze/boot/dts/vcu118_quad_ad9081_204c_txmode_11_rxmode_4.dts
@@ -354,28 +354,28 @@
 				reg = <0>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx0_ad9081_rx_fddc_chan0>, <&trx0_ad9081_rx_fddc_chan2>; /* Static for now */
 			};
 			trx0_ad9081_adc1: adc@1 {
 				reg = <1>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <(AD9081_RX_MAIN_NCO_SHIFT)>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx0_ad9081_rx_fddc_chan1>, <&trx0_ad9081_rx_fddc_chan3>; /* Static for now */
 			};
 			trx0_ad9081_adc2: adc@2 {
 				reg = <2>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx0_ad9081_rx_fddc_chan4>, <&trx0_ad9081_rx_fddc_chan6>; /* Static for now */
 			};
 			trx0_ad9081_adc3: adc@3 {
 				reg = <3>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx0_ad9081_rx_fddc_chan5>, <&trx0_ad9081_rx_fddc_chan7>; /* Static for now */
 			};
 		};
@@ -550,28 +550,28 @@
 				reg = <0>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx1_ad9081_rx_fddc_chan0>, <&trx1_ad9081_rx_fddc_chan2>; /* Static for now */
 			};
 			trx1_ad9081_adc1: adc@1 {
 				reg = <1>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <(AD9081_RX_MAIN_NCO_SHIFT)>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx1_ad9081_rx_fddc_chan1>, <&trx1_ad9081_rx_fddc_chan3>; /* Static for now */
 			};
 			trx1_ad9081_adc2: adc@2 {
 				reg = <2>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx1_ad9081_rx_fddc_chan4>, <&trx1_ad9081_rx_fddc_chan6>; /* Static for now */
 			};
 			trx1_ad9081_adc3: adc@3 {
 				reg = <3>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx1_ad9081_rx_fddc_chan5>, <&trx1_ad9081_rx_fddc_chan7>; /* Static for now */
 			};
 		};
@@ -746,28 +746,28 @@
 				reg = <0>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx2_ad9081_rx_fddc_chan0>, <&trx2_ad9081_rx_fddc_chan2>; /* Static for now */
 			};
 			trx2_ad9081_adc1: adc@1 {
 				reg = <1>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <(AD9081_RX_MAIN_NCO_SHIFT)>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx2_ad9081_rx_fddc_chan1>, <&trx2_ad9081_rx_fddc_chan3>; /* Static for now */
 			};
 			trx2_ad9081_adc2: adc@2 {
 				reg = <2>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx2_ad9081_rx_fddc_chan4>, <&trx2_ad9081_rx_fddc_chan6>; /* Static for now */
 			};
 			trx2_ad9081_adc3: adc@3 {
 				reg = <3>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx2_ad9081_rx_fddc_chan5>, <&trx2_ad9081_rx_fddc_chan7>; /* Static for now */
 			};
 		};
@@ -942,28 +942,28 @@
 				reg = <0>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx3_ad9081_rx_fddc_chan0>, <&trx3_ad9081_rx_fddc_chan2>; /* Static for now */
 			};
 			trx3_ad9081_adc1: adc@1 {
 				reg = <1>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <(AD9081_RX_MAIN_NCO_SHIFT)>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx3_ad9081_rx_fddc_chan1>, <&trx3_ad9081_rx_fddc_chan3>; /* Static for now */
 			};
 			trx3_ad9081_adc2: adc@2 {
 				reg = <2>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx3_ad9081_rx_fddc_chan4>, <&trx3_ad9081_rx_fddc_chan6>; /* Static for now */
 			};
 			trx3_ad9081_adc3: adc@3 {
 				reg = <3>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx3_ad9081_rx_fddc_chan5>, <&trx3_ad9081_rx_fddc_chan7>; /* Static for now */
 			};
 		};

--- a/arch/microblaze/boot/dts/vcu118_quad_ad9081_204c_txmode_11_rxmode_4_direct_6g.dts
+++ b/arch/microblaze/boot/dts/vcu118_quad_ad9081_204c_txmode_11_rxmode_4_direct_6g.dts
@@ -360,28 +360,28 @@
 				reg = <0>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx0_ad9081_rx_fddc_chan0>, <&trx0_ad9081_rx_fddc_chan2>; /* Static for now */
 			};
 			trx0_ad9081_adc1: adc@1 {
 				reg = <1>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <(AD9081_RX_MAIN_NCO_SHIFT)>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx0_ad9081_rx_fddc_chan1>, <&trx0_ad9081_rx_fddc_chan3>; /* Static for now */
 			};
 			trx0_ad9081_adc2: adc@2 {
 				reg = <2>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx0_ad9081_rx_fddc_chan4>, <&trx0_ad9081_rx_fddc_chan6>; /* Static for now */
 			};
 			trx0_ad9081_adc3: adc@3 {
 				reg = <3>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx0_ad9081_rx_fddc_chan5>, <&trx0_ad9081_rx_fddc_chan7>; /* Static for now */
 			};
 		};
@@ -561,28 +561,28 @@
 				reg = <0>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx1_ad9081_rx_fddc_chan0>, <&trx1_ad9081_rx_fddc_chan2>; /* Static for now */
 			};
 			trx1_ad9081_adc1: adc@1 {
 				reg = <1>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <(AD9081_RX_MAIN_NCO_SHIFT)>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx1_ad9081_rx_fddc_chan1>, <&trx1_ad9081_rx_fddc_chan3>; /* Static for now */
 			};
 			trx1_ad9081_adc2: adc@2 {
 				reg = <2>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx1_ad9081_rx_fddc_chan4>, <&trx1_ad9081_rx_fddc_chan6>; /* Static for now */
 			};
 			trx1_ad9081_adc3: adc@3 {
 				reg = <3>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx1_ad9081_rx_fddc_chan5>, <&trx1_ad9081_rx_fddc_chan7>; /* Static for now */
 			};
 		};
@@ -762,28 +762,28 @@
 				reg = <0>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx2_ad9081_rx_fddc_chan0>, <&trx2_ad9081_rx_fddc_chan2>; /* Static for now */
 			};
 			trx2_ad9081_adc1: adc@1 {
 				reg = <1>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <(AD9081_RX_MAIN_NCO_SHIFT)>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx2_ad9081_rx_fddc_chan1>, <&trx2_ad9081_rx_fddc_chan3>; /* Static for now */
 			};
 			trx2_ad9081_adc2: adc@2 {
 				reg = <2>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx2_ad9081_rx_fddc_chan4>, <&trx2_ad9081_rx_fddc_chan6>; /* Static for now */
 			};
 			trx2_ad9081_adc3: adc@3 {
 				reg = <3>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx2_ad9081_rx_fddc_chan5>, <&trx2_ad9081_rx_fddc_chan7>; /* Static for now */
 			};
 		};
@@ -963,28 +963,28 @@
 				reg = <0>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx3_ad9081_rx_fddc_chan0>, <&trx3_ad9081_rx_fddc_chan2>; /* Static for now */
 			};
 			trx3_ad9081_adc1: adc@1 {
 				reg = <1>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <(AD9081_RX_MAIN_NCO_SHIFT)>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx3_ad9081_rx_fddc_chan1>, <&trx3_ad9081_rx_fddc_chan3>; /* Static for now */
 			};
 			trx3_ad9081_adc2: adc@2 {
 				reg = <2>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx3_ad9081_rx_fddc_chan4>, <&trx3_ad9081_rx_fddc_chan6>; /* Static for now */
 			};
 			trx3_ad9081_adc3: adc@3 {
 				reg = <3>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx3_ad9081_rx_fddc_chan5>, <&trx3_ad9081_rx_fddc_chan7>; /* Static for now */
 			};
 		};

--- a/arch/microblaze/boot/dts/vcu118_quad_ad9081_204c_txmode_23_rxmode_25_revc.dts
+++ b/arch/microblaze/boot/dts/vcu118_quad_ad9081_204c_txmode_23_rxmode_25_revc.dts
@@ -388,14 +388,14 @@
 				reg = <0>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx0_ad9081_rx_fddc_chan0>, <&trx0_ad9081_rx_fddc_chan2>; /* Static for now */
 			};
 			trx0_ad9081_adc1: adc@1 {
 				reg = <1>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx0_ad9081_rx_fddc_chan1>, <&trx0_ad9081_rx_fddc_chan3>; /* Static for now */
 			};
 		};
@@ -520,14 +520,14 @@
 				reg = <0>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx1_ad9081_rx_fddc_chan0>, <&trx1_ad9081_rx_fddc_chan2>; /* Static for now */
 			};
 			trx1_ad9081_adc1: adc@1 {
 				reg = <1>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx1_ad9081_rx_fddc_chan1>, <&trx1_ad9081_rx_fddc_chan3>; /* Static for now */
 			};
 		};
@@ -652,14 +652,14 @@
 				reg = <0>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx2_ad9081_rx_fddc_chan0>, <&trx2_ad9081_rx_fddc_chan2>; /* Static for now */
 			};
 			trx2_ad9081_adc1: adc@1 {
 				reg = <1>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx2_ad9081_rx_fddc_chan1>, <&trx2_ad9081_rx_fddc_chan3>; /* Static for now */
 			};
 		};
@@ -784,14 +784,14 @@
 				reg = <0>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx3_ad9081_rx_fddc_chan0>, <&trx3_ad9081_rx_fddc_chan2>; /* Static for now */
 			};
 			trx3_ad9081_adc1: adc@1 {
 				reg = <1>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx3_ad9081_rx_fddc_chan1>, <&trx3_ad9081_rx_fddc_chan3>; /* Static for now */
 			};
 		};

--- a/arch/microblaze/boot/dts/vcu118_quad_ad9081_204c_txmode_29_rxmode_24_revc.dts
+++ b/arch/microblaze/boot/dts/vcu118_quad_ad9081_204c_txmode_29_rxmode_24_revc.dts
@@ -406,28 +406,28 @@
 				reg = <0>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx0_ad9081_rx_fddc_chan0>, <&trx0_ad9081_rx_fddc_chan2>; /* Static for now */
 			};
 			trx0_ad9081_adc1: adc@1 {
 				reg = <1>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <(AD9081_RX_MAIN_NCO_SHIFT)>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx0_ad9081_rx_fddc_chan1>, <&trx0_ad9081_rx_fddc_chan3>; /* Static for now */
 			};
 			trx0_ad9081_adc2: adc@2 {
 				reg = <2>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx0_ad9081_rx_fddc_chan4>, <&trx0_ad9081_rx_fddc_chan6>; /* Static for now */
 			};
 			trx0_ad9081_adc3: adc@3 {
 				reg = <3>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx0_ad9081_rx_fddc_chan5>, <&trx0_ad9081_rx_fddc_chan7>; /* Static for now */
 			};
 		};
@@ -585,28 +585,28 @@
 				reg = <0>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx1_ad9081_rx_fddc_chan0>, <&trx1_ad9081_rx_fddc_chan2>; /* Static for now */
 			};
 			trx1_ad9081_adc1: adc@1 {
 				reg = <1>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx1_ad9081_rx_fddc_chan1>, <&trx1_ad9081_rx_fddc_chan3>; /* Static for now */
 			};
 			trx1_ad9081_adc2: adc@2 {
 				reg = <2>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx1_ad9081_rx_fddc_chan4>, <&trx1_ad9081_rx_fddc_chan6>; /* Static for now */
 			};
 			trx1_ad9081_adc3: adc@3 {
 				reg = <3>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx1_ad9081_rx_fddc_chan5>, <&trx1_ad9081_rx_fddc_chan7>; /* Static for now */
 			};
 		};
@@ -764,28 +764,28 @@
 				reg = <0>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx2_ad9081_rx_fddc_chan0>, <&trx2_ad9081_rx_fddc_chan2>; /* Static for now */
 			};
 			trx2_ad9081_adc1: adc@1 {
 				reg = <1>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx2_ad9081_rx_fddc_chan1>, <&trx2_ad9081_rx_fddc_chan3>; /* Static for now */
 			};
 			trx2_ad9081_adc2: adc@2 {
 				reg = <2>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx2_ad9081_rx_fddc_chan4>, <&trx2_ad9081_rx_fddc_chan6>; /* Static for now */
 			};
 			trx2_ad9081_adc3: adc@3 {
 				reg = <3>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx2_ad9081_rx_fddc_chan5>, <&trx2_ad9081_rx_fddc_chan7>; /* Static for now */
 			};
 		};
@@ -943,28 +943,28 @@
 				reg = <0>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx3_ad9081_rx_fddc_chan0>, <&trx3_ad9081_rx_fddc_chan2>; /* Static for now */
 			};
 			trx3_ad9081_adc1: adc@1 {
 				reg = <1>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx3_ad9081_rx_fddc_chan1>, <&trx3_ad9081_rx_fddc_chan3>; /* Static for now */
 			};
 			trx3_ad9081_adc2: adc@2 {
 				reg = <2>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx3_ad9081_rx_fddc_chan4>, <&trx3_ad9081_rx_fddc_chan6>; /* Static for now */
 			};
 			trx3_ad9081_adc3: adc@3 {
 				reg = <3>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx3_ad9081_rx_fddc_chan5>, <&trx3_ad9081_rx_fddc_chan7>; /* Static for now */
 			};
 		};

--- a/arch/microblaze/boot/dts/vcu118_quad_ad9082_204c_txmode_12_rxmode_13.dts
+++ b/arch/microblaze/boot/dts/vcu118_quad_ad9082_204c_txmode_12_rxmode_13.dts
@@ -351,7 +351,7 @@
 				reg = <0>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx0_ad9081_rx_fddc_chan0>, <&trx0_ad9081_rx_fddc_chan2>; /* Static for now */
 			};
 		};
@@ -460,7 +460,7 @@
 				reg = <0>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx1_ad9081_rx_fddc_chan0>, <&trx1_ad9081_rx_fddc_chan2>; /* Static for now */
 			};
 		};
@@ -569,7 +569,7 @@
 				reg = <0>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx2_ad9081_rx_fddc_chan0>, <&trx2_ad9081_rx_fddc_chan2>; /* Static for now */
 			};
 		};
@@ -678,7 +678,7 @@
 				reg = <0>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx3_ad9081_rx_fddc_chan0>, <&trx3_ad9081_rx_fddc_chan2>; /* Static for now */
 			};
 		};

--- a/arch/microblaze/boot/dts/vcu118_quad_ad9082_204c_txmode_23_rxmode_25.dts
+++ b/arch/microblaze/boot/dts/vcu118_quad_ad9082_204c_txmode_23_rxmode_25.dts
@@ -374,14 +374,14 @@
 				reg = <0>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx0_ad9081_rx_fddc_chan0>, <&trx0_ad9081_rx_fddc_chan2>; /* Static for now */
 			};
 			trx0_ad9081_adc1: adc@1 {
 				reg = <1>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx0_ad9081_rx_fddc_chan1>, <&trx0_ad9081_rx_fddc_chan3>; /* Static for now */
 			};
 		};
@@ -507,14 +507,14 @@
 				reg = <0>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx1_ad9081_rx_fddc_chan0>, <&trx1_ad9081_rx_fddc_chan2>; /* Static for now */
 			};
 			trx1_ad9081_adc1: adc@1 {
 				reg = <1>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx1_ad9081_rx_fddc_chan1>, <&trx1_ad9081_rx_fddc_chan3>; /* Static for now */
 			};
 		};
@@ -640,14 +640,14 @@
 				reg = <0>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx2_ad9081_rx_fddc_chan0>, <&trx2_ad9081_rx_fddc_chan2>; /* Static for now */
 			};
 			trx2_ad9081_adc1: adc@1 {
 				reg = <1>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx2_ad9081_rx_fddc_chan1>, <&trx2_ad9081_rx_fddc_chan3>; /* Static for now */
 			};
 		};
@@ -773,14 +773,14 @@
 				reg = <0>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx3_ad9081_rx_fddc_chan0>, <&trx3_ad9081_rx_fddc_chan2>; /* Static for now */
 			};
 			trx3_ad9081_adc1: adc@1 {
 				reg = <1>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx3_ad9081_rx_fddc_chan1>, <&trx3_ad9081_rx_fddc_chan3>; /* Static for now */
 			};
 		};

--- a/arch/microblaze/boot/dts/vcu118_quad_ad9082_204c_txmode_3_rxmode_2.dts
+++ b/arch/microblaze/boot/dts/vcu118_quad_ad9082_204c_txmode_3_rxmode_2.dts
@@ -375,14 +375,14 @@
 				reg = <0>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx0_ad9081_rx_fddc_chan0>, <&trx0_ad9081_rx_fddc_chan2>; /* Static for now */
 			};
 			trx0_ad9081_adc1: adc@1 {
 				reg = <1>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <(AD9081_RX_MAIN_NCO_SHIFT)>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx0_ad9081_rx_fddc_chan1>, <&trx0_ad9081_rx_fddc_chan3>; /* Static for now */
 			};
 		};
@@ -526,14 +526,14 @@
 				reg = <0>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx1_ad9081_rx_fddc_chan0>, <&trx1_ad9081_rx_fddc_chan2>; /* Static for now */
 			};
 			trx1_ad9081_adc1: adc@1 {
 				reg = <1>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx1_ad9081_rx_fddc_chan1>, <&trx1_ad9081_rx_fddc_chan3>; /* Static for now */
 			};
 		};
@@ -677,14 +677,14 @@
 				reg = <0>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx2_ad9081_rx_fddc_chan0>, <&trx2_ad9081_rx_fddc_chan2>; /* Static for now */
 			};
 			trx2_ad9081_adc1: adc@1 {
 				reg = <1>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx2_ad9081_rx_fddc_chan1>, <&trx2_ad9081_rx_fddc_chan3>; /* Static for now */
 			};
 		};
@@ -828,14 +828,14 @@
 				reg = <0>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx3_ad9081_rx_fddc_chan0>, <&trx3_ad9081_rx_fddc_chan2>; /* Static for now */
 			};
 			trx3_ad9081_adc1: adc@1 {
 				reg = <1>;
 				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&trx3_ad9081_rx_fddc_chan1>, <&trx3_ad9081_rx_fddc_chan3>; /* Static for now */
 			};
 		};

--- a/arch/microblaze/boot/dts/vcu128_ad9081_m8_l4.dts
+++ b/arch/microblaze/boot/dts/vcu128_ad9081_m8_l4.dts
@@ -184,28 +184,28 @@
 				reg = <0>;
 				adi,decimation = <4>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <400000000>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&ad9081_rx_fddc_chan0>, <&ad9081_rx_fddc_chan2>; /* Static for now */
 			};
 			ad9081_adc1: adc@1 {
 				reg = <1>;
 				adi,decimation = <4>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <(-400000000)>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&ad9081_rx_fddc_chan1>, <&ad9081_rx_fddc_chan3>; /* Static for now */
 			};
 			ad9081_adc2: adc@2 {
 				reg = <2>;
 				adi,decimation = <4>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <100000000>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&ad9081_rx_fddc_chan4>, <&ad9081_rx_fddc_chan6>; /* Static for now */
 			};
 			ad9081_adc3: adc@3 {
 				reg = <3>;
 				adi,decimation = <4>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <100000000>;
-				adi,nco-mode = <AD9081_ADC_NCO_VIF>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 				//adi,crossbar-select = <&ad9081_rx_fddc_chan5>, <&ad9081_rx_fddc_chan7>; /* Static for now */
 			};
 		};


### PR DESCRIPTION
Rename adi,nco-mode -> adi,nco-mixer-mode in order to reflect the
latest ad9081 driver code.

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>