### PR TITLE
arm64: dts: adrv9009-zu11eg-fmcomms8: Added coarse delays

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-revb-adrv2crr-fmc-revb-sync-fmcomms8-jesd204-fsm-using-clockdist.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-revb-adrv2crr-fmc-revb-sync-fmcomms8-jesd204-fsm-using-clockdist.dts
@@ -141,6 +141,7 @@
 		adi,driver-mode = <HMC7044_DRIVER_MODE_LVPECL>;
 		adi,startup-mode-dynamic-enable;
 		adi,high-performance-mode-disable;
+		adi,coarse-digital-delay = <0x01>;
 		adi,force-mute-enable;
 	};
 
@@ -148,6 +149,7 @@
 		reg = <9>;
 		adi,extended-name = "REFCLK_OUT4";
 		adi,divider = <REF_DIV>;
+		adi,coarse-digital-delay = <0x01>;
 		adi,driver-mode = <HMC7044_DRIVER_MODE_LVPECL>;
 	};
 };

--- a/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-revb-adrv2crr-fmc-revb-sync-fmcomms8-jesd204-fsm.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-revb-adrv2crr-fmc-revb-sync-fmcomms8-jesd204-fsm.dts
@@ -162,3 +162,7 @@
 	/delete-property/ adi,pll2-autocal-bypass-manual-cap-bank-sel;
 	adi,hmc-two-level-tree-sync-en;
 };
+
+&hmc7044_car_c9 {
+	adi,coarse-digital-delay = <0x01>;
+};


### PR DESCRIPTION
Added coarse delays on the carrier in order to compensate for trace mismatch.

Signed-off-by: Mihai Bancisor <bancisor.mihai@gmail.com>