### PR TITLE
spi: spi-xilinx: Fix bits_per_word_mask

### DIFF
--- a/drivers/spi/spi-xilinx.c
+++ b/drivers/spi/spi-xilinx.c
@@ -816,7 +816,7 @@ static int xilinx_spi_probe(struct platform_device *pdev)
 	master->transfer_one = xspi_start_transfer;
 	master->prepare_transfer_hardware = xspi_prepare_transfer_hardware;
 	master->unprepare_transfer_hardware = xspi_unprepare_transfer_hardware;
-	master->bits_per_word_mask = SPI_BPW_MASK(8);
+	master->bits_per_word_mask = SPI_BPW_MASK(bits_per_word);
 	master->mode_bits = SPI_CPOL | SPI_CPHA | SPI_CS_HIGH;
 
 	xspi->bytes_per_word = bits_per_word / 8;


### PR DESCRIPTION
The bits-per-word property can be specified in the devicetree
but the bits_per_word_mask is always set to support only 8-bit
word transfers.

Fixes: ad7897e45022 ("spi: spi-xilinx: Updated axi-qspi controller driver")
Signed-off-by: Sergiu Cuciurean <sergiu.cuciurean@analog.com>
Reviewed-by: Shubhrajyoti Datta <Shubhrajyoti.datta@xilinx.com>