### PR TITLE
arch: arm64: dts: stingray: Configure CLKIN priority

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-stingray.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-stingray.dts
@@ -328,3 +328,7 @@
 			"pll0-clk-rf16", "pll0-clk-rf32";
 	};
 };
+
+&hmc7044 {
+	adi,pll1-ref-prio-ctrl = <0xE1>; /* prefer CLKIN1 -> CLKIN0 -> CLKIN2 -> CLKIN3 */
+};


### PR DESCRIPTION
Set default clock priority to CLKIN1 -> CLKIN0 -> CLKIN2 -> CLKIN3. When an
external reference clock is applied on CLKIN1 this will be used as
reference for PLL1 otherwise the onboard CLKIN0 will be used.

Signed-off-by: Cristian Pop <cristian.pop@analog.com>