### PR TITLE
arm: dts: add rpi-max14830

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -224,6 +224,8 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	rpi-ltc2497.dtbo \
 	rpi-ltc2688.dtbo \
 	rpi-ltc6952.dtbo \
+	rpi-max14830-i2c.dtbo \
+	rpi-max14830-spi.dtbo \
 	rpi-poe.dtbo \
 	rpi-poe-plus.dtbo \
 	rpi-proto.dtbo \

--- a/arch/arm/boot/dts/overlays/rpi-max14830-i2c-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-max14830-i2c-overlay.dts
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-2.0
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+
+/ {
+	compatible = "brcm,bcm2835", "brcm,bcm2711";
+
+	fragment@0 {
+		target-path = "/clocks";
+
+		__overlay__ {
+			max14830_xtal: max14830_xtal {
+				compatible = "fixed-clock";
+				#clock-cells = <0>;
+				clock-frequency = <3686400>;
+			};
+		};
+
+	};
+
+	fragment@1 {
+		target = <&i2c1>;
+
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			status = "okay";
+
+			max14830@6c {
+				compatible = "maxim,max14830";
+				reg = <0x6c>;
+
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				gpio-controller;
+				#gpio-cells = <2>;
+
+				interrupts = <27 IRQ_TYPE_EDGE_FALLING>;
+				interrupt-parent = <&gpio>;
+
+				clocks = <&max14830_xtal>;
+				clock-names = "xtal";
+			};
+		};
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-max14830-spi-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-max14830-spi-overlay.dts
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-2.0
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+
+/ {
+	compatible = "brcm,bcm2835", "brcm,bcm2711";
+
+	fragment@0 {
+		target-path = "/clocks";
+
+		__overlay__ {
+			max14830_xtal: max14830_xtal {
+				compatible = "fixed-clock";
+				#clock-cells = <0>;
+				clock-frequency = <3686400>;
+			};
+		};
+
+	};
+
+	fragment@1 {
+		target = <&spi0>;
+
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			cs-gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			status = "okay";
+
+			max14830@0 {
+				compatible = "maxim,max14830";
+				reg = <0>;
+
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				gpio-controller;
+				#gpio-cells = <2>;
+
+				spi-max-frequency = <5000000>;
+				interrupts = <27 IRQ_TYPE_EDGE_FALLING>;
+				interrupt-parent = <&gpio>;
+
+				clocks = <&max14830_xtal>;
+				clock-names = "xtal";
+			};
+		};
+	};
+
+	fragment@2 {
+		target = <&spidev0>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@3 {
+		target = <&spidev1>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+};


### PR DESCRIPTION
The MAX14830 is an advanced quad universal asynchronous receiver-transmitter (UART), each UART having 128 words of receive and transmit first-in/first-out (FIFO) and a high-speed serial peripheral interface (SPI) or I2C controller interface. A PLL and fractional baud-rate generators allow a high degree of flexibility in baud-rate programming and reference clock selection.

Each of the four UARTs is selected by in-band SPI/I2C addressing. The 128-word FIFOs have advanced FIFO control reducing host processor data flow management.

Signed-off-by: Cosmin Tanislav <cosmin.tanislav@analog.com>