### PR TITLE
QuadMxFE dev

### DIFF
--- a/arch/microblaze/boot/dts/vcu118_quad_ad9081_204b_txmode_5_rxmode_6.dts
+++ b/arch/microblaze/boot/dts/vcu118_quad_ad9081_204b_txmode_5_rxmode_6.dts
@@ -1,0 +1,722 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices Quad-MxFE
+ * https://wiki.analog.com/resources/eval/user-guides/quadmxfe
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-mxfe/ad9081
+ * https://wiki.analog.com/resources/eval/user-guides/ad_quadmxfe1_ebz/ad_quadmxfe1_ebz_hdl
+ *
+ * hdl_project: <ad_quadmxfe1_ebz/vcu118>
+ * board_revision: <>
+ *
+ * Copyright (C) 2022 Analog Devices Inc.
+ */
+
+#include <dt-bindings/iio/frequency/hmc7044.h>
+#include <dt-bindings/iio/adc/adi,ad9081.h>
+#include <dt-bindings/gpio/gpio.h>
+
+#include "vcu118_quad_ad9081.dtsi"
+
+// This setup assumes 500MHz clock into J41 (0 dBm)
+// ad9081_204b_txmode_5_rxmode_6: Np 16 use case with low lane rate
+//     * 2Txs / 2Rxs per MxFE
+//     * DAC_CLK = 4GSPS
+//     * ADC_CLK = 4GSPS
+//     * Tx I/Q Rate: 125 MSPS (Interpolation of 4x8)
+//     * Rx I/Q Rate: 125 MSPS (Decimation of 4x8)
+//     * DAC JESD204B: Mode 5, L=2, M=4, N=N'=16
+//     * ADC JESD204B: Mode 6, L=2, M=4, N=N'=16
+//     * DAC-Side JESD204B Lane Rate: 5.00Gbps
+//     * ADC-Side JESD204B Lane Rate: 5.00Gbps
+
+#define ADRF4360_RFx_FREQUENCY_HZ		4000000000
+
+#define HMC7043_FPGA_XCVR_CLKDIV		2
+#define HMC7043_FPGA_LINK_CLKDIV		4
+#define HMC7043_SYSREF_CLKDIV			256
+#define HMC7043_SYSREF_TIMER			(HMC7043_SYSREF_CLKDIV * 4)
+
+#define AD9081_DAC_FREQUENCY			ADRF4360_RFx_FREQUENCY_HZ
+#define AD9081_ADC_FREQUENCY			ADRF4360_RFx_FREQUENCY_HZ
+
+ /* TX path */
+#define AD9081_TX_MAIN_INTERPOLATION		4
+#define AD9081_TX_CHAN_INTERPOLATION		8
+
+#ifndef AD9081_TX_MAIN_NCO_SHIFT
+#define AD9081_TX_MAIN_NCO_SHIFT		433000000
+#endif
+#ifndef AD9081_TX_CHAN_NCO_SHIFT
+#define AD9081_TX_CHAN_NCO_SHIFT		0
+#endif
+
+#define AD9081_GAIN				2048
+
+#define AD9081_TX_JESD_MODE			5
+#define AD9081_TX_JESD_SUBCLASS			1
+#define AD9081_TX_JESD_VERSION			1
+#define AD9081_TX_JESD_M			4
+#define AD9081_TX_JESD_F			4
+#define AD9081_TX_JESD_K			32
+#define AD9081_TX_JESD_N			16
+#define AD9081_TX_JESD_NP			16
+#define AD9081_TX_JESD_CS			0
+#define AD9081_TX_JESD_L			2
+#define AD9081_TX_JESD_S			1
+#define AD9081_TX_JESD_HD			0
+
+/* RX path */
+#define AD9081_RX_MAIN_DECIMATION		4
+#define AD9081_RX_CHAN_DECIMATION		8
+
+#ifndef AD9081_RX_MAIN_NCO_SHIFT
+#define AD9081_RX_MAIN_NCO_SHIFT		433000000
+#endif
+#ifndef AD9081_RX_CHAN_NCO_SHIFT
+#define AD9081_RX_CHAN_NCO_SHIFT		0
+#endif
+
+#ifndef AD9081_ADC_NYQUIST_ZONE
+#define AD9081_ADC_NYQUIST_ZONE		AD9081_ADC_NYQUIST_ZONE_EVEN
+#endif
+
+#define AD9081_RX_JESD_MODE			6
+#define AD9081_RX_JESD_SUBCLASS			1
+#define AD9081_RX_JESD_VERSION			1
+#define AD9081_RX_JESD_M			4
+#define AD9081_RX_JESD_F			4
+#define AD9081_RX_JESD_K			32
+#define AD9081_RX_JESD_N			16
+#define AD9081_RX_JESD_NP			16
+#define AD9081_RX_JESD_CS			0
+#define AD9081_RX_JESD_L			2
+#define AD9081_RX_JESD_S			1
+#define AD9081_RX_JESD_HD			0
+
+&axi_ad9081_adxcvr_rx {
+	adi,sys-clk-select = <XCVR_QPLL>;
+	adi,out-clk-select = <XCVR_PROGDIV_CLK>;
+};
+
+&axi_ad9081_adxcvr_tx {
+	adi,sys-clk-select = <XCVR_QPLL>;
+	adi,out-clk-select = <XCVR_PROGDIV_CLK>;
+};
+
+&axi_gpio {
+	/delete-node/ adrf5020_ctrl;
+	adrf5020_ctrl {
+		gpio-hog;
+		gpios = <34 GPIO_ACTIVE_HIGH>;
+#if ADRF4360_RFx_FREQUENCY_HZ < 8000000000
+#define ADF4371_OUTPUT 1
+		output-low; /* output-low for the RF2 <-> clk-rfaux8 output */
+#else
+#define ADF4371_OUTPUT 2
+		output-high; /* output-high for the RF2 <-> clk-rf16 output */
+#endif
+		line-name = "ADRF5020_CTRL";
+	};
+};
+
+&adf4371_clk0 {
+	channel@ADF4371_OUTPUT {
+		reg = <ADF4371_OUTPUT>;
+		adi,power-up-frequency = /bits/ 64 <ADRF4360_RFx_FREQUENCY_HZ>;
+	};
+};
+
+&adf4371_clk1 {
+	channel@ADF4371_OUTPUT {
+		reg = <ADF4371_OUTPUT>;
+		adi,power-up-frequency = /bits/ 64 <ADRF4360_RFx_FREQUENCY_HZ>;
+	};
+};
+
+&adf4371_clk2 {
+	channel@ADF4371_OUTPUT {
+		reg = <ADF4371_OUTPUT>;
+		adi,power-up-frequency = /bits/ 64 <ADRF4360_RFx_FREQUENCY_HZ>;
+	};
+};
+
+&adf4371_clk3 {
+	channel@ADF4371_OUTPUT {
+		reg = <ADF4371_OUTPUT>;
+		adi,power-up-frequency = /bits/ 64 <ADRF4360_RFx_FREQUENCY_HZ>;
+	};
+};
+
+&hmc7043 {
+	hmc7043_c0: channel@0 {
+		reg = <0>;
+		adi,extended-name = "FPGA_REFCLK";
+		adi,divider = <HMC7043_FPGA_XCVR_CLKDIV>;
+		adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
+	};
+	hmc7043_c8: channel@8 {
+		reg = <8>;
+		adi,extended-name = "CORE_LINK_CLK";
+		adi,divider = <HMC7043_FPGA_LINK_CLKDIV>;
+		adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
+	};
+	hmc7043_c1: channel@1 {
+		reg = <1>;
+		adi,extended-name = "SYSREF_MXFE0";
+		adi,divider = <HMC7043_SYSREF_CLKDIV>;
+		adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
+		adi,coarse-digital-delay = <0>;
+		adi,fine-analog-delay = <24>; /* max analog */
+		adi,output-mux-mode = <1>;
+		adi,jesd204-sysref-chan;
+	};
+	hmc7043_c3: channel@3 {
+		reg = <3>;
+		adi,extended-name = "SYSREF_MXFE1";
+		adi,divider = <HMC7043_SYSREF_CLKDIV>;
+		adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
+		adi,coarse-digital-delay = <1>; /* 1 ns */
+		adi,fine-analog-delay = <0>;
+		adi,output-mux-mode = <0>;
+		adi,jesd204-sysref-chan;
+	};
+	hmc7043_c5: channel@5 {
+		reg = <5>;
+		adi,extended-name = "SYSREF_MXFE2";
+		adi,divider = <HMC7043_SYSREF_CLKDIV>;
+		adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
+		adi,coarse-digital-delay = <0>;
+		adi,fine-analog-delay = <16>;
+		adi,output-mux-mode = <1>;
+		adi,jesd204-sysref-chan;
+	};
+	hmc7043_c7: channel@7 {
+		reg = <7>;
+		adi,extended-name = "SYSREF_MXFE3";
+		adi,divider = <HMC7043_SYSREF_CLKDIV>;
+		adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
+		adi,coarse-digital-delay = <0>;
+		adi,fine-analog-delay = <0>;
+		adi,output-mux-mode = <0>;
+		adi,jesd204-sysref-chan;
+	};
+	hmc7043_c9: channel@9 {
+		reg = <9>;
+		adi,extended-name = "SYSREF_FPGA";
+		adi,divider = <HMC7043_SYSREF_CLKDIV>;
+		adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
+		adi,jesd204-sysref-chan;
+	};
+};
+
+&trx0_ad9081 {
+	clocks = <&adf4371_clk0 ADF4371_OUTPUT>;
+
+	adi,tx-dacs {
+		#size-cells = <0>;
+		#address-cells = <1>;
+		adi,dac-frequency-hz = /bits/ 64 <AD9081_DAC_FREQUENCY>;
+		adi,main-data-paths {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			adi,interpolation = <AD9081_TX_MAIN_INTERPOLATION>;
+			trx0_ad9081_dac0: dac@0 {
+				reg = <0>;
+				adi,crossbar-select = <&trx0_ad9081_tx_fddc_chan0>;
+				adi,nco-frequency-shift-hz = /bits/ 64 <AD9081_TX_MAIN_NCO_SHIFT>; /* 100 MHz */
+			};
+			trx0_ad9081_dac1: dac@1 {
+				reg = <1>;
+				adi,crossbar-select = <&trx0_ad9081_tx_fddc_chan1>;
+				adi,nco-frequency-shift-hz = /bits/ 64 <AD9081_TX_MAIN_NCO_SHIFT>; /* 200 MHz */
+			};
+		};
+		adi,channelizer-paths {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			adi,interpolation = <AD9081_TX_CHAN_INTERPOLATION>;
+			trx0_ad9081_tx_fddc_chan0: channel@0 {
+				reg = <0>;
+				adi,gain = <AD9081_GAIN>; /* value * 10^(gain_dB/20) */
+				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_TX_CHAN_NCO_SHIFT>;
+			};
+			trx0_ad9081_tx_fddc_chan1: channel@1 {
+				reg = <1>;
+				adi,gain = <AD9081_GAIN>; /* value * 10^(gain_dB/20) */
+				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_TX_CHAN_NCO_SHIFT>;
+			};
+		};
+		adi,jesd-links {
+			#size-cells = <0>;
+			#address-cells = <1>;
+			trx0_ad9081_tx_jesd_l0: link@0 {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				reg = <0>;
+				adi,logical-lane-mapping = /bits/ 8 <0 1 2 3 4 5 6 7>;
+				adi,link-mode = <AD9081_TX_JESD_MODE>;			/* JESD Quick Configuration Mode */
+				adi,subclass = <AD9081_TX_JESD_SUBCLASS>;			/* JESD SUBCLASS 0,1,2 */
+				adi,version = <AD9081_TX_JESD_VERSION>;			/* JESD VERSION 0=204A,1=204B,2=204C */
+				adi,dual-link = <0>;			/* JESD Dual Link Mode */
+				adi,converters-per-device = <AD9081_TX_JESD_M>;	/* JESD M */
+				adi,octets-per-frame = <AD9081_TX_JESD_F>;		/* JESD F */
+				adi,frames-per-multiframe = <AD9081_TX_JESD_K>;	/* JESD K */
+				adi,converter-resolution = <AD9081_TX_JESD_N>;	/* JESD N */
+				adi,bits-per-sample = <AD9081_TX_JESD_N>;		/* JESD NP' */
+				adi,control-bits-per-sample = <AD9081_TX_JESD_CS>;	/* JESD CS */
+				adi,lanes-per-device = <AD9081_TX_JESD_L>;		/* JESD L */
+				adi,samples-per-converter-per-frame = <AD9081_TX_JESD_S>; /* JESD S */
+				adi,high-density = <AD9081_TX_JESD_HD>;			/* JESD HD */
+			};
+		};
+	};
+	adi,rx-adcs {
+		#size-cells = <0>;
+		#address-cells = <1>;
+		adi,adc-frequency-hz = /bits/ 64 <AD9081_ADC_FREQUENCY>;
+		adi,nyquist-zone = <AD9081_ADC_NYQUIST_ZONE>;
+		adi,main-data-paths {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			trx0_ad9081_adc0: adc@0 {
+				reg = <0>;
+				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
+				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
+				//adi,crossbar-select = <&trx0_ad9081_rx_fddc_chan0>, <&trx0_ad9081_rx_fddc_chan2>; /* Static for now */
+			};
+			trx0_ad9081_adc1: adc@1 {
+				reg = <1>;
+				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
+				adi,nco-frequency-shift-hz =  /bits/ 64 <(AD9081_RX_MAIN_NCO_SHIFT)>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
+				//adi,crossbar-select = <&trx0_ad9081_rx_fddc_chan1>, <&trx0_ad9081_rx_fddc_chan3>; /* Static for now */
+			};
+		};
+		adi,channelizer-paths {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			trx0_ad9081_rx_fddc_chan0: channel@0 {
+				reg = <0>;
+				adi,decimation = <AD9081_RX_CHAN_DECIMATION>;
+				adi,gain = <AD9081_GAIN>; /* value * 10^(gain_dB/20) */
+				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_CHAN_NCO_SHIFT>;
+			};
+			trx0_ad9081_rx_fddc_chan1: channel@1 {
+				reg = <1>;
+				adi,decimation = <AD9081_RX_CHAN_DECIMATION>;
+				adi,gain = <AD9081_GAIN>; /* value * 10^(gain_dB/20) */
+				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_CHAN_NCO_SHIFT>;
+			};
+		};
+		adi,jesd-links {
+			#size-cells = <0>;
+			#address-cells = <1>;
+			trx0_ad9081_rx_jesd_l0: link@0 {
+				reg = <0>;
+				adi,converter-select =
+					<&trx0_ad9081_rx_fddc_chan0 FDDC_I>, <&trx0_ad9081_rx_fddc_chan0 FDDC_Q>,
+					<&trx0_ad9081_rx_fddc_chan1 FDDC_I>, <&trx0_ad9081_rx_fddc_chan1 FDDC_Q>;
+				adi,logical-lane-mapping = /bits/ 8 <0 1 2 3 4 5 6 7>;
+				adi,link-mode = <AD9081_RX_JESD_MODE>;			/* JESD Quick Configuration Mode */
+				adi,subclass = <AD9081_RX_JESD_SUBCLASS>;			/* JESD SUBCLASS 0,1,2 */
+				adi,version = <AD9081_RX_JESD_VERSION>;			/* JESD VERSION 0=204A,1=204B,2=204C */
+				adi,dual-link = <0>;			/* JESD Dual Link Mode */
+				adi,device-id = <0>;
+				adi,converters-per-device = <AD9081_RX_JESD_M>;	/* JESD M */
+				adi,octets-per-frame = <AD9081_RX_JESD_F>;		/* JESD F */
+				adi,frames-per-multiframe = <AD9081_RX_JESD_K>;	/* JESD K */
+				adi,converter-resolution = <AD9081_RX_JESD_N>;	/* JESD N */
+				adi,bits-per-sample = <AD9081_RX_JESD_NP>;		/* JESD NP' */
+				adi,control-bits-per-sample = <AD9081_RX_JESD_CS>;	/* JESD CS */
+				adi,lanes-per-device = <AD9081_RX_JESD_L>;		/* JESD L */
+				adi,samples-per-converter-per-frame = <AD9081_RX_JESD_S>; /* JESD S */
+				adi,high-density = <AD9081_RX_JESD_HD>;			/* JESD HD */
+			};
+		};
+	};
+};
+
+&trx1_ad9081 {
+	clocks = <&adf4371_clk1 ADF4371_OUTPUT>;
+
+	adi,tx-dacs {
+		#size-cells = <0>;
+		#address-cells = <1>;
+		adi,dac-frequency-hz = /bits/ 64 <AD9081_DAC_FREQUENCY>;
+		adi,main-data-paths {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			adi,interpolation = <AD9081_TX_MAIN_INTERPOLATION>;
+			trx1_ad9081_dac0: dac@0 {
+				reg = <0>;
+				adi,crossbar-select = <&trx1_ad9081_tx_fddc_chan0>;
+				adi,nco-frequency-shift-hz = /bits/ 64 <AD9081_TX_MAIN_NCO_SHIFT>; /* 100 MHz */
+			};
+			trx1_ad9081_dac1: dac@1 {
+				reg = <1>;
+				adi,crossbar-select = <&trx1_ad9081_tx_fddc_chan1>;
+				adi,nco-frequency-shift-hz = /bits/ 64 <AD9081_TX_MAIN_NCO_SHIFT>; /* 200 MHz */
+			};
+		};
+		adi,channelizer-paths {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			adi,interpolation = <AD9081_TX_CHAN_INTERPOLATION>;
+			trx1_ad9081_tx_fddc_chan0: channel@0 {
+				reg = <0>;
+				adi,gain = <AD9081_GAIN>; /* value * 10^(gain_dB/20) */
+				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_TX_CHAN_NCO_SHIFT>;
+			};
+			trx1_ad9081_tx_fddc_chan1: channel@1 {
+				reg = <1>;
+				adi,gain = <AD9081_GAIN>; /* value * 10^(gain_dB/20) */
+				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_TX_CHAN_NCO_SHIFT>;
+			};
+		};
+		adi,jesd-links {
+			#size-cells = <0>;
+			#address-cells = <1>;
+			trx1_ad9081_tx_jesd_l0: link@0 {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				reg = <0>;
+				adi,logical-lane-mapping = /bits/ 8 <0 1 2 3 4 5 6 7>;
+				adi,link-mode = <AD9081_TX_JESD_MODE>;			/* JESD Quick Configuration Mode */
+				adi,subclass = <AD9081_TX_JESD_SUBCLASS>;			/* JESD SUBCLASS 0,1,2 */
+				adi,version = <AD9081_TX_JESD_VERSION>;			/* JESD VERSION 0=204A,1=204B,2=204C */
+				adi,dual-link = <0>;			/* JESD Dual Link Mode */
+				adi,converters-per-device = <AD9081_TX_JESD_M>;	/* JESD M */
+				adi,octets-per-frame = <AD9081_TX_JESD_F>;		/* JESD F */
+				adi,frames-per-multiframe = <AD9081_TX_JESD_K>;	/* JESD K */
+				adi,converter-resolution = <AD9081_TX_JESD_N>;	/* JESD N */
+				adi,bits-per-sample = <AD9081_TX_JESD_N>;		/* JESD NP' */
+				adi,control-bits-per-sample = <AD9081_TX_JESD_CS>;	/* JESD CS */
+				adi,lanes-per-device = <AD9081_TX_JESD_L>;		/* JESD L */
+				adi,samples-per-converter-per-frame = <AD9081_TX_JESD_S>; /* JESD S */
+				adi,high-density = <AD9081_TX_JESD_HD>;			/* JESD HD */
+			};
+		};
+	};
+	adi,rx-adcs {
+		#size-cells = <0>;
+		#address-cells = <1>;
+		adi,adc-frequency-hz = /bits/ 64 <AD9081_ADC_FREQUENCY>;
+		adi,nyquist-zone = <AD9081_ADC_NYQUIST_ZONE>;
+		adi,main-data-paths {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			trx1_ad9081_adc0: adc@0 {
+				reg = <0>;
+				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
+				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
+				//adi,crossbar-select = <&trx1_ad9081_rx_fddc_chan0>, <&trx1_ad9081_rx_fddc_chan2>; /* Static for now */
+			};
+			trx1_ad9081_adc1: adc@1 {
+				reg = <1>;
+				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
+				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
+				//adi,crossbar-select = <&trx1_ad9081_rx_fddc_chan1>, <&trx1_ad9081_rx_fddc_chan3>; /* Static for now */
+			};
+		};
+		adi,channelizer-paths {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			trx1_ad9081_rx_fddc_chan0: channel@0 {
+				reg = <0>;
+				adi,decimation = <AD9081_RX_CHAN_DECIMATION>;
+				adi,gain = <AD9081_GAIN>; /* value * 10^(gain_dB/20) */
+				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_CHAN_NCO_SHIFT>;
+			};
+			trx1_ad9081_rx_fddc_chan1: channel@1 {
+				reg = <1>;
+				adi,decimation = <AD9081_RX_CHAN_DECIMATION>;
+				adi,gain = <AD9081_GAIN>; /* value * 10^(gain_dB/20) */
+				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_CHAN_NCO_SHIFT>;
+			};
+		};
+		adi,jesd-links {
+			#size-cells = <0>;
+			#address-cells = <1>;
+			trx1_ad9081_rx_jesd_l0: link@0 {
+				reg = <0>;
+				adi,converter-select =
+					<&trx1_ad9081_rx_fddc_chan0 FDDC_I>, <&trx1_ad9081_rx_fddc_chan0 FDDC_Q>,
+					<&trx1_ad9081_rx_fddc_chan1 FDDC_I>, <&trx1_ad9081_rx_fddc_chan1 FDDC_Q>;
+				adi,logical-lane-mapping = /bits/ 8 <0 1 2 3 4 5 6 7>;
+				adi,link-mode = <AD9081_RX_JESD_MODE>;			/* JESD Quick Configuration Mode */
+				adi,subclass = <AD9081_RX_JESD_SUBCLASS>;			/* JESD SUBCLASS 0,1,2 */
+				adi,version = <AD9081_RX_JESD_VERSION>;			/* JESD VERSION 0=204A,1=204B,2=204C */
+				adi,dual-link = <0>;			/* JESD Dual Link Mode */
+				adi,device-id = <1>;
+				adi,converters-per-device = <AD9081_RX_JESD_M>;	/* JESD M */
+				adi,octets-per-frame = <AD9081_RX_JESD_F>;		/* JESD F */
+				adi,frames-per-multiframe = <AD9081_RX_JESD_K>;	/* JESD K */
+				adi,converter-resolution = <AD9081_RX_JESD_N>;	/* JESD N */
+				adi,bits-per-sample = <AD9081_RX_JESD_NP>;		/* JESD NP' */
+				adi,control-bits-per-sample = <AD9081_RX_JESD_CS>;	/* JESD CS */
+				adi,lanes-per-device = <AD9081_RX_JESD_L>;		/* JESD L */
+				adi,samples-per-converter-per-frame = <AD9081_RX_JESD_S>; /* JESD S */
+				adi,high-density = <AD9081_RX_JESD_HD>;			/* JESD HD */
+			};
+		};
+	};
+};
+
+&trx2_ad9081 {
+	clocks = <&adf4371_clk2 ADF4371_OUTPUT>;
+
+	adi,tx-dacs {
+		#size-cells = <0>;
+		#address-cells = <1>;
+		adi,dac-frequency-hz = /bits/ 64 <AD9081_DAC_FREQUENCY>;
+		adi,main-data-paths {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			adi,interpolation = <AD9081_TX_MAIN_INTERPOLATION>;
+			trx2_ad9081_dac0: dac@0 {
+				reg = <0>;
+				adi,crossbar-select = <&trx2_ad9081_tx_fddc_chan0>;
+				adi,nco-frequency-shift-hz = /bits/ 64 <AD9081_TX_MAIN_NCO_SHIFT>; /* 100 MHz */
+			};
+			trx2_ad9081_dac1: dac@1 {
+				reg = <1>;
+				adi,crossbar-select = <&trx2_ad9081_tx_fddc_chan1>;
+				adi,nco-frequency-shift-hz = /bits/ 64 <AD9081_TX_MAIN_NCO_SHIFT>; /* 200 MHz */
+			};
+		};
+		adi,channelizer-paths {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			adi,interpolation = <AD9081_TX_CHAN_INTERPOLATION>;
+			trx2_ad9081_tx_fddc_chan0: channel@0 {
+				reg = <0>;
+				adi,gain = <AD9081_GAIN>; /* value * 10^(gain_dB/20) */
+				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_TX_CHAN_NCO_SHIFT>;
+			};
+			trx2_ad9081_tx_fddc_chan1: channel@1 {
+				reg = <1>;
+				adi,gain = <AD9081_GAIN>; /* value * 10^(gain_dB/20) */
+				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_TX_CHAN_NCO_SHIFT>;
+			};
+		};
+		adi,jesd-links {
+			#size-cells = <0>;
+			#address-cells = <1>;
+			trx2_ad9081_tx_jesd_l0: link@0 {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				reg = <0>;
+				adi,logical-lane-mapping = /bits/ 8 <0 1 2 3 4 5 6 7>;
+				adi,link-mode = <AD9081_TX_JESD_MODE>;			/* JESD Quick Configuration Mode */
+				adi,subclass = <AD9081_TX_JESD_SUBCLASS>;			/* JESD SUBCLASS 0,1,2 */
+				adi,version = <AD9081_TX_JESD_VERSION>;			/* JESD VERSION 0=204A,1=204B,2=204C */
+				adi,dual-link = <0>;			/* JESD Dual Link Mode */
+				adi,converters-per-device = <AD9081_TX_JESD_M>;	/* JESD M */
+				adi,octets-per-frame = <AD9081_TX_JESD_F>;		/* JESD F */
+				adi,frames-per-multiframe = <AD9081_TX_JESD_K>;	/* JESD K */
+				adi,converter-resolution = <AD9081_TX_JESD_N>;	/* JESD N */
+				adi,bits-per-sample = <AD9081_TX_JESD_N>;		/* JESD NP' */
+				adi,control-bits-per-sample = <AD9081_TX_JESD_CS>;	/* JESD CS */
+				adi,lanes-per-device = <AD9081_TX_JESD_L>;		/* JESD L */
+				adi,samples-per-converter-per-frame = <AD9081_TX_JESD_S>; /* JESD S */
+				adi,high-density = <AD9081_TX_JESD_HD>;			/* JESD HD */
+			};
+		};
+	};
+	adi,rx-adcs {
+		#size-cells = <0>;
+		#address-cells = <1>;
+		adi,adc-frequency-hz = /bits/ 64 <AD9081_ADC_FREQUENCY>;
+		adi,nyquist-zone = <AD9081_ADC_NYQUIST_ZONE>;
+		adi,main-data-paths {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			trx2_ad9081_adc0: adc@0 {
+				reg = <0>;
+				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
+				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
+				//adi,crossbar-select = <&trx2_ad9081_rx_fddc_chan0>, <&trx2_ad9081_rx_fddc_chan2>; /* Static for now */
+			};
+			trx2_ad9081_adc1: adc@1 {
+				reg = <1>;
+				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
+				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
+				//adi,crossbar-select = <&trx2_ad9081_rx_fddc_chan1>, <&trx2_ad9081_rx_fddc_chan3>; /* Static for now */
+			};
+		};
+		adi,channelizer-paths {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			trx2_ad9081_rx_fddc_chan0: channel@0 {
+				reg = <0>;
+				adi,decimation = <AD9081_RX_CHAN_DECIMATION>;
+				adi,gain = <AD9081_GAIN>; /* value * 10^(gain_dB/20) */
+				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_CHAN_NCO_SHIFT>;
+			};
+			trx2_ad9081_rx_fddc_chan1: channel@1 {
+				reg = <1>;
+				adi,decimation = <AD9081_RX_CHAN_DECIMATION>;
+				adi,gain = <AD9081_GAIN>; /* value * 10^(gain_dB/20) */
+				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_CHAN_NCO_SHIFT>;
+			};
+		};
+		adi,jesd-links {
+			#size-cells = <0>;
+			#address-cells = <1>;
+			trx2_ad9081_rx_jesd_l0: link@0 {
+				reg = <0>;
+				adi,converter-select =
+					<&trx2_ad9081_rx_fddc_chan0 FDDC_I>, <&trx2_ad9081_rx_fddc_chan0 FDDC_Q>,
+					<&trx2_ad9081_rx_fddc_chan1 FDDC_I>, <&trx2_ad9081_rx_fddc_chan1 FDDC_Q>;
+				adi,logical-lane-mapping = /bits/ 8 <0 1 2 3 4 5 6 7>;
+				adi,link-mode = <AD9081_RX_JESD_MODE>;			/* JESD Quick Configuration Mode */
+				adi,subclass = <AD9081_RX_JESD_SUBCLASS>;			/* JESD SUBCLASS 0,1,2 */
+				adi,version = <AD9081_RX_JESD_VERSION>;			/* JESD VERSION 0=204A,1=204B,2=204C */
+				adi,dual-link = <0>;			/* JESD Dual Link Mode */
+				adi,device-id = <2>;
+				adi,converters-per-device = <AD9081_RX_JESD_M>;	/* JESD M */
+				adi,octets-per-frame = <AD9081_RX_JESD_F>;		/* JESD F */
+				adi,frames-per-multiframe = <AD9081_RX_JESD_K>;	/* JESD K */
+				adi,converter-resolution = <AD9081_RX_JESD_N>;	/* JESD N */
+				adi,bits-per-sample = <AD9081_RX_JESD_NP>;		/* JESD NP' */
+				adi,control-bits-per-sample = <AD9081_RX_JESD_CS>;	/* JESD CS */
+				adi,lanes-per-device = <AD9081_RX_JESD_L>;		/* JESD L */
+				adi,samples-per-converter-per-frame = <AD9081_RX_JESD_S>; /* JESD S */
+				adi,high-density = <AD9081_RX_JESD_HD>;			/* JESD HD */
+			};
+		};
+	};
+};
+
+&trx3_ad9081 {
+	clocks = <&adf4371_clk3 ADF4371_OUTPUT>;
+
+	adi,tx-dacs {
+		#size-cells = <0>;
+		#address-cells = <1>;
+		adi,dac-frequency-hz = /bits/ 64 <AD9081_DAC_FREQUENCY>;
+		adi,main-data-paths {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			adi,interpolation = <AD9081_TX_MAIN_INTERPOLATION>;
+			trx3_ad9081_dac0: dac@0 {
+				reg = <0>;
+				adi,crossbar-select = <&trx3_ad9081_tx_fddc_chan0>;
+				adi,nco-frequency-shift-hz = /bits/ 64 <AD9081_TX_MAIN_NCO_SHIFT>; /* 100 MHz */
+			};
+			trx3_ad9081_dac1: dac@1 {
+				reg = <1>;
+				adi,crossbar-select = <&trx3_ad9081_tx_fddc_chan1>;
+				adi,nco-frequency-shift-hz = /bits/ 64 <AD9081_TX_MAIN_NCO_SHIFT>; /* 200 MHz */
+			};
+		};
+		adi,channelizer-paths {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			adi,interpolation = <AD9081_TX_CHAN_INTERPOLATION>;
+			trx3_ad9081_tx_fddc_chan0: channel@0 {
+				reg = <0>;
+				adi,gain = <AD9081_GAIN>; /* value * 10^(gain_dB/20) */
+				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_TX_CHAN_NCO_SHIFT>;
+			};
+			trx3_ad9081_tx_fddc_chan1: channel@1 {
+				reg = <1>;
+				adi,gain = <AD9081_GAIN>; /* value * 10^(gain_dB/20) */
+				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_TX_CHAN_NCO_SHIFT>;
+			};
+		};
+		adi,jesd-links {
+			#size-cells = <0>;
+			#address-cells = <1>;
+			trx3_ad9081_tx_jesd_l0: link@0 {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				reg = <0>;
+				adi,logical-lane-mapping = /bits/ 8 <0 1 2 3 4 5 6 7>;
+				adi,link-mode = <AD9081_TX_JESD_MODE>;			/* JESD Quick Configuration Mode */
+				adi,subclass = <AD9081_TX_JESD_SUBCLASS>;			/* JESD SUBCLASS 0,1,2 */
+				adi,version = <AD9081_TX_JESD_VERSION>;			/* JESD VERSION 0=204A,1=204B,2=204C */
+				adi,dual-link = <0>;			/* JESD Dual Link Mode */
+				adi,converters-per-device = <AD9081_TX_JESD_M>;	/* JESD M */
+				adi,octets-per-frame = <AD9081_TX_JESD_F>;		/* JESD F */
+				adi,frames-per-multiframe = <AD9081_TX_JESD_K>;	/* JESD K */
+				adi,converter-resolution = <AD9081_TX_JESD_N>;	/* JESD N */
+				adi,bits-per-sample = <AD9081_TX_JESD_N>;		/* JESD NP' */
+				adi,control-bits-per-sample = <AD9081_TX_JESD_CS>;	/* JESD CS */
+				adi,lanes-per-device = <AD9081_TX_JESD_L>;		/* JESD L */
+				adi,samples-per-converter-per-frame = <AD9081_TX_JESD_S>; /* JESD S */
+				adi,high-density = <AD9081_TX_JESD_HD>;			/* JESD HD */
+			};
+		};
+	};
+	adi,rx-adcs {
+		#size-cells = <0>;
+		#address-cells = <1>;
+		adi,adc-frequency-hz = /bits/ 64 <AD9081_ADC_FREQUENCY>;
+		adi,nyquist-zone = <AD9081_ADC_NYQUIST_ZONE>;
+		adi,main-data-paths {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			trx3_ad9081_adc0: adc@0 {
+				reg = <0>;
+				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
+				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
+				//adi,crossbar-select = <&trx3_ad9081_rx_fddc_chan0>, <&trx3_ad9081_rx_fddc_chan2>; /* Static for now */
+			};
+			trx3_ad9081_adc1: adc@1 {
+				reg = <1>;
+				adi,decimation = <AD9081_RX_MAIN_DECIMATION>;
+				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_MAIN_NCO_SHIFT>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
+				//adi,crossbar-select = <&trx3_ad9081_rx_fddc_chan1>, <&trx3_ad9081_rx_fddc_chan3>; /* Static for now */
+			};
+		};
+		adi,channelizer-paths {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			trx3_ad9081_rx_fddc_chan0: channel@0 {
+				reg = <0>;
+				adi,decimation = <AD9081_RX_CHAN_DECIMATION>;
+				adi,gain = <AD9081_GAIN>; /* value * 10^(gain_dB/20) */
+				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_CHAN_NCO_SHIFT>;
+			};
+			trx3_ad9081_rx_fddc_chan1: channel@1 {
+				reg = <1>;
+				adi,decimation = <AD9081_RX_CHAN_DECIMATION>;
+				adi,gain = <AD9081_GAIN>; /* value * 10^(gain_dB/20) */
+				adi,nco-frequency-shift-hz =  /bits/ 64 <AD9081_RX_CHAN_NCO_SHIFT>;
+			};
+		};
+		adi,jesd-links {
+			#size-cells = <0>;
+			#address-cells = <1>;
+			trx3_ad9081_rx_jesd_l0: link@0 {
+				reg = <0>;
+				adi,converter-select =
+					<&trx3_ad9081_rx_fddc_chan0 FDDC_I>, <&trx3_ad9081_rx_fddc_chan0 FDDC_Q>,
+					<&trx3_ad9081_rx_fddc_chan1 FDDC_I>, <&trx3_ad9081_rx_fddc_chan1 FDDC_Q>;
+				adi,logical-lane-mapping = /bits/ 8 <0 1 2 3 4 5 6 7>;
+				adi,link-mode = <AD9081_RX_JESD_MODE>;			/* JESD Quick Configuration Mode */
+				adi,subclass = <AD9081_RX_JESD_SUBCLASS>;			/* JESD SUBCLASS 0,1,2 */
+				adi,version = <AD9081_RX_JESD_VERSION>;			/* JESD VERSION 0=204A,1=204B,2=204C */
+				adi,dual-link = <0>;			/* JESD Dual Link Mode */
+				adi,device-id = <3>;
+				adi,converters-per-device = <AD9081_RX_JESD_M>;	/* JESD M */
+				adi,octets-per-frame = <AD9081_RX_JESD_F>;		/* JESD F */
+				adi,frames-per-multiframe = <AD9081_RX_JESD_K>;	/* JESD K */
+				adi,converter-resolution = <AD9081_RX_JESD_N>;	/* JESD N */
+				adi,bits-per-sample = <AD9081_RX_JESD_NP>;		/* JESD NP' */
+				adi,control-bits-per-sample = <AD9081_RX_JESD_CS>;	/* JESD CS */
+				adi,lanes-per-device = <AD9081_RX_JESD_L>;		/* JESD L */
+				adi,samples-per-converter-per-frame = <AD9081_RX_JESD_S>; /* JESD S */
+				adi,high-density = <AD9081_RX_JESD_HD>;			/* JESD HD */
+			};
+		};
+	};
+};

