### PR TITLE
iio: adrv9002: fix multiple definition of 'adrv9002_debugfs_create()'

### DIFF
--- a/drivers/iio/adc/navassa/adrv9002.h
+++ b/drivers/iio/adc/navassa/adrv9002.h
@@ -215,6 +215,6 @@ static inline void adrv9002_sync_gpio_toogle(const struct adrv9002_rf_phy *phy)
 #ifdef CONFIG_DEBUG_FS
 void adrv9002_debugfs_create(struct adrv9002_rf_phy *phy, struct dentry *d);
 #else
-void adrv9002_debugfs_create(struct adrv9002_rf_phy *phy, struct dentry *d) {}
+static inline void adrv9002_debugfs_create(struct adrv9002_rf_phy *phy, struct dentry *d) {}
 #endif
 #endif


### PR DESCRIPTION
The linker error was triggered when CONFIG_DEBUG_FS is not set as the function was not being statically inlined.

Signed-off-by: Nuno Sá <nuno.sa@analog.com>
(cherry picked from commit 0b220f4242d11ac18e4ba311238d1ca6d892c23c)

Yeps, old branch but it looks like someone needs this fix:

https://ez.analog.com/linux-software-drivers/f/q-a/567809/petalinux-2019-1-use-adi-linux-kernel-build-error-board-is-zc7020-ad9363