### PR TITLE
zc706-ad9739a-fmc.dts: Change node name to LPC

### DIFF
--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad9739a-fmc.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad9739a-fmc.dts
@@ -64,7 +64,7 @@
 		};
 	};
 
-	axi_ad9739a_core: axi-ad9739a-hpc@74204000 {
+	axi_ad9739a_core: axi-ad9739a-lpc@74204000 {
 		compatible = "adi,axi-ad9739a-8.00.b";
 		reg = < 0x74204000 0x4000 >;
 		dmas = <&tx_dma 0>;


### PR DESCRIPTION
 * The AD9739A-FMC-EBZ board is placed on the LPC FMC port of ZC706
 * See also [AD9739A Native FMC Card / Xilinx Reference Designs](https://wiki.analog.com/resources/fpga/xilinx/fmc/ad9739a#:~:text=Legacy%20(limited%20support)-,ZC706%20LPC%20Slot,-Quick%20Start%20Guide) wiki page and the [HDL constraints](https://github.com/analogdevicesinc/hdl/blob/master/projects/ad9739a_fmc/zc706/system_constr.xdc#L4) mentioning LPC