### PR TITLE
Fix ADIN1110 T1L driver, properly set MAC addr.

### DIFF
--- a/drivers/net/ethernet/adi/adin1110.c
+++ b/drivers/net/ethernet/adi/adin1110.c
@@ -573,7 +573,7 @@ static int adin1110_set_mac_address(struct net_device *netdev, void *addr)
 	if (!is_valid_ether_addr(sa->sa_data))
 		return -EADDRNOTAVAIL;
 
-	ether_addr_copy(netdev->dev_addr, addr);
+	ether_addr_copy(netdev->dev_addr, sa->sa_data);
 	memset(mask, 0xFF, ETH_ALEN);
 
 	return adin1110_write_mac_address(priv, 0, netdev->dev_addr, mask);


### PR DESCRIPTION
It was not possible to set the MAC address of the ADIN1110 via ioctl
SIOCSIFHWADDR (ndo_set_mac_address) and the Linux ip utility.

Setting the MAC address via command 'ip link set addr' would set an unusable
invalid address. Providing a MAC of 'xx:yy:zz:aa:bb:cc' would result in
'1:0:xx:yy:zz:aa' being set, which is rejected when trying to bring the
interface up.

* Use correct address pointer of struct sockaddr in call to ether_addr_copy