### PR TITLE
arch/arm/dts/de10nano: Add sysid support to master

### DIFF
--- a/arch/arm/boot/dts/socfpga_cyclone5_de10_nano.dtsi
+++ b/arch/arm/boot/dts/socfpga_cyclone5_de10_nano.dtsi
@@ -106,6 +106,11 @@
 		};
 	};
 
+	axi_sysid_0: axi-sysid-0@00018000 {
+		compatible = "adi,axi-sysid-1.00.a";
+		reg = <0x00018000 0x8000>;
+	};
+
 	hdmi_tx_dma: dma@0x00080000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x00080000 0x00000800>;


### PR DESCRIPTION
Commit originally added to release branch 2021_R1. Adding this commit to master, for issue:
[Master] No sysid in kernel message
https://jira.analog.com/projects/SDGREL/issues/SDGREL-589?filter=allopenissues

Previous commit on 2021_R1:
[arch: arm: dts: de10nano: add sysid support]
https://github.com/analogdevicesinc/linux/commit/5d3532c4c5740473b7b1d413d67ba2a7fa47f70b