### PR TITLE
Adin2111 add support

### DIFF
--- a/Documentation/devicetree/bindings/net/adi,adin1110.yaml
+++ b/Documentation/devicetree/bindings/net/adi,adin1110.yaml
@@ -18,12 +18,21 @@ description: |
   an Ethernet PHY core with a MAC and all the associated analog
   circuitry, input and output clock buffering.
 
+  The ADIN2111 is a low power, low complexity, two-Ethernet ports
+  switch with integrated 10BASE-T1L PHYs and one serial peripheral
+  interface (SPI) port. The device is designed for industrial Ethernet
+  applications using low power constrained nodes and is compliant
+  with the IEEE 802.3cg-2019 Ethernet standard for long reach
+  10 Mbps single pair Ethernet (SPE).
+
   The device has a 4-wire SPI interface for communication
   between the MAC and host processor.
 
 properties:
   compatible:
-    const: adi,adin1110
+    enum:
+      - adi,adin1110
+      - adi,adin2111
 
   '#address-cells':
     const: 1
@@ -42,17 +51,31 @@ properties:
   interrupts:
     maxItems: 1
 
-  phy@0:
+patternProperties:
+  "^phy@[0-1]$":
     description: |
       ADIN1100 PHY that is present on the same chip as the MAC.
     type: object
 
     properties:
       reg:
-        const: 0
+        items:
+          maximum: 1
 
-      compatible:
-        const: ethernet-phy-id0283.bc91
+    allOf:
+      - if:
+          properties:
+            compatible:
+              contains:
+                const: adi,adin1110
+        then:
+          properties:
+            compatible:
+              const: ethernet-phy-id0283.bc91
+        else:
+          properties:
+            compatible:
+              const: ethernet-phy-id0283.bca1
 
     required:
       - compatible

--- a/drivers/net/ethernet/adi/adin1110.c
+++ b/drivers/net/ethernet/adi/adin1110.c
@@ -494,7 +494,8 @@ static irqreturn_t adin1110_irq(int irq, void *p)
 		return IRQ_HANDLED;
 	}
 
-	priv->tx_space = val;
+	/* TX FIFO space is expressed in half-words */
+	priv->tx_space = 2 * val;
 
 	if (status1 & ADIN1110_RX_RDY)
 		adin1110_read_frames(priv);
@@ -685,7 +686,7 @@ static int adin1110_net_open(struct net_device *net_dev)
 		return ret;
 	}
 
-	priv->tx_space = val;
+	priv->tx_space = 2 * val;
 
 	ret = adin1110_init_mac(priv);
 	if (ret < 0)

--- a/drivers/net/ethernet/adi/adin1110.c
+++ b/drivers/net/ethernet/adi/adin1110.c
@@ -689,8 +689,10 @@ static int adin1110_net_open(struct net_device *net_dev)
 	priv->tx_space = 2 * val;
 
 	ret = adin1110_init_mac(priv);
-	if (ret < 0)
+	if (ret < 0) {
+		mutex_unlock(&priv->lock);
 		return ret;
+	}
 
 	mutex_unlock(&priv->lock);
 

--- a/drivers/net/phy/adin1100.c
+++ b/drivers/net/phy/adin1100.c
@@ -16,6 +16,7 @@
 
 #define PHY_ID_ADIN1100				0x0283bc81
 #define PHY_ID_ADIN1110				0x0283bc91
+#define PHY_ID_ADIN2111				0x0283bca1
 
 static const int phy_10_features_array[] = {
 	ETHTOOL_LINK_MODE_10baseT_Full_BIT,
@@ -130,6 +131,8 @@ static int adin_match_phy_device(struct phy_device *phydev)
 	case PHY_ID_ADIN1100:
 		return 1;
 	case PHY_ID_ADIN1110:
+		return 1;
+	case PHY_ID_ADIN2111:
 		return 1;
 	default:
 		return 0;
@@ -482,7 +485,8 @@ static int adin_probe(struct phy_device *phydev)
 
 static struct phy_driver adin_driver[] = {
 	{
-		PHY_ID_MATCH_MODEL(PHY_ID_ADIN1100),
+		.phy_id			= PHY_ID_ADIN1100,
+		.phy_id_mask		= GENMASK(31, 8),
 		.name			= "ADIN1100",
 		.get_features		= adin_get_features,
 		.match_phy_device	= adin_match_phy_device,
@@ -506,6 +510,7 @@ module_phy_driver(adin_driver);
 static struct mdio_device_id __maybe_unused adin_tbl[] = {
 	{ PHY_ID_MATCH_MODEL(PHY_ID_ADIN1100) },
 	{ PHY_ID_MATCH_MODEL(PHY_ID_ADIN1110) },
+	{ PHY_ID_MATCH_MODEL(PHY_ID_ADIN2111) },
 	{ }
 };
 


### PR DESCRIPTION
The ADIN2111 is a low power, low complexity, two-Ethernet ports
switch with integrated 10BASE-T1L PHYs and one serial peripheral
interface (SPI) port.

ADIN2111 contains two ADIN1100 PHYs that are exposed to the user via an
internal MDIO bus. The bus can be accessed via read/write of the MAC's SPI
MDIO control registers.

The driver will register and allocate two struct net_dev structures called "port netdevs".
These are the highest level abstraction of a MAC's physical port.
In this way 

Using standard netdev tools (iproute2, ethtool, etc), the port netdev can also provide to
the user access to the physical properties of the switch port such as PHY link state and I/O statistics.

Ex:

```
adin2111-0-p0: flags=4099<UP,BROADCAST,MULTICAST>  mtu 1500
        inet 192.168.160.160  netmask 255.255.255.0  broadcast 192.168.160.255
        inet6 fe80::c82f:b7ff:fe10:2363  prefixlen 64  scopeid 0x20<link>
        ether ca:2f:b7:10:23:63  txqueuelen 1000  (Ethernet)
        RX packets 29  bytes 2400 (2.3 KiB)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 99  bytes 11666 (11.3 KiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
        device interrupt 199
adin2111-0-p1: flags=4419<UP,BROADCAST,RUNNING,PROMISC,MULTICAST>  mtu 1500
        inet 192.168.160.160  netmask 255.255.255.0  broadcast 192.168.160.255
        inet6 fe80::c82f:b7ff:fe10:2364  prefixlen 64  scopeid 0x20<link>
        ether ca:2f:b7:10:23:64  txqueuelen 1000  (Ethernet)
        RX packets 69  bytes 6696 (6.5 KiB)
        RX errors 2  dropped 0  overruns 0  frame 0
        TX packets 126  bytes 17366 (16.9 KiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
        device interrupt 199

```