--- a/arch/microblaze/boot/dts/vcu118_quad_ad9081_204b_txmode_5_rxmode_6_onchip_pll_revc.dts
+++ b/arch/microblaze/boot/dts/vcu118_quad_ad9081_204b_txmode_5_rxmode_6_onchip_pll_revc.dts
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices Quad-MxFE (using internal PLL)
+ * https://wiki.analog.com/resources/eval/user-guides/quadmxfe
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-mxfe/ad9081
+ * https://wiki.analog.com/resources/eval/user-guides/ad_quadmxfe1_ebz/ad_quadmxfe1_ebz_hdl
+ *
+ * hdl_project: <ad_quadmxfe1_ebz/vcu118>
+ * board_revision: <Rev.C>
+ *
+ * Copyright (C) 2022 Analog Devices Inc.
+ */
+
+// For MxFE0
+//	* Cap rotate: DNI C886, Populate C1118
+//	* Cap rotate: DNI C887, Populate C1119
+// For MxFE1
+//	* Cap rotate: DNI C936, Populate C1120
+//	* Cap rotate: DNI C937, Populate C1267
+// For MxFE2
+//	* Cap rotate: DNI C986, Populate C1293
+//	* Cap rotate: DNI C987, Populate C1312
+// For MxFE3
+//	* Cap rotate: DNI C1036, Populate C1325
+//	* Cap rotate: DNI C1037, Populate C1326
+
+#define HMC7043_MXFE_CLKIN_CLKDIV 1
+
+#include "vcu118_quad_ad9081_204b_txmode_5_rxmode_6_revc.dts"
+
+&adf4371_clk0 {
+	adi,chip-powerdown-and-exit-enable;
+};
+
+&adf4371_clk1 {
+	adi,chip-powerdown-and-exit-enable;
+};
+
+&adf4371_clk2 {
+	adi,chip-powerdown-and-exit-enable;
+};
+
+&adf4371_clk3 {
+	adi,chip-powerdown-and-exit-enable;
+};
+
+&hmc7043 {
+	adi,high-performance-mode-clock-dist-enable;
+
+	hmc7043_c6: channel@6 {
+		reg = <6>;
+		adi,extended-name = "CLKIN_MXFE0";
+		adi,divider = <HMC7043_MXFE_CLKIN_CLKDIV>;
+		adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
+	};
+	hmc7043_c8: channel@8 {
+		reg = <8>;
+		adi,extended-name = "CLKIN_MXFE1";
+		adi,divider = <HMC7043_MXFE_CLKIN_CLKDIV>;
+		adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
+	};
+	hmc7043_c10: channel@10 {
+		reg = <10>;
+		adi,extended-name = "CLKIN_MXFE0";
+		adi,divider = <HMC7043_MXFE_CLKIN_CLKDIV>;
+		adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
+	};
+	hmc7043_c12: channel@12 {
+		reg = <12>;
+		adi,extended-name = "CLKIN_MXFE0";
+		adi,divider = <HMC7043_MXFE_CLKIN_CLKDIV>;
+		adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
+	};
+};
+
+&trx0_ad9081 {
+	clocks = <&hmc7043 6>;
+	/delete-property/ dev_clk-clock-scales;
+};
+
+&trx1_ad9081 {
+	clocks = <&hmc7043 8>;
+	/delete-property/ dev_clk-clock-scales;
+};
+
+&trx2_ad9081 {
+	clocks = <&hmc7043 10>;
+	/delete-property/ dev_clk-clock-scales;
+};
+
+&trx3_ad9081 {
+	clocks = <&hmc7043 12>;
+	/delete-property/ dev_clk-clock-scales;
+};

