### PR TITLE
drivers:iio:dac: add max5380 support

### DIFF
--- a/Documentation/devicetree/bindings/iio/dac/adi,max5380.yaml
+++ b/Documentation/devicetree/bindings/iio/dac/adi,max5380.yaml
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: (GPL-2.0 OR BSD-2-Clause)
+# Copyright 2023 Analog Devices Inc.
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/iio/dac/adi,max5380.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
+
+title: Analog Devices MAX5380 8-bit DAC Device Driver
+
+description: |
+   The MAX5380 are low-cost, 8-bit digital-to-analog converters (DACs)
+   in miniature 5-pin SOT23 packages, with a simple 2-wire serial
+   interface that allows communication with multiple devices.
+
+   More details here:
+   https://www.analog.com/media/en/technical-documentation/data-sheets/MAX5380-MAX5382.pdf
+
+maintainers:
+  - Marc Paolo Sosa <marcpaolo.sosa@analog.com>
+
+properties:
+  compatible:
+    enum:
+      - maxim,max5380
+
+  reg:
+    maxItems: 1
+
+  '#address-cells':
+    const: 1
+
+  '#size-cells':
+    const: 0
+
+required:
+  - compatible
+  - reg
+
+unevaluatedProperties: false
+
+examples:
+  - |
+
+    &i2c1 {
+         #address-cells = <1>;
+         #size-cells = <0>;
+
+        max5380: dac@0 {
+                compatible = "maxim,max5380";
+                reg=<0x31>;
+          };
+    };
+...

--- a/drivers/iio/Kconfig.adi
+++ b/drivers/iio/Kconfig.adi
@@ -190,3 +190,4 @@ config IIO_ALL_ADI_DRIVERS
 	imply ADI_IIO_FAKEDEV
 	imply LTC2688
 	imply MAX11410
+    imply MAX5380

--- a/drivers/iio/dac/Kconfig
+++ b/drivers/iio/dac/Kconfig
@@ -370,6 +370,16 @@ config MAX517
 	  This driver can also be built as a module.  If so, the module
 	  will be called max517.
 
+config MAX5380
+	tristate "Maxim MAX5380 DAC driver"
+	depends on I2C
+	help
+	  Say yes here if you want to build a driver for the Analog Devices
+	  MAX5380 8-bit digital-to-analog converter (DAC) with I2C interface.
+
+	  This driver can also be built as a module.  If so, the module
+	  will be called max5380.
+
 config MAX5821
 	tristate "Maxim MAX5821 DAC driver"
 	depends on I2C

--- a/drivers/iio/dac/Makefile
+++ b/drivers/iio/dac/Makefile
@@ -39,6 +39,7 @@ obj-$(CONFIG_LTC2632) += ltc2632.o
 obj-$(CONFIG_LTC2688) += ltc2688.o
 obj-$(CONFIG_M62332) += m62332.o
 obj-$(CONFIG_MAX517) += max517.o
+obj-$(CONFIG_MAX5380) += max5380.o
 obj-$(CONFIG_MAX5821) += max5821.o
 obj-$(CONFIG_MCP4725) += mcp4725.o
 obj-$(CONFIG_MCP4922) += mcp4922.o

--- a/drivers/iio/dac/max5380.c
+++ b/drivers/iio/dac/max5380.c
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ *  max5380.c support for Maxim MAX5380
+ *
+ *  Copyright (C) 2023 Marc Paolo Sosa <marcpaolososa@analog.com>
+ */
+
+#include <linux/module.h>
+#include <linux/device.h>
+#include <linux/i2c.h>
+
+enum max5380_device_ids {
+	ID_MAX5380,
+};
+
+struct max5380_data {
+	struct i2c_client *client;
+	u8 value;
+};
+
+static int max5380_i2c_write(struct max5380_data *data, u8 value)
+{
+	int ret;
+
+	data->value = value & 0xff;
+
+	ret = i2c_master_send(data->client, &data->value, sizeof(data->value));
+
+	return 0;
+}
+
+static int max5380_i2c_probe(struct i2c_client *client,
+			     const struct i2c_device_id *id)
+{
+	struct max5380_data *data;
+
+	if (!i2c_check_functionality(client->adapter, I2C_FUNC_I2C))
+		return -ENODEV;
+
+	data = devm_kzalloc(&client->dev, sizeof(struct max5380_data), GFP_KERNEL);
+	i2c_set_clientdata(client, data);
+	data->client = client;
+
+	max5380_i2c_write(data, 0);
+
+	return 0;
+}
+
+static const struct i2c_device_id max5380_id[] = {
+	{"max5380", 0},
+	{},
+};
+MODULE_DEVICE_TABLE(i2c, max5380_id);
+
+static struct i2c_driver max5380_driver = {
+	.driver = {
+		.name = "max5380",
+	},
+	.probe = max5380_i2c_probe,
+	.id_table = max5380_id,
+};
+module_i2c_driver(max5380_driver);
+
+MODULE_AUTHOR("Marc Paolo Sosa <marcpaolo.sosa@analog.com>");
+MODULE_DESCRIPTION("MAX5380/5381/5382 8-bit DAC");
+MODULE_LICENSE("GPL");


### PR DESCRIPTION
Added driver implementation for MAX5380 8-bit DAC.

More information: https://www.analog.com/media/en/technical-documentation/data-sheets/MAX5380-MAX5382.pdf

Signed-off-by: Marc Paolo Sosa <marcpaolo.sosa@analog.com>