### PR TITLE
CI: install GitPython for checkpatch

### DIFF
--- a/ci/travis/run-build.sh
+++ b/ci/travis/run-build.sh
@@ -238,7 +238,7 @@ build_checkpatch() {
 	fi
 
 	# install checkpatch dependencies
-	sudo pip install ply
+	sudo pip install ply GitPython
 
 	__update_git_ref "${ref_branch}" "${ref_branch}"
 


### PR DESCRIPTION
Without GitPython installed, the checkpatch script prints an error when trying to run the spdxcheck.py script.

Traceback (most recent call last):
  File "scripts/spdxcheck.py", line 10, in <module>
    import git
ModuleNotFoundError: No module named 'git'

Although it is not fatal, just install the python package to get rid of it.

Signed-off-by: Cosmin Tanislav <cosmin.tanislav@analog.com>