### PR TITLE
a2b: patches for configs and kernel panic fix

### DIFF
--- a/Documentation/devicetree/bindings/mfd/adi,ad242x-master.yaml
+++ b/Documentation/devicetree/bindings/mfd/adi,ad242x-master.yaml
@@ -145,6 +145,34 @@ properties:
     description: Drives RX pins on falling edge of BCLK
     type: boolean
 
+  adi,sff-divisor:
+    description:
+      Output rate of PDM demodulators will be Superframe rate
+      divided by sff-divisor
+    allOf:
+      - $ref: '/schemas/types.yaml#/definitions/uint32'
+      - enum: [1, 2, 4]
+
+  adi,pdm0-enable:
+    description: Enables PDM reception on RX0 pin
+    type: boolean
+
+  adi,pdm0-stereo:
+    description: Selects two channels of PDM signal on RX0 pin
+    type: boolean
+
+  adi,pdm1-enable:
+    description: Enables PDM reception on RX1 pin
+    type: boolean
+
+  adi,pdm1-stereo:
+    description: Selects two channels of PDM signal on RX1 pin
+    type: boolean
+
+  adi,hpf-enable:
+    description: Enables High Pass filtering on received PDM data
+    type: boolean
+
 required:
   - compatible
   - reg

--- a/Documentation/devicetree/bindings/mfd/adi,ad242x-master.yaml
+++ b/Documentation/devicetree/bindings/mfd/adi,ad242x-master.yaml
@@ -113,6 +113,38 @@ properties:
     description: Selects high spectrum spreading mode
     type: boolean
 
+  adi,tx0-enable:
+    description: Enables I2S/TDM data on TX0 pin
+    type: boolean
+
+  adi,tx1-enable:
+    description: Enables I2S/TDM data on TX1 pin
+    type: boolean
+
+  adi,tx2-pin-interleave:
+    description: Enables slots interleaving on TX pins
+    type: boolean
+
+  adi,tx-bclk-invert:
+    description: Drives TX pins on falling edge of BCLK
+    type: boolean
+
+  adi,rx0-enable:
+    description: Enables I2S/TDM data on RX0 pin
+    type: boolean
+
+  adi,rx1-enable:
+    description: Enables I2S/TDM data on RX1 pin
+    type: boolean
+
+  adi,rx2-pin-interleave:
+    description: Enables slots interleaving on RX pins
+    type: boolean
+
+  adi,rx-bclk-invert:
+    description: Drives RX pins on falling edge of BCLK
+    type: boolean
+
 required:
   - compatible
   - reg

--- a/Documentation/devicetree/bindings/mfd/adi,ad242x-slave.yaml
+++ b/Documentation/devicetree/bindings/mfd/adi,ad242x-slave.yaml
@@ -88,6 +88,34 @@ properties:
     description: Drives RX pins on falling edge of BCLK
     type: boolean
 
+  adi,sff-divisor:
+    description:
+      Output rate of PDM demodulators will be Superframe rate
+      divided by sff-divisor
+    allOf:
+      - $ref: '/schemas/types.yaml#/definitions/uint32'
+      - enum: [1, 2, 4]
+
+  adi,pdm0-enable:
+    description: Enables PDM reception on RX0 pin
+    type: boolean
+
+  adi,pdm0-stereo:
+    description: Selects two channels of PDM signal on RX0 pin
+    type: boolean
+
+  adi,pdm1-enable:
+    description: Enables PDM reception on RX1 pin
+    type: boolean
+
+  adi,pdm1-stereo:
+    description: Selects two channels of PDM signal on RX1 pin
+    type: boolean
+
+  adi,hpf-enable:
+    description: Enables High Pass filtering on received PDM data
+    type: boolean
+
   upstream:
     type: object
     properties:

--- a/Documentation/devicetree/bindings/mfd/adi,ad242x-slave.yaml
+++ b/Documentation/devicetree/bindings/mfd/adi,ad242x-slave.yaml
@@ -56,6 +56,38 @@ properties:
     description: Selects high spectrum spreading mode
     type: boolean
 
