### PR TITLE
drivers: iio: adc: one-bit-adc-dac: Fix read_label()

### DIFF
--- a/drivers/iio/addac/one-bit-adc-dac.c
+++ b/drivers/iio/addac/one-bit-adc-dac.c
@@ -19,7 +19,6 @@ enum ch_direction {
 
 struct one_bit_adc_dac_state {
 	int			in_num_ch;
-	int			out_num_ch;
 	struct platform_device  *pdev;
 	struct gpio_descs       *in_gpio_descs;
 	struct gpio_descs       *out_gpio_descs;

--- a/drivers/iio/addac/one-bit-adc-dac.c
+++ b/drivers/iio/addac/one-bit-adc-dac.c
@@ -142,14 +142,14 @@ static int one_bit_adc_dac_parse_dt(struct iio_dev *indio_dev)
 {
 	struct one_bit_adc_dac_state *st = iio_priv(indio_dev);
 	struct iio_chan_spec *channels;
-	int ret, in_num_ch = 0, out_num_ch = 0;
+	int ret, out_num_ch = 0;
 
 	st->in_gpio_descs = devm_gpiod_get_array_optional(&st->pdev->dev, "in", GPIOD_IN);
 	if (IS_ERR(st->in_gpio_descs))
 		return PTR_ERR(st->in_gpio_descs);
 
 	if (st->in_gpio_descs)
-		in_num_ch = st->in_gpio_descs->ndescs;
+		st->in_num_ch = st->in_gpio_descs->ndescs;
 
 	st->out_gpio_descs = devm_gpiod_get_array_optional(&st->pdev->dev, "out", GPIOD_OUT_LOW);
 	if (IS_ERR(st->out_gpio_descs))
@@ -157,26 +157,25 @@ static int one_bit_adc_dac_parse_dt(struct iio_dev *indio_dev)
 
 	if (st->out_gpio_descs)
 		out_num_ch = st->out_gpio_descs->ndescs;
-
-	channels = devm_kcalloc(indio_dev->dev.parent, in_num_ch + out_num_ch,
+	channels = devm_kcalloc(indio_dev->dev.parent, st->in_num_ch + out_num_ch,
 				sizeof(*channels), GFP_KERNEL);
 	if (!channels)
 		return -ENOMEM;
 
-	ret = one_bit_adc_dac_set_ch(&channels[0], in_num_ch, CH_IN);
+	ret = one_bit_adc_dac_set_ch(&channels[0], st->in_num_ch, CH_IN);
 	if (ret)
 		return ret;
 
-	ret = one_bit_adc_dac_set_ch(&channels[in_num_ch], out_num_ch, CH_OUT);
+	ret = one_bit_adc_dac_set_ch(&channels[st->in_num_ch], out_num_ch, CH_OUT);
 	if (ret)
 		return ret;
 
-	ret = one_bit_adc_dac_set_channel_label(indio_dev, channels, in_num_ch + out_num_ch);
+	ret = one_bit_adc_dac_set_channel_label(indio_dev, channels, st->in_num_ch + out_num_ch);
 	if (ret)
 		return ret;
 
 	indio_dev->channels = channels;
-	indio_dev->num_channels = in_num_ch + out_num_ch;
+	indio_dev->num_channels = st->in_num_ch + out_num_ch;
 
 	return 0;
 }


### PR DESCRIPTION
In one_bit_adc_dac_read_label() the number of input channels
is being read from st->in_num_ch which is not initialized.

Fixes: 88c34541d056 ("drivers: iio: addac: one-bit-adc-dac: Update label storage")
Signed-off-by: Sergiu Cuciurean <sergiu.cuciurean@analog.com>