### PR TITLE
zynqmp-zcu102-rev10-ad9082: fix HDL project tag

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9082-204c-txmode22-rxmode23-dual-multi-top.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9082-204c-txmode22-rxmode23-dual-multi-top.dts
@@ -4,7 +4,7 @@
  * https://wiki.analog.com/resources/eval/user-guides/quadmxfe/quick-start
  * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-mxfe/ad9081
  *
- * hdl_project: <ad9081_fmca_ebz/zcu102>
+ * hdl_project: <ad9082_fmca_ebz/zcu102>
  * board_revision: <>
  *
  * Copyright (C) 2021 Analog Devices Inc.

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9082-204c-txmode22-rxmode23-dual.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9082-204c-txmode22-rxmode23-dual.dts
@@ -4,7 +4,7 @@
  * https://wiki.analog.com/resources/eval/user-guides/quadmxfe/quick-start
  * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-mxfe/ad9081
  *
- * hdl_project: <ad9081_fmca_ebz/zcu102>
+ * hdl_project: <ad9082_fmca_ebz/zcu102>
  * board_revision: <>
  *
  * Copyright (C) 2021 Analog Devices Inc.

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9082-204c-txmode22-rxmode23-sc1.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9082-204c-txmode22-rxmode23-sc1.dts
@@ -4,7 +4,7 @@
  * https://wiki.analog.com/resources/eval/user-guides/quadmxfe/quick-start
  * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-mxfe/ad9081
  *
- * hdl_project: <ad9081_fmca_ebz/zcu102>
+ * hdl_project: <ad9082_fmca_ebz/zcu102>
  * board_revision: <>
  *
  * Copyright (C) 2022 Analog Devices Inc.

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9082-204c-txmode22-rxmode23.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9082-204c-txmode22-rxmode23.dts
@@ -4,7 +4,7 @@
  * https://wiki.analog.com/resources/eval/user-guides/quadmxfe/quick-start
  * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-mxfe/ad9081
  *
- * hdl_project: <ad9081_fmca_ebz/zcu102>
+ * hdl_project: <ad9082_fmca_ebz/zcu102>
  * board_revision: <>
  *
  * Copyright (C) 2021 Analog Devices Inc.

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9082-m4-l8.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9082-m4-l8.dts
@@ -4,7 +4,7 @@
  * https://wiki.analog.com/resources/eval/user-guides/quadmxfe/quick-start
  * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-mxfe/ad9081
  *
- * hdl_project: <ad9081_fmca_ebz/zcu102>
+ * hdl_project: <ad9082_fmca_ebz/zcu102>
  * board_revision: <>
  *
  * Copyright (C) 2019-2021 Analog Devices Inc.


### PR DESCRIPTION
Fix HDL projects tags for all ad9082+zcu102 device trees.
The tag is used by boot partition scripts to pair DTS with HDL output files.

Signed-off-by: stefan.raus <stefan.raus@analog.com>