### PR TITLE
CI: change artifacts structure

### DIFF
--- a/azure-pipelines-rpi.yml
+++ b/azure-pipelines-rpi.yml
@@ -49,6 +49,10 @@ stages:
       clean: true
     - script: ./ci/travis/run-build-docker.sh
       displayName: "Build test for '$(DEFCONFIG)'"
+    - script: |
+        cd $(Build.ArtifactStagingDirectory)
+        tar -C /home/vsts/work/1/s/modules/lib/modules -cvf /home/vsts/work/1/a/rpi_modules.tar.gz *
+      displayName: 'Copy modules'
     - task: CopyFiles@2
       inputs:
         sourceFolder: '$(Agent.BuildDirectory)/s/arch/arm/boot/dts/overlays'
@@ -76,7 +80,7 @@ stages:
     KEY_FILE: $(key.secureFilePath)
   jobs:
   - job: Push_to_SWDownloads
-    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/rpi-5.10.y'))
+    #condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/rpi-5.10.y'))
     pool:
       vmImage: 'ubuntu-latest'
     steps:
@@ -95,7 +99,7 @@ stages:
           DEST_SERVER: $(SERVER_ADDRESS)
         displayName: "Push to SWDownloads"
   - job: Push_to_Artifactory
-    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/rpi-5.10.y'))
+    #condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/rpi-5.10.y'))
     pool:
       name: Default
       demands:

