### PR TITLE
LTC2499 support

### DIFF
--- a/Documentation/devicetree/bindings/iio/adc/lltc,ltc2497.yaml
+++ b/Documentation/devicetree/bindings/iio/adc/lltc,ltc2497.yaml
@@ -13,10 +13,14 @@ description: |
   16bit ADC supporting up to 16 single ended or 8 differential inputs.
   I2C interface.
 
+  https://www.analog.com/media/en/technical-documentation/data-sheets/2497fb.pdf
+  https://www.analog.com/media/en/technical-documentation/data-sheets/2499fe.pdf
+
 properties:
   compatible:
     const:
       lltc,ltc2497
+      lltc,ltc2499
 
   reg: true
   vref-supply: true

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1234,6 +1234,7 @@ W:	http://ez.analog.com/community/linux-device-drivers
 F:	Documentation/ABI/testing/sysfs-bus-iio-frequency-ad9523
 F:	Documentation/ABI/testing/sysfs-bus-iio-frequency-adf4350
 F:	Documentation/devicetree/bindings/iio/*/adi,*
+F:	Documentation/devicetree/bindings/iio/adc/lltc,ltc2497.yaml
 F:	Documentation/devicetree/bindings/iio/dac/ad5758.txt
 F:	drivers/iio/*/ad*
 F:	drivers/iio/adc/ltc249*

--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -220,6 +220,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	rpi-ft5406.dtbo \
 	rpi-lm75.dtbo \
 	rpi-ltc2497.dtbo \
+	rpi-ltc2499.dtbo \
 	rpi-ltc2688.dtbo \
 	rpi-ltc6952.dtbo \
 	rpi-poe.dtbo \

--- a/arch/arm/boot/dts/overlays/rpi-ltc2499-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ltc2499-overlay.dts
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+&{/} {
+	vref: fixedregulator@0 {
+		compatible = "regulator-fixed";
+		regulator-name = "vref";
+		regulator-min-microvolt = <2500000>;
+		regulator-max-microvolt = <2500000>;
+		phandle = <0x1>;
+	};
+
+	__overrides__ {
+		addr = <&ltc2499>,"reg:0";
+	};
+};
+
+&i2c1 {
+	#address-cells = <0x1>;
+	#size-cells = <0x0>;
+	status = "okay";
+	ltc2499: ltc2499@76 {
+		compatible = "lltc,ltc2499";
+		reg = <0x76>;
+		label = "my_ltc2499";
+		vref-supply = <&vref>;
+		clock-frequency = <400000>;
+		status = "okay";
+	};
+};

--- a/drivers/iio/adc/ltc2496.c
+++ b/drivers/iio/adc/ltc2496.c
@@ -87,8 +87,13 @@ static int ltc2496_remove(struct spi_device *spi)
 	return 0;
 }
 
+static struct chip_info ltc2496_info = {
+	.type = TYPE_LTC2496,
+	.resolution = 16
+};
+
 static const struct of_device_id ltc2496_of_match[] = {
-	{ .compatible = "lltc,ltc2496", },
+	{ .compatible = "lltc,ltc2496", .data = (void *)&ltc2496_info },
 	{},
 };
 MODULE_DEVICE_TABLE(of, ltc2496_of_match);

--- a/drivers/iio/adc/ltc2497-core.c
+++ b/drivers/iio/adc/ltc2497-core.c
@@ -95,7 +95,7 @@ static int ltc2497core_read_raw(struct iio_dev *indio_dev,
 			return ret;
 
 		*val = ret / 1000;
-		*val2 = 17;
+		*val2 = ddata->chip_info->resolution + 1;
 
 		return IIO_VAL_FRACTIONAL_LOG2;
 
@@ -168,6 +168,8 @@ int ltc2497core_probe(struct device *dev, struct iio_dev *indio_dev)
 {
 	struct ltc2497core_driverdata *ddata = iio_priv(indio_dev);
 	int ret;
+
+	ddata->chip_info = device_get_match_data(dev);
 
 	indio_dev->name = dev_name(dev);
 	indio_dev->info = &ltc2497core_info;

--- a/drivers/iio/adc/ltc2497.c
+++ b/drivers/iio/adc/ltc2497.c
@@ -41,13 +41,14 @@ static int ltc2497_result_and_measure(struct ltc2497core_driverdata *ddata,
 		}
 
 		*val = (be32_to_cpu(st->buf) >> 14) - (1 << 17);
+	} else {
+		ret = i2c_smbus_write_byte(st->client,
+					   LTC2497_ENABLE | address);
+		if (ret)
+			dev_err(&st->client->dev, "i2c transfer failed: %pe\n",
+				ERR_PTR(ret));
 	}
 
-	ret = i2c_smbus_write_byte(st->client,
-				   LTC2497_ENABLE | address);
-	if (ret)
-		dev_err(&st->client->dev, "i2c transfer failed: %pe\n",
-			ERR_PTR(ret));
 	return ret;
 }
 

