### PR TITLE
arch:arm:dts: fix daq2 zc706 dts

### DIFF
--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcdaq2.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcdaq2.dts
@@ -25,11 +25,6 @@
 			reg = <0x50>;
 		};
 
-		eeprom@54 {
-			compatible = "at24,24c02";
-			reg = <0x54>;
-		};
-
 		ad7291@2f {
 			compatible = "adi,ad7291";
 			reg = <0x2f>;


### PR DESCRIPTION
The board has only one EEPROM device mapped at address 0x50.

Fixes error: `xiic-i2c 41600000.i2c: Timeout waiting at Tx empty`

Schematic:
https://wiki.analog.com/_media/resources/eval/user-guides/ad-fmcdaq2-ebz/fmcdaq2_reve.pdf

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>