### PR TITLE
arch:arm:boot:dts:adrv9002 update TX DMA interrupt

### DIFF
--- a/arch/arm/boot/dts/zynq-adrv9002-rx2tx2.dtsi
+++ b/arch/arm/boot/dts/zynq-adrv9002-rx2tx2.dtsi
@@ -28,7 +28,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x44A50000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 55 IRQ_TYPE_LEVEL_HIGH>;
+		interrupts = <0 53 IRQ_TYPE_LEVEL_HIGH>;
 		clock-names = "s_axi_aclk", "m_src_axi_aclk", "m_axis_aclk";
 		clocks = <&clkc 15>, <&clkc 16>, <&misc_clk_0>;
 

--- a/arch/arm/boot/dts/zynq-adrv9002.dtsi
+++ b/arch/arm/boot/dts/zynq-adrv9002.dtsi
@@ -50,7 +50,7 @@
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x44A50000 0x10000>;
 		#dma-cells = <1>;
-		interrupts = <0 55 IRQ_TYPE_LEVEL_HIGH>;
+		interrupts = <0 53 IRQ_TYPE_LEVEL_HIGH>;
 		clock-names = "s_axi_aclk", "m_src_axi_aclk", "m_axis_aclk";
 		clocks = <&clkc 15>, <&clkc 16>, <&misc_clk_0>;
 


### PR DESCRIPTION
Update TX DMA interrupt number to avoid having the same on as the FMC I2C
interrupt. New ID is according to HDL update.

Signed-off-by: Andrei Drimbarean <andrei.drimbarean@analog.com>

This PR should be passed after [corresponding HDL update](https://github.com/analogdevicesinc/hdl/pull/876) is merged.