### PR TITLE
arch: arm: dts: eeprom zynq zed 

### DIFF
--- a/arch/arm/boot/dts/zynq-zed-adv7511-cn0363.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-cn0363.dts
@@ -13,3 +13,7 @@
 #include "zynq-zed.dtsi"
 #include "zynq-zed-adv7511.dtsi"
 #include "adi-zynq-cn0363.dtsi"
+
+&eeprom1 {
+	status = "disabled";
+};

--- a/arch/arm/boot/dts/zynq-zed-adv7511.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511.dts
@@ -14,3 +14,7 @@
 
 #include "zynq-zed.dtsi"
 #include "zynq-zed-adv7511.dtsi"
+
+&eeprom1 {
+	status = "disabled";
+};

--- a/arch/arm/boot/dts/zynq-zed-adv7511.dtsi
+++ b/arch/arm/boot/dts/zynq-zed-adv7511.dtsi
@@ -69,7 +69,7 @@
 			#size-cells = <0>;
 			#address-cells = <1>;
 
-			eeprom@50 {
+			eeprom1: eeprom@50 {
 				compatible = "at24,24c02";
 				reg = <0x50>;
 			};


### PR DESCRIPTION
- arch: arm: dts: zed-adv7511 add eeprom label
- arch: arm: dts: zynq-zed-adv7511: disable EEPROM
- arch: dts: zynq-zed-adv7511-cn0363: disable EEPROM

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>