+  adi,tx0-enable:
+    description: Enables I2S/TDM data on TX0 pin
+    type: boolean
+
+  adi,tx1-enable:
+    description: Enables I2S/TDM data on TX1 pin
+    type: boolean
+
+  adi,tx2-pin-interleave:
+    description: Enables slots interleaving on TX pins
+    type: boolean
+
+  adi,tx-bclk-invert:
+    description: Drives TX pins on falling edge of BCLK
+    type: boolean
+
+  adi,rx0-enable:
+    description: Enables I2S/TDM data on RX0 pin
+    type: boolean
+
+  adi,rx1-enable:
+    description: Enables I2S/TDM data on RX1 pin
+    type: boolean
+
+  adi,rx2-pin-interleave:
+    description: Enables slots interleaving on RX pins
+    type: boolean
+
+  adi,rx-bclk-invert:
+    description: Drives RX pins on falling edge of BCLK
+    type: boolean
+
   upstream:
     type: object
     properties:

--- a/drivers/a2b/a2b-core.c
+++ b/drivers/a2b/a2b-core.c
@@ -497,6 +497,31 @@ static int a2b_node_set_i2s_config(struct a2b_node *node)
 	return a2b_node_write(node, A2B_I2SCTL, val);
 }
 
+static int a2b_node_set_pdm_config(struct a2b_node *node)
+{
+	struct a2b_pdm_config *pdm_cfg = &node->pdm_config;
+	uint8_t val = 0;
+
+	val |= A2B_PDMCTL_PDMRATE(pdm_cfg->sff_divisor);
+
+	if (pdm_cfg->pdm0_enable)
+		val |= A2B_PDMCTL_PDM0EN;
+
+	if (pdm_cfg->pdm0_stereo)
+		val |= A2B_PDMCTL_PDM0SLOTS;
+
+	if (pdm_cfg->pdm1_enable)
+		val |= A2B_PDMCTL_PDM1EN;
+
+	if (pdm_cfg->pdm1_stereo)
+		val |= A2B_PDMCTL_PDM1SLOTS;
+
+	if (pdm_cfg->hpf_enable)
+		val |= A2B_PDMCTL_HPFEN;
+
+	return a2b_node_write(node, A2B_PDMCTL, val);
+}
+
 static int a2b_bus_discover(struct a2b_mainnode *mainnode)
 {
 	struct a2b_mainnode_slot_config mainnode_config;
@@ -610,6 +635,10 @@ static int a2b_bus_discover(struct a2b_mainnode *mainnode)
 			return ret;
 
 		ret = a2b_node_set_i2s_config(&subnode->node);
+		if (ret)
+			return ret;
+
+		ret = a2b_node_set_pdm_config(&subnode->node);
 		if (ret)
 			return ret;
 
@@ -742,6 +771,10 @@ static int a2b_mainnode_startup(struct a2b_mainnode *mainnode)
 		return ret;
 
 	ret = a2b_node_set_i2s_config(&mainnode->node);
+	if (ret)
+		return ret;
+
+	ret = a2b_node_set_pdm_config(&mainnode->node);
 	if (ret)
 		return ret;
 

--- a/drivers/a2b/a2b-core.c
+++ b/drivers/a2b/a2b-core.c
@@ -465,6 +465,38 @@ static int a2b_node_set_pll_config(struct a2b_node *node)
 	return a2b_node_write(node, A2B_PLLCTL, val);
 }
 
