### PR TITLE
Adin1110 fix forwarding

### DIFF
--- a/drivers/net/ethernet/adi/adin1110.c
+++ b/drivers/net/ethernet/adi/adin1110.c
@@ -122,9 +122,9 @@
 
 #define ADIN_MAC_MAX_PORTS			2
 
-#define ADIN_MAC_ADDR_SLOT			0
-#define ADIN_MAC_BROADCAST_ADDR_SLOT		1
-#define ADIN_MAC_MULTICAST_ADDR_SLOT		2
+#define ADIN_MAC_MULTICAST_ADDR_SLOT		0
+#define ADIN_MAC_ADDR_SLOT			1
+#define ADIN_MAC_BROADCAST_ADDR_SLOT		2
 
 DECLARE_CRC8_TABLE(adin1110_crc_table);
 
@@ -633,13 +633,18 @@ static int adin1110_write_mac_address(struct adin1110_port_priv *port_priv, int 
 	if (ret < 0)
 		return ret;
 
-	val = get_unaligned_be16(&mask[0]);
-	ret = adin1110_write_reg(priv, ADIN1110_MAC_ADDR_MASK_UPR + offset, val);
-	if (ret < 0)
-		return ret;
+	/* only the first two MAC address slots support masking */
+	if (mac_nr < ADIN_MAC_BROADCAST_ADDR_SLOT) {
+		val = get_unaligned_be16(&mask[0]);
+		ret = adin1110_write_reg(priv, ADIN1110_MAC_ADDR_MASK_UPR + offset, val);
+		if (ret < 0)
+			return ret;
 
-	val = get_unaligned_be32(&mask[2]);
-	return adin1110_write_reg(priv, ADIN1110_MAC_ADDR_MASK_LWR + offset, val);
+		val = get_unaligned_be32(&mask[2]);
+		return adin1110_write_reg(priv, ADIN1110_MAC_ADDR_MASK_LWR + offset, val);
+	}
+
+	return 0;
 }
 
 static int adin1110_clear_mac_address(struct adin1110_port_priv *port_priv, int mac_nr)

--- a/drivers/net/ethernet/adi/adin1110.c
+++ b/drivers/net/ethernet/adi/adin1110.c
@@ -72,6 +72,7 @@
 #define   ADIN2111_MAC_ADDR_APPLY2PORT2		BIT(31)
 #define   ADIN1110_MAC_ADDR_APPLY2PORT		BIT(30)
 #define   ADIN1110_MAC_ADDR_HOST_PRI		BIT(19)
+#define   ADIN2111_MAC_ADDR_TO_OTHER_PORT	BIT(17)
 #define   ADIN1110_MAC_ADDR_TO_HOST		BIT(16)
 #define   ADIN1110_MAC_ADDR			GENMASK(15, 0)
 
@@ -618,8 +619,13 @@ static int adin1110_write_mac_address(struct adin1110_port_priv *port_priv, int 
 	u32 val;
 
 	port_rules = ADIN1110_MAC_ADDR_APPLY2PORT;
-	if (priv->cfg->id == ADIN2111_MAC)
+	if (priv->cfg->id == ADIN2111_MAC) {
 		port_rules |= ADIN2111_MAC_ADDR_APPLY2PORT2;
+
+		/* Broadcast and multicast should also be forwarded to the other port */
+		if (mac_nr != ADIN_MAC_ADDR_SLOT)
+			port_rules |= ADIN2111_MAC_ADDR_TO_OTHER_PORT;
+	}
 
 	/* tell MAC to forward this DA to host */
 	val = port_rules | ADIN1110_MAC_ADDR_TO_HOST;


### PR DESCRIPTION
25a55e7a040d - net: ethernet: adi: adin1110: Fix forwarding
304a700bce83 - net: ethernet: adi: adin1110: Fix MAC address masking

Just found out that ADIN2111 can't mask more than 2 MAC Addresses and that it can perform forwarding offloading in case of multicast and broadcast addresses (no need for the user to start playing with iptables)