### PR TITLE
iio: adc: ad9083: Don't ignore the EPROBE_DEFER requests

### DIFF
--- a/drivers/iio/adc/ad9083.c
+++ b/drivers/iio/adc/ad9083.c
@@ -1049,7 +1049,7 @@ static int ad9083_probe(struct spi_device *spi)
 
 	ret = ad9083_setup(conv);
 	if (ret < 0)
-		return -ENODEV;
+		return ret;
 
 	return jesd204_fsm_start(jdev, JESD204_LINKS_ALL);
 }


### PR DESCRIPTION
ad9083_request_clks() will return EPROBE_DEFER if adc_ref_clk is not
yet available. Don't treat this as an error, but ask for a probe defer.

Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>