### PR TITLE
drivers: uio_dmem_genirq: Fix NULL pointer dereference

### DIFF
--- a/drivers/uio/uio_dmem_genirq.c
+++ b/drivers/uio/uio_dmem_genirq.c
@@ -164,7 +164,7 @@ static int uio_dmem_genirq_probe(struct platform_device *pdev)
 					       pdev->dev.of_node);
 		uioinfo->version = "devicetree";
 		/* alloc pdata */
-		pdata = kzalloc(sizeof(pdata), GFP_KERNEL);
+		pdata = kzalloc(sizeof(*pdata), GFP_KERNEL);
 		if (!pdata) {
 			ret = -ENOMEM;
 			dev_err(&pdev->dev, "unable to kmalloc\n");


### PR DESCRIPTION
The issue was reported on: https://github.com/analogdevicesinc/linux/issues/1837

Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>