### PR TITLE
arch:arm:boot:dts: emove extra eeprom nodes

### DIFF
--- a/arch/arm/boot/dts/adi-fmcomms1.dtsi
+++ b/arch/arm/boot/dts/adi-fmcomms1.dtsi
@@ -170,16 +170,5 @@
 			adi,output-power = <3>;
 			adi,mute-till-lock-enable;
 		};
-
-	};
-
-	eeprom@50 {
-		compatible = "at24,24c02";
-		reg = <0x50>;
-	};
-
-	eeprom@54 {
-		compatible = "at24,24c02";
-		reg = <0x54>;
 	};
 };

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad9136-fmc-ebz.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad9136-fmc-ebz.dts
@@ -13,11 +13,6 @@
 			compatible = "at24,24c02";
 			reg = <0x50>;
 		};
-
-		eeprom@54 {
-			compatible = "at24,24c02";
-			reg = <0x54>;
-		};
 	};
 };
 

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9008-1.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9008-1.dts
@@ -27,11 +27,6 @@
 			reg = <0x50>;
 		};
 
-		eeprom@54 {
-			compatible = "at24,24c02";
-			reg = <0x54>;
-		};
-
 		ad7291@2f {
 			compatible = "adi,ad7291";
 			reg = <0x2f>;

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9008-2.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9008-2.dts
@@ -27,11 +27,6 @@
 			reg = <0x50>;
 		};
 
-		eeprom@54 {
-			compatible = "at24,24c02";
-			reg = <0x54>;
-		};
-
 		ad7291@2f {
 			compatible = "adi,ad7291";
 			reg = <0x2f>;

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcdaq3.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcdaq3.dts
@@ -25,11 +25,6 @@
 			reg = <0x50>;
 		};
 
-		eeprom@54 {
-			compatible = "at24,24c02";
-			reg = <0x54>;
-		};
-
 		ad7291@2f {
 			compatible = "adi,ad7291";
 			reg = <0x2f>;


### PR DESCRIPTION
Remove eeproms that are not hardware available on multiple fmc boards.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>