### PR TITLE
ci improve sync_branches_with_main handling

### DIFF
--- a/ci/travis/run-build.sh
+++ b/ci/travis/run-build.sh
@@ -224,6 +224,9 @@ build_checkpatch() {
 		exit 1
 	fi
 
+	# install checkpatch dependencies
+	sudo pip install ply
+
 	__update_git_ref "${ref_branch}" "${ref_branch}"
 
 	scripts/checkpatch.pl --git "${ref_branch}.." \


### PR DESCRIPTION
The main purpose of this PR is to improve how these branches are automatically synced. More details are described on the  commit message.

The last patch is for installing checkpatch dependencies so that we stop seeing the annoying `ModuleNotFoundError: No module named 'ply'` warning in the job. 