### PR TITLE
zcu102_ad9695.dts: update hdl tag

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9695.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9695.dts
@@ -4,7 +4,7 @@
  * https://wiki.analog.com/resources/eval/ad9208-3000ebz
  * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-adc/ad9208
  *
- * hdl_project: <ad9695/zcu102>
+ * hdl_project: <ad9695_fmc/zcu102>
  * board_revision: <>
  *
  * Copyright (C) 2019-2022 Analog Devices Inc.


### PR DESCRIPTION
zynqmp-zcu102-rev10-ad9695.dts: update hdl tag

Signed-off-by: stefan.raus <stefan.raus@analog.com>