### PR TITLE
arch/arm/boot/dts: a10soc_ad9136 dts: add hdl tag

### DIFF
--- a/arch/arm/boot/dts/socfpga_arria10_socdk_ad9136_fmc_ebz.dts
+++ b/arch/arm/boot/dts/socfpga_arria10_socdk_ad9136_fmc_ebz.dts
@@ -1,3 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD9136-FMC-EBZ
+ * https://wiki.analog.com/resources/eval/dpg/eval-ad9136
+ *
+ * hdl_project: <dac_fmc_ebz/a10soc>
+ * board_revision: <>
+ *
+ * Copyright (C) 2019-2022 Analog Devices Inc.
+ */
 /dts-v1/;
 
 #define fmc_gpio sys_gpio_out


### PR DESCRIPTION
Add HDL project tag and Copyright lines in
arch/arm/boot/dts/socfpga_arria10_socdk_ad9136_fmc_ebz.dts

Signed-off-by: stefan.raus <stefan.raus@analog.com>