### PR TITLE
arch: arm: boot: dts: rename SPI Engine AXI CLKGEN

### DIFF
--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad7768-1-evb.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad7768-1-evb.dts
@@ -56,7 +56,7 @@
 		};
 	};
 
-	spi_clock: axi-clkgen@44a70000 {
+	spi_clock: spieng-axi-clkgen@44a70000 {
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x44a70000 0x10000>;
 		#clock-cells = <0>;


### PR DESCRIPTION
Having the same node name as the HDMI AXI CLKGEN defined in
zynq-zed-adv7511.dtsi caused an error where the clk driver could not be
instantiated because it already existed.

Signed-off-by: Andrei Drimbarean <andrei.drimbarean@analog.com>