### PR TITLE
adrv9002 ext lo support

### DIFF
--- a/arch/arm/boot/dts/adi-adrv9002.dtsi
+++ b/arch/arm/boot/dts/adi-adrv9002.dtsi
@@ -25,7 +25,7 @@
 
 		spi-max-frequency = <20000000>;
 		/* Clocks */
-		clocks = <&adrv9002_clkin 0>;
+		clocks = <&adrv9002_clkin>;
 		clock-names = "adrv9002_ext_refclk";
 		clock-output-names = "rx1_sampl_clk", "tx1_sampl_clk", "tdd1_intf_clk",
 				"rx2_sampl_clk", "tx2_sampl_clk", "tdd2_intf_clk";

--- a/arch/arm64/boot/dts/xilinx/adi-adrv9002.dtsi
+++ b/arch/arm64/boot/dts/xilinx/adi-adrv9002.dtsi
@@ -25,7 +25,7 @@
 
 		spi-max-frequency = <20000000>;
 		/* Clocks */
-		clocks = <&adrv9002_clkin 0>;
+		clocks = <&adrv9002_clkin>;
 		clock-names = "adrv9002_ext_refclk";
 		clock-output-names = "rx1_sampl_clk", "tx1_sampl_clk", "tdd1_intf_clk",
 				"rx2_sampl_clk", "tx2_sampl_clk", "tdd2_intf_clk";


### PR DESCRIPTION
Add support for having external LOS connected to the device. This has to be enabled in the loaded profile. While doing, one bugs in the devicetree was found, so the first 2 patches are fixing it (for different platforms)