### PR TITLE
arch: arm64: boot: dts: update stingray HDL tags

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-stingray-direct-clk.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-stingray-direct-clk.dts
@@ -4,7 +4,7 @@
  * https://wiki.analog.com/resources/eval/user-guides/quadmxfe/quick-start
  * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-mxfe/ad9081
  *
- * hdl_project: <ad9081_fmca_ebz/zcu102>
+ * hdl_project: <ad9081_fmca_ebz_x_band/zcu102>
  * board_revision: <>
  *
  * Copyright (C) 2019-2020 Analog Devices Inc.

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-stingray-vcxo100-direct-clk.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-stingray-vcxo100-direct-clk.dts
@@ -4,7 +4,7 @@
  * https://wiki.analog.com/resources/eval/user-guides/quadmxfe/quick-start
  * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-mxfe/ad9081
  *
- * hdl_project: <ad9081_fmca_ebz/zcu102>
+ * hdl_project: <ad9081_fmca_ebz_x_band/zcu102>
  * board_revision: <>
  *
  * Copyright (C) 2019-2020 Analog Devices Inc.

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-stingray-vcxo100.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-stingray-vcxo100.dts
@@ -4,7 +4,7 @@
  * https://wiki.analog.com/resources/eval/user-guides/quadmxfe/quick-start
  * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-mxfe/ad9081
  *
- * hdl_project: <ad9081_fmca_ebz/zcu102>
+ * hdl_project: <ad9081_fmca_ebz_x_band/zcu102>
  * board_revision: <>
  *
  * Copyright (C) 2019-2020 Analog Devices Inc.

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-stingray.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-stingray.dts
@@ -4,7 +4,7 @@
  * https://wiki.analog.com/resources/eval/user-guides/quadmxfe/quick-start
  * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-mxfe/ad9081
  *
- * hdl_project: <ad9081_fmca_ebz/zcu102>
+ * hdl_project: <ad9081_fmca_ebz_x_band/zcu102>
  * board_revision: <>
  *
  * Copyright (C) 2019-2020 Analog Devices Inc.


### PR DESCRIPTION
Update HDL tags in next device tree files:
 zynqmp-zcu102-rev10-stingray.dts
 zynqmp-zcu102-rev10-stingray-vcxo100.dts
 zynqmp-zcu102-rev10-stingray-direct-clk.dts
 zynqmp-zcu102-rev10-stingray-vcxo100-direct-clk.dts
to match new HDL project name.

Signed-off-by: stefan.raus <stefan.raus@analog.com>