### PR TITLE
turn `iio_dmaengine_buffer_alloc()` static

### DIFF
--- a/drivers/iio/adc/ad7768-1.c
+++ b/drivers/iio/adc/ad7768-1.c
@@ -838,10 +838,9 @@ static int ad7768_hardware_buffer_alloc(struct iio_dev *indio_dev)
 
 	indio_dev->modes |=  INDIO_BUFFER_HARDWARE;
 	indio_dev->setup_ops = &ad7768_buffer_ops;
-	buffer = iio_dmaengine_buffer_alloc(indio_dev->dev.parent,
-					    "rx",
-					    &dma_buffer_ops,
-					    indio_dev);
+	buffer = devm_iio_dmaengine_buffer_alloc(indio_dev->dev.parent,
+						 "rx", &dma_buffer_ops,
+						 indio_dev);
 	if (IS_ERR(buffer))
 		return PTR_ERR(buffer);
 

--- a/drivers/iio/adc/ad7768-1.c
+++ b/drivers/iio/adc/ad7768-1.c
@@ -842,10 +842,8 @@ static int ad7768_hardware_buffer_alloc(struct iio_dev *indio_dev)
 					    "rx",
 					    &dma_buffer_ops,
 					    indio_dev);
-	if (IS_ERR(buffer)) {
-		iio_dmaengine_buffer_free(indio_dev->buffer);
+	if (IS_ERR(buffer))
 		return PTR_ERR(buffer);
-	}
 
 	iio_device_attach_buffer(indio_dev, buffer);
 

--- a/drivers/iio/adc/admc_adc.c
+++ b/drivers/iio/adc/admc_adc.c
@@ -109,8 +109,8 @@ static int axiadc_configure_ring_stream(struct iio_dev *indio_dev,
 	if (dma_name == NULL)
 		dma_name = "rx";
 
-	buffer = iio_dmaengine_buffer_alloc(indio_dev->dev.parent, dma_name,
-			&axiadc_dma_buffer_ops, indio_dev);
+	buffer = devm_iio_dmaengine_buffer_alloc(indio_dev->dev.parent, dma_name,
+						 &axiadc_dma_buffer_ops, indio_dev);
 	if (IS_ERR(buffer))
 		return PTR_ERR(buffer);
 
@@ -118,11 +118,6 @@ static int axiadc_configure_ring_stream(struct iio_dev *indio_dev,
 	iio_device_attach_buffer(indio_dev, buffer);
 
 	return 0;
-}
-
-static void axiadc_unconfigure_ring_stream(struct iio_dev *indio_dev)
-{
-	iio_dmaengine_buffer_free(indio_dev->buffer);
 }
 
 static int axiadc_reg_access(struct iio_dev *indio_dev,
@@ -235,29 +230,14 @@ static int axiadc_probe(struct platform_device *pdev)
 	if (ret < 0)
 		return ret;
 
-	ret = iio_device_register(indio_dev);
+	ret = devm_iio_device_register(&pdev->dev, indio_dev);
 	if (ret)
-		goto err_unconfigure_ring;
+		return ret;
 
 	dev_info(&pdev->dev, "ADI AIM (0x%X) at 0x%08llX mapped to 0x%p, probed ADC %s as %s\n",
 		 st->pcore_version,
 		 (unsigned long long)mem->start, st->regs, chip_info->name,
 		 axiadc_read(st, ADI_AXI_REG_ID) ? "SLAVE" : "MASTER");
-
-	return 0;
-
-err_unconfigure_ring:
-	axiadc_unconfigure_ring_stream(indio_dev);
-
-	return ret;
-}
-
-static int axiadc_remove(struct platform_device *pdev)
-{
-	struct iio_dev *indio_dev = platform_get_drvdata(pdev);
-
-	iio_device_unregister(indio_dev);
-	axiadc_unconfigure_ring_stream(indio_dev);
 
 	return 0;
 }
@@ -276,7 +256,6 @@ static struct platform_driver axiadc_driver = {
 		.of_match_table = axiadc_of_match,
 	},
 	.probe	  = axiadc_probe,
-	.remove	 = axiadc_remove,
 };
 
 module_platform_driver(axiadc_driver);

