### PR TITLE
iio: frequency: ad9172: Fix jesd204-fsm final state transition

### DIFF
--- a/drivers/iio/frequency/ad9172.c
+++ b/drivers/iio/frequency/ad9172.c
@@ -1040,8 +1040,14 @@ static int ad9172_jesd204_post_running_stage(struct jesd204_dev *jdev,
 {
 	struct ad9172_jesd204_priv *priv = jesd204_dev_priv(jdev);
 	struct ad9172_state *st = priv->st;
+	int ret;
 
-	return ad9172_finalize_setup(st);
+	ret = ad9172_finalize_setup(st);
+
+	if (ret < 0)
+		return ret;
+
+	return JESD204_STATE_CHANGE_DONE;
 }
 
 static const struct jesd204_dev_data jesd204_ad9172_init = {


### PR DESCRIPTION
jesd204-fsm callbacks must return JESD204_STATE_CHANGE_DONE on success. Returning 0 is equal to JESD204_STATE_CHANGE_DEFER, which will stop/stall the FSM until it is resumed.

This fixes this erroneous behavior.

fixes: 7a4e388df955 ("iio: frequency: ad9172: Add support for jesd204-fsm")

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>