### PR TITLE
iio: adc: adrv9002: remove check for "</table" in frequency hopping

### DIFF
--- a/drivers/iio/adc/navassa/adrv9002.c
+++ b/drivers/iio/adc/navassa/adrv9002.c
@@ -4419,11 +4419,6 @@ static ssize_t adrv9002_fh_bin_table_write(struct adrv9002_rf_phy *phy, char *bu
 
 	memcpy(tbl->bin_table + off, buf, count);
 
-	if (!strnstr(tbl->bin_table, "</table>", off + count)) {
-		mutex_unlock(&phy->lock);
-		return count;
-	}
-
 	if (phy->fh.mode == ADI_ADRV9001_FHMODE_LO_RETUNE_REALTIME_PROCESS_DUAL_HOP)
 		max_sz /= 2;
 


### PR DESCRIPTION
Having the "<table>", "</table>" markers should not really be mandatory for loading a table (as long as the entries are valid). However, with this change they can still be used which means applications using them should still work.

Moreover, if the pattern was not found we where still returning as everything went good although no table was loaded. This could be confusing for userspace.

Signed-off-by: Nuno Sá <nuno.sa@analog.com>