### PR TITLE
microblaze: dts: Update compatible xlnx,axi-iic-2.1

### DIFF
--- a/arch/microblaze/boot/dts/kc705.dtsi
+++ b/arch/microblaze/boot/dts/kc705.dtsi
@@ -272,7 +272,7 @@
 			#size-cells = <0>;
 			clock-frequency = <100000000>;
 			clocks = <&clk_bus_0>;
-			compatible = "xlnx,axi-iic-2.0", "xlnx,xps-iic-2.00.a";
+			compatible = "xlnx,axi-iic-2.1", "xlnx,xps-iic-2.00.a";
 			interrupt-names = "iic2intc_irpt";
 			interrupt-parent = <&axi_intc>;
 			interrupts = <9 2>;

--- a/arch/microblaze/boot/dts/kcu105.dtsi
+++ b/arch/microblaze/boot/dts/kcu105.dtsi
@@ -282,7 +282,7 @@
 			#size-cells = <0>;
 			clock-frequency = <100000000>;
 			clocks = <&clk_bus_0>;
-			compatible = "xlnx,axi-iic-2.0", "xlnx,xps-iic-2.00.a";
+			compatible = "xlnx,axi-iic-2.1", "xlnx,xps-iic-2.00.a";
 			interrupt-names = "iic2intc_irpt";
 			interrupt-parent = <&axi_intc>;
 			interrupts = <9 2>;

--- a/arch/microblaze/boot/dts/vc707.dtsi
+++ b/arch/microblaze/boot/dts/vc707.dtsi
@@ -306,7 +306,7 @@
 			#size-cells = <0>;
 			clock-frequency = <100000000>;
 			clocks = <&clk_bus_0>;
-			compatible = "xlnx,axi-iic-2.0", "xlnx,xps-iic-2.00.a";
+			compatible = "xlnx,axi-iic-2.1", "xlnx,xps-iic-2.00.a";
 			interrupt-names = "iic2intc_irpt";
 			interrupt-parent = <&axi_intc>;
 			interrupts = <9 2>;

--- a/arch/microblaze/boot/dts/vcu118.dtsi
+++ b/arch/microblaze/boot/dts/vcu118.dtsi
@@ -287,7 +287,7 @@
 			#size-cells = <0>;
 			clock-frequency = <100000000>;
 			clocks = <&clk_bus_0>;
-			compatible = "xlnx,axi-iic-2.0", "xlnx,xps-iic-2.00.a";
+			compatible = "xlnx,axi-iic-2.1", "xlnx,xps-iic-2.00.a";
 			interrupt-names = "iic2intc_irpt";
 			interrupt-parent = <&axi_intc>;
 			interrupts = <9 2>;


### PR DESCRIPTION
Update [kc705|kcu105|vc707|vcu118].dtsi to use compatible xlnx,axi-iic-2.1 This removes some quirk necessary for 2.0, which in return causes issues with 2.1.