### PR TITLE
arch: arm: dts: zynq-coraz7s: add sysid support

### DIFF
--- a/arch/arm/boot/dts/zynq-coraz7s.dtsi
+++ b/arch/arm/boot/dts/zynq-coraz7s.dtsi
@@ -41,6 +41,11 @@
 		#address-cells = <0x1>;
 		#size-cells = <0x1>;
 		ranges;
+
+		axi_sysid_0: axi-sysid-0@45000000 {
+			compatible = "adi,axi-sysid-1.00.a";
+			reg = <0x45000000 0x10000>;
+		};
 	};
 };
 


### PR DESCRIPTION
Add axi sysid node in device tree to enable sysid for
coraz7s based designs

Signed-off-by: Sergiu Arpadi <sergiu.arpadi@analog.com>