### PR TITLE
dts: zynqmp-zcu102-rev10-ad9082-204c-txmode36-rxmode28: New use case

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9082-204c-txmode36-rxmode28-tplw6.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9082-204c-txmode36-rxmode28-tplw6.dts
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD9082-FMC-EBZ
+ * https://wiki.analog.com/resources/eval/user-guides/quadmxfe/quick-start
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-mxfe/ad9081
+ *
+ * hdl_project: <ad9082_fmca_ebz/zcu102>
+ * board_revision: <>
+ *
+ * Copyright (C) 2022 Analog Devices Inc.
+ */
+
+// 204C use case with Subclass 1,
+// Med. lane rate, using gearbox and PRGOGDIV
+//     * 1Txs / 1Rxs per MxFE
+//     * DAC_CLK = 3.84 GSPS
+//     * ADC_CLK = 3.84 GSPS
+//     * Tx I/Q Rate: 3.84 GSPS (Interpolation of 1x1)
+//     * Rx I/Q Rate: 3.84 GSPS (Decimation of 1x1)
+//     * DAC JESD204B: Mode 36, L=8, M=2, N=N'=12
+//     * ADC JESD204B: Mode 28, L=8, M=2, N=N'=12
+//     * DAC-Side JESD204C Lane Rate: 11.88Gbps
+//     * ADC-Side JESD204C Lane Rate: 11.88Gbps
+//
+// Transport Layer Width 6 octets  (link layer gerbox ration 8:6)
+//
+
+// HDL Synthesis Parameters:
+// JESD_MODE=64B66B \
+// RX_RATE=12 \
+// TX_RATE=12 \
+// RX_JESD_M=2 \
+// RX_JESD_L=8 \
+// RX_JESD_S=8 \
+// RX_JESD_NP=12 \
+// RX_TPL_WIDTH=6 \
+// TX_JESD_M=2 \
+// TX_JESD_L=8 \
+// TX_JESD_S=8 \
+// TX_JESD_NP=12 \
+// TX_TPL_WIDTH=6
+
+#include "zynqmp-zcu102-rev10-ad9082-204c-txmode36-rxmode28.dts"
+
+&hmc7044 {
+
+		hmc7044_c6: channel@6 {
+			reg = <6>;
+			adi,extended-name = "CORE_CLK_TX";
+			adi,divider = <12>;  // 240 MHz
+			adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
+		};
+
+		hmc7044_c10: channel@10 {
+			reg = <10>;
+			adi,extended-name = "CORE_CLK_RX_ALT";
+			adi,divider = <12>; // 240 MHz
+			adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
+		};
+};
+

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9082-204c-txmode36-rxmode28.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9082-204c-txmode36-rxmode28.dts
@@ -1,0 +1,370 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD9082-FMC-EBZ
+ * https://wiki.analog.com/resources/eval/user-guides/quadmxfe/quick-start
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-mxfe/ad9081
+ *
+ * hdl_project: <ad9082_fmca_ebz/zcu102>
+ * board_revision: <>
+ *
+ * Copyright (C) 2022 Analog Devices Inc.
+ */
+
+// 204C use case with Subclass 1,
+// Med. lane rate, using gearbox and PRGOGDIV
+//     * 1Txs / 1Rxs per MxFE
+//     * DAC_CLK = 3.84 GSPS
+//     * ADC_CLK = 3.84 GSPS
+//     * Tx I/Q Rate: 3.84 GSPS (Interpolation of 1x1)
+//     * Rx I/Q Rate: 3.84 GSPS (Decimation of 1x1)
+//     * DAC JESD204B: Mode 36, L=8, M=2, N=N'=12
+//     * ADC JESD204B: Mode 28, L=8, M=2, N=N'=12
+//     * DAC-Side JESD204C Lane Rate: 11.88Gbps
+//     * ADC-Side JESD204C Lane Rate: 11.88Gbps
+
+// HDL Synthesis Parameters:
+// JESD_MODE=64B66B \
+// RX_RATE=12 \
+// TX_RATE=12 \
+// RX_JESD_M=2 \
+// RX_JESD_L=8 \
+// RX_JESD_S=8 \
+// RX_JESD_NP=12 \
+// TX_JESD_M=2 \
+// TX_JESD_L=8 \
+// TX_JESD_S=8 \
+// TX_JESD_NP=12 \
+
+#include "zynqmp-zcu102-rev10-ad9081-m8-l4-do.dts"
+
+// Enable PL FIFO due high data rates
+&axi_ad9081_core_tx {
+	adi,axi-pl-fifo-enable;
+};
+
+&axi_ad9081_rx_jesd {
+	clocks = <&zynqmp_clk 71>, <&hmc7044 10>, <&axi_ad9081_adxcvr_rx 1>, <&axi_ad9081_adxcvr_rx 0>;
+	clock-names = "s_axi_aclk", "device_clk", "link_clk", "lane_clk";
+};
+
+&axi_ad9081_tx_jesd {
+	clocks = <&zynqmp_clk 71>, <&hmc7044 6>, <&axi_ad9081_adxcvr_tx 1>, <&axi_ad9081_adxcvr_tx 0>;
+	clock-names = "s_axi_aclk", "device_clk", "link_clk", "lane_clk";
+};
+
+&axi_ad9081_adxcvr_rx {
+	adi,sys-clk-select = <XCVR_QPLL>;
+	adi,out-clk-select = <XCVR_PROGDIV_CLK>;
+};
+
+&axi_ad9081_adxcvr_tx {
+	adi,sys-clk-select = <XCVR_QPLL>;
+	adi,out-clk-select = <XCVR_PROGDIV_CLK>;
+};
+
+&spi1 {
+	status = "okay";
+
+	/delete-node/ hmc7044@0;
+
+	hmc7044: hmc7044@0 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		#clock-cells = <1>;
+		compatible = "adi,hmc7044";
+		reg = <0>;
+		spi-max-frequency = <1000000>;
+
+		jesd204-device;
+		#jesd204-cells = <2>;
+		jesd204-sysref-provider;
+
+		adi,jesd204-max-sysref-frequency-hz = <2000000>; /* 2 MHz */
+
+		/*
+		 * There are different versions of the AD9081-FMCA-EBZ & AD9082-FMCA-EBZ
+		 * VCXO = 122.880 MHz, XO = 122.880MHz (AD9081-FMC-EBZ & AD9082-FMC-EBZ)
+		 * VCXO = 100.000 MHz, XO = 100.000MHz (AD9081-FMC-EBZ-A2 & AD9082-FMC-EBZ-A2)
+		 * To determine which board is which, read the freqency printed on the VCXO
+		 * or use the fru-dump utility:
+		 * #fru-dump -b /sys/bus/i2c/devices/15-0050/eeprom
+		 */
+
+		//adi,pll1-clkin-frequencies = <122880000 30720000 0 0>;
+		//adi,vcxo-frequency = <122880000>;
+
+		adi,pll1-clkin-frequencies = <100000000 10000000 0 0>;
+		adi,vcxo-frequency = <100000000>;
+
+		adi,pll1-loop-bandwidth-hz = <200>;
+
+		adi,pll2-output-frequency = <2880000000>;
+
+		adi,sysref-timer-divider = <1024>;
+		adi,pulse-generator-mode = <0>;
+
+		adi,clkin0-buffer-mode  = <0x07>;
+		adi,clkin1-buffer-mode  = <0x07>;
+		adi,oscin-buffer-mode = <0x15>;
+
+		adi,gpi-controls = <0x00 0x00 0x00 0x00>;
+		adi,gpo-controls = <0x37 0x33 0x00 0x00>;
+
+		clock-output-names =
+			"hmc7044_out0", "hmc7044_out1", "hmc7044_out2",
+			"hmc7044_out3", "hmc7044_out4", "hmc7044_out5",
+			"hmc7044_out6", "hmc7044_out7", "hmc7044_out8",
+			"hmc7044_out9", "hmc7044_out10", "hmc7044_out11",
+			"hmc7044_out12", "hmc7044_out13";
+
+		hmc7044_c0: channel@0 { // UNUSED
+			reg = <0>;
+			adi,extended-name = "CORE_CLK_RX";
+			adi,divider = <48>;
+			adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
+			adi,disable; /* Completely disable channel */
+
+		};
+		hmc7044_c2: channel@2 {
+			reg = <2>;
+			adi,extended-name = "DEV_REFCLK";
+			adi,divider = <4>; /* 720 MHz */
+			adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
+		};
+
+		hmc7044_c3: channel@3 {
+			reg = <3>;
+			adi,extended-name = "DEV_SYSREF";
+			adi,divider = <768>;
+			adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
+			adi,jesd204-sysref-chan;
+			//adi,disable; /* Completely disable channel */
+		};
+
+		hmc7044_c6: channel@6 {
+			reg = <6>;
+			adi,extended-name = "CORE_CLK_TX";
+			adi,divider = <24>;  // 120 MHz
+			adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
+		};
+
+		hmc7044_c8: channel@8 { // UNUSED
+			reg = <8>;
+			adi,extended-name = "FPGA_REFCLK1";
+			adi,divider = <64>;
+			adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
+			adi,disable; /* Completely disable channel */
+		};
+
+		hmc7044_c10: channel@10 {
+			reg = <10>;
+			adi,extended-name = "CORE_CLK_RX_ALT";
+			adi,divider = <24>; // 120 MHz
+			adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
+		};
+
+		hmc7044_c12: channel@12 {
+			reg = <12>;
+			adi,extended-name = "FPGA_REFCLK2";
+			adi,divider = <16>;
+			adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
+		};
+
+		hmc7044_c13: channel@13 {
+			reg = <13>;
+			adi,extended-name = "FPGA_SYSREF";
+			adi,divider = <768>;
+			adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
+			adi,jesd204-sysref-chan;
+			//adi,disable; /* Completely disable channel */
+		};
+	};
+};
+
+&fmc_spi {
+	/delete-node/ ad9081@0;
+
+	trx0_ad9081: ad9082@0 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "adi,ad9082";
+		reg = <0>;
+		spi-max-frequency = <5000000>;
+
+		reset-gpios = <&gpio 133 0>;
+
+		/* Clocks */
+		clocks = <&hmc7044 2>;
+		clock-names = "dev_clk";
+
+		clock-output-names = "rx_sampl_clk", "tx_sampl_clk";
+		#clock-cells = <1>;
+
+		jesd204-device;
+		#jesd204-cells = <2>;
+		jesd204-top-device = <0>; /* This is the TOP device */
+		jesd204-link-ids = <FRAMER_LINK0_RX DEFRAMER_LINK0_TX>;
+
+		jesd204-inputs =
+			<&axi_ad9081_core_rx 0 FRAMER_LINK0_RX>,
+			<&axi_ad9081_core_tx 0 DEFRAMER_LINK0_TX>;
+
+		adi,continuous-sysref-mode-disable;
+
+		adi,tx-dacs {
+			#size-cells = <0>;
+			#address-cells = <1>;
+
+			adi,dac-frequency-hz = /bits/ 64 <3840000000>;
+
+			adi,main-data-paths {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				adi,interpolation = <1>;
+
+				ad9081_dac0: dac@0 {
+					reg = <0>;
+					adi,crossbar-select = <&ad9081_tx_fddc_chan0>;
+					adi,nco-frequency-shift-hz = /bits/ 64 <0>; /* 0 MHz */
+				};
+
+				ad9081_dac2: dac@2 {
+					reg = <2>;
+					adi,crossbar-select = <&ad9081_tx_fddc_chan1>;
+					adi,maindp-dac-1x-non1x-crossbar-select = <1>; /* Required to map correct datapath !*/
+					adi,nco-frequency-shift-hz = /bits/ 64 <0>; /* 0 MHz */
+				};
+			};
+
+			adi,channelizer-paths {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				adi,interpolation = <1>;
+
+				ad9081_tx_fddc_chan0: channel@0 {
+					reg = <0>;
+					adi,gain = <2048>; /* 2048 * 10^(gain_dB/20) */
+					adi,nco-frequency-shift-hz =  /bits/ 64 <0>;
+
+				};
+
+				ad9081_tx_fddc_chan1: channel@1 {
+					reg = <1>;
+					adi,gain = <2048>; /* 2048 * 10^(gain_dB/20) */
+					adi,nco-frequency-shift-hz =  /bits/ 64 <0>;
+
+				};
+			};
+
+			adi,jesd-links {
+				#size-cells = <0>;
+				#address-cells = <1>;
+
+				ad9081_tx_jesd_l0: link@0 {
+					#address-cells = <1>;
+					#size-cells = <0>;
+					reg = <0>;
+
+					adi,logical-lane-mapping = /bits/ 8 <0 2 7 6 1 5 4 3>;
+
+					adi,link-mode = <36>;			/* JESD Quick Configuration Mode */
+					adi,subclass = <1>;			/* JESD SUBCLASS 0,1,2 */
+					adi,version = <2>;			/* JESD VERSION 0=204A,1=204B,2=204C */
+					adi,dual-link = <0>;			/* JESD Dual Link Mode */
+
+					adi,converters-per-device = <2>;	/* JESD M */
+					adi,octets-per-frame = <3>;		/* JESD F */
+
+					adi,frames-per-multiframe = <256>;	/* JESD K */
+					adi,converter-resolution = <12>;	/* JESD N */
+					adi,bits-per-sample = <12>;		/* JESD NP' */
+					adi,control-bits-per-sample = <0>;	/* JESD CS */
+					adi,lanes-per-device = <8>;		/* JESD L */
+					adi,samples-per-converter-per-frame = <8>; /* JESD S */
+					adi,high-density = <0>;			/* JESD HD */
+
+					adi,tpl-phase-adjust = <25>;
+				};
+			};
+		};
+
+		adi,rx-adcs {
+			#size-cells = <0>;
+			#address-cells = <1>;
+
+			adi,adc-frequency-hz = /bits/ 64 <3840000000>;
+
+			adi,main-data-paths {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				ad9081_adc0: adc@0 {
+					reg = <0>;
+					adi,decimation = <1>;
+					adi,nco-frequency-shift-hz =  /bits/ 64 <0>;
+				};
+				ad9081_adc1: adc@1 {
+					reg = <1>;
+					adi,decimation = <1>;
+					adi,nco-frequency-shift-hz =  /bits/ 64 <0>;
+				};
+			};
+
+			adi,channelizer-paths {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				ad9081_rx_fddc_chan0: channel@0 {
+					reg = <0>;
+					adi,decimation = <1>;
+					adi,gain = <2048>; /* 2048 * 10^(gain_dB/20) */
+					adi,nco-frequency-shift-hz =  /bits/ 64 <0>;
+					adi,nco-mixer-mode = <AD9081_ADC_NCO_ZIF>;
+
+				};
+
+				ad9081_rx_fddc_chan1: channel@1 {
+					reg = <1>;
+					adi,decimation = <1>;
+					adi,gain = <2048>; /* 2048 * 10^(gain_dB/20) */
+					adi,nco-frequency-shift-hz =  /bits/ 64 <0>;
+					adi,nco-mixer-mode = <AD9081_ADC_NCO_ZIF>;
+				};
+			};
+
+			adi,jesd-links {
+				#size-cells = <0>;
+				#address-cells = <1>;
+
+				ad9081_rx_jesd_l0: link@0 {
+					reg = <0>;
+					adi,converter-select =
+						<&ad9081_rx_fddc_chan0 FDDC_I>, <&ad9081_rx_fddc_chan1 FDDC_I>;
+
+					adi,logical-lane-mapping = /bits/ 8 <2 0 7 6 5 4 3 1>;
+
+					adi,link-mode = <28>;			/* JESD Quick Configuration Mode */
+					adi,subclass = <1>;			/* JESD SUBCLASS 0,1,2 */
+					adi,version = <2>;			/* JESD VERSION 0=204A,1=204B,2=204C */
+					adi,dual-link = <0>;			/* JESD Dual Link Mode */
+
+					adi,converters-per-device = <2>;	/* JESD M */
+					adi,octets-per-frame = <3>;		/* JESD F */
+
+					adi,frames-per-multiframe = <256>;	/* JESD K */
+					adi,converter-resolution = <12>;	/* JESD N */
+					adi,bits-per-sample = <12>;		/* JESD NP' */
+					adi,control-bits-per-sample = <0>;	/* JESD CS */
+					adi,lanes-per-device = <8>;		/* JESD L */
+					adi,samples-per-converter-per-frame = <8>; /* JESD S */
+					adi,high-density = <0>;			/* JESD HD */
+				};
+			};
+		};
+	};
+};
+
+&axi_ad9081_core_tx {
+	single-shot-output-gpios = <&gpio 139 0>;
+};


### PR DESCRIPTION
204C use case with Subclass 1,
Med. lane rate, using gearbox and PRGOGDIV
    * 1Txs / 1Rxs per MxFE
    * DAC_CLK = 3.84 GSPS
    * ADC_CLK = 3.84 GSPS
    * Tx I/Q Rate: 3.84 GSPS (Interpolation of 1x1)
    * Rx I/Q Rate: 3.84 GSPS (Decimation of 1x1)
    * DAC JESD204B: Mode 36, L=8, M=2, N=N'=12
    * ADC JESD204B: Mode 28, L=8, M=2, N=N'=12
    * DAC-Side JESD204C Lane Rate: 11.88Gbps
    * ADC-Side JESD204C Lane Rate: 11.88Gbps

Signed-off-by: Laszlo Nagy <laszlo.nagy@analog.com>