### PR TITLE
iio: adc: ad9081: Update API to Version 1.2.2

### DIFF
--- a/drivers/iio/adc/ad9081/adi_ad9081_config.h
+++ b/drivers/iio/adc/ad9081/adi_ad9081_config.h
@@ -40,7 +40,7 @@
 #define __FUNCTION_NAME__ __FUNCTION__
 #endif
 
-#define AD9081_API_REV 0x00010200
+#define AD9081_API_REV 0x00010202
 #define AD9081_API_HW_RESET_LOW 600000
 #define AD9081_API_RESET_WAIT 500000
 #define AD9081_PLL_LOCK_TRY 75
@@ -363,6 +363,20 @@ adi_ad9081_device_nco_sync_reset_via_sysref_set(adi_ad9081_device_t *device,
 int32_t adi_ad9081_device_nco_sync_trigger_set(adi_ad9081_device_t *device);
 
 /**
+ * \brief Enables digital logic.
+ *
+ * This includes JESD digital, digital clock gen., digital data path.
+ *
+ *
+ * \param[in]  device	         Pointer to device handler structure.
+ * \param[in]  enable            1: enable digital logic.
+ *
+ * \returns API_CMS_ERROR_OK is returned upon success. Otherwise, a failure code.
+ */
+int32_t adi_ad9081_device_digital_logic_enable_set(adi_ad9081_device_t *device,
+						   uint8_t enable);
+
+/**
  * \brief  Enable dual SPI mode
  *
  * Selecting dual0 will enable access to control registers in ranges 0x180-0x194, 0x60-0x7E, and 0x140-0x178.
@@ -395,20 +409,6 @@ int32_t adi_ad9081_dac_d2a_dual_spi_enable_set(adi_ad9081_device_t *device,
  * \returns API_CMS_ERROR_OK is returned upon success. Otherwise, a failure code.
  */
 int32_t adi_ad9081_dac_dll_startup(adi_ad9081_device_t *device, uint8_t dacs);
-
-/**
- * \brief Enables digital logic.
- *
- * This includes JESD digital, digital clock gen., digital data path.
- *
- *
- * \param[in]  device	         Pointer to device handler structure.
- * \param[in]  enable            1: enable digital logic.
- *
- * \returns API_CMS_ERROR_OK is returned upon success. Otherwise, a failure code.
- */
-int32_t adi_ad9081_dac_digital_logic_enable_set(adi_ad9081_device_t *device,
-						uint8_t enable);
 
 /**
  * \brief Sets frequency tuning word for specified DACs and channels.

--- a/drivers/iio/adc/ad9081/adi_ad9081_dac.c
+++ b/drivers/iio/adc/ad9081/adi_ad9081_dac.c
@@ -939,21 +939,6 @@ int32_t adi_ad9081_dac_spi_enable_set(adi_ad9081_device_t *device,
 	return API_CMS_ERROR_OK;
 }
 
-int32_t adi_ad9081_dac_digital_logic_enable_set(adi_ad9081_device_t *device,
-						uint8_t enable)
-{
-	int32_t err;
-	AD9081_NULL_POINTER_RETURN(device);
-	AD9081_LOG_FUNC();
-
-	/* enable digital logic, including jrx digital, digital clock gen., digital data path */
-	err = adi_ad9081_hal_bf_set(device, REG_DIG_RESET_ADDR,
-				    BF_DIG_RESET_INFO, !enable); /* not paged */
-	AD9081_ERROR_RETURN(err);
-
-	return API_CMS_ERROR_OK;
-}
-
 int32_t adi_ad9081_dac_dll_startup(adi_ad9081_device_t *device, uint8_t dacs)
 {
 	int32_t err;

--- a/drivers/iio/adc/ad9081/adi_ad9081_device.c
+++ b/drivers/iio/adc/ad9081/adi_ad9081_device.c
@@ -221,6 +221,21 @@ int32_t adi_ad9081_device_boot_post_clock(adi_ad9081_device_t *device)
 	return API_CMS_ERROR_OK;
 }
 
