### PR TITLE
arch: arm64: dts: xmicrowave: fix hdl tag

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-revb-adrv2crr-fmc-revb-jesd204-fsm-xmicrowave.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-revb-adrv2crr-fmc-revb-jesd204-fsm-xmicrowave.dts
@@ -7,7 +7,7 @@
  * https://wiki.analog.com/resources/tools-software/linux-software/adrv9009_advanced_plugin
  * https://wiki.analog.com/resources/eval/user-guides/adrv9009-zu11eg/adrv2crr-fmc_carrier_board
  *
- * hdl_project: <adrv9009zu11eg/adrv2crr_fmc>
+ * hdl_project: <adrv9009zu11eg/adrv2crr_xmicrowave>
  * board_revision: <B>
  *
  * Copyright (C) 2021 Analog Devices Inc.


### PR DESCRIPTION
Update the hdl tag to match the actual hdl project.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>