### PR TITLE
ad7124 fix for 2021.2

### DIFF
--- a/drivers/iio/adc/ad7124.c
+++ b/drivers/iio/adc/ad7124.c
@@ -22,7 +22,7 @@
 #include <linux/iio/adc/ad_sigma_delta.h>
 #include <linux/iio/sysfs.h>
 
-#define AD7124_SEQUENCER_SLOTS		16
+#define AD7124_SEQUENCER_SLOTS		8
 
 /* AD7124 registers */
 #define AD7124_COMMS			0x00


### PR DESCRIPTION
There was a divergence between the upstream and ADI version of the driver regarding the maximum number of active slots. As it turns out the upstream version is the correct one and we can't have more than 8 channels sampled without a stop. Thus, we need to fix it in our end...

Fixes: 541a8ff397e4f ("iio: adc: ad7124: allow multiple-channels enabled")
Signed-off-by: Nuno Sa <nuno.sa@analog.com>
(cherry picked from commit cbdcc4022a5e9ff947533f0dc3542ff06cb5817d)