+int32_t adi_ad9081_device_digital_logic_enable_set(adi_ad9081_device_t *device,
+						   uint8_t enable)
+{
+	int32_t err;
+	AD9081_NULL_POINTER_RETURN(device);
+	AD9081_LOG_FUNC();
+
+	/* enable digital logic, digital clock gen., digital data path */
+	err = adi_ad9081_hal_bf_set(device, REG_DIG_RESET_ADDR,
+				    BF_DIG_RESET_INFO, !enable); /* not paged */
+	AD9081_ERROR_RETURN(err);
+
+	return API_CMS_ERROR_OK;
+}
+
 int32_t adi_ad9081_device_clk_pll_lock_status_get(adi_ad9081_device_t *device,
 						  uint8_t *status)
 {
@@ -556,8 +571,8 @@ int32_t adi_ad9081_device_clk_config_set(adi_ad9081_device_t *device,
 	err = adi_ad9081_device_boot_pre_clock(device);
 	AD9081_ERROR_RETURN(err);
 
-	/* enable dac digital logic */
-	err = adi_ad9081_dac_digital_logic_enable_set(device, 1);
+	/* enable digital logic */
+	err = adi_ad9081_device_digital_logic_enable_set(device, 1);
 	AD9081_ERROR_RETURN(err);
 
 	/* enable dac spi regs access */
@@ -841,7 +856,7 @@ int32_t adi_ad9081_device_init(adi_ad9081_device_t *device)
 				       "api v%d.%d.%d commit %s for ad%x ",
 				       (AD9081_API_REV & 0xff0000) >> 16,
 				       (AD9081_API_REV & 0xff00) >> 8,
-				       (AD9081_API_REV & 0xff), "e1ac8d2",
+				       (AD9081_API_REV & 0xff), "5b813df",
 				       AD9081_ID);
 	AD9081_ERROR_RETURN(err);
 

--- a/drivers/iio/adc/ad9081/adi_ad9081_sync.c
+++ b/drivers/iio/adc/ad9081/adi_ad9081_sync.c
@@ -92,12 +92,6 @@ int32_t adi_ad9081_jesd_oneshot_sync(adi_ad9081_device_t *device,
 	AD9081_NULL_POINTER_RETURN(device);
 	AD9081_LOG_FUNC();
 
-	if (subclass == JESD_SUBCLASS_0) {
-		adi_ad9081_jesd_tx_force_digital_reset_set(
-			device, AD9081_LINK_ALL,
-			1); /* FORCE_LINK_RESET if subclass 0 */
-	}
-
 	err = adi_ad9081_hal_bf_get(device, REG_CLK_CTRL1_ADDR, 0x00000102,
 				    &pd_fdacby4, 1); /* not paged */
 	AD9081_ERROR_RETURN(err);
@@ -108,9 +102,11 @@ int32_t adi_ad9081_jesd_oneshot_sync(adi_ad9081_device_t *device,
 				    BF_ROTATION_MODE_INFO, 1); /* not paged */
 	AD9081_ERROR_RETURN(err);
 
-	//d2a0, d2a1, anacenter
-	err = adi_ad9081_dac_d2a_dual_spi_enable_set(device, AD9081_LINK_ALL,
-						     1);
+	err = adi_ad9081_hal_bf_set(device, REG_SPI_ENABLE_DAC_ADDR,
+				    BF_SPI_EN_D2A0_INFO, 1);
+	AD9081_ERROR_RETURN(err);
+	err = adi_ad9081_hal_bf_set(device, REG_SPI_ENABLE_DAC_ADDR,
+				    BF_SPI_EN_D2A1_INFO, 1);
 	AD9081_ERROR_RETURN(err);
 	err = adi_ad9081_hal_bf_set(device, REG_SPI_ENABLE_DAC_ADDR,
 				    BF_SPI_EN_ANACENTER_INFO, 1);
@@ -157,17 +153,13 @@ int32_t adi_ad9081_jesd_oneshot_sync(adi_ad9081_device_t *device,
 					    0); /* not paged */
 		AD9081_ERROR_RETURN(err);
 	}
+
 	err = adi_ad9081_hal_bf_set(device, REG_CLK_CTRL1_ADDR, 0x00000102,
 				    pd_fdacby4); /* not paged */
 	AD9081_ERROR_RETURN(err);
 
-	if (subclass == JESD_SUBCLASS_0) {
-		adi_ad9081_jesd_tx_force_digital_reset_set(
-			device, AD9081_LINK_ALL,
-			0); /* FORCE_LINK_RESET if subclass 0 */
-		if (sync_done != 1) {
-			return API_CMS_ERROR_JESD_SYNC_NOT_DONE;
-		}
+	if (sync_done != 1) {
+		return API_CMS_ERROR_JESD_SYNC_NOT_DONE;
 	}
 
 	return API_CMS_ERROR_OK;


### PR DESCRIPTION
 - Fix Oneshot sync may cause JTX links to fail in certain use cases.
 - Fix adi_adxxxx_dac_digital_logic_enable_set needed for all devices,
   not just those containing DAC side implementation.

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>