### PR TITLE
Rpi adin1110 overlays

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -167,6 +167,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	qca7000-uart0.dtbo \
 	rotary-encoder.dtbo \
 	rpi-ada4250.dtbo \
+	rpi-adin1110.dtbo \
 	rpi-adau1761.dtbo \
 	rpi-adau1472.dtbo \
 	rpi-addi9036.dtbo \

--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -168,6 +168,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	rotary-encoder.dtbo \
 	rpi-ada4250.dtbo \
 	rpi-adin1110.dtbo \
+	rpi-adin2111.dtbo \
 	rpi-adau1761.dtbo \
 	rpi-adau1472.dtbo \
 	rpi-addi9036.dtbo \

--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -211,6 +211,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	rpi-cn0508.dtbo \
 	rpi-cn0511.dtbo \
 	rpi-cn0566.dtbo \
+	rpi-cn0575.dtbo \
 	rpi-dac.dtbo \
 	rpi-dc1962c.dtbo \
 	rpi-display.dtbo \

--- a/arch/arm/boot/dts/overlays/rpi-adin1110-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-adin1110-overlay.dts
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR BSD-3-Clause)
+/* Overlay for EVAL-ADIN1110EBZ Rev. B
+ *
+ * Copyright 2022 Analog Devices Inc.
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/interrupt-controller/irq.h>
+
+&spidev0 {
+	status = "disabled";
+};
+
+&spidev1 {
+	status = "disabled";
+};
+
+&spi0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	ethernet@0 {
+		compatible = "adi,adin1110";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		adi,spi-crc;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		interrupt-parent = <&gpio>;
+		interrupts = <25 IRQ_TYPE_LEVEL_LOW>;
+		mac-address = [ CA 2F B7 10 23 63 ];
+
+		phy@0 {
+			compatible = "ethernet-phy-id0283.bc91";
+			reg = <0x0>;
+		};
+	};
+};
+
+&gpio {
+	gpio_overrides: gpio_overrides {
+		pin-13-reset-high {
+			pins = "gpio27";
+			function = "gpio_out";
+			bias-pull-up;
+			output-high;
+			export;
+		};
+	};
+};
+

--- a/arch/arm/boot/dts/overlays/rpi-adin2111-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-adin2111-overlay.dts
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR BSD-3-Clause)
+/* Overlay for EVAL-ADIN2111EBZ Rev. B
+ *
+ * Copyright 2022 Analog Devices Inc.
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/interrupt-controller/irq.h>
+
+&spidev0 {
+	status = "disabled";
+};
+
+&spidev1 {
+	status = "disabled";
+};
+
+&spi0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	ethernet@0 {
+		compatible = "adi,adin2111";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		interrupt-parent = <&gpio>;
+		interrupts = <25 IRQ_TYPE_LEVEL_LOW>;
+		mac-address = [ CA 2F B7 10 23 63 ];
+
+		phy@0 {
+			compatible = "ethernet-phy-id0283.bca1";
+			reg = <0x0>;
+		};
+
+		phy@1 {
+			compatible = "ethernet-phy-id0283.bca1";
+			reg = <0x1>;
+		};
+	};
+};
+
+&gpio {
+	gpio_overrides: gpio_overrides {
+		pin-13-reset-high {
+			pins = "gpio27";
+			function = "gpio_out";
+			bias-pull-up;
+			output-high;
+			export;
+		};
+	};
+};
+

--- a/arch/arm/boot/dts/overlays/rpi-cn0575-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-cn0575-overlay.dts
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR BSD-3-Clause)
+/* Overlay for EVAL-CN0575-RPIZ Rev. A
+ *
+ * Copyright 2022 Analog Devices Inc.
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/interrupt-controller/irq.h>
+
+&spidev0 {
+	status = "disabled";
+};
+
+&spidev1 {
+	status = "disabled";
+};
+
+&spi0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	ethernet@0 {
+		compatible = "adi,adin1110";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		interrupt-parent = <&gpio>;
+		interrupts = <25 IRQ_TYPE_LEVEL_LOW>;
+		mac-address = [ CA 2F B7 10 23 63 ];
+
+		phy@0 {
+			compatible = "ethernet-phy-id0283.bc91";
+			reg = <0x0>;
+		};
+	};
+};
+
+&i2c1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	adt75@48 {
+		reg = <0x48>;
+		compatible = "adi,adt75";
+	};
+};
+
+&gpio {
+	gpio_overrides: gpio_overrides {
+		pin-13-reset-high {
+			pins = "gpio27";
+			function = "gpio_out";
+			bias-pull-up;
+			output-high;
+			export;
+		};
+	};
+};
+


### PR DESCRIPTION
c4d61df2595b - arch: arm: overlays: add eval-adin2111 overlay
fb13e779f923 - arch: arm: overlays: add cn0575 overlay
451e0c33f3f6 - arch: arm: overlays: add adin1110 overlay

A bunch of overlays for every adin1110 eval board out there.