### PR TITLE
arm64: dts: zynqmp-zcu102-rev10-ad9082-m4-l8.dts: Fix ref clock

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9082-m4-l8.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9082-m4-l8.dts
@@ -119,7 +119,7 @@
 		hmc7044_c12: channel@12 {
 			reg = <12>;
 			adi,extended-name = "FPGA_REFCLK2";
-			adi,divider = <6>;
+			adi,divider = <4>;
 			adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
 		};
 		hmc7044_c13: channel@13 {


### PR DESCRIPTION
Lane rate for this mode is 15Gbps,  the link clock (375MHz) is set
to ref clock by 2.  So the ref clock must be 750MHz.

Signed-off-by: Laszlo Nagy <laszlo.nagy@analog.com>