### PR TITLE
ci: fix building inside docker

### DIFF
--- a/ci/travis/run-build.sh
+++ b/ci/travis/run-build.sh
@@ -189,6 +189,11 @@ build_default() {
 	APT_LIST="$APT_LIST git"
 
 	apt_update_install $APT_LIST
+
+	# make sure git does not complain about unsafe repositories when
+	# building inside docker.
+	[ -d /docker_build_dir ] && git config --global --add safe.directory /docker_build_dir
+
 	make ${DEFCONFIG}
 	if [[ "${SYSTEM_PULLREQUEST_TARGETBRANCH}" =~ ^rpi-.* || "${BUILD_SOURCEBRANCH}" =~ ^refs/heads/rpi-.* \
 		|| "${BUILD_SOURCEBRANCH}" =~ ^refs/heads/staging-rpi ]]; then


### PR DESCRIPTION
With new git versions, git will stop executing when looking at .git
directories with different ownership from the current user. This is
fixing some vulnerabilities recently found in git. More info in [1].

In our case, this will happen because we are running the build inside a
container which is running as the root user (not sharing UID with the
host) while the repository is being checked out by the host system (azure
VM) with a different UID.

Fix it by adding the docker path to git safe.directory. At some point we
should just stop doing builds inside docker wih azure (it runs it's own
vm per job already).

[1]: https://github.blog/2022-04-12-git-security-vulnerability-announced/
Signed-off-by: Nuno Sá <nuno.sa@analog.com>