### PR TITLE
iio: adc: adrv9002: dynamically export valid interface gain values

### DIFF
--- a/drivers/iio/adc/navassa/adrv9002.h
+++ b/drivers/iio/adc/navassa/adrv9002.h
@@ -89,6 +89,7 @@ enum adrv9002_rx_ext_info {
 	RX_ADC_SWITCH,
 	RX_BBDC,
 	RX_BBDC_LOOP_GAIN,
+	RX_INTERFACE_GAIN_AVAIL,
 };
 
 enum adrv9002_tx_ext_info {


### PR DESCRIPTION
Improve the reported available interface gain values. These values can change when loading a new profile as they depend on the RX interface rate and Gain Table type. The values are reported like this:

Compensated Gain && rate >= 1MHz
  0dB -6dB -12dB -18dB -24dB -30dB -36dB
Compensated Gain && rate < 1MHz
  18dB 12dB 6dB 0dB -6dB -12dB -18dB -24dB -30dB -36dB
Correction Gain && rate >= 1MHz
  0dB
Correction Gain && rate < 1MHz
  18dB 12dB 6dB 0dB