### PR TITLE
Adin1110 add reset gpio

### DIFF
--- a/Documentation/devicetree/bindings/net/adi,adin1110.yaml
+++ b/Documentation/devicetree/bindings/net/adi,adin1110.yaml
@@ -51,6 +51,10 @@ properties:
   interrupts:
     maxItems: 1
 
+  reset-gpios:
+    maxItems: 1
+    description: GPIO connected to active low reset
+
 patternProperties:
   "^phy@[0-1]$":
     description: |


### PR DESCRIPTION
36f616882b33 - dt-bindings: net: adin1110: Document reset
f7f0b029487a - net: ethernet: adi: adin1110: add reset GPIO

Both are accepted upstream. Need them backported.