### PR TITLE
iio: adc: ad9081: Remove "adi_utils.h" include

### DIFF
--- a/drivers/iio/adc/ad9081/adi_ad9081_jesd.c
+++ b/drivers/iio/adc/ad9081/adi_ad9081_jesd.c
@@ -16,7 +16,6 @@
 /*============= I N C L U D E S ============*/
 #include "adi_ad9081_config.h"
 #include "adi_ad9081_hal.h"
-#include "adi_utils.h"
 
 #define NELEMS(x) (sizeof(x) / sizeof((x)[0]))
 /*============= C O D E ====================*/

--- a/drivers/iio/adc/ad9081/adi_ad9081_sync.c
+++ b/drivers/iio/adc/ad9081/adi_ad9081_sync.c
@@ -16,7 +16,6 @@
 /*============= I N C L U D E S ============*/
 #include "adi_ad9081_config.h"
 #include "adi_ad9081_hal.h"
-#include "adi_utils.h"
 
 /*============= C O D E ====================*/
 


### PR DESCRIPTION
Not available but not used either.

Fixes:
   fatal error: adi_utils.h: No such file or directory

Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>