### PR TITLE
arch: arm64: dts: stingray: Add ZUD1A-BREAKOUT eval board EEPROM

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-stingray.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-stingray.dts
@@ -332,3 +332,19 @@
 &hmc7044 {
 	adi,pll1-ref-prio-ctrl = <0xE1>; /* prefer CLKIN1 -> CLKIN0 -> CLKIN2 -> CLKIN3 */
 };
+
+&i2c1 {
+	i2c-mux@75 {
+		i2c@1 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <1>;
+			/* HPC1_IIC */
+			eeprom@50 {
+				compatible = "at24,24c02";
+				reg = <0x50>;
+			};
+
+		};
+	};
+};


### PR DESCRIPTION
This is useful for EEPROM programming and VADJ enable, using fru-dump tool.

Signed-off-by: Cristian Pop <cristian.pop@analog.com>