### PR TITLE
ci: remove make savedefconfig

### DIFF
--- a/ci/travis/run-build.sh
+++ b/ci/travis/run-build.sh
@@ -195,15 +195,6 @@ build_default() {
 	if [ "$CHECK_ALL_ADI_DRIVERS_HAVE_BEEN_BUILT" = "1" ] ; then
 		check_all_adi_files_have_been_built
 	fi
-
-	make savedefconfig
-	mv defconfig arch/$ARCH/configs/$DEFCONFIG
-
-	git diff --exit-code || {
-		echo_red "Defconfig file should be updated: 'arch/$ARCH/configs/$DEFCONFIG'"
-		echo_red "Run 'make savedefconfig', overwrite it and commit it"
-		return 1
-	}
 }
 
 build_allmodconfig() {


### PR DESCRIPTION
The build step removed with this patch was generating a separate
defconfig file in the root folder and overwriting the specific
defconfig in the arch/$ARCH/configs/$DEFCONFIG path, that already is
up to date.

This patch fixes false positive issues like in
commit cb671e0075be ("arch: arm64: adi_zynq_defconfig: Build SI5341 driver")
where the make savedefconfig command generates a different defconfig
that only changes the order of the parameters in the config file.

Fixes: bd020a412df416187c97b5613d964f4d4b6060ea (ci,build: enforce that
users update ADI defconfigs)
Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>