### PR TITLE
arch: arm64: dts: zcu102-fmcomms8: add sysid support

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9009-fmcomms8.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9009-fmcomms8.dts
@@ -296,5 +296,10 @@
 			adi,axi-pl-fifo-enable;
 			plddrbypass-gpios = <&gpio 146 0>;
 		};
+
+		axi_sysid_0: axi-sysid-0@85000000 {
+			compatible = "adi,axi-sysid-1.00.a";
+			reg = <0x85000000 0x2000>;
+		};
 	};
 };


### PR DESCRIPTION
Device tree was missing sysid node

Signed-off-by: Sergiu Arpadi sergiu.arpadi@analog.com