### PR TITLE
iio: adc: cf_axi_adc_core: Fix masklenght initialization

### DIFF
--- a/drivers/iio/adc/cf_axi_adc_core.c
+++ b/drivers/iio/adc/cf_axi_adc_core.c
@@ -835,7 +835,6 @@ static int axiadc_channel_setup(struct iio_dev *indio_dev,
 
 	indio_dev->channels = st->channels;
 	indio_dev->num_channels = cnt;
-	indio_dev->masklength = cnt;
 
 	return 0;
 }


### PR DESCRIPTION
Don't explicitly set the masklength (wrong), the IIO core will set it for us, based on the max scan_index. In this particular case we copy all channels and assume all are buffer channels (scan_index > 0) This is not always the case, so we end up with a larger than necessary scan_mask. So far this didn't cause issues. However on 5.15 master-next branch this causes a NULL pointer dereference:

[  110.301120] Call trace:
[  110.303551]  iio_compute_scan_bytes+0x90/0x138
[  110.307986]  __iio_update_buffers+0x818/0x8b8
[  110.312334]  iio_buffer_store_enable+0x13c/0x170 [  110.316943]  dev_attr_store+0x18/0x30
[  110.320597]  sysfs_kf_write+0x44/0x60


Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>