### PR TITLE
dmaengine: axi-dmac: check cache coherency register

### DIFF
--- a/drivers/dma/dma-axi-dmac.c
+++ b/drivers/dma/dma-axi-dmac.c
@@ -18,6 +18,7 @@
 #include <linux/module.h>
 #include <linux/of.h>
 #include <linux/of_dma.h>
+#include <linux/of_address.h>
 #include <linux/platform_device.h>
 #include <linux/regmap.h>
 #include <linux/slab.h>
@@ -55,6 +56,9 @@
 #define   AXI_DMAC_DMA_DST_TYPE_GET(x)	FIELD_GET(AXI_DMAC_DMA_DST_TYPE_MSK, x)
 #define   AXI_DMAC_DMA_DST_WIDTH_MSK	GENMASK(3, 0)
 #define   AXI_DMAC_DMA_DST_WIDTH_GET(x)	FIELD_GET(AXI_DMAC_DMA_DST_WIDTH_MSK, x)
+#define AXI_DMAC_REG_COHERENCY_DESC	0x14
+#define   AXI_DMAC_DST_COHERENT_MSK	BIT(0)
+#define   AXI_DMAC_DST_COHERENT_GET(x)	FIELD_GET(AXI_DMAC_DST_COHERENT_MSK, x)
 
 #define AXI_DMAC_REG_IRQ_MASK		0x80
 #define AXI_DMAC_REG_IRQ_PENDING	0x84
@@ -1005,6 +1009,18 @@ static int axi_dmac_probe(struct platform_device *pdev)
 	dma_dev->copy_align = (dmac->chan.address_align_mask + 1);
 
 	axi_dmac_write(dmac, AXI_DMAC_REG_IRQ_MASK, 0x00);
+
+	if (of_dma_is_coherent(pdev->dev.of_node)) {
+		ret = axi_dmac_read(dmac, AXI_DMAC_REG_COHERENCY_DESC);
+
+		if (version < ADI_AXI_PCORE_VER(4, 4, 'a') ||
+		    !AXI_DMAC_DST_COHERENT_GET(ret)) {
+			dev_err(dmac->dma_dev.dev,
+				"Coherent DMA not supported in hardware");
+			ret = -EINVAL;
+			goto err_clk_disable;
+		}
+	}
 
 	ret = dma_async_device_register(dma_dev);
 	if (ret)


### PR DESCRIPTION
Marking the DMA as cache coherent (dma-coherent in devicetree) is only
safe with versions of axi_dmac that have this feature enabled.

Related to https://github.com/analogdevicesinc/hdl/pull/925.

Example devicetree using the dma-coherent property:

```
mydma: dma@82510000 {
	compatible = "adi,axi-dmac-1.00.a";
	reg = <0x0 0x0082510000 0x0 0x1000>;
	interrupt-parent = <&gic>;
	interrupts = <0 111 4>;
	clock-names = "s_axi_aclk";
	clocks = <&zynqmp_clk 71>;
	#dma-cells = <1>;
	dma-coherent;

	adi,channels {
		#size-cells = <0>;
		#address-cells = <1>;

		dma-channel@0 {
			reg = <0>;
			adi,source-bus-width = <64>;
			adi,source-bus-type = <AXI_DMAC_TYPE_AXI_STREAM>;
			adi,destination-bus-width = <128>;
			adi,destination-bus-type = <AXI_DMAC_TYPE_AXI_MM>;
		};
	};
};
```
Data can be corrupt if used with a version of axi-dmac that does not support
this feature.

Thoughts? Anything I've missed?