### PR TITLE
iio: adc: ad9361: Export pl_intf_clk reflecing interface PL clock rate

### DIFF
--- a/drivers/iio/adc/ad9361.c
+++ b/drivers/iio/adc/ad9361.c
@@ -5740,7 +5740,10 @@ static inline int ad9361_set_muldiv(struct refclk_scale *priv, u32 mul, u32 div)
 static int ad9361_get_clk_scaler(struct clk_hw *hw)
 {
 	struct refclk_scale *clk_priv = to_clk_priv(hw);
+	struct ad9361_rf_phy *phy = clk_priv->phy;
+	struct ad9361_phy_platform_data *pd = phy->pdata;
 	struct spi_device *spi = clk_priv->spi;
+	const bool lvds_mode = pd->port_ctrl.pp_conf[2] & LVDS_MODE;
 	u32 tmp, tmp1;
 
 	switch (clk_priv->source) {
@@ -5805,6 +5808,8 @@ static int ad9361_get_clk_scaler(struct clk_hw *hw)
 			tmp = (1 << (tmp - 1));
 
 		return ad9361_set_muldiv(clk_priv, 1, tmp);
+	case PL_INTF_CLK:
+		return ad9361_set_muldiv(clk_priv, (ad9361_uses_rx2tx2(phy) + 1) << lvds_mode, 1);
 	default:
 		return -EINVAL;
 	}
@@ -5973,6 +5978,8 @@ static int ad9361_set_clk_scaler(struct clk_hw *hw, bool set)
 			return ad9361_spi_writef(spi, REG_TX_ENABLE_FILTER_CTRL,
 					TX_FIR_ENABLE_INTERPOLATION(~0), tmp);
 		break;
+	case PL_INTF_CLK:
+		break;
 	default:
 		return -EINVAL;
 	}
@@ -6046,6 +6053,11 @@ static int ad9361_clk_factor_set_rate(struct clk_hw *hw, unsigned long rate,
 static const struct clk_ops refclk_scale_ops = {
 	.round_rate = ad9361_clk_factor_round_rate,
 	.set_rate = ad9361_clk_factor_set_rate,
+	.recalc_rate = ad9361_clk_factor_recalc_rate,
+};
+
+static const struct clk_ops pl_intf_clk_ops = {
+	.round_rate = ad9361_clk_factor_round_rate,
 	.recalc_rate = ad9361_clk_factor_recalc_rate,
 };
 
@@ -6570,6 +6582,9 @@ static int ad9361_clk_register(struct ad9361_rf_phy *phy,
 	case TX_RFPLL:
 		init.ops = &rfpll_clk_ops;
 		break;
+	case PL_INTF_CLK:
+		init.ops = &pl_intf_clk_ops;
+		break;
 	default:
 		init.ops = &refclk_scale_ops;
 	}
@@ -6685,6 +6700,9 @@ static int register_clocks(struct ad9361_rf_phy *phy)
 
 	ad9361_clk_register(phy, "-tx_sampl_clk", "-clktf_clk", NULL,
 		flags | CLK_IGNORE_UNUSED, TX_SAMPL_CLK);
+
+	ad9361_clk_register(phy, "-pl_intf_clk", "-tx_sampl_clk", NULL,
+		flags | CLK_IGNORE_UNUSED, PL_INTF_CLK);
 
 	ad9361_clk_register(phy, "-rx_rfpll_int", "-rx_refclk", NULL,
 		flags | CLK_IGNORE_UNUSED, RX_RFPLL_INT);

--- a/drivers/iio/adc/ad9361.h
+++ b/drivers/iio/adc/ad9361.h
@@ -32,6 +32,7 @@ enum ad9361_clocks {
 	TX_RFPLL_DUMMY,
 	RX_RFPLL,
 	TX_RFPLL,
+	PL_INTF_CLK,
 	NUM_AD9361_CLKS,
 };
 


### PR DESCRIPTION
This commit adds a new clock to the clock tree that reflects the actual
receive clock rate. For 1RX1TX configurations this simply mirrors the
sample clock, while for 2RX2TX configs the receive clock is twice as
fast as the sample clock, because two channels are served using the same
data width.

This patch is something that came up in the discussion around Phaser, where we needed a clock tree entry that properly reflects the current ADC clock. I'm also still open to changing the nomenclature here, specifically because it's not just a PL interface clock, that's only the function that was important to me.

Note that this is the first time that i'm messing with the clock framework, so I'd love for somebody with more experience to make sure that i haven't done anything stupid ;)