--- a/arch/microblaze/boot/dts/vcu118_quad_ad9081_204b_txmode_5_rxmode_6_onchip_pll_revc_nz1.dts
+++ b/arch/microblaze/boot/dts/vcu118_quad_ad9081_204b_txmode_5_rxmode_6_onchip_pll_revc_nz1.dts
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices Quad-MxFE AD-QUADMXFE2-EBZ first Nyquist Zone operation
+ * https://wiki.analog.com/resources/eval/user-guides/quadmxfe
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-mxfe/ad9081
+ * https://wiki.analog.com/resources/eval/user-guides/ad_quadmxfe1_ebz/ad_quadmxfe1_ebz_hdl
+ *
+ * hdl_project: <ad_quadmxfe1_ebz/vcu118>
+ * board_revision: <Rev.C>
+ *
+ * Copyright (C) 2022 Analog Devices Inc.
+ */
+
+#include <dt-bindings/iio/adc/adi,ad9081.h>
+
+#define AD9081_TX_MAIN_NCO_SHIFT		1000000000
+#define AD9081_TX_CHAN_NCO_SHIFT		0
+
+#define AD9081_RX_MAIN_NCO_SHIFT		1000000000
+#define AD9081_RX_CHAN_NCO_SHIFT		0
+
+#define AD9081_ADC_NYQUIST_ZONE		AD9081_ADC_NYQUIST_ZONE_ODD
+
+#include "vcu118_quad_ad9081_204b_txmode_5_rxmode_6_onchip_pll_revc.dts"
+
+/ {
+	model = "Analog Devices AD-QUADMXFE2-EBZ";
+};

