### PR TITLE
Iio channel label

### DIFF
--- a/drivers/iio/adc/cf_axi_adc.h
+++ b/drivers/iio/adc/cf_axi_adc.h
@@ -260,6 +260,9 @@ struct axiadc_converter {
 			enum iio_event_direction dir,
 			int state);
 
+	int (*read_label)(struct iio_dev *indio_dev,
+			const struct iio_chan_spec *chan, char *label);
+
 	int (*post_setup)(struct iio_dev *indio_dev);
 	int (*post_iio_register)(struct iio_dev *indio_dev);
 	int (*set_pnsel)(struct iio_dev *indio_dev, unsigned chan,

--- a/drivers/iio/adc/cf_axi_adc_core.c
+++ b/drivers/iio/adc/cf_axi_adc_core.c
@@ -642,6 +642,20 @@ static int axiadc_write_raw(struct iio_dev *indio_dev,
 	}
 }
 
+static int axiadc_read_label(struct iio_dev *indio_dev,
+			     const struct iio_chan_spec *chan, char *label)
+{
+	struct axiadc_state *st = iio_priv(indio_dev);
+	struct axiadc_converter *conv = to_converter(st->dev_spi);
+
+	if (conv && conv->read_label)
+		return conv->read_label(indio_dev, chan, label);
+	else if (chan->extend_name)
+		return sprintf(label, "%s\n", chan->extend_name);
+	else
+		return -ENOSYS;
+}
+
 static int axiadc_read_event_value(struct iio_dev *indio_dev,
 	const struct iio_chan_spec *chan, enum iio_event_type type,
 	enum iio_event_direction dir, enum iio_event_info info, int *val,
@@ -784,6 +798,7 @@ static const struct iio_info axiadc_info = {
 	.write_event_config = &axiadc_write_event_config,
 	.debugfs_reg_access = &axiadc_reg_access,
 	.update_scan_mode = &axiadc_update_scan_mode,
+	.read_label = &axiadc_read_label,
 };
 
 struct axiadc_spidev {

--- a/drivers/iio/addac/one-bit-adc-dac.c
+++ b/drivers/iio/addac/one-bit-adc-dac.c
@@ -18,9 +18,12 @@ enum ch_direction {
 };
 
 struct one_bit_adc_dac_state {
+	int			in_num_ch;
+	int			out_num_ch;
 	struct platform_device  *pdev;
 	struct gpio_descs       *in_gpio_descs;
 	struct gpio_descs       *out_gpio_descs;
+	const char		**labels;
 };
 
 static int one_bit_adc_dac_read_raw(struct iio_dev *indio_dev,
@@ -65,9 +68,24 @@ static int one_bit_adc_dac_write_raw(struct iio_dev *indio_dev,
 	}
 }
 
+static int one_bit_adc_dac_read_label(struct iio_dev *indio_dev,
+	const struct iio_chan_spec *chan, char *label)
+{
+	struct one_bit_adc_dac_state *st = iio_priv(indio_dev);
+	int ch;
+
+	if (chan->output)
+		ch = chan->channel + st->in_num_ch;
+	else
+		ch = chan->channel;
+
+	return sprintf(label, "%s\n", st->labels[ch]);
+}
+
 static const struct iio_info one_bit_adc_dac_info = {
 	.read_raw = &one_bit_adc_dac_read_raw,
 	.write_raw = &one_bit_adc_dac_write_raw,
+	.read_label = &one_bit_adc_dac_read_label,
 };
 
 static int one_bit_adc_dac_set_ch(struct iio_chan_spec *channels,
@@ -87,17 +105,23 @@ static int one_bit_adc_dac_set_ch(struct iio_chan_spec *channels,
 	return 0;
 }
 
-static void one_bit_adc_dac_set_channel_label(struct device *device,
+static int one_bit_adc_dac_set_channel_label(struct iio_dev *indio_dev,
 						struct iio_chan_spec *channels,
 						int num_channels)
 {
+	struct device *device = indio_dev->dev.parent;
+	struct one_bit_adc_dac_state *st = iio_priv(indio_dev);
 	struct fwnode_handle *fwnode;
 	struct fwnode_handle *child;
-	struct iio_chan_spec *chan;
 	const char *label;
 	int crt_ch = 0;
 
 	fwnode = dev_fwnode(device);
+
+	st->labels = devm_kcalloc(device, num_channels, sizeof(*st->labels), GFP_KERNEL);
+	if (!st->labels)
+		return -ENOMEM;
+
 	fwnode_for_each_child_node(fwnode, child) {
 		if (fwnode_property_read_u32(child, "reg", &crt_ch))
 			continue;
@@ -108,10 +132,10 @@ static void one_bit_adc_dac_set_channel_label(struct device *device,
 		if (fwnode_property_read_string(child, "label", &label))
 			continue;
 
-		chan = &channels[crt_ch];
-		chan->info_mask_separate |= BIT(IIO_CHAN_INFO_LABEL);
-		chan->label_name = label;
+		st->labels[crt_ch] = label;
 	}
+
+	return 0;
 }
 
 static int one_bit_adc_dac_parse_dt(struct iio_dev *indio_dev)
@@ -147,7 +171,10 @@ static int one_bit_adc_dac_parse_dt(struct iio_dev *indio_dev)
 	if (ret)
 		return ret;
 
-	one_bit_adc_dac_set_channel_label(indio_dev->dev.parent, channels, in_num_ch + out_num_ch);
+	ret = one_bit_adc_dac_set_channel_label(indio_dev, channels, in_num_ch + out_num_ch);
+	if (ret)
+		return ret;
+
 	indio_dev->channels = channels;
 	indio_dev->num_channels = in_num_ch + out_num_ch;
 

--- a/drivers/iio/beamformer/adar300x.c
+++ b/drivers/iio/beamformer/adar300x.c
@@ -182,9 +182,7 @@
 	.channel = (_num),					\
 	.address = (_id),					\
 	.info_mask_separate = BIT(IIO_CHAN_INFO_RAW) |		\
-			      BIT(IIO_CHAN_INFO_SCALE) |	\
-			      BIT(IIO_CHAN_INFO_LABEL),		\
-	.label_name = name,					\
+			      BIT(IIO_CHAN_INFO_SCALE),		\
 	.scan_index = (_id),					\
 	.scan_type = {						\
 		.sign = 'u',					\
@@ -202,9 +200,7 @@
 	.channel = (_num),					\
 	.address = (_id),					\
 	.info_mask_separate = BIT(IIO_CHAN_INFO_RAW) |		\
-			      BIT(IIO_CHAN_INFO_SCALE) |	\
-			      BIT(IIO_CHAN_INFO_LABEL),		\
-	.label_name = name,					\
+			      BIT(IIO_CHAN_INFO_SCALE),		\
 	.scan_index = (_id),					\
 	.scan_type = {						\
 		.sign = 'u',					\

--- a/drivers/iio/industrialio-core.c
+++ b/drivers/iio/industrialio-core.c
@@ -141,7 +141,6 @@ static const char * const iio_modifier_names[] = {
 /* relies on pairs of these shared then separate */
 static const char * const iio_chan_info_postfix[] = {
 	[IIO_CHAN_INFO_RAW] = "raw",
-	[IIO_CHAN_INFO_LABEL] = "label",
 	[IIO_CHAN_INFO_PROCESSED] = "input",
 	[IIO_CHAN_INFO_SCALE] = "scale",
 	[IIO_CHAN_INFO_OFFSET] = "offset",
@@ -684,6 +683,19 @@ ssize_t iio_format_value(char *buf, unsigned int type, int size, int *vals)
 }
 EXPORT_SYMBOL_GPL(iio_format_value);
 
+static ssize_t iio_read_channel_label(struct device *dev,
+				      struct device_attribute *attr,
+				      char *buf)
+{
+	struct iio_dev *indio_dev = dev_to_iio_dev(dev);
+	struct iio_dev_attr *this_attr = to_iio_dev_attr(attr);
+
+	if (!indio_dev->info->read_label)
+		return -EINVAL;
+
+	return indio_dev->info->read_label(indio_dev, this_attr->c, buf);
+}
+
 static ssize_t iio_read_channel_info(struct device *dev,
 				     struct device_attribute *attr,
 				     char *buf)
@@ -694,19 +706,14 @@ static ssize_t iio_read_channel_info(struct device *dev,
 	int ret;
 	int val_len = 2;
 
-	if (indio_dev->info->read_raw_multi) {
+	if (indio_dev->info->read_raw_multi)
 		ret = indio_dev->info->read_raw_multi(indio_dev, this_attr->c,
 							INDIO_MAX_RAW_ELEMENTS,
 							vals, &val_len,
 							this_attr->address);
-	} else {
-		if (this_attr->address == IIO_CHAN_INFO_LABEL &&
-			this_attr->c->label_name)
-			return sprintf(buf, "%s\n", this_attr->c->label_name);
-
+	else
 		ret = indio_dev->info->read_raw(indio_dev, this_attr->c,
 				    &vals[0], &vals[1], this_attr->address);
-	}
 
 	if (ret < 0)
 		return ret;
@@ -1157,6 +1164,29 @@ error_iio_dev_attr_free:
 	return ret;
 }
 
+static int iio_device_add_channel_label(struct iio_dev *indio_dev,
+					 struct iio_chan_spec const *chan)
+{
+	struct iio_dev_opaque *iio_dev_opaque = to_iio_dev_opaque(indio_dev);
+	int ret;
+
+	if (!indio_dev->info->read_label)
+		return 0;
+
+	ret = __iio_add_chan_devattr("label",
+				     chan,
+				     &iio_read_channel_label,
+				     NULL,
+				     0,
+				     IIO_SEPARATE,
+				     &indio_dev->dev,
+				     &iio_dev_opaque->channel_attr_list);
+	if (ret < 0)
+		return ret;
+
+	return 1;
+}
+
 static int iio_device_add_info_mask_type(struct iio_dev *indio_dev,
 					 struct iio_chan_spec const *chan,
 					 enum iio_shared_by shared_by,
@@ -1286,6 +1316,11 @@ static int iio_device_add_channel_sysfs(struct iio_dev *indio_dev,
 	ret = iio_device_add_info_mask_type_avail(indio_dev, chan,
 						  IIO_SHARED_BY_ALL,
 						  &chan->info_mask_shared_by_all_available);
+	if (ret < 0)
+		return ret;
+	attrcount += ret;
+
+	ret = iio_device_add_channel_label(indio_dev, chan);
 	if (ret < 0)
 		return ret;
 	attrcount += ret;
@@ -1449,7 +1484,6 @@ static int iio_device_register_sysfs(struct iio_dev *indio_dev)
 			attrcount_orig++;
 	}
 	attrcount = attrcount_orig;
-
 	/*
 	 * New channel registration method - relies on the fact a group does
 	 * not need to be initialized if its name is NULL.

--- a/include/linux/iio/iio.h
+++ b/include/linux/iio/iio.h
@@ -240,7 +240,6 @@ struct iio_event_spec {
  *			correspond to the first name that the channel is referred
  *			to by in the datasheet (e.g. IND), or the nearest
  *			possible compound name (e.g. IND-INC).
- * @label_name:		Unique name to identify which channel this is.
  * @modified:		Does a modifier apply to this channel. What these are
  *			depends on the channel type.  Modifier is set in
  *			channel2. Examples are IIO_MOD_X for axial sensors about
@@ -278,7 +277,6 @@ struct iio_chan_spec {
 	const struct iio_chan_spec_ext_info *ext_info;
 	const char		*extend_name;
 	const char		*datasheet_name;
-	const char		*label_name;
 	unsigned		modified:1;
 	unsigned		indexed:1;
 	unsigned		output:1;
@@ -386,6 +384,8 @@ struct iio_trigger; /* forward declaration */
  *			and max. For lists, all possible values are enumerated.
  * @write_raw:		function to write a value to the device.
  *			Parameters are the same as for read_raw.
+ * @read_label:		function to request label name for a specified label,
+ *			for better channel identification.
  * @write_raw_get_fmt:	callback function to query the expected
  *			format/precision. If not set by the driver, write_raw
  *			returns IIO_VAL_INT_PLUS_MICRO.
@@ -443,6 +443,10 @@ struct iio_info {
 			 int val,
 			 int val2,
 			 long mask);
+
+	int (*read_label)(struct iio_dev *indio_dev,
+			 struct iio_chan_spec const *chan,
+			 char *label);
 
 	int (*write_raw_get_fmt)(struct iio_dev *indio_dev,
 			 struct iio_chan_spec const *chan,

--- a/include/linux/iio/types.h
+++ b/include/linux/iio/types.h
@@ -34,7 +34,6 @@ enum iio_available_type {
 
 enum iio_chan_info_enum {
 	IIO_CHAN_INFO_RAW = 0,
-	IIO_CHAN_INFO_LABEL,
 	IIO_CHAN_INFO_PROCESSED,
 	IIO_CHAN_INFO_SCALE,
 	IIO_CHAN_INFO_OFFSET,


### PR DESCRIPTION
Update with the upstream version of channel label:
https://git.kernel.org/pub/scm/linux/kernel/git/jic23/iio.git/commit/?id=1d4ef9b39ebecca827642b8897d2d79ea2026682