### PR TITLE
arch: arm64: dts: adrv9002: Fix/Update TX DMA interrupt

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9002-rx2tx2.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9002-rx2tx2.dts
@@ -60,7 +60,7 @@
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x84A50000 0x10000>;
 			#dma-cells = <1>;
-			interrupts = <0 107 IRQ_TYPE_LEVEL_HIGH>;
+			interrupts = <0 105 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&zynqmp_clk 71>;
 
 			adi,channels {

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9002.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9002.dts
@@ -80,7 +80,7 @@
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x84A50000 0x10000>;
 			#dma-cells = <1>;
-			interrupts = <0 107 IRQ_TYPE_LEVEL_HIGH>;
+			interrupts = <0 105 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&zynqmp_clk 71>;
 
 			adi,channels {


### PR DESCRIPTION
Update TX DMA interrupt number according to HDL update.

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>