### PR TITLE
drivers: ad9361: fix fast lock addressing

### DIFF
--- a/drivers/iio/adc/ad9361.c
+++ b/drivers/iio/adc/ad9361.c
@@ -4572,7 +4572,7 @@ static int ad9361_fastlock_store(struct ad9361_rf_phy *phy, bool tx, u32 profile
 	/* Wide BW option: N = 1
 	 * Set init and steady state values to the same - let user space handle it
 	 */
-	val[6] = (x << 3) | y;
+	val[6] = (x << 6) | y;
 	val[7] = y;
 
 	x = ad9361_spi_readf(spi, REG_RX_LOOP_FILTER_3 + offs, LOOP_FILTER_R3(~0));


### PR DESCRIPTION
Charge Pump Current value is 6 bits wide, therefore the VCO Bias Tcf value for profile6 needs to be shifted with 6 bits instead of 3.

Fixes: c44c35b ("drivers/iio/adc/ad9361: Add Fastlock Profile Support")