### PR TITLE
iio: addac: one-bit-adc-dac: Set indio_dev->name to of_node->name

### DIFF
--- a/drivers/iio/addac/one-bit-adc-dac.c
+++ b/drivers/iio/addac/one-bit-adc-dac.c
@@ -192,7 +192,7 @@ static int one_bit_adc_dac_probe(struct platform_device *pdev)
 	st = iio_priv(indio_dev);
 	st->pdev = pdev;
 	indio_dev->dev.parent = &pdev->dev;
-	indio_dev->name = "one-bit-adc-dac";
+	indio_dev->name = pdev->dev.of_node->name;
 	indio_dev->modes = INDIO_DIRECT_MODE;
 	indio_dev->info = &one_bit_adc_dac_info;
 


### PR DESCRIPTION
Currently,  MATLAB doesn't handle libiio labels, so, if multiple one-bit-adc-dac instances are present, all will be identicaly identified.

Make the change only on the 2021_R2 branch since the limitation will be removed from MATLAB soon.