### PR TITLE
arch: arm: dts: overlays: add rpi-ad4130

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -178,6 +178,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	rpi-admv1014.dtbo \
 	rpi-admv8818.dtbo \
 	rpi-adrf6780.dtbo \
+	rpi-ad4130.dtbo \
 	rpi-ad5592r.dtbo \
 	rpi-ad5593r.dtbo \
 	rpi-ad5677r.dtbo \

--- a/arch/arm/boot/dts/overlays/rpi-ad4130-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ad4130-overlay.dts
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-2.0
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+
+/ {
+	compatible = "brcm,bcm2835", "brcm,bcm2711";
+};
+
+&spi0 {
+	cs-gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+	status = "okay";
+
+	ad4130@0 {
+		compatible = "adi,ad4130";
+		reg = <0>;
+
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		spi-max-frequency = <5000000>;
+		interrupts = <27 IRQ_TYPE_EDGE_FALLING>;
+		interrupt-parent = <&gpio>;
+
+		channel@0 {
+			reg = <0>;
+
+			adi,reference-select = <2>;
+
+			/* AIN8, AIN9 */
+			diff-channels = <8 9>;
+		};
+
+		channel@1 {
+			reg = <1>;
+
+			adi,reference-select = <2>;
+
+			/* AIN10, AIN11 */
+			diff-channels = <10 11>;
+		};
+
+		channel@2 {
+			reg = <2>;
+
+			adi,reference-select = <2>;
+
+			/* Temperature Sensor, DGND */
+			diff-channels = <16 19>;
+		};
+
+		channel@3 {
+			reg = <3>;
+
+			adi,reference-select = <2>;
+
+			/* Internal reference, DGND */
+			diff-channels = <18 19>;
+		};
+
+		channel@4 {
+			reg = <4>;
+
+			adi,reference-select = <2>;
+
+			/* DGND, DGND */
+			diff-channels = <19 19>;
+		};
+	};
+};
+
+&spidev0 {
+	status = "disabled";
+};
+
+&spidev1 {
+	status = "disabled";
+};


### PR DESCRIPTION
AD4130-8 is an ultra-low power, high precision, measurement solution for low bandwidth battery operated applications.

The fully integrated AFE (Analog Front-End) includes a multiplexer for up to 16 single-ended or 8 differential inputs, PGA (Programmable Gain Amplifier), 24-bit Sigma-Delta ADC, on-chip reference and oscillator, selectable filter options, smart sequencer, sensor biasing and excitation options, diagnostics, and a FIFO buffer.

Signed-off-by: Cosmin Tanislav <cosmin.tanislav@analog.com>