### PR TITLE
allyesconfig fixes

### DIFF
--- a/drivers/clk/clk-xlnx-clock-wizard-v.c
+++ b/drivers/clk/clk-xlnx-clock-wizard-v.c
@@ -7,6 +7,7 @@
  *  Shubhrajyoti Datta <shubhrajyoti.datta@xilinx.com>
  */
 
+#include <linux/bitfield.h>
 #include <linux/platform_device.h>
 #include <linux/clk.h>
 #include <linux/clk-provider.h>

--- a/drivers/clk/clk-xlnx-clock-wizard-v.c
+++ b/drivers/clk/clk-xlnx-clock-wizard-v.c
@@ -14,6 +14,7 @@
 #include <linux/slab.h>
 #include <linux/io.h>
 #include <linux/of.h>
+#include <linux/math64.h>
 #include <linux/module.h>
 #include <linux/err.h>
 #include <linux/iopoll.h>
@@ -229,7 +230,7 @@ static int clk_wzrd_get_divisors(struct clk_hw *hw, unsigned long rate,
 			vco_freq = DIV_ROUND_CLOSEST((parent_rate * m), d);
 			if (vco_freq >= WZRD_VCO_MIN && vco_freq <= WZRD_VCO_MAX) {
 				for (o = WZRD_O_MIN; o <= WZRD_O_MAX; o++) {
-					freq = DIV_ROUND_CLOSEST(vco_freq, o);
+					freq = DIV_ROUND_CLOSEST_ULL(vco_freq, o);
 					diff = abs(freq - rate);
 
 					if (diff < WZRD_MIN_ERR) {

--- a/drivers/clk/clk-xlnx-clock-wizard.c
+++ b/drivers/clk/clk-xlnx-clock-wizard.c
@@ -14,6 +14,7 @@
 #include <linux/slab.h>
 #include <linux/io.h>
 #include <linux/of.h>
+#include <linux/math64.h>
 #include <linux/module.h>
 #include <linux/err.h>
 
@@ -277,7 +278,7 @@ static u64 clk_wzrd_get_divisors(struct clk_hw *hw, unsigned long rate,
 			vco_freq = DIV_ROUND_CLOSEST((parent_rate * m), d);
 			if (vco_freq >= WZRD_VCO_MIN && vco_freq <= WZRD_VCO_MAX) {
 				for (o = WZRD_O_MIN; o <= WZRD_O_MAX; o++) {
-					freq = DIV_ROUND_CLOSEST(vco_freq, o);
+					freq = DIV_ROUND_CLOSEST_ULL(vco_freq, o);
 					diff = abs(freq - rate);
 
 					if (diff < WZRD_MIN_ERR) {
@@ -314,11 +315,11 @@ static int clk_wzrd_dynamic_all_nolock(struct clk_hw *hw, unsigned long rate,
 		pr_err("failed to get divisors\n");
 
 	vco_freq = DIV_ROUND_CLOSEST((parent_rate * divider->valuem), divider->valued);
-	rate_div = DIV_ROUND_CLOSEST((vco_freq * WZRD_FRAC_POINTS), rate);
+	rate_div = DIV_ROUND_CLOSEST_ULL((vco_freq * WZRD_FRAC_POINTS), rate);
 
-	clockout0_div = rate_div / WZRD_FRAC_POINTS;
+	clockout0_div = div_u64(rate_div, WZRD_FRAC_POINTS);
 
-	pre = DIV_ROUND_CLOSEST((vco_freq * WZRD_FRAC_POINTS), rate);
+	pre = DIV_ROUND_CLOSEST_ULL((vco_freq * WZRD_FRAC_POINTS), rate);
 	f = (u32)(pre - (clockout0_div * WZRD_FRAC_POINTS));
 	f = f & WZRD_CLKOUT_FRAC_MASK;
 

--- a/drivers/clk/clk-xlnx-clock-wizard.c
+++ b/drivers/clk/clk-xlnx-clock-wizard.c
@@ -7,6 +7,7 @@
  *  Sören Brinkmann <soren.brinkmann@xilinx.com>
  */
 
+#include <linux/bitfield.h>
 #include <linux/platform_device.h>
 #include <linux/clk.h>
 #include <linux/clk-provider.h>

--- a/drivers/media/platform/xilinx/xilinx-hdmirxss.c
+++ b/drivers/media/platform/xilinx/xilinx-hdmirxss.c
@@ -10,6 +10,7 @@
 #include <linux/bitfield.h>
 #include <linux/delay.h>
 #include <linux/firmware.h>
+#include <linux/math64.h>
 #include <linux/of.h>
 #include <linux/phy/phy.h>
 #include <linux/platform_device.h>
@@ -2535,7 +2536,7 @@ static void xhdmirx_vtdint_handler(struct xhdmirx_state *xhdmi)
 
 					vidclk = activepixfrlratio *
 						 DIV_ROUND_CLOSEST(xhdmi->frlclkfreqkhz, 100);
-					vidclk = DIV_ROUND_CLOSEST(vidclk, totalpixfrlratio);
+					vidclk = DIV_ROUND_CLOSEST_ULL(vidclk, totalpixfrlratio);
 					xhdmi->stream.refclk = vidclk * 100000;
 					if (xhdmirx1_get_video_properties(xhdmi))
 						dev_err_ratelimited(xhdmi->dev, "Failed get video properties!");
@@ -2547,9 +2548,8 @@ static void xhdmirx_vtdint_handler(struct xhdmirx_state *xhdmi)
 					u32 remainder;
 
 					vidclk = (xhdmi->stream.pixelclk / 100000) / COREPIXPERCLK;
-					vidclk = xhdmi->vidclkfreqkhz / vidclk;
-					remainder = vidclk % 100;
-					vidclk = vidclk / 100;
+					vidclk = div64_u64(xhdmi->vidclkfreqkhz, vidclk);
+					vidclk = div_u64_rem(vidclk, 100, &remainder);
 					if (remainder >= 50)
 						vidclk++;
 

--- a/drivers/pwm/pwm-sti.c
+++ b/drivers/pwm/pwm-sti.c
@@ -371,10 +371,10 @@ static int sti_pwm_capture(struct pwm_chip *chip, struct pwm_device *pwm,
 		effective_ticks = clk_get_rate(pc->cpt_clk);
 
 		result->period = (high + low) * NSEC_PER_SEC;
-		result->period /= effective_ticks;
+		result->period = div_u64(result->period, effective_ticks);
 
 		result->duty_cycle = high * NSEC_PER_SEC;
-		result->duty_cycle /= effective_ticks;
+		result->duty_cycle = div_u64(result->duty_cycle, effective_ticks);
 
 		break;
 

--- a/drivers/spi/spi-bcm2835.c
+++ b/drivers/spi/spi-bcm2835.c
@@ -1107,8 +1107,7 @@ static int bcm2835_spi_transfer_one(struct spi_controller *ctlr,
 	bcm2835_wr(bs, BCM2835_SPI_CLK, cdiv);
 
 	/* handle all the 3-wire mode */
-	if (spi->mode & SPI_3WIRE && tfr->rx_buf &&
-	    tfr->rx_buf != master->dummy_rx)
+	if (spi->mode & SPI_3WIRE && tfr->rx_buf)
 		cs |= BCM2835_SPI_CS_REN;
 
 	/* set transmit buffers and length */

--- a/drivers/usb/phy/phy-ulpi.c
+++ b/drivers/usb/phy/phy-ulpi.c
@@ -240,6 +240,21 @@ static int ulpi_set_vbus(struct usb_otg *otg, bool on)
 	return usb_phy_io_write(phy, flags, ULPI_OTG_CTRL);
 }
 
+static void otg_ulpi_init(struct usb_phy *phy, struct usb_otg *otg,
+			  struct usb_phy_io_ops *ops,
+			  unsigned int flags)
+{
+	phy->label	= "ULPI";
+	phy->flags	= flags;
+	phy->io_ops	= ops;
+	phy->otg	= otg;
+	phy->init	= ulpi_init;
+
+	otg->usb_phy	= phy;
+	otg->set_host	= ulpi_set_host;
+	otg->set_vbus	= ulpi_set_vbus;
+}
+
 struct usb_phy *
 otg_ulpi_create(struct usb_phy_io_ops *ops,
 		unsigned int flags)
@@ -257,16 +272,32 @@ otg_ulpi_create(struct usb_phy_io_ops *ops,
 		return NULL;
 	}
 
-	phy->label	= "ULPI";
-	phy->flags	= flags;
-	phy->io_ops	= ops;
-	phy->otg	= otg;
-	phy->init	= ulpi_init;
-
-	otg->usb_phy	= phy;
-	otg->set_host	= ulpi_set_host;
-	otg->set_vbus	= ulpi_set_vbus;
+	otg_ulpi_init(phy, otg, ops, flags);
 
 	return phy;
 }
 EXPORT_SYMBOL_GPL(otg_ulpi_create);
+
+struct usb_phy *
+devm_otg_ulpi_create(struct device *dev,
+		     struct usb_phy_io_ops *ops,
+		     unsigned int flags)
+{
+	struct usb_phy *phy;
+	struct usb_otg *otg;
+
+	phy = devm_kzalloc(dev, sizeof(*phy), GFP_KERNEL);
+	if (!phy)
+		return NULL;
+
+	otg = devm_kzalloc(dev, sizeof(*otg), GFP_KERNEL);
+	if (!otg) {
+		devm_kfree(dev, phy);
+		return NULL;
+	}
+
+	otg_ulpi_init(phy, otg, ops, flags);
+
+	return phy;
+}
+EXPORT_SYMBOL_GPL(devm_otg_ulpi_create);

--- a/include/linux/remoteproc.h
+++ b/include/linux/remoteproc.h
@@ -387,7 +387,7 @@ struct rproc_ops {
 	void (*kick)(struct rproc *rproc, int vqid);
 	bool (*peek_remote_kick)(struct rproc *rproc, char *buf, size_t *len);
 	void (*ack_remote_kick)(struct rproc *rproc);
-	void * (*da_to_va)(struct rproc *rproc, u64 da, int len);
+	void * (*da_to_va)(struct rproc *rproc, u64 da, size_t len);
 	int (*parse_fw)(struct rproc *rproc, const struct firmware *fw);
 	int (*handle_rsc)(struct rproc *rproc, u32 rsc_type, void *rsc,
 			  int offset, int avail);


### PR DESCRIPTION
This PR fixes #2005... I went a step further and tried ARM and ARM64 allyesconfigs and realized that also miserably fails. It's a mixture of xilinx mess with my own and some of our out of tree code. Anyways, as we should have a working tree (as much as possible) not only for our own configs, I'm backporting some xilinx fixes plus fixing the other places myself.

Note that the last 3 patches were also sent to xilinx so let's not merge this until we get some feedback.

Lessons learned:

running allyesconfigs can actually be helpful to spot issues when merging with newer kernels (probably also a good idea to have such builds run, from times to times, on some CI system) ...