### PR TITLE
a2b: fix typo in A2B_DNMASK definition

### DIFF
--- a/include/linux/a2b/a2b-regs.h
+++ b/include/linux/a2b/a2b-regs.h
@@ -280,7 +280,7 @@
 #define A2B_UPOFFSET 0x64
 #define A2B_UPOFFSET_VAL(X) ((X)&0x1f)
 
-#define A2B_DNMASK(X) (0x65 + ((X) % 3))
+#define A2B_DNMASK(X) (0x65 + ((X)&3))
 
 #define A2B_DNOFFSET 0x69
 #define A2B_DNOFFSET_VAL(X) ((X)&0x1f)


### PR DESCRIPTION
Fix typo in `A2B_DNMASK` definition.

Signed-off-by: Jay Mistry <jay.mistry@getcruise.com>