### PR TITLE
zc706 dts: remove extra eeprom devices

### DIFF
--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad9625-fmcadc2.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad9625-fmcadc2.dts
@@ -58,11 +58,6 @@
 			compatible = "at24,24c02";
 			reg = <0x50>;
 		};
-
-		eeprom@54 {
-			compatible = "at24,24c02";
-			reg = <0x54>;
-		};
 	};
 
 	i2c@6 { /* LPC IIC */
@@ -72,11 +67,6 @@
 		eeprom@50 {
 			compatible = "at24,24c02";
 			reg = <0x50>;
-		};
-
-		eeprom@54 {
-			compatible = "at24,24c02";
-			reg = <0x54>;
 		};
 	};
 };

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad9625-fmcadc7.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad9625-fmcadc7.dts
@@ -80,11 +80,6 @@
 			compatible = "at24,24c02";
 			reg = <0x50>;
 		};
-
-		eeprom@54 {
-			compatible = "at24,24c02";
-			reg = <0x54>;
-		};
 	};
 
 	i2c@6 { /* LPC IIC */
@@ -94,11 +89,6 @@
 		eeprom@50 {
 			compatible = "at24,24c02";
 			reg = <0x50>;
-		};
-
-		eeprom@54 {
-			compatible = "at24,24c02";
-			reg = <0x54>;
 		};
 	};
 };

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcjesdadc1.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcjesdadc1.dts
@@ -25,11 +25,6 @@
 			reg = <0x50>;
 		};
 
-		eeprom@54 {
-			compatible = "at24,24c02";
-			reg = <0x54>;
-		};
-
 		ad7291@2f {
 			compatible = "adi,ad7291";
 			reg = <0x2f>;


### PR DESCRIPTION
According to the schematics, there is only one eeprom device connected to
the fmc i2c, having the slave address 0x50.

https://wiki.analog.com/_media/resources/eval/user-guides/ad-fmcadc2-ebz/02_036007d.pdf
https://wiki.analog.com/_media/resources/eval/user-guides/ad_fmcadcv7b.pdf
https://wiki.analog.com/_media/resources/eval/user-guides/ad-fmcjesdadc1-ebz/ad-fmcjesdadc1_r1.1.pdf