### PR TITLE
arch: arm: overlays: cn0575: gpio control

### DIFF
--- a/arch/arm/boot/dts/overlays/rpi-cn0575-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-cn0575-overlay.dts
@@ -64,3 +64,26 @@
 	};
 };
 
+&{/} {
+	#include <dt-bindings/gpio/gpio.h>
+
+	one-bit-adc-dac {
+		compatible = "adi,one-bit-adc-dac";
+		label = "gpios";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		in-gpios = <&gpio 16 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+		out-gpios = <&gpio 26 GPIO_ACTIVE_HIGH>;
+		status = "okay";
+
+		channel@0 {
+			reg = <0>;
+			label = "EXT_BTN";
+		};
+
+		channel@1 {
+			reg = <1>;
+			label = "EXT_LED";
+		};
+	};
+};


### PR DESCRIPTION
CN0575 has a Red LED exposed on GPIO 26 and a pull-down button that
is connected to GPIO 16. Those are now being exposed to the userspace
via the one-bit adc/dac driver with appropriate labels in iio_info.

Signed-off-by: Alexandru Tachici <alexandru.tachici@analog.com>