### PR TITLE
iio: filter: admv8818: fix out-of-bounds read

### DIFF
--- a/drivers/iio/filter/admv8818.c
+++ b/drivers/iio/filter/admv8818.c
@@ -306,7 +306,7 @@ static int __admv8818_read_hpf_freq(struct admv8818_dev *dev, unsigned int *hpf_
 		return ret;
 
 	hpf_band = FIELD_GET(ADMV8818_SW_IN_WR0_MSK, data);
-	if (!hpf_band) {
+	if (!hpf_band || hpf_band > 4) {
 		*hpf_freq = 0;
 		return ret;
 	}
@@ -344,7 +344,7 @@ static int __admv8818_read_lpf_freq(struct admv8818_dev *dev, unsigned int *lpf_
 		return ret;
 
 	lpf_band = FIELD_GET(ADMV8818_SW_OUT_WR0_MSK, data);
-	if (!lpf_band) {
+	if (!lpf_band || lpf_band > 4) {
 		*lpf_freq = 0;
 		return ret;
 	}


### PR DESCRIPTION
ADMV8818_SW_IN_WR0_MSK and ADMV8818_SW_OUT_WR0_MSK have 3 bits,
which means a length of 8, but freq_range_hpf and freq_range_lpf array size is 4,
may end up reading 4 elements beyond the end of those arrays.

Fix to check value first before access freq_range_hpf and freq_range_lpf.

Fixes: bd10500 ("iio:filter:admv8818: add support for ADMV8818")
Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>