### PR TITLE
iio: adc: adrv9002: fix tdd rate calculation

### DIFF
--- a/drivers/iio/adc/navassa/adrv9002.c
+++ b/drivers/iio/adc/navassa/adrv9002.c
@@ -235,7 +235,7 @@ static int adrv9002_ssi_configure(struct adrv9002_rf_phy *phy)
 			if (!rx->channel.enabled)
 				continue;
 
-			rate = adrv9002_axi_dds_rate_get(phy, chann->idx) * chann->rate;
+			rate = adrv9002_axi_dds_rate_get(phy, chann->idx) * rx->channel.rate;
 			clk_set_rate(rx->tdd_clk, rate);
 		}
 	}


### PR DESCRIPTION
The TDD core rate is calculated by dds_rate * rx_rate. In commit
3fc394629138 ("iio: adc: adrv9002: fix tdd clock export") the logic was
changed to fix another bug so that the current channel when dealing with
TDD rate is a TX port. Hence 'chann->rate' cannot be used as we want the
RX rate which is not guaranteed to be the same as TX.

Fixes: 3fc394629138 ("iio: adc: adrv9002: fix tdd clock export")
Signed-off-by: Nuno Sá <nuno.sa@analog.com>