### PR TITLE
arch: arm64: dts: zcu102-cn0506: add sysid support

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-cn0506-mii.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-cn0506-mii.dts
@@ -10,3 +10,18 @@
  */
 #include "zynqmp-zcu102-rev1.0.dts"
 #include "adi-cn0506-mii.dtsi"
+
+/ {
+	fpga_axi: fpga-axi@0 {
+		interrupt-parent = <&gic>;
+		compatible = "simple-bus";
+		#address-cells = <0x1>;
+		#size-cells = <0x1>;
+		ranges = <0 0 0 0xffffffff>;
+
+		axi_sysid_0: axi-sysid-0@85000000 {
+			compatible = "adi,axi-sysid-1.00.a";
+			reg = <0x85000000 0x2000>;
+		};
+	};
+};

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-cn0506-rgmii.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-cn0506-rgmii.dts
@@ -10,3 +10,18 @@
  */
 #include "zynqmp-zcu102-rev1.0.dts"
 #include "adi-cn0506-rgmii.dtsi"
+
+/ {
+	fpga_axi: fpga-axi@0 {
+		interrupt-parent = <&gic>;
+		compatible = "simple-bus";
+		#address-cells = <0x1>;
+		#size-cells = <0x1>;
+		ranges = <0 0 0 0xffffffff>;
+
+		axi_sysid_0: axi-sysid-0@85000000 {
+			compatible = "adi,axi-sysid-1.00.a";
+			reg = <0x85000000 0x2000>;
+		};
+	};
+};

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-cn0506-rmii.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-cn0506-rmii.dts
@@ -10,3 +10,18 @@
  */
 #include "zynqmp-zcu102-rev1.0.dts"
 #include "adi-cn0506-rmii.dtsi"
+
+/ {
+	fpga_axi: fpga-axi@0 {
+		interrupt-parent = <&gic>;
+		compatible = "simple-bus";
+		#address-cells = <0x1>;
+		#size-cells = <0x1>;
+		ranges = <0 0 0 0xffffffff>;
+
+		axi_sysid_0: axi-sysid-0@85000000 {
+			compatible = "adi,axi-sysid-1.00.a";
+			reg = <0x85000000 0x2000>;
+		};
+	};
+};


### PR DESCRIPTION
Device trees for zcu102-cn0506-mii/rmii/rgmii projects
were missing sysid node.

Signed-off-by: Sergiu Arpadi <sergiu.arpadi@analog.com>