### PR TITLE
drivers: pwm

### DIFF
--- a/Documentation/ABI/testing/sysfs-class-pwm
+++ b/Documentation/ABI/testing/sysfs-class-pwm
@@ -86,3 +86,10 @@ Description:
 		Capture information about a PWM signal. The output format is a
 		pair unsigned integers (period and duty cycle), separated by a
 		single space.
+
+What:		/sys/class/pwm/pwmchipN/pwmX/phase
+Date:		Apr 2022
+KernelVersion:	5.10
+Contact:	Sergiu Cuciurean <sergiu.cuciurean@analog.com>
+Description:
+		Sets the PWM signal phase in nanoseconds.

--- a/Documentation/ABI/testing/sysfs-class-pwm
+++ b/Documentation/ABI/testing/sysfs-class-pwm
@@ -93,3 +93,10 @@ KernelVersion:	5.10
 Contact:	Sergiu Cuciurean <sergiu.cuciurean@analog.com>
 Description:
 		Sets the PWM signal phase in nanoseconds.
+
+What:		/sys/class/pwm/pwmchipN/pwmX/time_unit
+Date:		Apr 2022
+KernelVersion:	5.10
+Contact:	Sergiu Cuciurean <sergiu.cuciurean@analog.com>
+Description:
+		Sets the PWM signal period, duty_cycle and phase time unit.

--- a/Documentation/driver-api/pwm.rst
+++ b/Documentation/driver-api/pwm.rst
@@ -46,8 +46,8 @@ After being requested, a PWM has to be configured using::
 
 	int pwm_apply_state(struct pwm_device *pwm, struct pwm_state *state);
 
-This API controls both the PWM period/duty_cycle config and the
-enable/disable state.
+This API controls the PWM period, duty_cycle and phase config together with
+the enable/disable state.
 
 The pwm_config(), pwm_enable() and pwm_disable() functions are just wrappers
 around pwm_apply_state() and should not be used if the user wants to change
@@ -101,6 +101,10 @@ channel that was exported. The following properties will then be available:
   duty_cycle
     The active time of the PWM signal (read/write).
     Value is in nanoseconds and must be less than the period.
+
+  phase
+    The phase difference between the actual PWM signal and the reference one.
+    The value is expressed in nanoseconds and must be lower than period.
 
   polarity
     Changes the polarity of the PWM signal (read/write).

--- a/Documentation/driver-api/pwm.rst
+++ b/Documentation/driver-api/pwm.rst
@@ -95,22 +95,30 @@ channel that was exported. The following properties will then be available:
 
   period
     The total period of the PWM signal (read/write).
-    Value is in nanoseconds and is the sum of the active and inactive
-    time of the PWM.
+    Value the sum of the active and inactive time of the PWM.
 
   duty_cycle
     The active time of the PWM signal (read/write).
-    Value is in nanoseconds and must be less than the period.
+    Value must be less than the period.
 
   phase
     The phase difference between the actual PWM signal and the reference one.
-    The value is expressed in nanoseconds and must be lower than period.
+    The value must be lower than period.
 
   polarity
     Changes the polarity of the PWM signal (read/write).
     Writes to this property only work if the PWM chip supports changing
     the polarity. The polarity can only be changed if the PWM is not
     enabled. Value is the string "normal" or "inversed".
+
+  time_unit
+    The time unit used to measure the pwm period, duty_cycle and phase.
+
+  - 1 - seconds
+  - 2 - miliseconds
+  - 3 - microseconds
+  - 4 - nanoseconds
+  - 5 - picoseconds
 
   enable
     Enable/disable the PWM signal (read/write).

--- a/drivers/pwm/core.c
+++ b/drivers/pwm/core.c
@@ -584,7 +584,7 @@ int pwm_apply_state(struct pwm_device *pwm, const struct pwm_state *state)
 	if (state->period == pwm->state.period &&
 	    state->duty_cycle == pwm->state.duty_cycle &&
 	    state->polarity == pwm->state.polarity &&
-	    state->offset == pwm->state.offset &&
+	    state->phase == pwm->state.phase &&
 	    state->enabled == pwm->state.enabled)
 		return 0;
 