--- a/arch/microblaze/boot/dts/vcu118_quad_ad9081_204b_txmode_5_rxmode_6_revc.dts
+++ b/arch/microblaze/boot/dts/vcu118_quad_ad9081_204b_txmode_5_rxmode_6_revc.dts
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices Quad-MxFE
+ * https://wiki.analog.com/resources/eval/user-guides/quadmxfe
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-mxfe/ad9081
+ * https://wiki.analog.com/resources/eval/user-guides/ad_quadmxfe1_ebz/ad_quadmxfe1_ebz_hdl
+ *
+ * hdl_project: <ad_quadmxfe1_ebz/vcu118>
+ * board_revision: <Rev.C>
+ *
+ * Copyright (C) 2022 Analog Devices Inc.
+ */
+
+#include "vcu118_quad_ad9081_204b_txmode_5_rxmode_6.dts"
+
+/ {
+	model = "Analog Devices AD-QUADMXFE1-EBZ Rev.C";
+};
+
+&gpio_hmc425a {
+	compatible = "adi,hmc540s";
+	ctrl-gpios = <&axi_gpio 38 GPIO_ACTIVE_HIGH>,
+		<&axi_gpio 37 GPIO_ACTIVE_HIGH>,
+		<&axi_gpio 36 GPIO_ACTIVE_HIGH>,
+		<&axi_gpio 35 GPIO_ACTIVE_HIGH>;
+};
+
+&fmc_i2c {
+	current_limiter@58 {
+		compatible = "adi,adm1177-iio";
+		reg = <0x58>;
+		adi,r-sense-mohm = <10>; /* 10 mOhm */
+		adi,shutdown-threshold-ma = <10000>; /* 10 A */
+		adi,vrange-high-enable;
+	};
+};
+
+&axi_ad9081_rx_jesd {
+	clocks = <&clk_bus_0>, <&hmc7043 2>, <&axi_ad9081_adxcvr_rx 1>, <&axi_ad9081_adxcvr_rx 0>;
+	clock-names = "s_axi_aclk", "device_clk", "link_clk", "lane_clk";
+};
+
+&axi_ad9081_tx_jesd {
+	clocks = <&clk_bus_0>, <&hmc7043 4>, <&axi_ad9081_adxcvr_tx 1>, <&axi_ad9081_adxcvr_tx 0>;
+	clock-names = "s_axi_aclk", "device_clk", "link_clk", "lane_clk";
+};
+
+&hmc7043 {
+	hmc7043_c0: channel@0 {
+		reg = <0>;
+		adi,extended-name = "FPGA_REFCLK";
+		adi,divider = <HMC7043_FPGA_XCVR_CLKDIV>;
+		adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
+	};
+
+	hmc7043_c1: channel@1 {
+		reg = <1>;
+		adi,extended-name = "SYSREF_FPGA";
+		adi,divider = <HMC7043_SYSREF_CLKDIV>;
+		adi,driver-mode = <HMC7044_DRIVER_MODE_LVPECL>;
+		adi,coarse-digital-delay = <0>;
+		adi,fine-analog-delay = <0>;
+		adi,output-mux-mode = <0>;
+		adi,jesd204-sysref-chan;
+	};
+
+	hmc7043_c2: channel@2 {
+		reg = <2>;
+		adi,extended-name = "RX_CORE_LINK_CLK";
+		adi,divider = <HMC7043_FPGA_LINK_CLKDIV>;
+		adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
+	};
+
+	/delete-node/ hmc7043_c3;
+
+	hmc7043_c4: channel@4 {
+		reg = <4>;
+		adi,extended-name = "TX_CORE_LINK_CLK";
+		adi,divider = <HMC7043_FPGA_LINK_CLKDIV>;
+		adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
+	};
+
+	/delete-node/ hmc7043_c5;
+	/delete-node/ hmc7043_c6;
+
+	hmc7043_c7: channel@7 {
+		reg = <7>;
+		adi,extended-name = "SYSREF_MXFE0";
+		adi,divider = <HMC7043_SYSREF_CLKDIV>;
+		adi,driver-mode = <HMC7044_DRIVER_MODE_LVPECL>;
+		adi,coarse-digital-delay = <0>;
+		adi,fine-analog-delay = <0>;
+		adi,output-mux-mode = <0>;
+		adi,jesd204-sysref-chan;
+	};
+
+	/delete-node/ hmc7043_c8;
+
+	hmc7043_c9: channel@9 {
+		reg = <9>;
+		adi,extended-name = "SYSREF_MXFE1";
+		adi,divider = <HMC7043_SYSREF_CLKDIV>;
+		adi,driver-mode = <HMC7044_DRIVER_MODE_LVPECL>;
+		adi,coarse-digital-delay = <0>;
+		adi,fine-analog-delay = <0>;
+		adi,output-mux-mode = <0>;
+		adi,jesd204-sysref-chan;
+	};
+
+	/delete-node/ hmc7043_c10;
+
+	hmc7043_c11: channel@11 {
+		reg = <11>;
+		adi,extended-name = "SYSREF_MXFE2";
+		adi,divider = <HMC7043_SYSREF_CLKDIV>;
+		adi,driver-mode = <HMC7044_DRIVER_MODE_LVPECL>;
+		adi,coarse-digital-delay = <0>;
+		adi,fine-analog-delay = <0>;
+		adi,output-mux-mode = <0>;
+		adi,jesd204-sysref-chan;
+	};
+
+	/delete-node/ hmc7043_c12;
+
+	hmc7043_c13: channel@13 {
+		reg = <13>;
+		adi,extended-name = "SYSREF_MXFE3";
+		adi,divider = <HMC7043_SYSREF_CLKDIV>;
+		adi,driver-mode = <HMC7044_DRIVER_MODE_LVPECL>;
+		adi,coarse-digital-delay = <0>;
+		adi,fine-analog-delay = <0>;
+		adi,output-mux-mode = <0>;
+		adi,jesd204-sysref-chan;
+	};
+};
+
+&trx0_ad9081 {
+	/delete-property/ adi,jesd-sync-pins-01-swap-enable;
+	adi,jesd-sync-pin-0a-cmos-enable;
+};
+
+&trx1_ad9081 {
+	/delete-property/ adi,jesd-sync-pins-01-swap-enable;
+	adi,jesd-sync-pin-0a-cmos-enable;
+};
+
+&trx2_ad9081 {
+	/delete-property/ adi,jesd-sync-pins-01-swap-enable;
+	adi,jesd-sync-pin-0a-cmos-enable;
+};
+
+&trx3_ad9081 {
+	/delete-property/ adi,jesd-sync-pins-01-swap-enable;
+	adi,jesd-sync-pin-0a-cmos-enable;
+};


### PR DESCRIPTION
This setup assumes 500MHz clock into J41 (0 dBm)
ad9081_204b_txmode_5_rxmode_6: Np 16 use case with low lane rate
    * 2Txs / 2Rxs per MxFE
    * DAC_CLK = 4GSPS
    * ADC_CLK = 4GSPS
    * Tx I/Q Rate: 125 MSPS (Interpolation of 4x8)
    * Rx I/Q Rate: 125 MSPS (Decimation of 4x8)
    * DAC JESD204B: Mode 5, L=2, M=4, N=N'=16
    * ADC JESD204B: Mode 6, L=2, M=4, N=N'=16
    * DAC-Side JESD204B Lane Rate: 5.00Gbps
    * ADC-Side JESD204B Lane Rate: 5.00Gbps

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>