### PR TITLE
AD9694 initial support

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9694.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9694.dts
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD9694 ANALOG-TO-DIGITAL CONVERTER
+ * https://wiki.analog.com/resources/eval/ad9694-500ebz
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-adc/ad9208
+ *
+ * hdl_project: <ad9694/zcu102>
+ * board_revision: <>
+ *
+ * Copyright (C) 2019-2023 Analog Devices Inc.
+ */
+
+#include "zynqmp-zcu102-rev1.0.dts"
+#include <dt-bindings/interrupt-controller/irq.h>
+#include <dt-bindings/iio/adc/adi,ad9208.h>
+#include <dt-bindings/jesd204/adxcvr.h>
+
+&i2c1 {
+	i2c-mux@75 {
+		i2c@0 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0>;
+
+			eeprom@50 {
+				compatible = "at24,24c02";
+				reg = <0x50>;
+			};
+		};
+	};
+};
+
+/ {
+	clocks {
+		ad9694_clkin: clock@0 {
+			#clock-cells = <0>;
+			compatible = "adjustable-clock";
+			clock-frequency = <500000000>;
+			clock-accuracy = <1000000000>;
+			clock-output-names = "ad9694_clk";
+		};
+		device_clk: clock@1 {
+			#clock-cells = <0>;
+			compatible = "adjustable-clock";
+			clock-frequency = <250000000>;
+			clock-accuracy = <1000000000>;
+			clock-output-names = "dev_clk";
+		};
+		sysref: clock@2 {
+			#clock-cells = <0>;
+			compatible = "adjustable-clock";
+			clock-frequency = <7812500>;
+			clock-accuracy = <1000000000>;
+			clock-output-names = "adc_sysref";
+		};
+	};
+	fpga_axi: fpga-axi@0 {
+		interrupt-parent = <&gic>;
+		compatible = "simple-bus";
+		#address-cells = <0x1>;
+		#size-cells = <0x1>;
+		ranges = <0 0 0 0xffffffff>;
+
+		rx_dma: rx-dmac@9c400000 {
+			#dma-cells = <1>;
+			compatible = "adi,axi-dmac-1.00.a";
+			reg = <0x9c400000 0x1000>;
+			interrupts = <0 109 IRQ_TYPE_LEVEL_HIGH>;
+			clocks = <&zynqmp_clk 71>;
+
+			adi,channels {
+				#size-cells = <0>;
+				#address-cells = <1>;
+
+				dma-channel@0 {
+					reg = <0>;
+					adi,source-bus-width = <128>;
+					adi,source-bus-type = <2>;
+					adi,destination-bus-width = <128>;
+					adi,destination-bus-type = <0>;
+				};
+			};
+		};
+
+		axi_ad9694_core: axi-ad9694-hpc@84a00000 {
+			compatible = "adi,axi-ad9208-1.0";
+			reg = <0x84a00000 0x2000>;
+			dmas = <&rx_dma 0>;
+			dma-names = "rx";
+			spibus-connected = <&adc0_ad9694>;
+		};
+
+		axi_ad9694_jesd: axi-jesd204-rx@84aa0000 {
+			compatible = "adi,axi-jesd204-rx-1.0";
+			reg = <0x84aa0000 0x4000>;
+			interrupts = <0 108 IRQ_TYPE_LEVEL_HIGH>;
+
+			clocks = <&zynqmp_clk 71>, <&device_clk>, <&axi_ad9694_adxcvr 0>;
+			clock-names = "s_axi_aclk", "device_clk", "lane_clk";
+
+			adi,octets-per-frame = <2>;
+			adi,frames-per-multiframe = <32>;
+
+			#clock-cells = <0>;
+			clock-output-names = "jesd_adc_lane_clk";
+		};
+
+		axi_ad9694_adxcvr: axi-adxcvr-rx@84a60000 {
+			compatible = "adi,axi-adxcvr-1.0";
+			reg = <0x84a60000 0x10000>;
+
+			clocks = <&device_clk>, <&device_clk>;
+			clock-names = "conv", "div40";
+
+			adi,sys-clk-select = <XCVR_QPLL>;
+			adi,out-clk-select = <XCVR_REFCLK>;
+			adi,use-lpm-enable;
+
+			#clock-cells = <1>;
+			clock-output-names = "adc_gt_clk", "rx_out_clk";
+		};
+
+		axi_sysid_0: axi-sysid-0@85000000 {
+			compatible = "adi,axi-sysid-1.00.a";
+			reg = <0x85000000 0x10000>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	adc0_ad9694: ad9694@0 {
+		compatible = "adi,ad9694";
+
+		powerdown-gpios = <&gpio 116 0>;
+		fastdetect-a-gpios = <&gpio 113 0>;
+		fastdetect-b-gpios = <&gpio 114 0>;
+
+		spi-cpol;
+		spi-cpha;
+		spi-max-frequency = <5000000>;
+		reg = <0>;
+
+		clocks = <&axi_ad9694_jesd>, <&ad9694_clkin>, <&sysref>;
+		clock-names = "jesd_adc_clk", "adc_clk", "adc_sysref";
+
+		adi,powerdown-mode = <AD9208_PDN_MODE_POWERDOWN>;
+
+		adi,sampling-frequency = /bits/ 64 <500000000>;
+		adi,input-clock-divider-ratio = <1>;
+		adi,duty-cycle-stabilizer-enable;
+
+		adi,analog-input-neg-buffer-current = <AD9208_BUFF_CURR_600_UA>;
+		adi,analog-input-pos-buffer-current = <AD9208_BUFF_CURR_600_UA>;
+
+		adi,sysref-lmfc-offset = <0>;
+		adi,sysref-pos-window-skew = <0>;
+		adi,sysref-neg-window-skew = <0>;
+		adi,sysref-mode = <AD9208_SYSREF_CONT>;
+		adi,sysref-nshot-ignore-count = <0>;
+
+		/* JESD204 parameters */
+		adi,octets-per-frame = <2>;
+		adi,frames-per-multiframe = <32>;
+		adi,converter-resolution = <16>;
+		adi,bits-per-sample = <16>;
+		adi,converters-per-device = <4>;
+		adi,control-bits-per-sample = <0>;
+		adi,lanes-per-device = <4>;
+		adi,subclass = <1>;
+
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+};

--- a/drivers/iio/adc/ad9208.c
+++ b/drivers/iio/adc/ad9208.c
@@ -1548,11 +1548,20 @@ static int ad9208_probe(struct spi_device *spi)
 	case CHIPID_AD9208:
 	case CHIPID_AD6684:
 	case CHIPID_AD9689:
-	case CHIPID_AD9694:
 		phy->ad9208.model = 0x9208;
 		phy->ad9208.input_clk_min_hz = 2500000000ULL;
 		phy->ad9208.input_clk_max_hz = 6000000000ULL;
 		phy->ad9208.adc_clk_min_hz = 2500000000ULL;
+		phy->ad9208.adc_clk_max_hz = 3100000000ULL;
+		phy->ad9208.slr_max_mbps = 16000;
+		phy->ad9208.slr_min_mbps = 390;
+		chan_id = (spi_id & ID_DUAL) ? ID_AD9208_X2 : ID_AD9208;
+		break;
+	case CHIPID_AD9694:
+		phy->ad9208.model = 0x9208;
+		phy->ad9208.input_clk_min_hz = 500000000ULL;
+		phy->ad9208.input_clk_max_hz = 600000000ULL;
+		phy->ad9208.adc_clk_min_hz = 500000000ULL;
 		phy->ad9208.adc_clk_max_hz = 3100000000ULL;
 		phy->ad9208.slr_max_mbps = 16000;
 		phy->ad9208.slr_min_mbps = 390;


### PR DESCRIPTION
Added custom config for the AD9694 board inside iio: adc: ad9208.
Created a devicetree for the ZCU102 carrier: arch: arm64: dts: add zynqmp-zcu102-rev10-ad9694 dts