### PR TITLE
arch: arm: dts: overlays: add rpi-ad74115

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -193,6 +193,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	rpi-ad738x.dtbo \
 	rpi-ad7746.dtbo \
 	rpi-ad7768-1.dtbo \
+	rpi-ad74115.dtbo \
 	rpi-ad74413r.dtbo \
 	rpi-ad9545-hmc7044.dtbo \
 	rpi-ad9834.dtbo \

--- a/arch/arm/boot/dts/overlays/rpi-ad74115-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ad74115-overlay.dts
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-2.0
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+
+/ {
+	compatible = "brcm,bcm2835", "brcm,bcm2711";
+};
+
+&{/} {
+	ad74115_avdd: fixed-regulator@1 {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-supply";
+		regulator-min-microvolt = <24000000>;
+		regulator-max-microvolt = <24000000>;
+		regulator-boot-on;
+	};
+};
+
+&spi0 {
+	cs-gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+	status = "okay";
+
+	ad74115h@0 {
+		compatible = "adi,ad74115h";
+		reg = <0>;
+
+		spi-max-frequency = <12000000>;
+		spi-cpol;
+
+		reset-gpios = <&gpio 27 GPIO_ACTIVE_LOW>;
+
+		interrupt-parent = <&gpio>;
+		interrupts = <26 IRQ_TYPE_EDGE_FALLING>;
+		interrupt-names = "adc_rdy";
+
+		avdd-supply = <&ad74115_avdd>;
+
+		adi,ch-func = <1>;
+		adi,conv2-mux = <2>;
+		adi,conv2-range-microvolt = <(-12000000) 12000000>;
+
+		adi,gpio0-mode = <1>;
+		adi,gpio1-mode = <1>;
+		adi,gpio2-mode = <1>;
+		adi,gpio3-mode = <1>;
+
+		adi,dac-bipolar;
+	};
+};
+
+&spidev0 {
+	status = "disabled";
+};
+
+&spidev1 {
+	status = "disabled";
+};


### PR DESCRIPTION
The AD74115H is a single-channel, software-configurable, input and output device for industrial control applications. The AD74115H provides a wide range of use cases, integrated on a single chip.

These use cases include analog output, analog input, digital output, digital input, resistance temperature detector (RTD), and thermocouple measurement capability. The AD74115H also has an integrated HART modem.

A serial peripheral interface (SPI) is used to handle all communications to the device, including communications with the HART modem. The digital input and digital outputs can be accessed via the SPI or the general-purpose input and output (GPIO) pins to support higher speed data rates.

The device features a 16-bit, sigma-delta analog-to-digital converter (ADC) and a 14-bit digital-to-analog converter (DAC). The AD74115H contains a high accuracy 2.5 V on-chip reference that can be used as the DAC and ADC reference.

Signed-off-by: Cosmin Tanislav <cosmin.tanislav@analog.com>