--- a/ci/travis/prepare_artifacts.sh
+++ b/ci/travis/prepare_artifacts.sh
@@ -11,40 +11,63 @@ artifacts_structure() {
 
 	GIT_SHA=$(git rev-parse --short HEAD)
 	GIT_SHA_DATE=$(git show -s --format="%ci" ${GIT_SHA} | sed -e "s/ \|\:/-/g")
-	echo "git_sha=${GIT_SHA}" >> ${timestamp}/properties.txt
-	echo "git_sha_date=${GIT_SHA_DATE}" >> ${timestamp}/properties.txt
+	echo "git_sha=${GIT_SHA}" >> ${timestamp}/rpi_git_properties.txt
+	echo "git_sha_date=${GIT_SHA_DATE}" >> ${timestamp}/rpi_git_properties.txt
 
 	for bcm in $bcm_types; do
 		cd adi_${bcm}_defconfig
 		mkdir overlays
 		mv ./*.dtbo ./overlays
 		if [ "${bcm}" = "bcm2709" ]; then
+			mv rpi_modules.tar.gz rpi_modules_kernel7.tar.gz
 			mv ./zImage ./kernel7.img
 		elif [ "${bcm}" = "bcm2711" ]; then
+			mv rpi_modules.tar.gz rpi_modules_kernel7l.tar.gz
 			mv ./zImage ./kernel7l.img
 		elif [ "${bcm}" = "bcmrpi" ]; then
+			mv rpi_modules.tar.gz rpi_modules_kernel.tar.gz
 			mv ./zImage ./kernel.img
 		fi
 		cd ../
-		mv ./adi_${bcm}_defconfig ./${timestamp}/adi_${bcm}_defconfig
+		cp -r ./adi_${bcm}_defconfig/* ./${timestamp}
 	done
 }
 
 #upload artifacts to Artifactory
 artifacts_artifactory() {
 	cd ${SOURCE_DIRECTORY}
-	python /root/myagent/_work/1/s/ci/travis/upload_to_artifactory.py --base_path="${ARTIFACTORY_PATH}" --server_path="linux_rpi/${BUILD_SOURCEBRANCHNAME}" --local_path="./${timestamp}" --token="${ARTIFACTORY_TOKEN}"
+	python /root/myagent/_work/1/s/ci/travis/upload_to_artifactory.py --base_path="${ARTIFACTORY_PATH}" \
+		--server_path="linux_rpi/${BUILD_SOURCEBRANCHNAME}" --local_path="./${timestamp}" --token="${ARTIFACTORY_TOKEN}"
 }
 
 #archive artifacts and upload to SWDownloads
 artifacts_swdownloads() {
 	cd ${SOURCE_DIRECTORY}/${timestamp}
 	chmod 600 ${KEY_FILE}
-	for bcm in $bcm_types; do
-		tar -zcvf adi_${bcm}_defconfig.tar adi_${bcm}_defconfig
-		scp -2 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o HostKeyAlgorithms=+ssh-dss \
-		    -i ${KEY_FILE} -r ${SOURCE_DIRECTORY}/${timestamp}/adi_${bcm}_defconfig.tar ${DEST_SERVER}
-	done
+	scp -2 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o HostKeyAlgorithms=+ssh-dss \
+		-i ${KEY_FILE} -r *.tar.gz ${DEST_SERVER}
+	md5_modules_kernel7=($(md5sum rpi_modules_kernel7.tar.gz| cut -d ' ' -f 1))
+	md5_modules_kernel7l=($(md5sum rpi_modules_kernel7l.tar.gz| cut -d ' ' -f 1))
+	md5_modules_kernel=($(md5sum rpi_modules_kernel.tar.gz| cut -d ' ' -f 1))
+
+	rm rpi_modules_kernel7.tar.gz rpi_modules_kernel7l.tar.gz rpi_modules_kernel.tar.gz rpi_git_properties.txt
+	tar -C ${PWD} -cvf rpi_latest_boot.tar.gz *
+	md5_boot=($(md5sum rpi_latest_boot.tar.gz| cut -d ' ' -f 1))
+	scp -2 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o HostKeyAlgorithms=+ssh-dss \
+	    -i ${KEY_FILE} -r rpi_latest_boot.tar.gz ${DEST_SERVER}
+
+	echo "boot_date=${timestamp}" >> rpi_archives_properties.txt
+	echo "https://swdownloads.analog.com/cse/linux_rpi/${BUILD_SOURCEBRANCHNAME}/rpi_modules_kernel7.tar.gz" >> rpi_archives_properties.txt
+	echo "https://swdownloads.analog.com/cse/linux_rpi/${BUILD_SOURCEBRANCHNAME}/rpi_modules_kernel7l.tar.gz" >> rpi_archives_properties.txt
+	echo "https://swdownloads.analog.com/cse/linux_rpi/${BUILD_SOURCEBRANCHNAME}/rpi_modules_kernel.tar.gz" >> rpi_archives_properties.txt
+	echo "https://swdownloads.analog.com/cse/linux_rpi/${BUILD_SOURCEBRANCHNAME}/latest_rpi_boot.tar.gz" >> rpi_archives_properties.txt
+	echo "checksum_modules_kernel7=${md5_modules_kernel7}" >> rpi_archives_properties.txt
+	echo "checksum_modules_kernel7l=${md5_modules_kernel7l}" >> rpi_archives_properties.txt
+	echo "checksum_modules_kernel=${md5_modules_kernel}" >> rpi_archives_properties.txt
+	echo "checksum_boot_files=${md5_boot}" >> rpi_archives_properties.txt
+
+	scp -2 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o HostKeyAlgorithms=+ssh-dss \
+                -i ${KEY_FILE} -r rpi_archives_properties.txt ${DEST_SERVER}
 }
 
 artifacts_${1}

--- a/ci/travis/run-build.sh
+++ b/ci/travis/run-build.sh
@@ -56,7 +56,7 @@ adjust_kcflags_against_gcc() {
 	export KCFLAGS
 }
 
-APT_LIST="make bc u-boot-tools flex bison libssl-dev"
+APT_LIST="make tar bc u-boot-tools flex bison kmod libssl-dev"
 
 if [ "$ARCH" = "arm64" ] ; then
 	if [ -z "$CROSS_COMPILE" ] ; then
@@ -190,7 +190,13 @@ build_default() {
 
 	apt_update_install $APT_LIST
 	make ${DEFCONFIG}
-	make -j$NUM_JOBS $IMAGE UIMAGE_LOADADDR=0x8000
+	if [[ "${BUILD_SOURCEBRANCHNAME}" == *"rpi-5.10.y"* || "${BUILD_SOURCEBRANCHNAME}" == *"staging-rpi"* ]]; then
+    	make -j$NUM_JOBS zImage modules dtbs
+		make INSTALL_MOD_PATH="${PWD}/modules" modules_install
+	else
+    	# normal build
+    	make -j$NUM_JOBS $IMAGE UIMAGE_LOADADDR=0x8000
+	fi
 
 	if [ "$CHECK_ALL_ADI_DRIVERS_HAVE_BEEN_BUILT" = "1" ] ; then
 		check_all_adi_files_have_been_built


### PR DESCRIPTION
The structure of artifacts deployed on Artifactory and SWDownloads was changed in order to not duplicate the files.
Was deployed rpi_modules.tar.gz containing modules files from rpi builds.

Signed-off-by: Raluca Chis <raluca.chis@analog.com>