--- a/drivers/iio/buffer/industrialio-buffer-dmaengine.c
+++ b/drivers/iio/buffer/industrialio-buffer-dmaengine.c
@@ -187,7 +187,7 @@ static const struct attribute *iio_dmaengine_buffer_attrs[] = {
  * Once done using the buffer iio_dmaengine_buffer_free() should be used to
  * release it.
  */
-struct iio_buffer *iio_dmaengine_buffer_alloc(struct device *dev,
+static struct iio_buffer *iio_dmaengine_buffer_alloc(struct device *dev,
 	const char *channel, const struct iio_dma_buffer_ops *ops,
 	void *driver_data)
 {
@@ -246,7 +246,6 @@ err_free:
 	kfree(dmaengine_buffer);
 	return ERR_PTR(ret);
 }
-EXPORT_SYMBOL(iio_dmaengine_buffer_alloc);
 
 /**
  * iio_dmaengine_buffer_free() - Free dmaengine buffer
@@ -254,7 +253,7 @@ EXPORT_SYMBOL(iio_dmaengine_buffer_alloc);
  *
  * Frees a buffer previously allocated with iio_dmaengine_buffer_alloc().
  */
-void iio_dmaengine_buffer_free(struct iio_buffer *buffer)
+static void iio_dmaengine_buffer_free(struct iio_buffer *buffer)
 {
 	struct dmaengine_buffer *dmaengine_buffer =
 		iio_buffer_to_dmaengine_buffer(buffer);
@@ -264,7 +263,6 @@ void iio_dmaengine_buffer_free(struct iio_buffer *buffer)
 
 	iio_buffer_put(buffer);
 }
-EXPORT_SYMBOL_GPL(iio_dmaengine_buffer_free);
 
 static void __devm_iio_dmaengine_buffer_free(struct device *dev, void *res)
 {

--- a/drivers/iio/frequency/cf_axi_dds_buffer_stream.c
+++ b/drivers/iio/frequency/cf_axi_dds_buffer_stream.c
@@ -93,8 +93,8 @@ int cf_axi_dds_configure_buffer(struct iio_dev *indio_dev)
 {
 	struct iio_buffer *buffer;
 
-	buffer = iio_dmaengine_buffer_alloc(indio_dev->dev.parent, "tx",
-			&dds_buffer_dma_buffer_ops, indio_dev);
+	buffer = devm_iio_dmaengine_buffer_alloc(indio_dev->dev.parent, "tx",
+						 &dds_buffer_dma_buffer_ops, indio_dev);
 	if (IS_ERR(buffer))
 		return PTR_ERR(buffer);
 
@@ -108,8 +108,3 @@ int cf_axi_dds_configure_buffer(struct iio_dev *indio_dev)
 }
 EXPORT_SYMBOL_GPL(cf_axi_dds_configure_buffer);
 
-void cf_axi_dds_unconfigure_buffer(struct iio_dev *indio_dev)
-{
-	iio_dmaengine_buffer_free(indio_dev->buffer);
-}
-EXPORT_SYMBOL_GPL(cf_axi_dds_unconfigure_buffer);

--- a/drivers/iio/logic/m2k-logic-analyzer.c
+++ b/drivers/iio/logic/m2k-logic-analyzer.c
@@ -1141,8 +1141,8 @@ static int m2k_la_probe(struct platform_device *pdev)
 	indio_dev_tx->direction = IIO_DEVICE_DIRECTION_OUT;
 	indio_dev_tx->setup_ops = &m2k_la_tx_setup_ops;
 
-	buffer_tx = iio_dmaengine_buffer_alloc(&pdev->dev, "tx",
-			&m2k_la_dma_buffer_ops, indio_dev_tx);
+	buffer_tx = devm_iio_dmaengine_buffer_alloc(&pdev->dev, "tx", &m2k_la_dma_buffer_ops,
+						    indio_dev_tx);
 	if (IS_ERR(buffer_tx))
 		return PTR_ERR(buffer_tx);
 	iio_device_attach_buffer(indio_dev_tx, buffer_tx);
@@ -1160,8 +1160,8 @@ static int m2k_la_probe(struct platform_device *pdev)
 	indio_dev_rx->channels = m2k_la_rx_chan_spec,
 	indio_dev_rx->num_channels = ARRAY_SIZE(m2k_la_rx_chan_spec);
 
-	buffer_rx = iio_dmaengine_buffer_alloc(&pdev->dev, "rx",
-			&m2k_la_dma_buffer_ops, indio_dev_rx);
+	buffer_rx = devm_iio_dmaengine_buffer_alloc(&pdev->dev, "rx", &m2k_la_dma_buffer_ops,
+						    indio_dev_rx);
 	if (IS_ERR(buffer_rx))
 		return PTR_ERR(buffer_rx);
 	iio_device_attach_buffer(indio_dev_rx, buffer_rx);

--- a/drivers/misc/mathworks/mw_stream_iio_channel.c
+++ b/drivers/misc/mathworks/mw_stream_iio_channel.c
@@ -306,22 +306,15 @@ static int devm_mw_stream_configure_buffer(struct iio_dev *indio_dev)
 {
 	struct mw_stream_iio_chandev *mwchan = iio_priv(indio_dev);
 	struct iio_buffer *buffer;
-	int status;
 
-	buffer = iio_dmaengine_buffer_alloc(indio_dev->dev.parent, mwchan->dmaname,
-			&mw_stream_iio_buffer_dma_buffer_ops, indio_dev);
+	buffer = devm_iio_dmaengine_buffer_alloc(indio_dev->dev.parent, mwchan->dmaname,
+						 &mw_stream_iio_buffer_dma_buffer_ops, indio_dev);
 	if (IS_ERR(buffer)) {
 		if(PTR_ERR(buffer) == -EPROBE_DEFER)
 			dev_info(&indio_dev->dev, "Deferring probe for DMA engine driver load\n");
 		else
 			dev_err(&indio_dev->dev, "Failed to allocate IIO DMA buffer: %ld\n", PTR_ERR(buffer));
 		return PTR_ERR(buffer);
-	}
-
-	status = devm_add_action(indio_dev->dev.parent,(devm_action_fn)iio_dmaengine_buffer_free, buffer);
-	if(status){
-		iio_dmaengine_buffer_free(buffer);
-		return status;
 	}
 
 	iio_device_attach_buffer(indio_dev, buffer);

--- a/include/linux/iio/buffer-dmaengine.h
+++ b/include/linux/iio/buffer-dmaengine.h
@@ -16,12 +16,6 @@ struct iio_dma_buffer_queue;
 int iio_dmaengine_buffer_submit_block(struct iio_dma_buffer_queue *queue,
 	struct iio_dma_buffer_block *block, int direction);
 void iio_dmaengine_buffer_abort(struct iio_dma_buffer_queue *queue);
-void iio_dmaengine_buffer_free(struct iio_buffer *buffer);
-
-struct iio_buffer *iio_dmaengine_buffer_alloc(struct device *dev,
-					      const char *channel,
-					      const struct iio_dma_buffer_ops *ops,
-					      void *data);
 
 struct iio_buffer *devm_iio_dmaengine_buffer_alloc(struct device *dev,
 						   const char *channel,


### PR DESCRIPTION
The goal of this PR is to turn `iio_dmaengine_buffer_alloc()` private and only use the devm variant. This will make us a little bit closer with what we have upstream. Along the way, I fixed some things and just moved all the probes() to be completely resource managed.

Regarding the last change where the move to static is done, I could have waited until we move to a newer kernel to do it, but I just want to sop any possible use of `iio_dmaengine_buffer_alloc()` in the meantime.