+static int a2b_node_set_i2s_config(struct a2b_node *node)
+{
+	struct a2b_i2s_config *i2s_cfg = &node->i2s_config;
+	uint8_t val = 0;
+
+	if (i2s_cfg->tx0_enable)
+		val |= A2B_I2SCTL_TX0EN;
+
+	if (i2s_cfg->tx1_enable)
+		val |= A2B_I2SCTL_TX1EN;
+
+	if (i2s_cfg->tx2_pin_intlv)
+		val |= A2B_I2SCTL_TX2PINTL;
+
+	if (i2s_cfg->tx_bclk_inv)
+		val |= A2B_I2SCTL_TXBCLKINV;
+
+	if (i2s_cfg->rx0_enable)
+		val |= A2B_I2SCTL_RX0EN;
+
+	if (i2s_cfg->rx1_enable)
+		val |= A2B_I2SCTL_RX1EN;
+
+	if (i2s_cfg->rx2_pin_intlv)
+		val |= A2B_I2SCTL_RX2PINTL;
+
+	if (i2s_cfg->rx_bclk_inv)
+		val |= A2B_I2SCTL_RXBCLKINV;
+
+	return a2b_node_write(node, A2B_I2SCTL, val);
+}
+
 static int a2b_bus_discover(struct a2b_mainnode *mainnode)
 {
 	struct a2b_mainnode_slot_config mainnode_config;
@@ -574,6 +606,10 @@ static int a2b_bus_discover(struct a2b_mainnode *mainnode)
 			return ret;
 
 		ret = a2b_node_set_pin_config(&subnode->node);
+		if (ret)
+			return ret;
+
+		ret = a2b_node_set_i2s_config(&subnode->node);
 		if (ret)
 			return ret;
 
@@ -702,6 +738,10 @@ static int a2b_mainnode_startup(struct a2b_mainnode *mainnode)
 		return ret;
 
 	ret = a2b_node_set_pin_config(&mainnode->node);
+	if (ret)
+		return ret;
+
+	ret = a2b_node_set_i2s_config(&mainnode->node);
 	if (ret)
 		return ret;
 

--- a/drivers/a2b/a2b-of.c
+++ b/drivers/a2b/a2b-of.c
@@ -122,6 +122,10 @@ static int a2b_of_subnode_read_config(struct a2b_subnode *subnode)
 	if (ret)
 		return ret;
 
+	ret = a2b_of_read_i2s_config(&subnode->node);
+	if (ret)
+		return ret;
+
 	return a2b_of_read_tdm_config(&subnode->node);
 }
 
@@ -266,6 +270,10 @@ int a2b_of_mainnode_read_config(struct a2b_mainnode *mainnode)
 	if (ret)
 		return ret;
 
+	ret = a2b_of_read_i2s_config(&mainnode->node);
+	if (ret)
+		return ret;
+
 	return a2b_of_read_tdm_config(&mainnode->node);
 }
 
@@ -386,6 +394,25 @@ int a2b_of_read_tdm_config(struct a2b_node *node)
 	cfg->alt_sync = of_property_read_bool(np, "adi,alternating-sync");
 	cfg->early_sync = of_property_read_bool(np, "adi,early-sync");
 	cfg->invert_sync = of_property_read_bool(np, "adi,invert-sync");
+
+	return 0;
+}
+
+int a2b_of_read_i2s_config(struct a2b_node *node)
+{
+	struct device_node *np = node->dev.of_node;
+	struct a2b_i2s_config *cfg = &node->i2s_config;
+
+	cfg->tx0_enable = of_property_read_bool(np, "adi,tx0-enable");
+	cfg->tx1_enable = of_property_read_bool(np, "adi,tx1-enable");
+	cfg->tx2_pin_intlv =
+		of_property_read_bool(np, "adi,tx2-pin-interleave");
+	cfg->tx_bclk_inv = of_property_read_bool(np, "adi,tx-bclk-invert");
+	cfg->rx0_enable = of_property_read_bool(np, "adi,rx0-enable");
+	cfg->rx1_enable = of_property_read_bool(np, "adi,rx1-enable");
+	cfg->rx2_pin_intlv =
+		of_property_read_bool(np, "adi,rx2-pin-interleave");
+	cfg->rx_bclk_inv = of_property_read_bool(np, "adi,rx-bclk-invert");
 
 	return 0;
 }

