### PR TITLE
arch: arm64: dts: stingray: Make vcxo100/122.88 distinction

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-stingray.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-stingray.dts
@@ -345,6 +345,9 @@
 };
 
 &hmc7044 {
+	adi,pll1-clkin-frequencies = <122880000 30720000 0 0>;
+	adi,vcxo-frequency = <122880000>;
+
 	adi,pll1-ref-prio-ctrl = <0xE1>; /* prefer CLKIN1 -> CLKIN0 -> CLKIN2 -> CLKIN3 */
 	adi,pll1-ref-autorevert-enable;
 };


### PR DESCRIPTION
Since zynqmp-zcu102-rev10-stingray-vcxo100.dts was explicitly created
to be used with the VCXO = 100.000 MHz version of AD9081-FMC-EBZ, make
zynqmp-zcu102-rev10-stingray.dts not being dependent on the default
setting from zynqmp-zcu102-rev10-ad9081-m8-l4.dts either.

Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>