### PR TITLE
arch:arm:dts: zc706 related fixes

### DIFF
--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad6676-fmc.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad6676-fmc.dts
@@ -85,16 +85,6 @@
 			reg = <0x50>;
 		};
 	};
-
-	i2c@6 { /* LPC IIC */
-		#address-cells = <1>;
-		#size-cells = <0>;
-		reg = <6>;
-		eeprom@50 {
-			compatible = "at24,24c02";
-			reg = <0x50>;
-		};
-	};
 };
 
 &fpga_axi {

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad9625-fmcadc2.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad9625-fmcadc2.dts
@@ -59,16 +59,6 @@
 			reg = <0x50>;
 		};
 	};
-
-	i2c@6 { /* LPC IIC */
-		#address-cells = <1>;
-		#size-cells = <0>;
-		reg = <6>;
-		eeprom@50 {
-			compatible = "at24,24c02";
-			reg = <0x50>;
-		};
-	};
 };
 
 &fpga_axi {

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmclidar1.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmclidar1.dts
@@ -20,9 +20,9 @@
 		#size-cells = <0>;
 		reg = <5>;
 
-		eeprom@54 {
+		eeprom@50 {
 			compatible = "at24,24c02";
-			reg = <0x54>;
+			reg = <0x50>;
 		};
 	};
 };


### PR DESCRIPTION
- arch:arm:dts:fmcadc2: remove extra i2c node
- arch:arm:dts:ad6676: remove extra i2c node
- arch:arm:dts:fmclidar1: update slave address

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>
