### PR TITLE
arch: arm: dts: add socfpga_arria10_socdk_adrv9002 dts

### DIFF
--- a/arch/arm/boot/dts/socfpga_arria10_socdk_adrv9002.dts
+++ b/arch/arm/boot/dts/socfpga_arria10_socdk_adrv9002.dts
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices ADRV9002
+ *
+ * hdl_project: <adrv9001/a10soc>
+ * board_revision: <>
+ *
+ * Copyright (C) 2022 Analog Devices Inc.
+ */
+/dts-v1/;
+#include "socfpga_arria10_socdk.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+
+&mmc {
+	status = "okay";
+	num-slots = <1>;
+	cap-sd-highspeed;
+	broken-cd;
+	bus-width = <4>;
+	altr,dw-mshc-ciu-div = <3>;
+	altr,dw-mshc-sdr-timing = <0 3>;
+};
+
+/ {
+	clocks {
+		dma_clk: dma_clk {
+			#clock-cells = <0x0>;
+			compatible = "fixed-clock";
+			clock-frequency = <250000000>;
+			clock-output-names = "dma_clk";
+		};
+	};
+
+	soc {
+		sys_hps_bridges: bridge@ff200000 {
+			compatible = "simple-bus";
+			reg = <0xff200000 0x00200000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges = <0x00000000 0xff200000 0x00200000>;
+
+			sys_spi: spi@40 {
+				compatible = "altr,spi-1.0";
+				reg = <0x00000040 0x00000020>;
+				interrupt-parent = <&intc>;
+				interrupts = <0 26 4>;
+				#address-cells = <0x1>;
+				#size-cells = <0x0>;
+			};
+
+			adrv9001_gpio: gpio@60000 {
+				compatible = "altr,pio-1.0";
+				reg = <0x00060000 0x00000010>;
+				interrupt-parent = <&intc>;
+				interrupts = <0 33 4>;
+				altr,gpio-bank-width = <19>;
+				altr,interrupt-type = <4>;
+				altr,interrupt_type = <4>;
+				level_trigger = <1>;
+				resetvalue = <0>;
+				#gpio-cells = <2>;
+				gpio-controller;
+			};
+
+			rx1_dma: dma@40000 {
+				compatible = "adi,axi-dmac-1.00.a";
+				reg = <0x00040000 0x800>;
+				#dma-cells = <1>;
+				interrupt-parent = <&intc>;
+				interrupts = <0 21 IRQ_TYPE_LEVEL_HIGH>;
+				clocks = <&dma_clk>;
+
+				adi,channels {
+					#size-cells = <0>;
+					#address-cells = <1>;
+
+					dma-channel@0 {
+						reg = <0>;
+						adi,source-bus-width = <64>;
+						adi,source-bus-type = <2>;
+						adi,destination-bus-width = <64>;
+						adi,destination-bus-type = <0>;
+					};
+				};
+			};
+
+			rx2_dma: dma@41000 {
+				compatible = "adi,axi-dmac-1.00.a";
+				reg = <0x00041000 0x800>;
+				#dma-cells = <1>;
+				interrupt-parent = <&intc>;
+				interrupts = <0 30 IRQ_TYPE_LEVEL_HIGH>;
+				clocks = <&dma_clk>;
+
+				adi,channels {
+					#size-cells = <0>;
+					#address-cells = <1>;
+
+					dma-channel@0 {
+						reg = <0>;
+						adi,source-bus-width = <64>;
+						adi,source-bus-type = <2>;
+						adi,destination-bus-width = <64>;
+						adi,destination-bus-type = <0>;
+					};
+				};
+			};
+
+			tx1_dma: dma@44000 {
+				compatible = "adi,axi-dmac-1.00.a";
+				reg = <0x00044000 0x00000800>;
+				#dma-cells = <1>;
+				interrupt-parent = <&intc>;
+				interrupts = <0 22 IRQ_TYPE_LEVEL_HIGH>;
+				clocks = <&dma_clk>;
+
+				adi,channels {
+					#size-cells = <0>;
+					#address-cells = <1>;
+
+					dma-channel@0 {
+						reg = <0>;
+						adi,source-bus-width = <64>;
+						adi,source-bus-type = <0>;
+						adi,destination-bus-width = <64>;
+						adi,destination-bus-type = <2>;
+					};
+				};
+			};
+
+			tx2_dma: dma@45000 {
+				compatible = "adi,axi-dmac-1.00.a";
+				reg = <0x00045000 0x00000800>;
+				#dma-cells = <1>;
+				interrupt-parent = <&intc>;
+				interrupts = <0 31 IRQ_TYPE_LEVEL_HIGH>;
+				clocks = <&dma_clk>;
+
+				adi,channels {
+					#size-cells = <0>;
+					#address-cells = <1>;
+
+					dma-channel@0 {
+						reg = <0>;
+						adi,source-bus-width = <64>;
+						adi,source-bus-type = <0>;
+						adi,destination-bus-width = <64>;
+						adi,destination-bus-type = <2>;
+					};
+				};
+			};
+
+			axi_adrv9002_core_rx1: axi-adrv9002-rx1-lpc@20000 {
+				compatible = "adi,axi-adrv9002-rx-1.0";
+				reg = <0x00020000 0x6000>;
+				clocks = <&adc0_adrv9002 0>;
+				dmas = <&rx1_dma 0>;
+				dma-names = "rx";
+				spibus-connected = <&adc0_adrv9002>;
+			};
+
+			axi_adrv9002_core_tx1: axi-adrv9002-tx1-lpc@2A000 {
+				compatible = "adi,axi-adrv9002-tx-1.0";
+				reg = <0x0002A000 0x2000>;
+				clocks = <&adc0_adrv9002 1>;
+				clock-names = "sampl_clk";
+				dmas = <&tx1_dma 0>;
+				dma-names = "tx";
+				adi,axi-dds-default-scale = <0x800>;
+				adi,axi-dds-default-frequency = <2000000>;
+			};
+
+			axi_adrv9002_core_tdd1: axi-adrv9002-core-tdd1-lpc@2C800 {
+				compatible = "adi,axi-tdd-1.00";
+				reg = <0x0002C800 0x400>;
+				clocks = <&dma_clk>, <&adc0_adrv9002 2>;
+				clock-names = "s_axi_aclk", "intf_clk";
+				label = "axi-core-tdd-1";
+			};
+
+			axi_adrv9002_core_rx2: axi-adrv9002-rx2-lpc@29000 {
+				compatible = "adi,axi-adrv9002-rx2-1.0";
+				reg = <0x00029000 0x1000>;
+				clocks = <&adc0_adrv9002 3>;
+				clock-names = "sampl_clk";
+				dmas = <&rx2_dma 0>;
+				dma-names = "rx";
+			};
+
+			axi_adrv9002_core_tx2: axi-adrv9002-tx2-lpc@2C000 {
+				compatible = "adi,axi-adrv9002-tx-1.0";
+				reg = <0x0002C000 0x2000>;
+				clocks = <&adc0_adrv9002 4>;
+				clock-names = "sampl_clk";
+				dmas = <&tx2_dma 0>;
+				dma-names = "tx";
+				adi,axi-dds-default-scale = <0x800>;
+				adi,axi-dds-default-frequency = <2000000>;
+			};
+
+			axi_adrv9002_core_tdd2: axi-adrv9002-core-tdd2-lpc@2CC00 {
+				compatible = "adi,axi-tdd-1.00";
+				reg = <0x0002CC00 0x400>;
+				clocks = <&dma_clk>, <&adc0_adrv9002 5>;
+				clock-names = "s_axi_aclk", "intf_clk";
+				label = "axi-core-tdd-2";
+			};
+		};
+	};
+};
+
+#define fmc_spi sys_spi
+
+#include "adi-adrv9002.dtsi"
+
+&adc0_adrv9002 {
+	reset-gpios = <&adrv9001_gpio 14 GPIO_ACTIVE_LOW>;
+};
+
+&rx0 {
+	orx-gpios = <&adrv9001_gpio 0 GPIO_ACTIVE_HIGH>; /* dgpio0 */
+};
+
+&rx1 {
+	orx-gpios = <&adrv9001_gpio 1 GPIO_ACTIVE_HIGH>; /* dgpio1 */
+};


### PR DESCRIPTION
Add devicetree support for adrv9002 with a10soc carrier.

Signed-off-by: Liviu.Iacob <liviu.iacob@analog.com>