### PR TITLE
iio: adc: ad9467: don't prepare clk for ad9250

### DIFF
--- a/drivers/iio/adc/ad9467.c
+++ b/drivers/iio/adc/ad9467.c
@@ -1239,7 +1239,7 @@ static int ad9467_probe(struct spi_device *spi)
 	if (IS_ERR(st->clk))
 		return PTR_ERR(st->clk);
 
-	if (info->id != CHIPID_AD9625) {
+	if (info->id != CHIPID_AD9625 && info->id != CHIPID_AD9250) {
 		ret = clk_prepare_enable(st->clk);
 		if (ret < 0)
 			return ret;


### PR DESCRIPTION
For the ad9250 the jesd lane clock must not be prepared prior to
the device configuration. Add chip idcheck for the ad9250.
With the current state of the driver the jesd rx clock is prepared
inside the ad9250_setup function after the device is configured.
This patch aims to fix capture issues on the fmcjesdadc1 and the
double call of the clk prepare/enable for the jesd lane clk.

Fixes: 52cc37b ("iio: adc: ad9467: rework clock init; use devm_ helpers")
Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>

**This is a partial fix for the fmcjesdadc1 capture issues.**