### PR TITLE
Declaration of xilinx_xcvr_gtx2_cpll_read_config as static

### DIFF
--- a/drivers/iio/jesd204/xilinx_transceiver.c
+++ b/drivers/iio/jesd204/xilinx_transceiver.c
@@ -646,7 +646,7 @@ int xilinx_xcvr_gth34_cpll_read_config(struct xilinx_xcvr *xcvr,
 	return 0;
 }
 
-int xilinx_xcvr_gtx2_cpll_read_config(struct xilinx_xcvr *xcvr,
+static int xilinx_xcvr_gtx2_cpll_read_config(struct xilinx_xcvr *xcvr,
 	unsigned int drp_port, struct xilinx_xcvr_cpll_config *conf)
 {
 	int val;


### PR DESCRIPTION
Made the xilinx_xcvr_gtx2_cpll_read_config function static, as is the case
of the xilinx_xcvr_gtx2_qpll_read_config function.

Signed-off-by: George Mois <george.mois@analog.com>