### PR TITLE
arm: dts: Add AD9083-FMC-EBZ + Arria 10 SoC Development Kit support

### DIFF
--- a/arch/arm/boot/dts/adi-ad9083-fmc-ebz.dtsi
+++ b/arch/arm/boot/dts/adi-ad9083-fmc-ebz.dtsi
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD9083-EVB
+ * Link: https://wiki.analog.com/resources/eval/ad9083
+ *
+ * Copyright (C) 2018-2022 Analog Devices Inc.
+ */
+#include <dt-bindings/iio/frequency/ad9528.h>
+#include <dt-bindings/iio/adc/adi,ad9083.h>
+
+&spi0 {
+	ad9528: ad9528@1 {
+		compatible = "adi,ad9528";
+		reg = <1>;
+		spi-cpol;
+		spi-cpha;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		jesd204-device;
+		#jesd204-cells = <2>;
+		jesd204-sysref-provider;
+
+		spi-max-frequency = <10000000>;
+		adi,spi-3wire-enable;
+
+		clock-output-names = "ad9528-1_out0", "ad9528-1_out1", "ad9528-1_out2",
+			"ad9528-1_out3", "ad9528-1_out4", "ad9528-1_out5", "ad9528-1_out6",
+			"ad9528-1_out7", "ad9528-1_out8", "ad9528-1_out9", "ad9528-1_out10",
+			"ad9528-1_out11", "ad9528-1_out12", "ad9528-1_out13";
+		#clock-cells = <1>;
+
+		adi,vcxo-freq = <100000000>;
+
+		adi,refa-enable;
+		adi,refa-diff-rcv-enable;
+		adi,refa-r-div = <1>;
+		adi,osc-in-cmos-neg-inp-enable;
+
+		/* SYSREF config */
+		adi,sysref-src = <SYSREF_SRC_INTERNAL>;
+		adi,sysref-pattern-mode = <SYSREF_PATTERN_NSHOT>;
+		adi,sysref-k-div = <256>;
+		adi,sysref-nshot-mode = <SYSREF_NSHOT_4_PULSES>;
+		adi,sysref-request-trigger-mode = <SYSREF_LEVEL_HIGH>;
+		adi,jesd204-max-sysref-frequency-hz = <400000>;
+
+		/* PLL1 config */
+		adi,pll1-feedback-src-vcxo;
+		adi,pll1-feedback-div = <4>;
+		adi,pll1-charge-pump-current-nA = <5000>;
+		adi,osc-in-diff-enable;
+
+		/* PLL2 config */
+		/*
+		 * Valid ranges based on VCO locking range:
+		 *   1150.000 MHz - 1341.666 MHz
+		 *    862.500 MHz - 1006.250 MHz
+		 *    690.000 MHz -  805.000 MHz
+		 */
+		adi,pll2-m1-frequency = <1000000000>;
+		adi,pll2-charge-pump-current-nA = <805000>;
+
+		adi,rpole2 = <RPOLE2_900_OHM>;
+		adi,rzero = <RZERO_1850_OHM>;
+		adi,cpole1 = <CPOLE1_16_PF>;
+
+		adi,status-mon-pin0-function-select = <0xFF>; /* No function */
+		adi,status-mon-pin1-function-select = <0xFF>; /* No function */
+
+		ad9528_0_c1: channel@1 {
+			reg = <1>;
+			adi,extended-name = "FPGA_GLBL_CLK";
+			adi,driver-mode = <DRIVER_MODE_LVDS>;
+			adi,divider-phase = <0>;
+			adi,channel-divider = <8>; /* 125 MHz */
+			adi,signal-source = <SOURCE_VCO>;
+		};
+
+		ad9528_0_c3: channel@3 {
+			reg = <3>;
+			adi,extended-name = "FPGA_REF_CLK";
+			adi,driver-mode = <DRIVER_MODE_LVDS>;
+			adi,divider-phase = <0>;
+			adi,channel-divider = <2>; /* 500 MHz */
+			adi,signal-source = <SOURCE_VCO>;
+		};
+
+		ad9528_0_c13: channel@13 {
+			reg = <13>;
+			adi,extended-name = "ADC_REF_CLK";
+			adi,driver-mode = <DRIVER_MODE_LVDS>;
+			adi,divider-phase = <0>;
+			adi,channel-divider = <4>; /* 250 MHz */
+			adi,signal-source = <SOURCE_VCO>;
+		};
+
+		ad9528_0_c12: channel@12 {
+			reg = <12>;
+			adi,extended-name = "DEV_SYSREF";
+			adi,driver-mode = <DRIVER_MODE_LVDS>;
+			adi,divider-phase = <0>;
+			adi,channel-divider = <5>;
+			adi,signal-source = <SOURCE_SYSREF_VCO>;
+		};
+
+		ad9528_0_c0: channel@0 {
+			reg = <0>;
+			adi,extended-name = "FMC_SYSREF";
+			adi,driver-mode = <DRIVER_MODE_LVDS>;
+			adi,divider-phase = <0>;
+			adi,channel-divider = <5>;
+			adi,signal-source = <SOURCE_SYSREF_VCO>;
+		};
+	};
+
+	adc0_ad9083: ad9083@0 {
+		compatible = "adi,ad9083";
+		reg = <0>;
+
+		jesd204-device;
+		#jesd204-cells = <2>;
+		jesd204-top-device = <0>;
+		jesd204-link-ids = <0>;
+		jesd204-inputs = <&axi_ad9083_core_rx 0 0>;
+
+		spi-max-frequency = <1000000>;
+		clocks = <&ad9528 13>;
+		clock-names = "adc_ref_clk";
+		adi,adc-frequency-hz= /bits/ 64 <2000000000>; /* 2 GHz */
+
+		/* adi_ad9083 config */
+
+		adi,vmax-microvolt = <1800>;
+		adi,fc-hz =  /bits/ 64 <800000000>;
+		adi,rterm-ohms = <100>;
+		adi,backoff = <0>;
+		adi,finmax-hz = /bits/ 64 <100000000>;
+		adi,nco0_freq-hz = /bits/ 64 <0>;
+		adi,nco1_freq-hz = /bits/ 64 <0>;
+		adi,nco2_freq-hz = /bits/ 64 <0>;
+		adi,cic_decimation = /bits/ 8 <AD9083_CIC_DEC_4>;
+		adi,j_decimation = /bits/ 8 <AD9083_J_DEC_4>;
+		adi,g_decimation = /bits/ 8 <0>;
+		adi,h_decimation = /bits/ 8 <0>;
+		adi,nco0_datapath_mode = /bits/ 8 <AD9083_DATAPATH_ADC_CIC_J>;
+
+		/* JESD204 parameters */
+
+		adi,octets-per-frame = <8>;
+		adi,frames-per-multiframe = <32>;
+		adi,converter-resolution = <16>;
+		adi,bits-per-sample = <16>;
+		adi,converters-per-device = <16>;
+		adi,control-bits-per-sample = <0>;
+		adi,lanes-per-device = <4>;
+		adi,subclass = <0>;
+	};
+};
+

