### PR TITLE
arch: arm: boot: dts: add rpi-cn0552

### DIFF
--- a/arch/arm/boot/dts/rpi-cn0552.dts
+++ b/arch/arm/boot/dts/rpi-cn0552.dts
@@ -1,0 +1,20 @@
+/dts-v1/;
+/plugin/;
+/ {
+	compatible = "brcm,bcm2708";
+	
+	fragment@0 {
+		target = <&i2c_arm>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			
+			status = "okay";
+			
+			adc: ad7746@48 {
+                compatible = "adi,ad7746";
+                reg = <0x48>;
+            };
+		};
+	};
+};


### PR DESCRIPTION
The EVAL-CN0552-PMDZ is a dual input channel capacitance-to-digital Converter (CDC) with an extended input range capability used in a wide array of industrial applications such as liquid level monitoring, position and humidity sensing, and many more.

The device features AD7746 and AD8515.