### PR TITLE
zc706 dts fixes

### DIFF
--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad6676-fmc.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad6676-fmc.dts
@@ -84,11 +84,6 @@
 			compatible = "at24,24c02";
 			reg = <0x50>;
 		};
-
-		eeprom@54 {
-			compatible = "at24,24c02";
-			reg = <0x54>;
-		};
 	};
 
 	i2c@6 { /* LPC IIC */
@@ -98,11 +93,6 @@
 		eeprom@50 {
 			compatible = "at24,24c02";
 			reg = <0x50>;
-		};
-
-		eeprom@54 {
-			compatible = "at24,24c02";
-			reg = <0x54>;
 		};
 	};
 };

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad9739a-fmc.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad9739a-fmc.dts
@@ -19,11 +19,6 @@
 		#size-cells = <0>;
 		#address-cells = <1>;
 		reg = <6>;
-
-		eeprom@50 {
-			compatible = "at24,24c02";
-			reg = <0x50>;
-		};
 	};
 };
 

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9009.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9009.dts
@@ -28,11 +28,6 @@
 			reg = <0x50>;
 		};
 
-		eeprom@54 {
-			compatible = "at24,24c02";
-			reg = <0x54>;
-		};
-
 		ad7291@2f {
 			compatible = "adi,ad7291";
 			reg = <0x2f>;

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9371.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9371.dts
@@ -27,11 +27,6 @@
 			reg = <0x50>;
 		};
 
-		eeprom@54 {
-			compatible = "at24,24c02";
-			reg = <0x54>;
-		};
-
 		ad7291@2f {
 			compatible = "adi,ad7291";
 			reg = <0x2f>;

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcomms11.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcomms11.dts
@@ -26,11 +26,6 @@
 			reg = <0x50>;
 		};
 
-		eeprom@54 {
-			compatible = "at24,24c02";
-			reg = <0x54>;
-		};
-
 		ad7291@2f {
 			compatible = "adi,ad7291";
 			reg = <0x2f>;


### PR DESCRIPTION
Remove extra eeproms added in the dts associated with the zc706 carrier.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>