### PR TITLE
arch:arm:dts: emove extra eeprom nodes

### DIFF
--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmclidar1.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmclidar1.dts
@@ -20,11 +20,6 @@
 		#size-cells = <0>;
 		reg = <5>;
 
-		eeprom@50 {
-			compatible = "at24,24c02";
-			reg = <0x50>;
-		};
-
 		eeprom@54 {
 			compatible = "at24,24c02";
 			reg = <0x54>;

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcomms11-RevA.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcomms11-RevA.dts
@@ -15,11 +15,6 @@
 			reg = <0x50>;
 		};
 
-		eeprom@54 {
-			compatible = "at24,24c02";
-			reg = <0x54>;
-		};
-
 		ad7291@2f {
 			compatible = "adi,ad7291";
 			reg = <0x2f>;


### PR DESCRIPTION
Remove eeproms that are not hardware available on multiple fmc boards:
- fmclidar1
- fmcomms11-revA

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>