### PR TITLE
overlays: cn0511: update power-up-frequency

### DIFF
--- a/arch/arm/boot/dts/overlays/rpi-cn0511-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-cn0511-overlay.dts
@@ -67,7 +67,7 @@
 				channel@0 {
 					reg = <0>;
 					adi,power-up-frequency = /bits/ 64
-								<5000000000>;
+								<6000000000>;
 				};
 			};
 


### PR DESCRIPTION
Set the rfout of adf4377 to 6GHz which serves as default DAC_CLK for
ad9166.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>