### PR TITLE
arch: arm: dts: Add fpga-axi dt node

### DIFF
--- a/arch/arm/boot/dts/zynq-zed-otg.dts
+++ b/arch/arm/boot/dts/zynq-zed-otg.dts
@@ -14,6 +14,15 @@
 
 #include "zynq-zed.dtsi"
 
+/{
+   fpga_axi: fpga-axi@0 {
+        compatible = "simple-bus";
+        #address-cells = <0x1>;
+        #size-cells = <0x1>;
+        ranges;
+   };
+};
+
 &usb0 {
 	dr_mode = "otg";
 };

--- a/arch/arm/boot/dts/zynq-zed-otg.dts
+++ b/arch/arm/boot/dts/zynq-zed-otg.dts
@@ -16,11 +16,11 @@
 
 /{
    fpga_axi: fpga-axi@0 {
-        compatible = "simple-bus";
-        #address-cells = <0x1>;
-        #size-cells = <0x1>;
-        ranges;
-   };
+	compatible = "simple-bus";
+	#address-cells = <0x1>;
+	#size-cells = <0x1>;
+	ranges;
+	};
 };
 
 &usb0 {


### PR DESCRIPTION
This change adds an fpga-axi node to the root device tree for
product evaluation. This will allow for multiple small overlays to be
applied to the device-tree at run-time.

Signed-off-by: Sean Smith <sean.smith@analog.com>