--- a/include/linux/a2b/a2b.h
+++ b/include/linux/a2b/a2b.h
@@ -92,6 +92,28 @@ struct a2b_pll_config {
 };
 
 /**
+ * struct a2b_i2s_config - A2B I2S configuration
+ * @tx0_enable: I2S TX 0 Enable
+ * @tx1_enable: I2S TX 1 Enable
+ * @tx2_pin_intlv: TX 2 Pin Interleave
+ * @tx_bclk_inv: TX BCLK Invert
+ * @rx0_enable: I2S RX 0 Enable
+ * @rx1_enable: I2S RX 1 Enable
+ * @rx2_pin_intlv: RX 2 Pin Interleave
+ * @rx_bclk_inv: RX BCLK Invert
+ */
+struct a2b_i2s_config {
+	bool tx0_enable : 1;
+	bool tx1_enable : 1;
+	bool tx2_pin_intlv : 1;
+	bool tx_bclk_inv : 1;
+	bool rx0_enable : 1;
+	bool rx1_enable : 1;
+	bool rx2_pin_intlv : 1;
+	bool rx_bclk_inv : 1;
+};
+
+/**
  * struct a2b_node - A2B node state struct
  * @id: ID of the device on the bus, A2B_MAINNODE_ID for mainnodes
  * @dev: Device driver framework base struct
@@ -119,6 +141,7 @@ struct a2b_node {
 	struct a2b_tdm_config tdm_config;
 	struct a2b_pll_config pll_config;
 	enum a2b_pin_drive_strength pin_config;
+	struct a2b_i2s_config i2s_config;
 
 	uint8_t vendor_id;
 	uint8_t product_id;
@@ -292,6 +315,7 @@ int a2b_of_read_transceiver_config(struct a2b_node *node);
 int a2b_of_read_tdm_config(struct a2b_node *node);
 int a2b_of_read_pll_config(struct a2b_node *node);
 int a2b_of_read_pin_config(struct a2b_node *node);
+int a2b_of_read_i2s_config(struct a2b_node *node);
 
 int a2b_node_init_extra_regmap(struct a2b_node *node);
 

--- a/include/linux/a2b/a2b.h
+++ b/include/linux/a2b/a2b.h
@@ -79,6 +79,18 @@ enum a2b_spread_spectrum_mode {
 };
 
 /**
+ * enum a2b_pdm_rate - PDM Sample Rate select
+ * @SUPERFRAME: Super frame rate
+ * @SUPERFRAME_DIV_2: Super frame rate divide by 2
+ * @SUPERFRAME_DIV_4: Super frame rate divide by 4
+ */
+enum a2b_sff_divisor {
+	SUPERFRAME,
+	SUPERFRAME_DIV_2,
+	SUPERFRAME_DIV_4,
+};
+
+/**
  * struct a2b_pll_config - A2B node PLL configuration
  * @spread_spectrum_mode: Spread spectrum mode
  * @spread_spectrum_high: Whether to use high or low spectrum depth of
@@ -114,6 +126,24 @@ struct a2b_i2s_config {
 };
 
 /**
+ * struct a2b_pdm_config - A2B PDM configuration
+ * @sff_divisor: Superframe rate divisor
+ * @pdm0_enable: PDM0 Enable
+ * @pdm0_stereo: PDM0 is stereo
+ * @pdm1_enable: PDM1 Enable
+ * @pdm1_stereo: PDM1 is stereo
+ * @hpf_enable: Highpass Filter Enable
+ */
+struct a2b_pdm_config {
+	enum a2b_sff_divisor sff_divisor;
+	bool pdm0_enable : 1;
+	bool pdm0_stereo : 1;
+	bool pdm1_enable : 1;
+	bool pdm1_stereo : 1;
+	bool hpf_enable : 1;
+};
+
+/**
  * struct a2b_node - A2B node state struct
  * @id: ID of the device on the bus, A2B_MAINNODE_ID for mainnodes
  * @dev: Device driver framework base struct
@@ -142,6 +172,7 @@ struct a2b_node {
 	struct a2b_pll_config pll_config;
 	enum a2b_pin_drive_strength pin_config;
 	struct a2b_i2s_config i2s_config;
+	struct a2b_pdm_config pdm_config;
 
 	uint8_t vendor_id;
 	uint8_t product_id;
@@ -316,6 +347,7 @@ int a2b_of_read_tdm_config(struct a2b_node *node);
 int a2b_of_read_pll_config(struct a2b_node *node);
 int a2b_of_read_pin_config(struct a2b_node *node);
 int a2b_of_read_i2s_config(struct a2b_node *node);
+int a2b_of_read_pdm_config(struct a2b_node *node);
 
 int a2b_node_init_extra_regmap(struct a2b_node *node);
 


### PR DESCRIPTION
This PR adds the following commits

1. Fix kernel panic in mailbox driver
2. Enable I2S configration in devicetree
3. Enable PDM configration in devicetree