### PR TITLE
ci: fix build inside docker

### DIFF
--- a/ci/travis/run-build-docker.sh
+++ b/ci/travis/run-build-docker.sh
@@ -18,7 +18,7 @@ else
 		fi
 	done
 	export OS_TYPE=ubuntu
-	export OS_VERSION=latest
+	export OS_VERSION=20.04
 	prepare_docker_image
 	run_docker_script run-build.sh
 fi


### PR DESCRIPTION
This is yet another try to fix the build when using docker. It was
already wrongly tried in commit b4f54a952278 ("ci: use latest ubuntu stable
image for docker builds"). The issue is that by using the latest tag,
the distro version used to build might change under our feet and break
things. This was indeed happening as ubuntu:latest now points to 22.04
which brings gcc-arm 11.2 which does not work with our kernel tree.

Fix this by using a version tag (in this case ubuntu 20.04) instead of
latest as that should not change in a way that major updates will occur in
it's packages and hence breaking the build.

Fixes: b4f54a952278 ("ci: use latest ubuntu stable image for docker builds")
Signed-off-by: Nuno Sá <nuno.sa@analog.com>