### PR TITLE
arch: arm64: boot: dts: Add devicetree for fmcomms8

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9009-fmcomms8-tx-l2-rx-l2-orx-l2.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9009-fmcomms8-tx-l2-rx-l2-orx-l2.dts
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD-FMCOMMS8-EBZ (JESD204 FSM variant)
+ * https://wiki.analog.com/resources/eval/user-guides/ad-fmcomms8-ebz
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9009
+ * https://wiki.analog.com/resources/tools-software/linux-software/adrv9009_advanced_plugin
+ *
+ * hdl_project: <fmcomms8/zcu102>
+ * board_revision: <>
+ *
+ * Copyright (C) 2022 Analog Devices Inc.
+ */
+
+#include "zynqmp-zcu102-rev10-adrv9009-fmcomms8-jesd204-fsm.dts"
+
+&fmc_spi {
+	trx2_adrv9009: adrv9009-phy-c@0 {
+		/* JESD204 */
+
+		/* JESD204 RX */
+		adi,jesd204-framer-a-m = <4>;
+		adi,jesd204-framer-a-f = <8>;
+		adi,jesd204-framer-a-serializer-lanes-enabled = <0x01>;
+
+		/* JESD204 OBS */
+		adi,jesd204-framer-b-m = <2>;
+		adi,jesd204-framer-b-serializer-lanes-enabled = <0x04>;
+
+		/* JESD204 TX */
+		adi,jesd204-deframer-a-m = <2>;
+		adi,jesd204-deframer-a-deserializer-lanes-enabled = <0x01>;
+
+		/* RX */
+		adi,rx-profile-rx-fir-coefs = /bits/ 16 <(0) (0) (2) (4) (4) (-10)     \
+		(-46) (-88) (-68) (78) (280) (278) (-154) (-772) (-792) (344) (1880)   \
+		(1844) (-932) (-4528) (-4408) (2592) (14186) (23192) (23192) (14186)   \
+		(2592) (-4408) (-4528) (-932) (1844) (1880) (344) (-792) (-772) (-154) \
+		(278) (280) (78) (-68) (-88) (-46) (-10) (4) (4) (2) (0) (0)>;
+
+		adi,rx-profile-rhb1-decimation = <2>;
+		adi,rx-profile-rx-output-rate_khz = <122880>;
+		adi,rx-profile-rf-bandwidth_hz = <60000000>;
+		adi,rx-profile-rx-bbf3d-bcorner_khz = <60000>;
+		adi,rx-profile-rx-adc-profile = /bits/ 16 <265 146 181 90 1280 366 \
+		1257 27 1258 17 718 39 48 46 27 161 0 0 0 0 40 0 7 6 42 0 7 6 42 0 \
+		25 27 0 0 25 27 0 0 165 44 31 905>;
+
+		/* ORX */
+		adi,orx-profile-rx-fir-decimation = <1>;
+		adi,orx-settings-obs-rx-channels-enable = <1>;
+
+		/* TX */
+		adi,tx-settings-tx-channels = <1>;
+
+		/* Clocks */
+		adi,dig-clocks-device-clock_khz = <122880>;
+	};
+	trx3_adrv9009: adrv9009-phy-d@1 {
+		/* JESD204 */
+
+		/* JESD204 RX */
+		adi,jesd204-framer-a-m = <4>;
+		adi,jesd204-framer-a-f = <8>;
+		adi,jesd204-framer-a-serializer-lanes-enabled = <0x01>;
+
+		/* JESD204 OBS */
+		adi,jesd204-framer-b-m = <2>;
+		adi,jesd204-framer-b-serializer-lanes-enabled = <0x04>;
+
+		/* JESD204 TX */
+		adi,jesd204-deframer-a-m = <2>;
+		adi,jesd204-deframer-a-deserializer-lanes-enabled = <0x01>;
+
+		/* RX */
+		adi,rx-profile-rx-fir-coefs = /bits/ 16 <(0) (0) (2) (4) (4) (-10)     \
+		(-46) (-88) (-68) (78) (280) (278) (-154) (-772) (-792) (344) (1880)   \
+		(1844) (-932) (-4528) (-4408) (2592) (14186) (23192) (23192) (14186)   \
+		(2592) (-4408) (-4528) (-932) (1844) (1880) (344) (-792) (-772) (-154) \
+		(278) (280) (78) (-68) (-88) (-46) (-10) (4) (4) (2) (0) (0)>;
+
+		adi,rx-profile-rhb1-decimation = <2>;
+		adi,rx-profile-rx-output-rate_khz = <122880>;
+		adi,rx-profile-rf-bandwidth_hz = <60000000>;
+		adi,rx-profile-rx-bbf3d-bcorner_khz = <60000>;
+		adi,rx-profile-rx-adc-profile = /bits/ 16 <265 146 181 90 1280 366 \
+		1257 27 1258 17 718 39 48 46 27 161 0 0 0 0 40 0 7 6 42 0 7 6 42 0 \
+		25 27 0 0 25 27 0 0 165 44 31 905>;
+
+		/* ORX */
+		adi,orx-profile-rx-fir-decimation = <1>;
+		adi,orx-settings-obs-rx-channels-enable = <1>;
+
+		/* TX */
+		adi,tx-settings-tx-channels = <1>;
+
+		/* Clocks */
+		adi,dig-clocks-device-clock_khz = <122880>;
+		};
+	};
+/ {
+	fpga_axi: fpga-axi@0 {
+
+		rx_dma: dma@9d420000 {
+			adi,channels {
+				dma-channel@0 {
+					adi,source-bus-width = <128>;
+					adi,destination-bus-width = <128>;
+				};
+			};
+		};
+
+		rx_obs_dma: dma@9d440000 {
+			adi,channels {
+				dma-channel@0 {
+					adi,source-bus-width = <64>;
+					adi,destination-bus-width = <128>;
+				};
+			};
+		};
+
+		tx_dma: dma@9d400000  {
+			adi,channels {
+				dma-channel@0 {
+					adi,source-bus-width = <128>;
+					adi,destination-bus-width = <64>;
+				};
+			};
+		};
+
+		axi_adrv9009_rx_jesd: axi-jesd204-rx@85a50000 {
+			clocks = <&zynqmp_clk 71>, <&hmc7044_fmc 9>, <&axi_adrv9009_adxcvr_rx 1>, <&axi_adrv9009_adxcvr_rx 0>;
+			clock-names = "s_axi_aclk", "device_clk", "link_clk", "lane_clk";
+
+			adi,octets-per-frame = <8>;
+		};
+
+		axi_adrv9009_tx_jesd: axi-jesd204-tx@85a30000 {
+			adi,converters-per-device = <2>;
+		};
+	};
+};
+

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9009-fmcomms8-tx-l4-rx-l2-orx-l2.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9009-fmcomms8-tx-l4-rx-l2-orx-l2.dts
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD-FMCOMMS8-EBZ (JESD204 FSM variant)
+ * https://wiki.analog.com/resources/eval/user-guides/ad-fmcomms8-ebz
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9009
+ * https://wiki.analog.com/resources/tools-software/linux-software/adrv9009_advanced_plugin
+ *
+ * hdl_project: <fmcomms8/zcu102>
+ * board_revision: <>
+ *
+ * Copyright (C) 2022 Analog Devices Inc.
+ */
+
+#include "zynqmp-zcu102-rev10-adrv9009-fmcomms8-jesd204-fsm.dts"
+
+&fmc_spi {
+	trx2_adrv9009: adrv9009-phy-c@0 {
+		/* JESD204 */
+
+		/* JESD204 RX */
+		adi,jesd204-framer-a-m = <4>;
+		adi,jesd204-framer-a-f = <8>;
+		adi,jesd204-framer-a-serializer-lanes-enabled = <0x01>;
+
+		/* JESD204 OBS */
+		adi,jesd204-framer-b-m = <2>;
+		adi,jesd204-framer-b-serializer-lanes-enabled = <0x04>;
+
+		/* JESD204 TX */
+		adi,jesd204-deframer-a-deserializer-lanes-enabled = <0x03>;
+
+		/* RX */
+		adi,rx-profile-rx-fir-coefs = /bits/ 16 <(0) (0) (2) (4) (4) (-10)     \
+		(-46) (-88) (-68) (78) (280) (278) (-154) (-772) (-792) (344) (1880)   \
+		(1844) (-932) (-4528) (-4408) (2592) (14186) (23192) (23192) (14186)   \
+		(2592) (-4408) (-4528) (-932) (1844) (1880) (344) (-792) (-772) (-154) \
+		(278) (280) (78) (-68) (-88) (-46) (-10) (4) (4) (2) (0) (0)>;
+
+		adi,rx-profile-rhb1-decimation = <2>;
+		adi,rx-profile-rx-output-rate_khz = <122880>;
+		adi,rx-profile-rf-bandwidth_hz = <60000000>;
+		adi,rx-profile-rx-bbf3d-bcorner_khz = <60000>;
+		adi,rx-profile-rx-adc-profile = /bits/ 16 <265 146 181 90 1280 366 \
+		1257 27 1258 17 718 39 48 46 27 161 0 0 0 0 40 0 7 6 42 0 7 6 42 0 \
+		25 27 0 0 25 27 0 0 165 44 31 905>;
+
+		/* ORX */
+		adi,orx-profile-rx-fir-decimation = <1>;
+		adi,orx-settings-obs-rx-channels-enable = <1>;
+
+		/* TX */
+		adi,tx-settings-tx-channels = <1>;
+
+		/* Clocks */
+		adi,dig-clocks-device-clock_khz = <122880>;
+	};
+	trx3_adrv9009: adrv9009-phy-d@1 {
+		/* JESD204 */
+
+		/* JESD204 RX */
+		adi,jesd204-framer-a-m = <4>;
+		adi,jesd204-framer-a-f = <8>;
+		adi,jesd204-framer-a-serializer-lanes-enabled = <0x01>;
+
+		/* JESD204 OBS */
+		adi,jesd204-framer-b-m = <2>;
+		adi,jesd204-framer-b-serializer-lanes-enabled = <0x04>;
+
+		/* JESD204 TX */
+		adi,jesd204-deframer-a-deserializer-lanes-enabled = <0x03>;
+
+		/* RX */
+		adi,rx-profile-rx-fir-coefs = /bits/ 16 <(0) (0) (2) (4) (4) (-10)     \
+		(-46) (-88) (-68) (78) (280) (278) (-154) (-772) (-792) (344) (1880)   \
+		(1844) (-932) (-4528) (-4408) (2592) (14186) (23192) (23192) (14186)   \
+		(2592) (-4408) (-4528) (-932) (1844) (1880) (344) (-792) (-772) (-154) \
+		(278) (280) (78) (-68) (-88) (-46) (-10) (4) (4) (2) (0) (0)>;
+
+		adi,rx-profile-rhb1-decimation = <2>;
+		adi,rx-profile-rx-output-rate_khz = <122880>;
+		adi,rx-profile-rf-bandwidth_hz = <60000000>;
+		adi,rx-profile-rx-bbf3d-bcorner_khz = <60000>;
+		adi,rx-profile-rx-adc-profile = /bits/ 16 <265 146 181 90 1280 366 \
+		1257 27 1258 17 718 39 48 46 27 161 0 0 0 0 40 0 7 6 42 0 7 6 42 0 \
+		25 27 0 0 25 27 0 0 165 44 31 905>;
+
+		/* ORX */
+		adi,orx-profile-rx-fir-decimation = <1>;
+		adi,orx-settings-obs-rx-channels-enable = <1>;
+
+		/* TX */
+		adi,tx-settings-tx-channels = <1>;
+
+		/* Clocks */
+		adi,dig-clocks-device-clock_khz = <122880>;
+		};
+	};
+/ {
+	fpga_axi: fpga-axi@0 {
+
+		rx_dma: dma@9d420000 {
+			adi,channels {
+				dma-channel@0 {
+					adi,source-bus-width = <128>;
+					adi,destination-bus-width = <128>;
+				};
+			};
+		};
+
+		rx_obs_dma: dma@9d440000 {
+			adi,channels {
+				dma-channel@0 {
+					adi,source-bus-width = <64>;
+					adi,destination-bus-width = <128>;
+				};
+			};
+		};
+
+		tx_dma: dma@9d400000  {
+			adi,channels {
+				dma-channel@0 {
+					adi,source-bus-width = <128>;
+					adi,destination-bus-width = <128>;
+				};
+			};
+		};
+
+		axi_adrv9009_rx_jesd: axi-jesd204-rx@85a50000 {
+			clocks = <&zynqmp_clk 71>, <&hmc7044_fmc 9>, <&axi_adrv9009_adxcvr_rx 1>, <&axi_adrv9009_adxcvr_rx 0>;
+			clock-names = "s_axi_aclk", "device_clk", "link_clk", "lane_clk";
+
+			adi,octets-per-frame = <8>;
+		};
+
+		axi_adrv9009_tx_jesd: axi-jesd204-tx@85a30000 {
+			adi,converters-per-device = <2>;
+		};
+	};
+};
+


### PR DESCRIPTION
TX_L=2 RX_L=2 ORX_L=2
TX_L=4 RX_L=2 ORX_L=2
The corresponding HDL project was built using the following parameters.

make TX_JESD_M=4 TX_JESD_L=2 RX_JESD_M=8 RX_JESD_L=2 RX_OS_JESD_M=4 RX_OS_JESD_L=2 make TX_JESD_M=8 TX_JESD_L=4 RX_JESD_M=8 RX_JESD_L=2 RX_OS_JESD_M=4 RX_OS_JESD_L=2

Signed-off-by: Liviu.Iacob <liviu.iacob@analog.com>