### PR TITLE
synchrona overlay refactor

### DIFF
--- a/arch/arm/boot/dts/overlays/rpi-ad9545-hmc7044-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ad9545-hmc7044-overlay.dts
@@ -70,6 +70,20 @@
 	};
 
 	fragment@1 {
+		target = <&spidev0>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@2 {
+		target = <&spidev1>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@3 {
 		target = <&spi0>;
 		__overlay__ {
 			compatible = "brcm,bcm2835-spi";
@@ -424,7 +438,7 @@
 		};
 	};
 
-	fragment@2 {
+	fragment@4 {
 		target = <&gpio>;
 		__overlay__ {
 
@@ -490,7 +504,7 @@
 		};
 	};
 
-	fragment@3 {
+	fragment@5 {
 		target-path = "/";
 		__overlay__ {
 			power_ctrl: power_ctrl {
@@ -501,7 +515,7 @@
 		};
 	};
 
-	fragment@4 {
+	fragment@6 {
 		target-path = "/soc";
 		__overlay__ {
 			shutdown_button: shutdown_button@3 {
@@ -515,20 +529,6 @@
 					debounce-interval = <100>;
 				};
 			};
-		};
-	};
-
-	fragment@5 {
-		target = <&spidev0>;
-		__overlay__ {
-			status = "disabled";
-		};
-	};
-
-	fragment@6 {
-		target = <&spidev1>;
-		__overlay__ {
-			status = "disabled";
 		};
 	};
 

--- a/arch/arm/boot/dts/overlays/rpi-ad9545-hmc7044-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ad9545-hmc7044-overlay.dts
@@ -511,6 +511,7 @@
 				compatible = "gpio-poweroff";
 				gpios = <&gpio 21 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 				input;
+				force;
 			};
 		};
 	};


### PR DESCRIPTION
The first change makes the removal of the overlay clean. So that we don't see any spidev related errors... The second patch is really a fix for being able to actually poweroff the device (using the poweroff gpio defined in the overlay).


PS: Just realized that the fix should actually be the first patch be ehh, since this is not to be backported anywhere, let's leave it as-is.