### PR TITLE
rpi overlays: ad7746, lm75, ltc2497

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -215,6 +215,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	rpi-display.dtbo \
 	rpi-ft5406.dtbo \
 	rpi-lm75.dtbo \
+	rpi-ltc2497.dtbo \
 	rpi-ltc6952.dtbo \
 	rpi-poe.dtbo \
 	rpi-poe-plus.dtbo \

--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -214,6 +214,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	rpi-dc1962c.dtbo \
 	rpi-display.dtbo \
 	rpi-ft5406.dtbo \
+	rpi-lm75.dtbo \
 	rpi-ltc6952.dtbo \
 	rpi-poe.dtbo \
 	rpi-poe-plus.dtbo \

--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -188,6 +188,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	rpi-ad7190.dtbo \
 	rpi-ad7293.dtbo \
 	rpi-ad738x.dtbo \
+	rpi-ad7746.dtbo \
 	rpi-ad7768-1.dtbo \
 	rpi-ad74413r.dtbo \
 	rpi-ad9545-hmc7044.dtbo \

--- a/arch/arm/boot/dts/overlays/rpi-ad7746-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ad7746-overlay.dts
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target = <&i2c1>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			ad7746: ad7746@48 {
+				compatible = "adi,ad7746";
+				clock-frequency = <400000>;
+				reg = <0x48>;
+				label = "my_ad7746";
+			};
+		};
+	};
+
+	__overrides__ {
+		addr = <&ad7746>,"reg:0";
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-lm75-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-lm75-overlay.dts
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target = <&i2c1>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			lm75: lm75@4c{
+				compatible = "lm75";
+				reg = <0x4c>;
+				label = "my_lm75";
+			};
+
+		};
+	};
+
+	__overrides__ {
+		addr = <&lm75>,"reg:0";
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-ltc2497-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ltc2497-overlay.dts
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target-path = "/";
+
+		__overlay__ {
+
+			vref: fixedregulator@0 {
+				compatible = "regulator-fixed";
+				regulator-name = "vref";
+				regulator-min-microvolt = <2500000>;
+				regulator-max-microvolt = <2500000>;
+				phandle = <0x1>;
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&i2c1>;
+		__overlay__ {
+			#address-cells = <0x1>;
+			#size-cells = <0x0>;
+			status = "okay";
+			ltc2497: ltc2497@76 {
+				compatible = "lltc,ltc2497";
+				reg = <0x76>;
+				label = "my_ltc2497";
+				vref-supply = <&vref>;
+				clock-frequency = <400000>;
+				status = "okay";
+			};
+		};
+	};
+
+	__overrides__ {
+		addr = <&ltc2497>,"reg:0";
+	};
+};


### PR DESCRIPTION
Add rpi overlays for the following devices:
 - ad7746
 - lm75
 - ltc2497