### PR TITLE
arch: arm: overlays: cn0511: Add EEPROMs support

### DIFF
--- a/arch/arm/boot/dts/overlays/rpi-cn0511-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-cn0511-overlay.dts
@@ -107,6 +107,20 @@
 				clock-frequency = <400000>;
 				reg = <0x4c>;
 			};
+
+			eeprom@51 {
+				compatible = "atmel,24c32";
+				reg = <0x51>;
+			};
+		};
+	};
+
+	fragment@6 {
+		target = <&i2c0>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
 		};
 	};
 };


### PR DESCRIPTION
HAT ID EEPROM is connected to I2C0.

Calibration coefficients EEPROM is connected to I2C1.

Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>