### PR TITLE
iio: adc: ad9371: Additional calibrations for LO change procedure

### DIFF
--- a/drivers/iio/adc/ad9371.h
+++ b/drivers/iio/adc/ad9371.h
@@ -231,6 +231,7 @@ struct ad9371_rf_phy {
 	u32			cal_mask;
 	u32			rf_bandwith[3];
 	bool			is_initialized;
+	bool			large_freq_step_cal_en;
 };
 
 int ad9371_hdl_loopback(struct ad9371_rf_phy *phy, bool enable);


### PR DESCRIPTION
This adds additional required calibrations in addition to
RX_QEC and TX_QEC, which are required for large frequency step
procedure as detailed in UG-992.

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>