### PR TITLE
drivers:iio:dac: add max5380 support

### DIFF
--- a/Documentation/devicetree/bindings/iio/dac/max5380.yaml
+++ b/Documentation/devicetree/bindings/iio/dac/max5380.yaml
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: (GPL-2.0 OR BSD-2-Clause)
+# Copyright 2023 Analog Devices Inc.
+%YAML 1.2
+---
+
+title: Analog Devices MAX5380 DAC device driver
+
+description: |
+
+  The MAX5380 are low-cost, 8-bit digital-to-analog converters (DACs) 
+  in miniature 5-pin SOT23 packages, with a simple 2-wire serial interface that allows 
+  communication with multiple devices.
+
+maintainers:
+  - Marc Paolo Sosa <marcpaolo.sosa@analog.com>
+
+description: |
+  Bindings for the Analog Devices MAX5380 current DAC device. Datasheet can be found here:
+  https://www.analog.com/media/en/technical-documentation/data-sheets/MAX5380-MAX5382.pdf
+
+properties:
+  compatible:
+    Must be "maxim,max5380"
+
+  reg:
+    Should contain the DAC I2C address
+
+  '#address-cells':
+    const: 1
+
+  '#size-cells':
+    const: 0
+
+required:
+  - compatible
+  - reg
+
+
+additionalProperties: false
+
+examples:
+  - |
+    i2c {
+        #address-cells = <1>;
+        #size-cells = <0>;
+
+        max5380: max5380@31 {
+                compatible = "maxim,max5380";
+                reg = <0x31>;
+                status = "okay";
+        };
+    };
+...

--- a/drivers/iio/dac/Kconfig
+++ b/drivers/iio/dac/Kconfig
@@ -326,6 +326,13 @@ config MAX517
 	  This driver can also be built as a module.  If so, the module
 	  will be called max517.
 
+config MAX5380
+	tristate "Maxim MAX5380 DAC driver"
+	depends on I2C
+	help
+	  Say yes here to build support for Maxim MAX5380
+	  8-bit DAC.
+
 config MAX5821
 	tristate "Maxim MAX5821 DAC driver"
 	depends on I2C

--- a/drivers/iio/dac/Makefile
+++ b/drivers/iio/dac/Makefile
@@ -35,6 +35,7 @@ obj-$(CONFIG_LTC1660) += ltc1660.o
 obj-$(CONFIG_LTC2632) += ltc2632.o
 obj-$(CONFIG_M62332) += m62332.o
 obj-$(CONFIG_MAX517) += max517.o
+obj-$(CONFIG_MAX5380) += max5380.o
 obj-$(CONFIG_MAX5821) += max5821.o
 obj-$(CONFIG_MCP4725) += mcp4725.o
 obj-$(CONFIG_MCP4922) += mcp4922.o

--- a/drivers/iio/dac/max5380.c
+++ b/drivers/iio/dac/max5380.c
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ *  max5380.c upport for Maxim MAX5380
+ *
+ *  Copyright (C) 2023 Marc Paolo Sosa <marcpaolososa@analog.com>
+ */
+
+
+#include <linux/module.h>
+#include <linux/i2c.h>
+#include <linux/err.h>
+
+#define MAX5380_DRV_NAME "max5380"
+
+enum max5380_device_ids {
+    ID_MAX5380,
+};
+
+struct max5380_data {
+    struct i2c_client *client;
+};
+
+static int max5380_i2c_write(struct max5380_data *data, u8 value)
+{
+    int ret;
+    u8 buf[1];
+
+    buf[0] = value & 0xff;
+
+    ret = i2c_master_send(data->client, buf, sizeof(buf));
+    if (ret < 0) {
+        dev_err(&data->client->dev, ret);
+        return ret;
+    }
+    if (ret != sizeof(buf)) {
+        dev_err(&data->client->dev,
+               ret, sizeof(buf));
+        return -EIO;
+    }
+
+    return 0;
+}
+
+static int max5380_i2c_probe(struct i2c_client *client, const struct i2c_device_id *id)
+{
+    struct max5380_data *data;
+    int ret;
+
+    if (!i2c_check_functionality(client->adapter, I2C_FUNC_I2C)) {
+        dev_err(&client->dev);
+        return -ENODEV;
+    }
+
+    data = devm_kzalloc(&client->dev, sizeof(struct max5380_data), GFP_KERNEL);
+    if (!data)
+        return -ENOMEM;
+
+    data->client = client;
+    i2c_set_clientdata(client, data);
+
+    ret = max5380_i2c_write(data, 0);
+    if (ret) {
+        dev_err(&client->dev);
+        return ret;
+    }
+
+    dev_info(&client->dev);
+    return 0;
+}
+
+static int max5380_i2c_remove(struct i2c_client *client)
+{
+    dev_info(&client->dev);
+    return 0;
+}
+
+static const struct i2c_device_id max5380_id[] = {
+    {"max5380", ID_MAX5380},
+    {},
+};
+MODULE_DEVICE_TABLE(i2c, max5380_id);
+
+static struct i2c_driver max5380_driver = {
+	.driver = {
+		.name = "max5380",
+
+	},
+	.probe = max5380_i2c_probe,
+	.remove = max5380_i2c_remove,
+	.id_table = max5380_id,
+};
+module_i2c_driver(max5380_driver);
+
+MODULE_AUTHOR("Marc Paolo Sosa <marcpaolo.sosa@analog.com>");
+MODULE_DESCRIPTION("MAX5380/5381/5382 8-bit DAC");
+MODULE_LICENSE("GPL");


### PR DESCRIPTION
Added driver implementation for MAX5380 8-bit DAC

More information: https://www.analog.com/media/en/technical-documentation/data-sheets/MAX5380-MAX5382.pdf

Signed-off-by: Marc Paolo Sosa <marcpaolo.sosa@analog.com>