### PR TITLE
arch: arm : boot: dts: set vcxo to 100 MHz

### DIFF
--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad9081-np12.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad9081-np12.dts
@@ -28,11 +28,7 @@
 
 		adi,jesd204-max-sysref-frequency-hz = <2000000>; /* 2 MHz */
 
-		adi,pll1-clkin-frequencies = <122880000 30720000 0 0>;
-
 		adi,pll1-loop-bandwidth-hz = <200>;
-
-		adi,vcxo-frequency = <122880000>;
 
 		adi,pll2-output-frequency = <3000000000>;
 


### PR DESCRIPTION
Do not overwrite values of pll1 clkin and vcxo frequencies in
zynq-zc706-adv7511-ad9081-np12.dts, but let them to 100 MHz
as they are set in adi-ad9081-fmc-ebz.dtsi

Signed-off-by: stefan.raus <stefan.raus@analog.com>