### PR TITLE
iio: buffer: fix rebase to rpi-5.15.y

### DIFF
--- a/drivers/iio/industrialio-buffer.c
+++ b/drivers/iio/industrialio-buffer.c
@@ -1949,6 +1949,8 @@ static void __iio_buffer_free_sysfs_and_mask(struct iio_buffer *buffer,
 					     struct iio_dev *indio_dev,
 					     int index)
 {
+	if (index == 0)
+		iio_buffer_unregister_legacy_sysfs_groups(indio_dev);
 	bitmap_free(buffer->channel_mask);
 	bitmap_free(buffer->scan_mask);
 	kfree(buffer->buffer_group.name);


### PR DESCRIPTION
Due to the fact that the rpi upstream branch is linux 5.15.92 and our master branch is linux 5.15.0 some mismatches might pop up when rebasing the new rpi branch.

That was what happened in here resulting in
iio_buffer_unregister_legacy_sysfs_groups() never being called.

Align the code with what exists upstream.