### PR TITLE
iio: adc: cf_axi_adc_core: Fix NULL pointer dereference in axiadc_rea…

### DIFF
--- a/drivers/iio/adc/cf_axi_adc_core.c
+++ b/drivers/iio/adc/cf_axi_adc_core.c
@@ -577,7 +577,7 @@ static int axiadc_read_raw(struct iio_dev *indio_dev,
 			llval = llval >> 16;
 		}
 
-		if (!strcmp(chan->extend_name, "user_logic")) {
+		if (chan->extend_name && !strcmp(chan->extend_name, "user_logic")) {
 			tmp = axiadc_read(st,
 				ADI_REG_CHAN_USR_CNTRL_2(channel));
 


### PR DESCRIPTION
…d_raw

Make sure extend_name exist before accessing it.

Fixes: dced6c9ccd31( "iio: adc: cf_axi_adc_core: Support for 64-bit")

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>