### PR TITLE
arch: arm: overlays: add max5380.dts

### DIFF
--- a/arch/arm/boot/dts/overlays/max5380.dts
+++ b/arch/arm/boot/dts/overlays/max5380.dts
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-2.0
+/* Overlay for max5380
+ *
+ *Copyright 2023 Analog Devices Inc.
+ */
+ 
+/dts-v1/;
+/plugin/;
+  
+&i2c1 {
+        status = "okay";
+
+        #address-cells = <1>;
+        #size-cells = <0>;
+
+        max5380: max5380@31 {
+                compatible = "maxim,max5380";
+                reg=<0x31>;
+
+        };
+};


### PR DESCRIPTION
added device tree overlay for max5380, rpi-5.15

Signed-off-by: Marc Paolo Sosa <marcpaolo.sosa@analog.com>