### PR TITLE
arch: arm: dts: overlays: add rpi-cn0552

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -207,6 +207,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	rpi-cn0504.dtbo \
 	rpi-cn0508.dtbo \
 	rpi-cn0511.dtbo \
+	rpi-cn0552.dtbo \
 	rpi-dac.dtbo \
 	rpi-dc1962c.dtbo \
 	rpi-display.dtbo \

--- a/arch/arm/boot/dts/overlays/rpi-cn0552-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-cn0552-overlay.dts
@@ -1,0 +1,19 @@
+/dts-v1/;
+/plugin/;
+/ {
+	compatible = "brcm,bcm2708";
+	
+	fragment@0 {
+		target = <&i2c_arm>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			
+			status = "okay";
+			adc: ad7746@48 {
+				compatible = "adi,ad7746";
+				reg = <0x48>;
+			};
+		};
+	};
+};


### PR DESCRIPTION
The EVAL-CN0552-PMDZ is a dual input channel capacitance-to-digital Converter (CDC) with an extended input range capability used in a wide array of industrial applications such as liquid level monitoring, position and humidity sensing, and many more.

The device features AD7746 and AD8515.

Signed-off by: Zuedmar Arceo zuedmar.arceo@analog.com