--- a/arch/arm/boot/dts/socfpga_arria10_socdk_ad9083_fmc_ebz.dts
+++ b/arch/arm/boot/dts/socfpga_arria10_socdk_ad9083_fmc_ebz.dts
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD9083-FMC-EBZ
+ * https://wiki.analog.com/resources/eval/dpg/ad9083-fmc-ebz
+ * https://wiki.analog.com/resources/eval/dpg/eval-ad9083
+ *
+ * hdl_project: <ad9083_evb/a10soc>
+ * board_revision: <>
+ *
+ * Copyright (C) 2021 Analog Devices Inc.
+ */
+/dts-v1/;
+
+#include "socfpga_arria10_socdk.dtsi"
+#include <dt-bindings/interrupt-controller/irq.h>
+#include <dt-bindings/jesd204/adxcvr.h>
+
+&mmc {
+	status = "okay";
+	num-slots = <1>;
+	cap-sd-highspeed;
+	broken-cd;
+	bus-width = <4>;
+	altr,dw-mshc-ciu-div = <3>;
+	altr,dw-mshc-sdr-timing = <0 3>;
+};
+
+/ {
+	clocks {
+		sys_clk: sys_clk {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <100000000>;
+			clock-output-names = "system_clock";
+		};
+
+		dma_clk: dma_clk {
+			#clock-cells = <0x0>;
+			compatible = "fixed-clock";
+			clock-frequency = <250000000>;
+			clock-output-names = "dma_clk";
+		};
+
+		rx_fixed_link_clk: clock@1 {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <250000000>;
+			clock-output-names = "rx_link_clk";
+		};
+	};
+
+	soc {
+		sys_hps_bridges: bridge@ff200000 {
+			compatible = "simple-bus";
+			reg = <0xff200000 0x00200000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges = <0x00000000 0xff200000 0x00200000>;
+
+			sys_gpio_out: gpio@20 {
+				compatible = "altr,pio-1.0";
+				reg = <0x00000020 0x00000010>;
+				altr,gpio-bank-width = <32>;
+				resetvalue = <0>;
+				#gpio-cells = <2>;
+				gpio-controller;
+			};
+
+			sys_spi: spi@40 {
+				compatible = "altr,spi-1.0";
+				reg = <0x00000040 0x00000020>;
+				interrupt-parent = <&intc>;
+				interrupts = <0 26 4>;
+				#address-cells = <0x1>;
+				#size-cells = <0x0>;
+			};
+
+			axi_ad9083_rx_jesd: axi-jesd204-rx@40000 {
+				compatible = "adi,axi-jesd204-rx-1.0";
+				reg = <0x00040000 0x4000>;
+
+				interrupt-parent = <&intc>;
+				interrupts = <0 32 IRQ_TYPE_LEVEL_HIGH>;
+
+				clocks = <&sys_clk>, <&ad9528 1>, <&axi_ad9083_adxcvr_rx 0>, <&rx_fixed_link_clk>;
+				clock-names = "s_axi_aclk", "device_clk", "lane_clk", "link_clk";
+
+				#clock-cells = <0>;
+				clock-output-names = "jesd_rx_lane_clk";
+
+				jesd204-device;
+				#jesd204-cells = <2>;
+				jesd204-inputs = <&axi_ad9083_adxcvr_rx 0 0>;
+			};
+
+			axi_ad9083_adxcvr_rx: axi-ad9083-rx-xcvr@44000 {
+				compatible = "adi,altera-adxcvr-1.00.a";
+				reg = <0x00044000 0x00001000>,
+					<0x00048000 0x00001000>,
+					<0x00049000 0x00001000>,
+					<0x0004A000 0x00001000>,
+					<0x0004B000 0x00001000>;
+				reg-names = "adxcvr", "adxcfg-0", "adxcfg-1", "adxcfg-2", "adxcfg-3";
+
+				clocks = <&ad9528 3>, <&rx_link_clk_pll>;
+				clock-names = "ref", "link";
+
+				#clock-cells = <0>;
+				clock-output-names = "jesd204_rx_lane_clock";
+
+				jesd204-device;
+				#jesd204-cells = <2>;
+				jesd204-inputs = <&ad9528 0 0>;
+			};
+
+			rx_link_clk_pll: altera-a10-fpll@45000 {
+				compatible = "altr,a10-fpll";
+				reg = <0x00045000 0x1000>;
+				clocks = <&ad9528 3>;
+
+				#clock-cells = <0>;
+				clock-output-names = "jesd204_rx_link_clock";
+			};
+
+			rx_dma: rx-dmac@4c000 {
+				compatible = "adi,axi-dmac-1.00.a";
+				reg = <0x0004c000 0x00004000>;
+				interrupt-parent = <&intc>;
+				interrupts = <0 31 IRQ_TYPE_LEVEL_HIGH>;
+				#dma-cells = <1>;
+				clocks = <&dma_clk>;
+			};
+
+			axi_ad9083_core_rx: axi-ad9083-rx-hpc@50000 {
+				compatible = "adi,axi-ad9083-rx-1.0";
+				reg = <0x00050000 0x00002000>;
+				dmas = <&rx_dma 0>;
+				dma-names = "rx";
+				spibus-connected = <&adc0_ad9083>;
+
+				jesd204-device;
+				#jesd204-cells = <2>;
+				jesd204-inputs = <&axi_ad9083_rx_jesd 0 0>;
+			};
+		};
+	};
+};
+
+#define spi0 sys_spi
+
+#include "adi-ad9083-fmc-ebz.dtsi"
+
+&ad9528 {
+	/delete-property/ spi-cpol;
+	/delete-property/ spi-cpha;
+};
+
+#define fmc_gpio_base -32	// ?
+
+&adc0_ad9083 {
+	pwdn-gpios = <&sys_gpio_out (fmc_gpio_base + 32) 0>;
+	rstb-gpios = <&sys_gpio_out (fmc_gpio_base + 33) 0>;
+	refsel-gpios = <&sys_gpio_out (fmc_gpio_base + 34) 0>;
+};


### PR DESCRIPTION
Tested on hardware.
Works, but jesd_status reports "measured link clock" as being double the value of "reported link clock".