### PR TITLE
arch: arm: overlays: Add CN0552 support

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -209,6 +209,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	rpi-cn0504.dtbo \
 	rpi-cn0508.dtbo \
 	rpi-cn0511.dtbo \
+	rpi-cn0552.dtbo \
 	rpi-cn0566.dtbo \
 	rpi-dac.dtbo \
 	rpi-dc1962c.dtbo \

--- a/arch/arm/boot/dts/overlays/rpi-cn0552-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-cn0552-overlay.dts
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-2.0
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2708";
+
+	fragment@0 {
+		target = <&i2c_arm>;
+		__overlay__ {
+			status = "okay";
+
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			adc: ad7746@48 {
+				compatible = "adi,ad7746";
+				reg = <0x48>;
+			};
+		};
+	};
+};


### PR DESCRIPTION
The EVAL-CN0552-PMDZ is a PMOD form-factor evaluation board for the
AD7746, a high resolution, sigma-delta capacitance-to-digital converter.

More details:
https://wiki.analog.com/resources/eval/user-guides/circuits-from-the-lab/cn0552

Signed-off by: Zuedmar Arceo <zuedmar.arceo@analog.com>
Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>