### PR TITLE
Add rpi-adxl313 spi & i2c overlay

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -197,6 +197,8 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	rpi-ad9834.dtbo \
 	rpi-adar1000.dtbo \
 	rpi-adgs1408.dtbo \
+	rpi-adxl313-spi.dtbo \
+	rpi-adxl313-i2c.dtbo \
 	rpi-adxl345.dtbo \
 	rpi-adxl355.dtbo \
 	rpi-adxl367.dtbo \

--- a/arch/arm/boot/dts/overlays/rpi-adxl313-i2c-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-adxl313-i2c-overlay.dts
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-2.0
+/* Overlay for ADXL312, ADXL313, ADXL314
+ *
+ * Copyright 2022 Analog Devices Inc.
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+
+&gpio {
+	adxl313_pins: adxl313_pins {
+		brcm,pins = <25>; // interrupt
+		brcm,function = <0>; // in
+	};
+};
+
+&i2c1 {
+	status = "okay";
+
+	adxl313_i2c: adxl313@1d {
+		compatible = "adi,adxl313";
+		reg = <0x1d>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&adxl313_pins>;
+		interrupt-parent = <&gpio>;
+		interrupts = <25 IRQ_TYPE_EDGE_RISING>;
+		interrupt-names = "DRDY";
+	};
+};
+
+/ {
+	__overrides__ {
+		addr = <&adxl313_i2c>,"reg:0";
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-adxl313-spi-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-adxl313-spi-overlay.dts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-2.0
+/* Overlay for ADXL312, ADXL313, ADXL314
+ *
+ * Copyright 2022 Analog Devices Inc.
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+
+&spidev0 {
+	status = "disabled";
+};
+
+&gpio {
+	adxl313_pins: adxl313_pins {
+		brcm,pins = <25>; // interrupt
+		brcm,function = <0>; // in
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	adxl313@0 {
+		compatible = "adi,adxl313";
+		reg = <0>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&adxl313_pins>;
+		spi-max-frequency = <5000000>;
+		interrupt-parent = <&gpio>;
+		interrupts = <25 IRQ_TYPE_EDGE_RISING>;
+		interrupt-names = "DRDY";
+	};
+};


### PR DESCRIPTION
Add SPI and I2C dt overlays for the ADXL313 driver.

Signed-off-by: George Mois <george.mois@analog.com>