### PR TITLE
Arria10 cn0506 fix

### DIFF
--- a/Documentation/devicetree/bindings/net/adi,adin.yaml
+++ b/Documentation/devicetree/bindings/net/adi,adin.yaml
@@ -36,6 +36,22 @@ properties:
     enum: [ 4, 8, 12, 16, 20, 24 ]
     default: 8
 
+  adi,phy-output-clock:
+    description: |
+      Select clock output on GP_CLK pin. Two clocks are available:
+      A 25MHz reference and a free-running 125MHz.
+      The phy can alternatively automatically switch between the reference and
+      the 125MHz clocks based on its internal state.
+    $ref: /schemas/types.yaml#/definitions/string
+    enum:
+      - 25mhz-reference
+      - 125mhz-free-running
+      - adaptive-free-running
+
+  adi,phy-output-reference-clock:
+    description: Enable 25MHz reference clock output on CLK25_REF pin.
+    type: boolean
+
 unevaluatedProperties: false
 
 examples:

--- a/arch/arm/boot/dts/adi-cn0506-socfpga-mii.dtsi
+++ b/arch/arm/boot/dts/adi-cn0506-socfpga-mii.dtsi
@@ -9,31 +9,35 @@
 &gmac1 {
 	status = "okay";
 	phy-mode = "mii";
-	phy-handle = <&ethernet_gmac1_phy1>;
+	mac-mode = "rgmii";
+	max-speed = <100>;
 
-	mdio {
-		#address-cells = <1>;
-		#size-cells = <0>;
-		compatible = "snps,dwmac-mdio";
+	#address-cells = <1>;
+	#size-cells = <0>;
 
-		ethernet_gmac1_phy1: ethernet-phy@1 {
-			reg = <1>;
-		};
+	ethernet_gmac1_phy1: phy@1 {
+		reg = <0x1>;
+
+		/* stmmac relies on the PHY to generate 25 MHz clock. */
+		adi,phy-output-reference-clock;
+		adi,phy-output-clock = "25mhz-reference";
 	};
 };
 
 &gmac2 {
 	status = "okay";
 	phy-mode = "mii";
-	phy-handle = <&ethernet_gmac2_phy2>;
+	mac-mode = "rgmii";
+	max-speed = <100>;
 
-	mdio {
-		#address-cells = <1>;
-		#size-cells = <0>;
-		compatible = "snps,dwmac-mdio";
+	#address-cells = <1>;
+	#size-cells = <0>;
 
-		ethernet_gmac2_phy2: ethernet-phy@2 {
-			reg = <2>;
-		};
+	ethernet_gmac2_phy2: phy@2 {
+		reg = <0x2>;
+
+		/* stmmac relies on the PHY to generate 25 MHz clock. */
+		adi,phy-output-reference-clock;
+		adi,phy-output-clock = "25mhz-reference";
 	};
 };

--- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
+++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
@@ -806,6 +806,14 @@ static void stmmac_validate(struct phylink_config *config,
 
 	/* Cut down 1G if asked to */
 	if ((max_speed > 0) && (max_speed < 1000)) {
+		/* Need to remove use of 1000baseT_Half also when asked
+		 * to go lower than 1000 Mbps otherwise wrong clock selection
+		 * will break incoming data form MAC to PHY on MII or RMII.
+		 *
+		 * Remove this patch after 5.18,
+		 * (It is fixed in the phy abstraction layer)
+		 */
+		phylink_set(mask, 1000baseT_Half);
 		phylink_set(mask, 1000baseT_Full);
 		phylink_set(mask, 1000baseX_Full);
 	} else if (priv->plat->has_xgmac) {

--- a/drivers/net/phy/adin.c
+++ b/drivers/net/phy/adin.c
@@ -72,6 +72,15 @@
 #define ADIN1300_GE_SOFT_RESET_REG		0xff0c
 #define   ADIN1300_GE_SOFT_RESET		BIT(0)
 
+#define ADIN1300_GE_CLK_CFG_REG			0xff1f
+#define   ADIN1300_GE_CLK_CFG_MASK		GENMASK(5, 0)
+#define   ADIN1300_GE_CLK_CFG_RCVR_125		BIT(5)
+#define   ADIN1300_GE_CLK_CFG_FREE_125		BIT(4)
+#define   ADIN1300_GE_CLK_CFG_REF_EN		BIT(3)
+#define   ADIN1300_GE_CLK_CFG_HRT_RCVR		BIT(2)
+#define   ADIN1300_GE_CLK_CFG_HRT_FREE		BIT(1)
+#define   ADIN1300_GE_CLK_CFG_25		BIT(0)
+
 #define ADIN1300_GE_RGMII_CFG_REG		0xff23
 #define   ADIN1300_GE_RGMII_RX_MSK		GENMASK(8, 6)
 #define   ADIN1300_GE_RGMII_RX_SEL(x)		\
@@ -407,6 +416,33 @@ static int adin_set_tunable(struct phy_device *phydev,
 	}
 }
 
+static int adin_config_clk_out(struct phy_device *phydev)
+{
+	struct device *dev = &phydev->mdio.dev;
+	const char *val = NULL;
+	u8 sel = 0;
+
+	device_property_read_string(dev, "adi,phy-output-clock", &val);
+	if (!val) {
+		/* property not present, do not enable GP_CLK pin */
+	} else if (strcmp(val, "25mhz-reference") == 0) {
+		sel |= ADIN1300_GE_CLK_CFG_25;
+	} else if (strcmp(val, "125mhz-free-running") == 0) {
+		sel |= ADIN1300_GE_CLK_CFG_FREE_125;
+	} else if (strcmp(val, "adaptive-free-running") == 0) {
+		sel |= ADIN1300_GE_CLK_CFG_HRT_FREE;
+	} else {
+		phydev_err(phydev, "invalid adi,phy-output-clock\n");
+		return -EINVAL;
+	}
+
+	if (device_property_read_bool(dev, "adi,phy-output-reference-clock"))
+		sel |= ADIN1300_GE_CLK_CFG_REF_EN;
+
+	return phy_modify_mmd(phydev, MDIO_MMD_VEND1, ADIN1300_GE_CLK_CFG_REG,
+			      ADIN1300_GE_CLK_CFG_MASK, sel);
+}
+
 static int adin_config_init(struct phy_device *phydev)
 {
 	int rc;
@@ -426,6 +462,10 @@ static int adin_config_init(struct phy_device *phydev)
 		return rc;
 
 	rc = adin_set_edpd(phydev, ETHTOOL_PHY_EDPD_DFLT_TX_MSECS);
+	if (rc < 0)
+		return rc;
+
+	rc = adin_config_clk_out(phydev);
 	if (rc < 0)
 		return rc;
 


### PR DESCRIPTION
ea5b2f2a2779 - arch: arm: boot: dts: Fix cn0506 socfpga DT
Tested with CN0506 connected to the arria 10 FMC port A.

99c3b00687cc - net: ethernet: stmicro: stmmac_main: Fix mode mask
This one is fixed in 5.18 but could not port it neatly. "Fixes" were made over multiple patches.

a2c2d569d041 - net: phy: adin: add support for clock output
cherry-picked from upstream, needed it backported.

8295ba3c59e9 - dt-bindings: net: adin: document phy clock output properties
cherry-picked from upstream, needed it backported.