--- a/drivers/pwm/core.c
+++ b/drivers/pwm/core.c
@@ -585,7 +585,8 @@ int pwm_apply_state(struct pwm_device *pwm, const struct pwm_state *state)
 	    state->duty_cycle == pwm->state.duty_cycle &&
 	    state->polarity == pwm->state.polarity &&
 	    state->phase == pwm->state.phase &&
-	    state->enabled == pwm->state.enabled)
+	    state->enabled == pwm->state.enabled &&
+	    state->time_unit == pwm->state.time_unit)
 		return 0;
 
 	if (chip->ops->apply) {
@@ -712,6 +713,7 @@ int pwm_adjust_config(struct pwm_device *pwm)
 		state.duty_cycle = 0;
 		state.period = pargs.period;
 		state.polarity = pargs.polarity;
+		state.time_unit = pargs.time_unit;
 
 		return pwm_apply_state(pwm, &state);
 	}
@@ -1267,6 +1269,15 @@ void devm_pwm_put(struct device *dev, struct pwm_device *pwm)
 EXPORT_SYMBOL_GPL(devm_pwm_put);
 
 #ifdef CONFIG_DEBUG_FS
+
+const char *pwm_time_unit_strings[] = {
+	[PWM_UNIT_SEC] = "s",
+	[PWM_UNIT_MSEC] = "ms",
+	[PWM_UNIT_USEC] = "us",
+	[PWM_UNIT_NSEC] = "ns",
+	[PWM_UNIT_PSEC] = "ps",
+};
+
 static void pwm_dbg_show(struct pwm_chip *chip, struct seq_file *s)
 {
 	unsigned int i;
@@ -1276,6 +1287,8 @@ static void pwm_dbg_show(struct pwm_chip *chip, struct seq_file *s)
 		struct pwm_state state;
 
 		pwm_get_state(pwm, &state);
+		if (!state.time_unit)
+			state.time_unit = PWM_UNIT_NSEC;
 
 		seq_printf(s, " pwm-%-3d (%-20.20s):", i, pwm->label);
 
@@ -1285,9 +1298,12 @@ static void pwm_dbg_show(struct pwm_chip *chip, struct seq_file *s)
 		if (state.enabled)
 			seq_puts(s, " enabled");
 
-		seq_printf(s, " period: %llu ns", state.period);
-		seq_printf(s, " duty: %llu ns", state.duty_cycle);
-		seq_printf(s, " phase: %llu ns", state.phase);
+		seq_printf(s, " period: %llu %s", state.period,
+			   pwm_time_unit_strings[state.time_unit]);
+		seq_printf(s, " duty: %llu %s", state.duty_cycle,
+			   pwm_time_unit_strings[state.time_unit]);
+		seq_printf(s, " phase: %llu %s", state.phase,
+			   pwm_time_unit_strings[state.time_unit]);
 		seq_printf(s, " polarity: %s",
 			   state.polarity ? "inverse" : "normal");
 

--- a/drivers/pwm/core.c
+++ b/drivers/pwm/core.c
@@ -1287,6 +1287,7 @@ static void pwm_dbg_show(struct pwm_chip *chip, struct seq_file *s)
 
 		seq_printf(s, " period: %llu ns", state.period);
 		seq_printf(s, " duty: %llu ns", state.duty_cycle);
+		seq_printf(s, " phase: %llu ns", state.phase);
 		seq_printf(s, " polarity: %s",
 			   state.polarity ? "inverse" : "normal");
 

--- a/drivers/pwm/pwm-axi-pwmgen.c
+++ b/drivers/pwm/pwm-axi-pwmgen.c
@@ -110,6 +110,52 @@ static int axi_pwmgen_apply(struct pwm_chip *chip, struct pwm_device *device,
 	return 0;
 }
 
+static int axi_pwmgen_capture(struct pwm_chip *chip, struct pwm_device *device,
+			      struct pwm_capture *capture,
+			      unsigned long timeout)
+{
+	struct axi_pwmgen *pwmgen = to_axi_pwmgen(chip);
+	unsigned long long rate, cnt, clk_period_ps;
+	unsigned int ch = device->hwpwm;
+
+	(void)(timeout);
+
+	rate = clk_get_rate(pwmgen->clk);
+	clk_period_ps = DIV_ROUND_CLOSEST_ULL(AXI_PWMGEN_PSEC_PER_SEC, rate);
+	cnt = axi_pwmgen_read(pwmgen, AXI_PWMGEN_CHX_PERIOD(ch));
+	cnt *= clk_period_ps;
+	capture->period = cnt ? DIV_ROUND_CLOSEST_ULL(cnt,
+				axi_pwmgen_scales[device->state.time_unit]) : 0;
+	cnt = axi_pwmgen_read(pwmgen, AXI_PWMGEN_CHX_DUTY(ch));
+	cnt *= clk_period_ps;
+	capture->duty_cycle = cnt ? DIV_ROUND_CLOSEST_ULL(cnt,
+				axi_pwmgen_scales[device->state.time_unit]) : 0;
+	cnt = axi_pwmgen_read(pwmgen, AXI_PWMGEN_CHX_PHASE(ch));
+	cnt *= clk_period_ps;
+	capture->phase = cnt ? DIV_ROUND_CLOSEST_ULL(cnt,
+				axi_pwmgen_scales[device->state.time_unit]) : 0;
+	capture->time_unit = device->state.time_unit;
+
+	return 0;
+}
+
+static void axi_pwmgen_get_state(struct pwm_chip *chip, struct pwm_device *pwm,
+				 struct pwm_state *state)
+{
+	struct pwm_capture capture;
+	int ret;
+	
+	ret = axi_pwmgen_capture(chip, pwm, &capture, 0);
+	if (ret < 0)
+		return;
+
+	state->enabled = state;
+	state->period = capture.period;
+	state->duty_cycle = capture.duty_cycle;
+	state->phase = capture.phase;
+	state->time_unit = capture.time_unit;
+}
+
 static void axi_pwmgen_disable(struct pwm_chip *chip, struct pwm_device *pwm)
 {
 	unsigned int ch = pwm->hwpwm;
@@ -134,6 +180,8 @@ static const struct pwm_ops axi_pwmgen_pwm_ops = {
 	.apply = axi_pwmgen_apply,
 	.disable = axi_pwmgen_disable,
 	.enable = axi_pwmgen_enable,
+	.capture = axi_pwmgen_capture,
+	.get_state = axi_pwmgen_get_state,
 	.owner = THIS_MODULE,
 };
 

--- a/drivers/pwm/sysfs.c
+++ b/drivers/pwm/sysfs.c
@@ -212,7 +212,7 @@ static ssize_t capture_show(struct device *child,
 	if (ret)
 		return ret;
 
-	return sprintf(buf, "%u %u\n", result.period, result.duty_cycle);
+	return sprintf(buf, "%llu %llu\n", result.period, result.duty_cycle);
 }
 
 static DEVICE_ATTR_RW(period);

--- a/drivers/pwm/sysfs.c
+++ b/drivers/pwm/sysfs.c
@@ -235,6 +235,69 @@ static ssize_t polarity_store(struct device *child,
 	return ret ? : size;
 }
 
+static ssize_t time_unit_show(struct device *child,
+			      struct device_attribute *attr,
+			      char *buf)
+{
+	const struct pwm_device *pwm = child_to_pwm_device(child);
+	const char *unit = "unknown";
+	struct pwm_state state;
+
+	pwm_get_state(pwm, &state);
+
+	switch (state.time_unit) {
+	case PWM_UNIT_SEC:
+		unit = "second";
+		break;
+	case PWM_UNIT_MSEC:
+		unit = "milisecond";
+		break;
+	case PWM_UNIT_USEC:
+		unit = "microsecond";
+		break;
+	case PWM_UNIT_NSEC:
+		unit = "nanosecond";
+		break;
+	case PWM_UNIT_PSEC:
+		unit = "picosecond";
+		break;
+	}
+
+	return sprintf(buf, "%s\n", unit);
+}
+
+static ssize_t time_unit_store(struct device *child,
+			       struct device_attribute *attr,
+			       const char *buf, size_t size)
+{
+	struct pwm_export *export = child_to_pwm_export(child);
+	struct pwm_device *pwm = export->pwm;
+	enum pwm_time_unit unit;
+	struct pwm_state state;
+	int ret;
+
+	if (sysfs_streq(buf, "second"))
+		unit = PWM_UNIT_SEC;
+	else if (sysfs_streq(buf, "milisecond"))
+		unit = PWM_UNIT_MSEC;
+	else if (sysfs_streq(buf, "microsecond"))
+		unit = PWM_UNIT_USEC;
+	else if (sysfs_streq(buf, "nanosecond"))
+		unit = PWM_UNIT_NSEC;
+	else if (sysfs_streq(buf, "picosecond"))
+		unit = PWM_UNIT_PSEC;
+	else
+		return -EINVAL;
+
+	mutex_lock(&export->lock);
+	pwm_get_state(pwm, &state);
+	state.time_unit = unit;
+	ret = pwm_apply_state(pwm, &state);
+	mutex_unlock(&export->lock);
+
+	return ret ? : size;
+}
+
 static ssize_t capture_show(struct device *child,
 			    struct device_attribute *attr,
 			    char *buf)
@@ -256,6 +319,7 @@ static DEVICE_ATTR_RW(duty_cycle);
 static DEVICE_ATTR_RW(phase);
 static DEVICE_ATTR_RW(enable);
 static DEVICE_ATTR_RW(polarity);
+static DEVICE_ATTR_RW(time_unit);
 static DEVICE_ATTR_RO(capture);
 
 static struct attribute *pwm_attrs[] = {
@@ -264,6 +328,7 @@ static struct attribute *pwm_attrs[] = {
 	&dev_attr_phase.attr,
 	&dev_attr_enable.attr,
 	&dev_attr_polarity.attr,
+	&dev_attr_time_unit.attr,
 	&dev_attr_capture.attr,
 	NULL
 };

--- a/include/linux/pwm.h
+++ b/include/linux/pwm.h
@@ -327,8 +327,8 @@ struct pwm_chip {
  * @duty_cycle: duty cycle of the PWM signal (in nanoseconds)
  */
 struct pwm_capture {
-	unsigned int period;
-	unsigned int duty_cycle;
+	u64 period;
+	u64 duty_cycle;
 	unsigned int phase;
 };
 
@@ -347,8 +347,8 @@ int pwm_adjust_config(struct pwm_device *pwm);
  *
  * Returns: 0 on success or a negative error code on failure.
  */
-static inline int pwm_config(struct pwm_device *pwm, int duty_ns,
-			     int period_ns)
+static inline int pwm_config(struct pwm_device *pwm, u64 duty_ns,
+			     u64 period_ns)
 {
 	struct pwm_state state;
 
@@ -457,8 +457,8 @@ static inline int pwm_adjust_config(struct pwm_device *pwm)
 	return -ENOTSUPP;
 }
 
-static inline int pwm_config(struct pwm_device *pwm, int duty_ns,
-			     int period_ns)
+static inline int pwm_config(struct pwm_device *pwm, u64 duty_ns,
+			     u64 period_ns)
 {
 	return -EINVAL;
 }

--- a/include/linux/pwm.h
+++ b/include/linux/pwm.h
@@ -41,7 +41,7 @@ enum pwm_polarity {
  */
 struct pwm_args {
 	u64 period;
-	unsigned int phase;
+	u64 phase;
 	enum pwm_polarity polarity;
 };
 
@@ -61,7 +61,7 @@ enum {
 struct pwm_state {
 	u64 period;
 	u64 duty_cycle;
-	unsigned int phase;
+	u64 phase;
 	enum pwm_polarity polarity;
 	bool enabled;
 };
@@ -141,13 +141,13 @@ static inline u64 pwm_get_duty_cycle(const struct pwm_device *pwm)
 	return state.duty_cycle;
 }
 
-static inline void pwm_set_phase(struct pwm_device *pwm, unsigned int phase)
+static inline void pwm_set_phase(struct pwm_device *pwm, u64 phase)
 {
 	if (pwm)
 		pwm->state.phase = phase;
 }
 
-static inline unsigned int pwm_get_phase(const struct pwm_device *pwm)
+static inline u64 pwm_get_phase(const struct pwm_device *pwm)
 {
 	struct pwm_state state;
 
@@ -329,7 +329,7 @@ struct pwm_chip {
 struct pwm_capture {
 	u64 period;
 	u64 duty_cycle;
-	unsigned int phase;
+	u64 phase;
 };
 
 #if IS_ENABLED(CONFIG_PWM)

--- a/include/linux/pwm.h
+++ b/include/linux/pwm.h
@@ -581,6 +581,7 @@ static inline void pwm_apply_args(struct pwm_device *pwm)
 	state.enabled = false;
 	state.polarity = pwm->args.polarity;
 	state.period = pwm->args.period;
+	state.phase = pwm->args.phase;
 
 	pwm_apply_state(pwm, &state);
 }

--- a/include/linux/pwm.h
+++ b/include/linux/pwm.h
@@ -29,7 +29,7 @@ enum pwm_polarity {
  * struct pwm_args - board-dependent PWM arguments
  * @period: reference period
  * @polarity: reference polarity
- * @offset: reference offset
+ * @phase: reference phase
  *
  * This structure describes board-dependent arguments attached to a PWM
  * device. These arguments are usually retrieved from the PWM lookup table or
@@ -41,7 +41,7 @@ enum pwm_polarity {
  */
 struct pwm_args {
 	u64 period;
-	unsigned int offset;
+	unsigned int phase;
 	enum pwm_polarity polarity;
 };
 
@@ -54,14 +54,14 @@ enum {
  * struct pwm_state - state of a PWM channel
  * @period: PWM period (in nanoseconds)
  * @duty_cycle: PWM duty cycle (in nanoseconds)
- * @offset: PWM offset (in nanoseconds)
+ * @phase: PWM phase (in nanoseconds)
  * @polarity: PWM polarity
  * @enabled: PWM enabled status
  */
 struct pwm_state {
 	u64 period;
 	u64 duty_cycle;
-	unsigned int offset;
+	unsigned int phase;
 	enum pwm_polarity polarity;
 	bool enabled;
 };
@@ -141,19 +141,19 @@ static inline u64 pwm_get_duty_cycle(const struct pwm_device *pwm)
 	return state.duty_cycle;
 }
 
-static inline void pwm_set_offset(struct pwm_device *pwm, unsigned int offset)
+static inline void pwm_set_phase(struct pwm_device *pwm, unsigned int phase)
 {
 	if (pwm)
-		pwm->state.offset = offset;
+		pwm->state.phase = phase;
 }
 
-static inline unsigned int pwm_get_offset(const struct pwm_device *pwm)
+static inline unsigned int pwm_get_phase(const struct pwm_device *pwm)
 {
 	struct pwm_state state;
 
 	pwm_get_state(pwm, &state);
 
-	return state.offset;
+	return state.phase;
 }
 
 static inline enum pwm_polarity pwm_get_polarity(const struct pwm_device *pwm)
@@ -202,7 +202,7 @@ static inline void pwm_init_state(const struct pwm_device *pwm,
 	state->period = args.period;
 	state->polarity = args.polarity;
 	state->duty_cycle = 0;
-	state->offset = 0;
+	state->phase = 0;
 }
 
 /**
@@ -329,7 +329,7 @@ struct pwm_chip {
 struct pwm_capture {
 	unsigned int period;
 	unsigned int duty_cycle;
-	unsigned int offset;
+	unsigned int phase;
 };
 
 #if IS_ENABLED(CONFIG_PWM)

--- a/include/linux/pwm.h
+++ b/include/linux/pwm.h
@@ -12,6 +12,23 @@ struct seq_file;
 struct pwm_chip;
 
 /**
+ * enum pwm_unit - the time unit in wich the pwm arguments are expressed.
+ * @PWM_UNIT_SEC:  the pwm_args members are specified in seconds
+ * @PWM_UNIT_MSEC: the pwm_args members are specified in miliseconds
+ * @PWM_UNIT_USEC: the pwm_args members are specified in microseconds
+ * @PWM_UNIT_NSEC: the pwm_args members are specified in nanoseconds
+ * @PWM_UNIT_PSEC: the pwm_args members are specified in picoseconds
+ */
+
+enum pwm_time_unit {
+	PWM_UNIT_SEC = 1,
+	PWM_UNIT_MSEC,
+	PWM_UNIT_USEC,
+	PWM_UNIT_NSEC,
+	PWM_UNIT_PSEC,
+};
+
+/**
  * enum pwm_polarity - polarity of a PWM signal
  * @PWM_POLARITY_NORMAL: a high signal for the duration of the duty-
  * cycle, followed by a low signal for the remainder of the pulse
@@ -30,6 +47,7 @@ enum pwm_polarity {
  * @period: reference period
  * @polarity: reference polarity
  * @phase: reference phase
+ * @time_unit: refference time unit
  *
  * This structure describes board-dependent arguments attached to a PWM
  * device. These arguments are usually retrieved from the PWM lookup table or
@@ -43,6 +61,7 @@ struct pwm_args {
 	u64 period;
 	u64 phase;
 	enum pwm_polarity polarity;
+	enum pwm_time_unit time_unit;
 };
 
 enum {
@@ -52,10 +71,11 @@ enum {
 
 /*
  * struct pwm_state - state of a PWM channel
- * @period: PWM period (in nanoseconds)
- * @duty_cycle: PWM duty cycle (in nanoseconds)
- * @phase: PWM phase (in nanoseconds)
+ * @period: PWM period (with the time unit expressed in ->time_unit)
+ * @duty_cycle: PWM duty cycle (with the time unit expressed in ->time_unit)
+ * @phase: PWM phase (with the time unit expressed in ->time_unit)
  * @polarity: PWM polarity
+ * @time_unit: PWM time unit
  * @enabled: PWM enabled status
  */
 struct pwm_state {
@@ -63,6 +83,7 @@ struct pwm_state {
 	u64 duty_cycle;
 	u64 phase;
 	enum pwm_polarity polarity;
+	enum pwm_time_unit time_unit;
 	bool enabled;
 };
 
@@ -156,6 +177,22 @@ static inline u64 pwm_get_phase(const struct pwm_device *pwm)
 	return state.phase;
 }
 
+static inline void pwm_set_time_unit(struct pwm_device *pwm,
+				     enum pwm_time_unit time_unit)
+{
+	if (pwm)
+		pwm->state.time_unit = time_unit;
+}
+
+static inline enum pwm_time_unit pwm_get_time_unit(const struct pwm_device *pwm)
+{
+	struct pwm_state state;
+
+	pwm_get_state(pwm, &state);
+
+	return state.time_unit;
+}
+
 static inline enum pwm_polarity pwm_get_polarity(const struct pwm_device *pwm)
 {
 	struct pwm_state state;
@@ -187,6 +224,8 @@ static inline void pwm_get_args(const struct pwm_device *pwm,
  * ->duty_cycle value exceed the pwm_args->period one, which would trigger
  * an error if the user calls pwm_apply_state() without adjusting ->duty_cycle
  * first.
+ * ->time_unit is initially set to PWM_UNIT_NSEC to align all the previous
+ * drivers that presume the pwm_state arguments time unit is nanoseconds.
  */
 static inline void pwm_init_state(const struct pwm_device *pwm,
 				  struct pwm_state *state)
@@ -203,6 +242,8 @@ static inline void pwm_init_state(const struct pwm_device *pwm,
 	state->polarity = args.polarity;
 	state->duty_cycle = 0;
 	state->phase = 0;
+	/* Set the default time unit to nsec ensuring backward compatibility */
+	state->time_unit = PWM_UNIT_NSEC;
 }
 
 /**
@@ -330,6 +371,7 @@ struct pwm_capture {
 	u64 period;
 	u64 duty_cycle;
 	u64 phase;
+	enum pwm_time_unit time_unit;
 };
 
 #if IS_ENABLED(CONFIG_PWM)
@@ -364,6 +406,7 @@ static inline int pwm_config(struct pwm_device *pwm, u64 duty_ns,
 
 	state.duty_cycle = duty_ns;
 	state.period = period_ns;
+	state.time_unit = PWM_UNIT_NSEC;
 	return pwm_apply_state(pwm, &state);
 }
 
@@ -582,6 +625,7 @@ static inline void pwm_apply_args(struct pwm_device *pwm)
 	state.polarity = pwm->args.polarity;
 	state.period = pwm->args.period;
 	state.phase = pwm->args.phase;
+	state.time_unit = pwm->args.time_unit;
 
 	pwm_apply_state(pwm, &state);
 }


### PR DESCRIPTION
This draft adds the following:
- PWM time unit (handled separately by each pwm driver) used for more specific timings
- Time unit support for AXI PWMgen
- Debug mode for AXI PWMgen