### PR TITLE
arch: arm: dts: overlays: add rpi-adxl367

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -196,6 +196,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	rpi-adgs1408.dtbo \
 	rpi-adxl345.dtbo \
 	rpi-adxl355.dtbo \
+	rpi-adxl367.dtbo \
 	rpi-adxl372.dtbo \
 	rpi-adxl375.dtbo \
 	rpi-adxrs290.dtbo \

--- a/arch/arm/boot/dts/overlays/rpi-adxl367-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-adxl367-overlay.dts
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-2.0
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+
+/ {
+	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709", "brcm,bcm2711";
+
+	fragment@0 {
+		target = <&spi0>;
+
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			cs-gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			status = "okay";
+
+			adxl367@0 {
+				compatible = "adi,adxl367";
+				reg = <0>;
+				spi-max-frequency = <1000000>;
+				interrupts = <26 IRQ_TYPE_EDGE_RISING>;
+				interrupt-parent = <&gpio>;
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&spidev0>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@2 {
+		target = <&spidev1>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+};


### PR DESCRIPTION
The ADXL367 is an ultralow power, 3-axis MEMS accelerometer.

The ADXL367 does not alias input signals to achieve ultralow power
consumption, it samples the full bandwidth of the sensor at all
data rates. Measurement ranges of +-2g, +-4g, and +-8g are available,
with a resolution of 0.25mg/LSB on the +-2 g range.

In addition to its ultralow power consumption, the ADXL367
has many features to enable true system level power reduction.
It includes a deep multimode output FIFO, a built-in micropower
temperature sensor, and an internal ADC for synchronous conversion
of an additional analog input.

Signed-off-by: Cosmin Tanislav <cosmin.tanislav@analog.com>