--- a/drivers/iio/adc/ltc2497.c
+++ b/drivers/iio/adc/ltc2497.c
@@ -33,20 +33,45 @@ static int ltc2497_result_and_measure(struct ltc2497core_driverdata *ddata,
 		container_of(ddata, struct ltc2497_driverdata, common_ddata);
 	int ret;
 
-	if (val) {
-		ret = i2c_master_recv(st->client, (char *)&st->buf, 3);
-		if (ret < 0) {
-			dev_err(&st->client->dev, "i2c_master_recv failed\n");
-			return ret;
+	switch (ddata->chip_info->type) {
+	case TYPE_LTC2497:
+		if (val) {
+			ret = i2c_master_recv(st->client, (char *)&st->buf, 3);
+			if (ret < 0) {
+				dev_err(&st->client->dev,
+					"i2c_master_recv failed\n");
+				return ret;
+			}
+			*val = (be32_to_cpu(st->buf) >> 14) - (1 << 17);
+		} else {
+			ret = i2c_smbus_write_byte(st->client,
+						   LTC2497_ENABLE | address);
+			if (ret)
+				dev_err(&st->client->dev,
+					"i2c transfer failed: %pe\n",
+					ERR_PTR(ret));
 		}
-
-		*val = (be32_to_cpu(st->buf) >> 14) - (1 << 17);
-	} else {
-		ret = i2c_smbus_write_byte(st->client,
-					   LTC2497_ENABLE | address);
-		if (ret)
-			dev_err(&st->client->dev, "i2c transfer failed: %pe\n",
-				ERR_PTR(ret));
+		break;
+	case TYPE_LTC2499:
+		if (val) {
+			ret = i2c_master_recv(st->client, (char *)&st->buf, 4);
+			if (ret < 0) {
+				dev_err(&st->client->dev,
+					"i2c_master_recv failed\n");
+				return ret;
+			}
+			*val = (be32_to_cpu(st->buf) >> 6) - (1 << 25);
+		} else {
+			ret = i2c_smbus_write_byte(st->client,
+						   LTC2497_ENABLE | address);
+			if (ret)
+				dev_err(&st->client->dev,
+					"i2c transfer failed: %pe\n",
+					ERR_PTR(ret));
+		}
+		break;
+	default:
+		return -EINVAL;
 	}
 
 	return ret;
@@ -84,15 +109,28 @@ static int ltc2497_remove(struct i2c_client *client)
 	return 0;
 }
 
+static struct chip_info ltc2497_info[] = {
+	[TYPE_LTC2497] = {
+		.type = TYPE_LTC2497,
+		.resolution = 16,
+	},
+	[TYPE_LTC2499] = {
+		.type = TYPE_LTC2499,
+		.resolution = 24,
+	}
+};
+
 static const struct i2c_device_id ltc2497_id[] = {
-	{ "ltc2497", 0 },
+	{ "ltc2497", TYPE_LTC2497 },
+	{ "ltc2499", TYPE_LTC2499 },
 	{ }
 };
 MODULE_DEVICE_TABLE(i2c, ltc2497_id);
 
 static const struct of_device_id ltc2497_of_match[] = {
-	{ .compatible = "lltc,ltc2497", },
-	{},
+	{ .compatible = "lltc,ltc2497", .data = (void *)&ltc2497_info[TYPE_LTC2497] },
+	{ .compatible = "lltc,ltc2499", .data = (void *)&ltc2497_info[TYPE_LTC2499] },
+	{ }
 };
 MODULE_DEVICE_TABLE(of, ltc2497_of_match);
 

--- a/drivers/iio/adc/ltc2497.h
+++ b/drivers/iio/adc/ltc2497.h
@@ -4,10 +4,23 @@
 #define LTC2497_CONFIG_DEFAULT		LTC2497_ENABLE
 #define LTC2497_CONVERSION_TIME_MS	150ULL
 
+enum chip_type {
+	TYPE_LTC2496,
+	TYPE_LTC2497,
+	TYPE_LTC2499
+};
+
+struct chip_info {
+	enum chip_type type;
+	u32 resolution;
+};
+
 struct ltc2497core_driverdata {
 	struct regulator *ref;
-	ktime_t	time_prev;
+	const struct chip_info *chip_info;
+	ktime_t time_prev;
 	u8 addr_prev;
+
 	int (*result_and_measure)(struct ltc2497core_driverdata *ddata,
 				  u8 address, int *val);
 };


### PR DESCRIPTION
Implemented LTC2499 support for the LTC2497 driver.

https://www.analog.com/media/en/technical-documentation/data-sheets/2497fb.pdf
https://www.analog.com/media/en/technical-documentation/data-sheets/2499fe.pdf

PR opened for internal review before sending it upstream.