### PR TITLE
arch: arm: overlays: rpi-ad9545-hmc7044: add LEDs

### DIFF
--- a/arch/arm/boot/dts/overlays/rpi-ad9545-hmc7044-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ad9545-hmc7044-overlay.dts
@@ -130,11 +130,18 @@
 					export;
 				};
 
-				pin-12-red_led {
+				pin-32-red_led {
 					pins = "gpio12";
 					function = "gpio_out";
 					bias-pull-up;
 					output-high;
+					export;
+				};
+
+				pin-36-green_led {
+					pins = "gpio16";
+					function = "gpio_out";
+					bias-pull-up;
 					export;
 				};
 


### PR DESCRIPTION
Pins 32 and 36 of RPi 4 are used here for LEDs control.
They are controlled by a user-space application.
Export them from DT instead of having the user to export
them and change direction.

Signed-off-by: Alexandru Tachici <alexandru.tachici@analog.com>