### PR TITLE
xmicrowave dts updates

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-revb-adrv2crr-fmc-revb-jesd204-fsm-xmicrowave.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-revb-adrv2crr-fmc-revb-jesd204-fsm-xmicrowave.dts
@@ -93,6 +93,7 @@
 		adi,det-prog = <4>;
 		adi,parity-en;
 		adi,bb-amp-gain-ctrl = <0>;
+		adi,det-en;
 	};
 
 	admv1014_b@3 {
@@ -109,6 +110,7 @@
 		adi,det-prog = <4>;
 		adi,parity-en;
 		adi,bb-amp-gain-ctrl = <0>;
+		adi,det-en;
 	};
 
 	lo_adf5356: adf5356@4 {

--- a/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-revb-adrv2crr-fmc-revb-jesd204-fsm-xmicrowave.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-revb-adrv2crr-fmc-revb-jesd204-fsm-xmicrowave.dts
@@ -51,6 +51,7 @@
 &axi_spi_1 {
 	admv1013_a@0 {
 		compatible = "adi,admv1013";
+		label = "admv1013_a";
 		reg = <0>;
 		spi-max-frequency = <5000000>;
 		clocks = <&lo_adf5356>;
@@ -65,6 +66,7 @@
 
 	admv1013_b@1 {
 		compatible = "adi,admv1013";
+		label = "admv1013_b";
 		reg = <1>;
 		spi-max-frequency = <5000000>;
 		clocks = <&lo_adf5356>;
@@ -79,6 +81,7 @@
 
 	admv1014_a@2 {
 		compatible = "adi,admv1014";
+		label = "admv1014_a";
 		reg = <2>;
 		spi-max-frequency = <5000000>;
 		clocks = <&lo_adf5356>;
@@ -94,6 +97,7 @@
 
 	admv1014_b@3 {
 		compatible = "adi,admv1014";
+		label = "admv1014_b";
 		reg = <3>;
 		spi-max-frequency = <5000000>;
 		clocks = <&lo_adf5356>;


### PR DESCRIPTION
- arch: arm64: xmicrowave.dts: enable detector
- arch: arm64: xmicrowave.dts: add labels

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>