### PR TITLE
Ad9545 fix zero delay property

### DIFF
--- a/Documentation/devicetree/bindings/clock/clk-ad9545.yaml
+++ b/Documentation/devicetree/bindings/clock/clk-ad9545.yaml
@@ -267,7 +267,7 @@ patternProperties:
       '#size-cells':
          const: 0
 
-      adi,pll-internal-zero-delay:
+      adi,pll-internal-zero-delay-feedback-hz:
         description: |
           Rate of the output that will be used as a feedback path for this PLL bloc.
         $ref: /schemas/types.yaml#/definitions/uint32

--- a/drivers/clk/adi/clk-ad9545.c
+++ b/drivers/clk/adi/clk-ad9545.c
@@ -838,7 +838,8 @@ static int ad9545_parse_dt_plls(struct ad9545_state *st)
 			st->pll_clks[addr].internal_zero_delay_source = val;
 		}
 
-		ret = fwnode_property_read_u32(child, "adi,pll-internal-zero-delay", &val);
+		ret = fwnode_property_read_u32(child, "adi,pll-internal-zero-delay-feedback-hz",
+					       &val);
 		if (prop_found && !ret) {
 			if (val >= AD9545_MAX_ZERO_DELAY_RATE) {
 				dev_err(st->dev, "Invalid zero-delay output rate: %u.", val);


### PR DESCRIPTION
0386d3447bcc - bindings: clock: ad9545: fix zero delay property
28711c9c8888 - clk: ad9545: fix zero delay property

Also, pyadi-dt uses the same property name as the one in this fix.