### PR TITLE
Add ad7606x_pi driver

### DIFF
--- a/Documentation/devicetree/bindings/iio/adc/adi,axi-ad7606.yaml
+++ b/Documentation/devicetree/bindings/iio/adc/adi,axi-ad7606.yaml
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/iio/adc/adi,axi-ad7606.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
+
+title: Analog Devices AD7606 Simultaneous Sampling ADC - Parallel Interface
+
+maintainers:
+  - Alin-Tudor Sferle <alin-tudor.sferle@analog.com>
+  - Marcelo Schmitt <marcelo.schmitt@analog.com>
+
+description: |
+  Analog Devices AD7606x Simultaneous Sampling ADC - Parallel Interface
+  https://www.analog.com/media/en/technical-documentation/data-sheets/ad7606c-16.pdf
+  https://www.analog.com/media/en/technical-documentation/data-sheets/ad7606c-18.pdf
+
+properties:
+
+  compatible:
+    enum:
+      - axi-ad7606c-16
+      - axi-ad7606c-18
+
+  clocks:
+    maxItems: 1
+    description:
+      Sampling clock
+
+  clock-names:
+    const: ad7606_conv_clk
+
+  pwms:
+    maxItems: 1
+    description:
+      PWM signal used to start the sampling procedure
+
+  pwm-names:
+    const: cnvst_n
+
+  reset-gpios:
+    maxItems: 1
+
+required:
+  - compatible
+  - clocks
+  - clock-names
+  - pwms
+  - pwm-names
+
+additionalProperties: false
+
+examples:
+  - |
+    #include <dt-bindings/interrupt-controller/irq.h>
+    #include <dt-bindings/gpio/gpio.h>
+    #include <dt-bindings/pwm/pwm.h>
+
+    adc: axi-ad7606 {
+        compatible = "axi-ad7606c-16";
+
+        pwms = <&axi_pwm_gen 0 0>;
+        pwm-names = "cnvst_n";
+
+        clocks = <&ext_clk>;
+        clock-names = "ad7606_conv_clk";
+
+        reset-gpios = <&gpio0 95 GPIO_ACTIVE_HIGH>;
+    };
+
+    fpga_axi {
+        #address-cells = <1>;
+        #size-cells = <1>;
+
+        rx_dma: dmac@44a30000 {
+            compatible = "adi,axi-dmac-1.00.a";
+            reg = <0x44a30000 0x1000>;
+            #dma-cells = <1>;
+            interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
+            clocks = <&ext_clk>;
+
+            adi,channels {
+                #size-cells = <0>;
+                #address-cells = <1>;
+
+                dma-channel@0 {
+                    reg = <0>;
+                    adi,source-bus-width = <128>;
+                    adi,source-bus-type = <2>;
+                    adi,destination-bus-width = <64>;
+                    adi,destination-bus-type = <0>;
+                };
+            };
+        };
+
+        cf_axi_adc@44a00000 {
+            compatible = "adi,axi-ad7606-1.0";
+            reg = <0x44a00000 0x20000>;
+            dmas = <&rx_dma 0>;
+            dma-names = "rx";
+            platformbus-connected = <&axi_ad7606>;
+        };
+    };
+...

--- a/arch/arm/boot/dts/zynq-zed-adv7511-axi-ad7606c-16.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-axi-ad7606c-16.dts
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD7606X
+ *
+ * hdl_project: <ad7606x_fmc/zed>
+ * board_revision: <A>
+ *
+ * Copyright (C) 2023 Analog Devices Inc.
+ */
+/dts-v1/;
+
+#include "zynq-zed.dtsi"
+#include "zynq-zed-adv7511.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/pwm/pwm.h>
+
+/ {
+	axi_ad7606: axi-ad7606 {
+		compatible = "axi-ad7606c-16";
+
+		pwms = <&axi_pwm_gen 0 0>;
+		pwm-names = "cnvst_n";
+
+		clocks = <&ext_clk>;
+		clock-names = "ad7606_conv_clk";
+
+		reset-gpios = <&gpio0 95 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+/ {
+	clocks {
+		ext_clk: clock@0 {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <100000000>;
+		};
+	};
+};
+
+&fpga_axi {
+	rx_dma: dmac@44a30000 {
+		compatible = "adi,axi-dmac-1.00.a";
+		reg = <0x44a30000 0x1000>;
+		#dma-cells = <1>;
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&ext_clk>;
+
+		adi,channels {
+			#size-cells = <0>;
+			#address-cells = <1>;
+
+			dma-channel@0 {
+				reg = <0>;
+				adi,source-bus-width = <128>;
+				adi,source-bus-type = <2>;
+				adi,destination-bus-width = <64>;
+				adi,destination-bus-type = <0>;
+			};
+		};
+	};
+
+	axi_pwm_gen: pwm@0x44a60000 {
+		compatible = "adi,axi-pwmgen";
+		reg = <0x44a60000 0x1000>;
+		#pwm-cells = <2>;
+		clocks = <&ext_clk>;
+	};
+
+	axi_adc_ad7606: cf_axi_adc@44a00000 {
+		compatible = "adi,axi-ad7606-1.0";
+		reg = <0x44a00000 0x20000>;
+		dmas = <&rx_dma 0>;
+		dma-names = "rx";
+		platformbus-connected = <&axi_ad7606>;
+	};
+
+};

--- a/arch/arm/boot/dts/zynq-zed-adv7511-axi-ad7606c-18.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-axi-ad7606c-18.dts
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD7606X
+ *
+ * hdl_project: <ad7606x_fmc/zed>
+ * board_revision: <A>
+ *
+ * Copyright (C) 2023 Analog Devices Inc.
+ */
+/dts-v1/;
+
+#include "zynq-zed.dtsi"
+#include "zynq-zed-adv7511.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/pwm/pwm.h>
+
+/ {
+	axi_ad7606: axi-ad7606 {
+		compatible = "axi-ad7606c-18";
+
+		pwms = <&axi_pwm_gen 0 0>;
+		pwm-names = "cnvst_n";
+
+		clocks = <&ext_clk>;
+		clock-names = "ad7606_conv_clk";
+
+		reset-gpios = <&gpio0 95 GPIO_ACTIVE_HIGH>;
+
+	};
+};
+
+/ {
+	clocks {
+		ext_clk: clock@0 {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <100000000>;
+		};
+	};
+};
+
+&fpga_axi {
+	rx_dma: dmac@44a30000 {
+		compatible = "adi,axi-dmac-1.00.a";
+		reg = <0x44a30000 0x1000>;
+		#dma-cells = <1>;
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&ext_clk>;
+
+		adi,channels {
+			#size-cells = <0>;
+			#address-cells = <1>;
+
+			dma-channel@0 {
+				reg = <0>;
+				adi,source-bus-width = <128>;
+				adi,source-bus-type = <2>;
+				adi,destination-bus-width = <64>;
+				adi,destination-bus-type = <0>;
+			};
+		};
+	};
+
+	axi_pwm_gen: pwm@0x44a60000 {
+		compatible = "adi,axi-pwmgen";
+		reg = <0x44a60000 0x1000>;
+		#pwm-cells = <2>;
+		clocks = <&ext_clk>;
+	};
+
+	axi_adc_ad7606: cf_axi_adc@44a00000 {
+		compatible = "adi,axi-ad7606-1.0";
+		reg = <0x44a00000 0x20000>;
+		dmas = <&rx_dma 0>;
+		dma-names = "rx";
+		platformbus-connected = <&axi_ad7606>;
+	};
+
+};

--- a/drivers/iio/Kconfig.adi
+++ b/drivers/iio/Kconfig.adi
@@ -52,6 +52,7 @@ config IIO_ALL_ADI_DRIVERS
 	imply AD7476
 	imply AD7606_IFACE_PARALLEL
 	imply AD7606_IFACE_SPI
+	imply AD7606_CONV
 	imply AD7766
 	imply AD7768
 	imply AD7768_1

--- a/drivers/iio/adc/Kconfig
+++ b/drivers/iio/adc/Kconfig
@@ -222,6 +222,19 @@ config AD7606_IFACE_SPI
 	  To compile this driver as a module, choose M here: the
 	  module will be called ad7606_spi.
 
+config AD7606_CONV
+	tristate "Analog Devices AD7606 AXI ADC driver"
+	depends on PWM
+	select IIO_BUFFER
+	select IIO_BUFFER_DMA
+	select IIO_BUFFER_DMAENGINE
+	help
+	  Say yes here to build support for Analog Devices AD7606 AXI ADC.
+	  Provides support for AD7606C-16/-18 devices connecting through
+	  parallel interface.
+	  This driver can also be built as a module. If so, the module will be
+	  called ad7606_conv.
+
 config AD7766
 	tristate "Analog Devices AD7766/AD7767 ADC driver"
 	depends on SPI_MASTER

--- a/drivers/iio/adc/Makefile
+++ b/drivers/iio/adc/Makefile
@@ -27,6 +27,7 @@ obj-$(CONFIG_AD7476) += ad7476.o
 obj-$(CONFIG_AD7606_IFACE_PARALLEL) += ad7606_par.o
 obj-$(CONFIG_AD7606_IFACE_SPI) += ad7606_spi.o
 obj-$(CONFIG_AD7606) += ad7606.o
+obj-$(CONFIG_AD7606_CONV) += ad7606_conv.o
 obj-$(CONFIG_AD7766) += ad7766.o
 obj-$(CONFIG_AD7768) += ad7768.o
 obj-$(CONFIG_AD7768_1) += ad7768-1.o

--- a/drivers/iio/adc/ad6676.c
+++ b/drivers/iio/adc/ad6676.c
@@ -141,7 +141,7 @@ static int ad6676_reg_access(struct iio_dev *indio_dev, unsigned int reg,
 	unsigned int writeval, unsigned int *readval)
 {
 	struct axiadc_converter *conv = iio_device_get_drvdata(indio_dev);
-	struct spi_device *spi = conv->spi;
+	struct spi_device *spi = to_spi_device(conv->dev);
 	int ret;
 
 	if (readval == NULL) {
@@ -187,14 +187,15 @@ static inline int ad6676_get_splitreg(struct spi_device *spi, u32 reg, u32 *val)
 
 static int ad6676_set_fadc(struct axiadc_converter *conv, u32 val)
 {
-	return ad6676_set_splitreg(conv->spi, AD6676_FADC_0,
-		clamp_t(u32, val, MIN_FADC, MAX_FADC) / MHz);
+	return ad6676_set_splitreg(to_spi_device(conv->dev), AD6676_FADC_0,
+				   clamp_t(u32, val, MIN_FADC, MAX_FADC) / MHz);
 }
 
 static inline u32 ad6676_get_fadc(struct axiadc_converter *conv)
 {
 	u32 val;
-	int ret = ad6676_get_splitreg(conv->spi, AD6676_FADC_0, &val);
+	int ret = ad6676_get_splitreg(to_spi_device(conv->dev), AD6676_FADC_0,
+				      &val);
 	if (ret < 0)
 		return 0;
 
@@ -206,9 +207,9 @@ static int ad6676_set_fif(struct axiadc_converter *conv, u32 val)
 	struct ad6676_phy *phy = conv_to_phy(conv);
 	struct ad6676_platform_data *pdata = phy->pdata;
 
-	return ad6676_set_splitreg(conv->spi, AD6676_FIF_0,
-		clamp_t(u32, val, pdata->base.f_if_min_hz,
-			pdata->base.f_if_max_hz) / MHz);
+	return ad6676_set_splitreg(to_spi_device(conv->dev), AD6676_FIF_0,
+				   clamp_t(u32, val, pdata->base.f_if_min_hz,
+					   pdata->base.f_if_max_hz) / MHz);
 }
 
 static u32 ad6676_get_fif(struct axiadc_converter *conv)
@@ -217,8 +218,9 @@ static u32 ad6676_get_fif(struct axiadc_converter *conv)
 	struct ad6676_platform_data *pdata = phy->pdata;
 	s64 mix1, mix2;
 
-	mix1 = ad6676_spi_read(conv->spi, AD6676_MIX1_TUNING);
-	mix2 = (s8)ad6676_spi_read(conv->spi, AD6676_MIX2_TUNING);
+	mix1 = ad6676_spi_read(to_spi_device(conv->dev), AD6676_MIX1_TUNING);
+	mix2 = (s8)ad6676_spi_read(to_spi_device(conv->dev),
+				   AD6676_MIX2_TUNING);
 
 	mix1 = mix1 * pdata->base.f_adc_hz;
 	mix2 = mix2 * pdata->base.f_adc_hz;
@@ -231,14 +233,15 @@ static u32 ad6676_get_fif(struct axiadc_converter *conv)
 
 static int ad6676_set_bw(struct axiadc_converter *conv, u32 val)
 {
-	return ad6676_set_splitreg(conv->spi, AD6676_BW_0,
-		clamp_t(u32, val, MIN_BW, MAX_BW) / MHz);
+	return ad6676_set_splitreg(to_spi_device(conv->dev), AD6676_BW_0,
+				   clamp_t(u32, val, MIN_BW, MAX_BW) / MHz);
 }
 
 static inline u32 ad6676_get_bw(struct axiadc_converter *conv)
 {
 	u32 val;
-	int ret = ad6676_get_splitreg(conv->spi, AD6676_BW_0, &val);
+	int ret = ad6676_get_splitreg(to_spi_device(conv->dev), AD6676_BW_0,
+				      &val);
 	if (ret < 0)
 		return 0;
 
@@ -270,12 +273,13 @@ static int ad6676_set_decimation(struct axiadc_converter *conv, u32 val)
 		return -EINVAL;
 	}
 
-	return ad6676_spi_write(conv->spi, AD6676_DEC_MODE, val);
+	return ad6676_spi_write(to_spi_device(conv->dev), AD6676_DEC_MODE,
+				val);
 }
 
 static int ad6676_set_clk_synth(struct axiadc_converter *conv, u32 refin_Hz, u32 freq)
 {
-	struct spi_device *spi = conv->spi;
+	struct spi_device *spi = to_spi_device(conv->dev);
 	u32 f_pfd, reg_val, tout, div_val;
 	u64 val64;
 	int ret;
@@ -397,7 +401,7 @@ static int ad6676_set_clk_synth(struct axiadc_converter *conv, u32 refin_Hz, u32
 
 static int ad6676_set_extclk_cntl(struct axiadc_converter *conv, u32 freq)
 {
-	struct spi_device *spi = conv->spi;
+	struct spi_device *spi = to_spi_device(conv->dev);
 	int ret;
 
 	dev_dbg(&spi->dev, "%s: frequency %u\n",
@@ -418,7 +422,7 @@ static int ad6676_set_extclk_cntl(struct axiadc_converter *conv, u32 freq)
 
 static int ad6676_jesd_setup(struct axiadc_converter *conv, struct ad6676_jesd_conf *conf)
 {
-	struct spi_device *spi = conv->spi;
+	struct spi_device *spi = to_spi_device(conv->dev);
 	int ret;
 
 	ret = ad6676_spi_write(spi, AD6676_SYNCB_CTRL,
@@ -454,12 +458,13 @@ static int ad6676_shuffle_setup(struct axiadc_converter *conv, struct ad6676_shu
 		reg_val |= (val << (i * 4));
 	}
 
-	return ad6676_set_splitreg(conv->spi, AD6676_SHUFFLE_THREG0, reg_val);
+	return ad6676_set_splitreg(to_spi_device(conv->dev),
+				   AD6676_SHUFFLE_THREG0, reg_val);
 }
 
 static int ad6676_calibrate(struct axiadc_converter *conv, unsigned cal)
 {
-	struct spi_device *spi = conv->spi;
+	struct spi_device *spi = to_spi_device(conv->dev);
 	int tout_i, tout_o = 2;
 	u32 done;
 
@@ -489,7 +494,8 @@ static int ad6676_calibrate(struct axiadc_converter *conv, unsigned cal)
 
 static int ad6676_reset(struct axiadc_converter *conv, bool spi3wire)
 {
-	int ret = ad6676_spi_write(conv->spi, AD6676_SPI_CONFIG,
+	int ret = ad6676_spi_write(to_spi_device(conv->dev),
+				   AD6676_SPI_CONFIG,
 				   SPI_CONF_SW_RESET |
 				   (spi3wire ? 0 : SPI_CONF_SDIO_DIR));
 	mdelay(2);
@@ -499,7 +505,7 @@ static int ad6676_reset(struct axiadc_converter *conv, bool spi3wire)
 
 static int ad6676_setup(struct axiadc_converter *conv)
 {
-	struct spi_device *spi = conv->spi;
+	struct spi_device *spi = to_spi_device(conv->dev);
 	struct ad6676_phy *phy = conv_to_phy(conv);
 	struct ad6676_platform_data *pdata = phy->pdata;
 	struct clk *clk;
@@ -604,7 +610,7 @@ static int ad6676_setup(struct axiadc_converter *conv)
 
 static int ad6676_update(struct axiadc_converter *conv, struct ad6676_platform_data *pdata)
 {
-	struct spi_device *spi = conv->spi;
+	struct spi_device *spi = to_spi_device(conv->dev);
 	int ret;
 
 	pdata->base.bw_hz = clamp_t(u32, pdata->base.bw_hz,
@@ -633,7 +639,7 @@ static int ad6676_update(struct axiadc_converter *conv, struct ad6676_platform_d
 
 static int ad6676_outputmode_set(struct axiadc_converter *conv, unsigned mode)
 {
-	struct spi_device *spi = conv->spi;
+	struct spi_device *spi = to_spi_device(conv->dev);
 	int ret;
 
 	ret = ad6676_spi_write(spi, AD6676_DP_CTRL, mode);
@@ -648,7 +654,7 @@ static int ad6676_testmode_set(struct iio_dev *indio_dev,
 {
 	struct axiadc_converter *conv = iio_device_get_drvdata(indio_dev);
 
-	ad6676_spi_write(conv->spi, AD6676_TEST_GEN, mode);
+	ad6676_spi_write(to_spi_device(conv->dev), AD6676_TEST_GEN, mode);
 
 	conv->testmode[chan] = mode;
 	return 0;
@@ -674,10 +680,12 @@ static int ad6676_set_pnsel(struct iio_dev *indio_dev, unsigned int chan,
 	}
 
 	if (mode == TESTGENMODE_OFF)
-		ret = ad6676_spi_write(conv->spi, AD6676_DP_CTRL,
+		ret = ad6676_spi_write(to_spi_device(conv->dev),
+				       AD6676_DP_CTRL,
 				       conv->adc_output_mode);
 	else
-		ret = ad6676_spi_write(conv->spi, AD6676_DP_CTRL,
+		ret = ad6676_spi_write(to_spi_device(conv->dev),
+				       AD6676_DP_CTRL,
 				       DP_CTRL_OFFSET_BINARY);
 
 	if (ret < 0)
@@ -994,9 +1002,11 @@ static int ad6676_write_raw(struct iio_dev *indio_dev,
 		return ad6676_update(conv, pdata);
 	case IIO_CHAN_INFO_HARDWAREGAIN:
 			pdata->base.attenuation = clamp(-1 * val, 0, 27);
-			ad6676_spi_write(conv->spi, AD6676_ATTEN_VALUE_PIN0,
+			ad6676_spi_write(to_spi_device(conv->dev),
+					 AD6676_ATTEN_VALUE_PIN0,
 					 pdata->base.attenuation);
-			ad6676_spi_write(conv->spi, AD6676_ATTEN_VALUE_PIN1,
+			ad6676_spi_write(to_spi_device(conv->dev),
+					 AD6676_ATTEN_VALUE_PIN1,
 					 pdata->base.attenuation);
 			break;
 	case IIO_CHAN_INFO_SAMP_FREQ:
@@ -1045,7 +1055,7 @@ struct gpio_board_cfg {
 static int ad6676_gpio_config(struct axiadc_converter *conv)
 {
 	struct ad6676_platform_data *pdata = conv_to_phy(conv)->pdata;
-	struct spi_device *spi = conv->spi;
+	struct spi_device *spi = to_spi_device(conv->dev);
 	struct gpio_board_cfg board_cfg[5];
 	enum gpiod_flags flags;
 	struct gpio_desc *temp;
@@ -1185,10 +1195,10 @@ static int ad6676_probe(struct spi_device *spi)
 	if (conv == NULL)
 		return -ENOMEM;
 
-	spi_set_drvdata(spi, conv);
+	dev_set_drvdata(&spi->dev, conv);
 	conv->phy = phy;
 	conv->clk = clk;
-	conv->spi = spi;
+	conv->dev = &spi->dev;
 
 	if (spi->dev.of_node)
 		phy->pdata = ad6676_parse_dt(&spi->dev);

--- a/drivers/iio/adc/ad7606_conv.c
+++ b/drivers/iio/adc/ad7606_conv.c
@@ -1,0 +1,309 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices ad7606C ADC driver for Parallel Interface
+ *
+ * Copyright 2023 Analog Devices Inc.
+ */
+
+#include <linux/clk.h>
+#include <linux/delay.h>
+#include <linux/errno.h>
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/platform_device.h>
+#include <linux/pwm.h>
+#include <linux/gpio/consumer.h>
+#include <linux/units.h>
+
+#include <linux/fpga/adi-axi-common.h>
+
+#include <linux/iio/iio.h>
+
+#include "cf_axi_adc.h"
+
+/* ADC Channel */
+/* Enable ADC channel with sign extension in HDL regmap's REG_CHAN_CNTRL register */
+#define ADI_ENABLE_FMT_SIGNEX		0x51
+
+#define KHZ				KILO
+#define FULL_RESET_TIME			3300
+#define SETUP_TIME			275
+
+#define AD7606C_MULTIPLE_CHAN(_idx, _storagebits, _realbits)		\
+	{								\
+		.type = IIO_VOLTAGE,					\
+		.info_mask_shared_by_all = BIT(IIO_CHAN_INFO_SAMP_FREQ),\
+		.indexed = 1,						\
+		.channel = _idx,					\
+		.scan_index = _idx,					\
+		.scan_type = {						\
+			.sign = 's',					\
+			.storagebits = _storagebits,			\
+			.realbits = _realbits,				\
+			.shift = 0,					\
+		},							\
+	}
+
+enum ad7606_conv_id {
+	ID_AD7606C_16,
+	ID_AD7606C_18,
+};
+
+static const struct axiadc_chip_info conv_chip_info[] = {
+	[ID_AD7606C_16] = {
+		.name = "AD7606C-16",
+		.num_channels = 8,
+		.channel[0] = AD7606C_MULTIPLE_CHAN(0, 16, 16),
+		.channel[1] = AD7606C_MULTIPLE_CHAN(1, 16, 16),
+		.channel[2] = AD7606C_MULTIPLE_CHAN(2, 16, 16),
+		.channel[3] = AD7606C_MULTIPLE_CHAN(3, 16, 16),
+		.channel[4] = AD7606C_MULTIPLE_CHAN(4, 16, 16),
+		.channel[5] = AD7606C_MULTIPLE_CHAN(5, 16, 16),
+		.channel[6] = AD7606C_MULTIPLE_CHAN(6, 16, 16),
+		.channel[7] = AD7606C_MULTIPLE_CHAN(7, 16, 16),
+	},
+	[ID_AD7606C_18] = {
+		.name = "AD7606C-18",
+		.num_channels = 8,
+		.channel[0] = AD7606C_MULTIPLE_CHAN(0, 32, 18),
+		.channel[1] = AD7606C_MULTIPLE_CHAN(1, 32, 18),
+		.channel[2] = AD7606C_MULTIPLE_CHAN(2, 32, 18),
+		.channel[3] = AD7606C_MULTIPLE_CHAN(3, 32, 18),
+		.channel[4] = AD7606C_MULTIPLE_CHAN(4, 32, 18),
+		.channel[5] = AD7606C_MULTIPLE_CHAN(5, 32, 18),
+		.channel[6] = AD7606C_MULTIPLE_CHAN(6, 32, 18),
+		.channel[7] = AD7606C_MULTIPLE_CHAN(7, 32, 18),
+	},
+};
+
+struct ad7606_conv_state {
+	const struct axiadc_chip_info		*device_info;
+	struct pwm_device			*cnvst_n;
+	struct clk				*ref_clk;
+
+	/* protect against concurrent device accesses */
+	struct mutex				lock;
+
+	int					sampling_freq;
+	unsigned long				ref_clk_rate;
+};
+
+static int ad7606_read_label(struct iio_dev *indio_dev,
+			     struct iio_chan_spec const *chan, char *label)
+{
+	return sysfs_emit(label, "voltage%d\n", chan->channel);
+}
+
+static int ad7606_conv_reg_access(struct iio_dev *indio_dev,
+				  unsigned int reg, unsigned int writeval,
+				  unsigned int *readval)
+{
+	struct axiadc_state *axiadc = iio_priv(indio_dev);
+	struct axiadc_converter *conv = iio_device_get_drvdata(indio_dev);
+	struct ad7606_conv_state *ad7606_conv = conv->phy;
+
+	mutex_lock(&ad7606_conv->lock);
+	if (!readval)
+		axiadc_write(axiadc, reg & 0xFFFF, writeval);
+	else
+		*readval = axiadc_read(axiadc, reg & 0xFFFF);
+	mutex_unlock(&ad7606_conv->lock);
+
+	return 0;
+}
+
+static int ad7606_conv_update_scan_mode(struct iio_dev *indio_dev,
+					const unsigned long *scan_mask)
+{
+	struct axiadc_state *axiadc = iio_priv(indio_dev);
+	struct axiadc_converter *conv = iio_device_get_drvdata(indio_dev);
+	struct ad7606_conv_state *ad7606_conv = conv->phy;
+	unsigned int i, ctrl;
+
+	mutex_lock(&ad7606_conv->lock);
+	for (i = 0; i < indio_dev->masklength; i++) {
+		ctrl = axiadc_read(axiadc, ADI_REG_CHAN_CNTRL(i));
+
+		if (test_bit(i, scan_mask))
+			ctrl |= ADI_ENABLE_FMT_SIGNEX;
+		else
+			ctrl &= ~ADI_ENABLE_FMT_SIGNEX;
+
+		axiadc_write(axiadc, ADI_REG_CHAN_CNTRL(i), ctrl);
+	}
+	mutex_unlock(&ad7606_conv->lock);
+
+	return 0;
+}
+
+static int ad7606_conv_set_sampling_freq(struct ad7606_conv_state *ad7606_conv,
+					 int freq)
+{
+	unsigned long long target, ref_clk_period_ps;
+	struct pwm_state cnvst_n_state;
+	int ret;
+
+	target = DIV_ROUND_CLOSEST_ULL(ad7606_conv->ref_clk_rate, freq);
+	ref_clk_period_ps = DIV_ROUND_CLOSEST_ULL(1000000000000ULL,
+						  ad7606_conv->ref_clk_rate);
+	cnvst_n_state.period = ref_clk_period_ps * target;
+	cnvst_n_state.duty_cycle = ref_clk_period_ps;
+	cnvst_n_state.phase = ref_clk_period_ps;
+	cnvst_n_state.time_unit = PWM_UNIT_PSEC;
+	cnvst_n_state.enabled = true;
+	ret = pwm_apply_state(ad7606_conv->cnvst_n, &cnvst_n_state);
+	if (ret)
+		return ret;
+
+	ad7606_conv->sampling_freq = DIV_ROUND_CLOSEST_ULL(ad7606_conv->ref_clk_rate, target);
+
+	return 0;
+}
+
+static int ad7606_conv_full_reset(struct platform_device *pdev,
+				  struct ad7606_conv_state *ad7606_conv)
+{
+	struct gpio_desc *adc_reset;
+
+	adc_reset = devm_gpiod_get_optional(&pdev->dev, "reset",
+					    GPIOD_OUT_HIGH);
+	if (IS_ERR(adc_reset))
+		return PTR_ERR(adc_reset);
+
+	if (adc_reset) {
+		ndelay(FULL_RESET_TIME); /* t_reset >= 3200ns */
+		/* bring it out of reset */
+		gpiod_set_value_cansleep(adc_reset, 0);
+		udelay(SETUP_TIME); /* Full reset t_device_setup >= 274ns */
+		devm_gpiod_put(&pdev->dev, adc_reset);
+	}
+	return 0;
+}
+
+static int ad7606_conv_read_raw(struct iio_dev *indio_dev,
+				const struct iio_chan_spec *chan, int *val,
+				int *val2, long info)
+{
+	struct ad7606_conv_state *ad7606_conv = iio_priv(indio_dev);
+	/* Scales are computed as 10000/32768 */
+	const int scale_10_s_ended = 305176;
+
+	switch (info) {
+	case IIO_CHAN_INFO_SAMP_FREQ:
+		*val = ad7606_conv->sampling_freq;
+		return IIO_VAL_INT;
+	case IIO_CHAN_INFO_SCALE:
+		*val = 0;
+		*val2 = scale_10_s_ended;
+		return IIO_VAL_INT_PLUS_MICRO;
+	default:
+		return -EINVAL;
+	}
+}
+
+static int ad7606_conv_write_raw(struct iio_dev *indio_dev,
+				 struct iio_chan_spec const *chan, int val,
+				 int val2, long info)
+{
+	struct ad7606_conv_state *ad7606_conv = iio_priv(indio_dev);
+
+	switch (info) {
+	case IIO_CHAN_INFO_SAMP_FREQ:
+		return ad7606_conv_set_sampling_freq(ad7606_conv, val);
+	default:
+		return -EINVAL;
+	}
+}
+
+static void ad7606_conv_pwm_disable(void *data)
+{
+	pwm_disable(data);
+}
+
+static int ad7606_conv_probe(struct platform_device *pdev)
+{
+	struct axiadc_converter	*conv;
+	struct ad7606_conv_state *st;
+	int ret;
+
+	st = devm_kzalloc(&pdev->dev, sizeof(*st), GFP_KERNEL);
+	if (!st)
+		return -ENOMEM;
+
+	conv = devm_kzalloc(&pdev->dev, sizeof(*conv), GFP_KERNEL);
+	if (!conv)
+		return -ENOMEM;
+
+	st->device_info = device_get_match_data(&pdev->dev);
+	if (!st->device_info)
+		return -EINVAL;
+
+	mutex_init(&st->lock);
+
+	ret = ad7606_conv_full_reset(pdev, st);
+	if (ret)
+		dev_warn(&pdev->dev, "failed to RESET ad7606 device\n");
+
+	st->ref_clk = devm_clk_get_enabled(&pdev->dev, "ad7606_conv_clk");
+	if (IS_ERR(st->ref_clk))
+		return dev_err_probe(&pdev->dev, PTR_ERR(st->ref_clk),
+				     "failed to get reference clock\n");
+
+	st->ref_clk_rate = clk_get_rate(st->ref_clk);
+
+	st->cnvst_n = devm_pwm_get(&pdev->dev, "cnvst_n");
+	if (IS_ERR(st->cnvst_n))
+		return PTR_ERR(st->cnvst_n);
+
+	ret = devm_add_action_or_reset(&pdev->dev, ad7606_conv_pwm_disable,
+				       st->cnvst_n);
+	if (ret)
+		return ret;
+
+	ret = ad7606_conv_set_sampling_freq(st, 100 * KHZ);
+	if (ret)
+		return dev_err_probe(&pdev->dev, ret,
+				     "ad7606_conv setup failed\n");
+
+	conv->dev = &pdev->dev;
+	conv->clk = st->ref_clk;
+	conv->chip_info = st->device_info;
+	conv->read_label = &ad7606_read_label;
+	conv->reg_access = &ad7606_conv_reg_access;
+	conv->write_raw = &ad7606_conv_write_raw;
+	conv->read_raw = &ad7606_conv_read_raw;
+	conv->update_scan_mode = &ad7606_conv_update_scan_mode;
+	conv->phy = st;
+
+	/* Without this, the axi_adc won't find the converter data */
+	dev_set_drvdata(&pdev->dev, conv);
+
+	return 0;
+}
+
+static const struct of_device_id ad7606_conv_of_match[] = {
+	{
+		.compatible = "axi-ad7606c-16",
+		.data = &conv_chip_info[ID_AD7606C_16]
+	},
+	{
+		.compatible = "axi-ad7606c-18",
+		.data = &conv_chip_info[ID_AD7606C_18]
+	},
+	{}
+};
+MODULE_DEVICE_TABLE(of, ad7606_conv_of_match);
+
+static struct platform_driver ad7606_conv_driver = {
+	.probe          = ad7606_conv_probe,
+	.driver         = {
+		.name   = "ad7606_conv",
+		.of_match_table = ad7606_conv_of_match,
+	},
+};
+module_platform_driver(ad7606_conv_driver);
+
+MODULE_AUTHOR("Alin-Tudor Sferle <alin-tudor.sferle@analog.com>");
+MODULE_AUTHOR("Dragos Bogdan <dragos.bogdan@analog.com>");
+MODULE_DESCRIPTION("Analog Devices AD7606X Parallel Interface ADC");
+MODULE_LICENSE("GPL");

--- a/drivers/iio/adc/ad7768.c
+++ b/drivers/iio/adc/ad7768.c
@@ -643,7 +643,7 @@ static int ad7768_register_axi_adc(struct ad7768_state *st)
 	if (conv == NULL)
 		return -ENOMEM;
 
-	conv->spi = st->spi;
+	conv->dev = &st->spi->dev;
 	conv->clk = st->mclk;
 	conv->chip_info = st->chip_info;
 	conv->adc_output_mode = AD7768_OUTPUT_MODE_TWOS_COMPLEMENT;
@@ -654,7 +654,7 @@ static int ad7768_register_axi_adc(struct ad7768_state *st)
 	conv->attrs = &ad7768_group;
 	conv->phy = st;
 	/* Without this, the axi_adc won't find the converter data */
-	spi_set_drvdata(st->spi, conv);
+	dev_set_drvdata(&st->spi->dev, conv);
 
 	return 0;
 }

--- a/drivers/iio/adc/ad9081.c
+++ b/drivers/iio/adc/ad9081.c
@@ -407,18 +407,18 @@ int32_t ad9081_log_write(void *user_data, int32_t log_type, const char *message,
 	case ADI_CMS_LOG_NONE:
 		break;
 	case ADI_CMS_LOG_MSG:
-		dev_dbg(&conv->spi->dev, "%s", logMessage);
+		dev_dbg(conv->dev, "%s", logMessage);
 		break;
 	case ADI_CMS_LOG_WARN:
-		dev_warn(&conv->spi->dev, "%s", logMessage);
+		dev_warn(conv->dev, "%s", logMessage);
 		break;
 	case ADI_CMS_LOG_ERR:
-		dev_err(&conv->spi->dev, "%s", logMessage);
+		dev_err(conv->dev, "%s", logMessage);
 		break;
 	case ADI_CMS_LOG_SPI:
 		break;
 	case ADI_CMS_LOG_API:
-		dev_dbg(&conv->spi->dev, "%s", logMessage);
+		dev_dbg(conv->dev, "%s", logMessage);
 		break;
 	case ADI_CMS_LOG_ALL:
 		printk(logMessage);
@@ -444,7 +444,7 @@ static int ad9081_spi_xfer(void *user_data, uint8_t *wbuf, uint8_t *rbuf,
 		.len = len & 0xFFFF,
 	};
 
-	if (conv->spi->mode & SPI_LSB_FIRST) {
+	if (to_spi_device(conv->dev)->mode & SPI_LSB_FIRST) {
 		int ret, i;
 		u8 tx[64], rx[64];
 
@@ -465,7 +465,7 @@ static int ad9081_spi_xfer(void *user_data, uint8_t *wbuf, uint8_t *rbuf,
 		for (i = 2; i < len; i++)
 			tx[i] =  wbuf[len - i + 1];
 
-		ret = spi_sync_transfer(conv->spi, &t, 1);
+		ret = spi_sync_transfer(to_spi_device(conv->dev), &t, 1);
 
 		for (i = 2; i < len; i++)
 			rbuf[i] =  rx[len - i + 1];
@@ -473,7 +473,7 @@ static int ad9081_spi_xfer(void *user_data, uint8_t *wbuf, uint8_t *rbuf,
 		return ret;
 	}
 
-	return spi_sync_transfer(conv->spi, &t, 1);
+	return spi_sync_transfer(to_spi_device(conv->dev), &t, 1);
 }
 
 static int ad9081_reset_pin_ctrl(void *user_data, u8 enable)
@@ -1873,7 +1873,7 @@ static int ad9081_request_clks(struct axiadc_converter *conv)
 	struct ad9081_phy *phy = conv->phy;
 	int ret;
 
-	phy->dev_clk = devm_clk_get(&conv->spi->dev, "dev_clk");
+	phy->dev_clk = devm_clk_get(conv->dev, "dev_clk");
 	if (IS_ERR(phy->dev_clk))
 		return PTR_ERR(phy->dev_clk);
 
@@ -2515,7 +2515,7 @@ static int ad9081_write_raw(struct iio_dev *indio_dev,
 
 		r_clk = clk_round_rate(conv->clk, val);
 		if (r_clk < 0 || r_clk > conv->chip_info->max_rate) {
-			dev_warn(&conv->spi->dev,
+			dev_warn(conv->dev,
 				 "Error setting ADC sample rate %ld", r_clk);
 			return -EINVAL;
 		}
@@ -2963,7 +2963,7 @@ static const struct attribute_group ad9081_phy_attribute_group = {
 
 static int ad9081_request_fd_irqs(struct axiadc_converter *conv)
 {
-	struct device *dev = &conv->spi->dev;
+	struct device *dev = conv->dev;
 	struct gpio_desc *gpio;
 
 	gpio = devm_gpiod_get(dev, "fastdetect-a", GPIOD_IN);
@@ -3783,7 +3783,7 @@ static int ad9081_post_iio_register(struct iio_dev *indio_dev)
 	int i;
 
 	if (iio_get_debugfs_dentry(indio_dev)) {
-		debugfs_create_devm_seqfile(&conv->spi->dev, "status",
+		debugfs_create_devm_seqfile(conv->dev, "status",
 					    iio_get_debugfs_dentry(indio_dev),
 					    ad9081_status_show);
 
@@ -4548,7 +4548,7 @@ static const struct iio_info ad9081_iio_info = {
 static int ad9081_register_iiodev(struct axiadc_converter *conv)
 {
 	struct iio_dev *indio_dev;
-	struct spi_device *spi = conv->spi;
+	struct spi_device *spi = to_spi_device(conv->dev);
 	struct ad9081_phy *phy = conv->phy;
 	int ret;
 
@@ -4991,8 +4991,8 @@ static int ad9081_probe(struct spi_device *spi)
 	conv->adc_clkscale.mult = 1;
 	conv->adc_clkscale.div = 1;
 
-	spi_set_drvdata(spi, conv);
-	conv->spi = spi;
+	dev_set_drvdata(&spi->dev, conv);
+	conv->dev = &spi->dev;
 	conv->phy = phy;
 	phy->spi = spi;
 	phy->jdev = jdev;

--- a/drivers/iio/adc/ad9208.c
+++ b/drivers/iio/adc/ad9208.c
@@ -124,9 +124,9 @@ static int ad9208_spi_xfer(void *user_data, uint8_t *wbuf,
 		.len = len,
 	};
 
-	ret = spi_sync_transfer(conv->spi, &t, 1);
+	ret = spi_sync_transfer(to_spi_device(conv->dev), &t, 1);
 
-	dev_dbg(&conv->spi->dev,"%s: reg=0x%X, val=0x%X",
+	dev_dbg(conv->dev, "%s: reg=0x%X, val=0x%X",
 		(wbuf[0] & 0x80) ? "rd" : "wr",
 		(wbuf[0] & 0x7F) << 8 | wbuf[1],
 		(wbuf[0] & 0x80) ? rbuf[2] : wbuf[2]);
@@ -737,18 +737,18 @@ static int ad9208_request_clks(struct axiadc_converter *conv)
 	struct ad9208_phy *phy = conv->phy;
 	int ret;
 
-	conv->clk = devm_clk_get(&conv->spi->dev, "adc_clk");
+	conv->clk = devm_clk_get(conv->dev, "adc_clk");
 	if (IS_ERR(conv->clk) && PTR_ERR(conv->clk) != -ENOENT)
 		return PTR_ERR(conv->clk);
 
 	if (phy->jdev)
 		return 0;
 
-	conv->lane_clk = devm_clk_get(&conv->spi->dev, "jesd_adc_clk");
+	conv->lane_clk = devm_clk_get(conv->dev, "jesd_adc_clk");
 	if (IS_ERR(conv->lane_clk) && PTR_ERR(conv->lane_clk) != -ENOENT)
 		return PTR_ERR(conv->lane_clk);
 
-	conv->sysref_clk = devm_clk_get(&conv->spi->dev, "adc_sysref");
+	conv->sysref_clk = devm_clk_get(conv->dev, "adc_sysref");
 	if (IS_ERR(conv->sysref_clk)) {
 		if (PTR_ERR(conv->sysref_clk) != -ENOENT)
 			return PTR_ERR(conv->sysref_clk);
@@ -979,7 +979,7 @@ static int ad9208_setup(struct spi_device *spi)
 		}
 	} while (!(pll_stat & AD9208_JESD_PLL_LOCK_STAT) && timeout--);
 
-	dev_info(&conv->spi->dev, "%s PLL %s\n", spi_get_device_id(spi)->name,
+	dev_info(conv->dev, "%s PLL %s\n", spi_get_device_id(spi)->name,
 		 pll_stat & AD9208_JESD_PLL_LOCK_STAT ? "LOCKED" : "UNLOCKED");
 
 	if (!phy->jdev) {
@@ -1095,7 +1095,7 @@ static int ad9208_write_raw(struct iio_dev *indio_dev,
 
 		r_clk = clk_round_rate(conv->clk, val);
 		if (r_clk < 0 || r_clk > conv->chip_info->max_rate) {
-			dev_warn(&conv->spi->dev,
+			dev_warn(conv->dev,
 				 "Error setting ADC sample rate %ld", r_clk);
 			return -EINVAL;
 		}
@@ -1113,7 +1113,7 @@ static int ad9208_write_raw(struct iio_dev *indio_dev,
 
 static int ad9208_request_fd_irqs(struct axiadc_converter *conv)
 {
-	struct device *dev = &conv->spi->dev;
+	struct device *dev = conv->dev;
 	struct gpio_desc *gpio;
 
 	gpio = devm_gpiod_get(dev, "fastdetect-a", GPIOD_IN);
@@ -1171,7 +1171,7 @@ static int ad9208_post_iio_register(struct iio_dev *indio_dev)
 	struct axiadc_converter *conv = iio_device_get_drvdata(indio_dev);
 
 	if (iio_get_debugfs_dentry(indio_dev)) {
-		debugfs_create_devm_seqfile(&conv->spi->dev, "status",
+		debugfs_create_devm_seqfile(conv->dev, "status",
 					    iio_get_debugfs_dentry(indio_dev),
 					    ad9208_status_show);
 	}
@@ -1494,8 +1494,8 @@ static int ad9208_probe(struct spi_device *spi)
 	conv->adc_clkscale.mult = 1;
 	conv->adc_clkscale.div = 1;
 
-	spi_set_drvdata(spi, conv);
-	conv->spi = spi;
+	dev_set_drvdata(&spi->dev, conv);
+	conv->dev = &spi->dev;
 	conv->phy = phy;
 
 	if (jdev) {

--- a/drivers/iio/adc/ad9361_conv.c
+++ b/drivers/iio/adc/ad9361_conv.c
@@ -313,8 +313,8 @@ static int ad9361_write_raw(struct iio_dev *indio_dev,
 
 		r_clk = clk_round_rate(conv->clk, val);
 		if (r_clk < 0 || r_clk > conv->chip_info->max_rate) {
-			dev_warn(&conv->spi->dev,
-				"Error setting ADC sample rate %ld", r_clk);
+			dev_warn(conv->dev,
+				 "Error setting ADC sample rate %ld", r_clk);
 			return -EINVAL;
 		}
 
@@ -746,13 +746,13 @@ int ad9361_register_axi_converter(struct ad9361_rf_phy *phy)
 	conv->write_raw = ad9361_write_raw;
 	conv->read_raw = ad9361_read_raw;
 	conv->post_setup = ad9361_post_setup;
-	conv->spi = spi;
+	conv->dev = &spi->dev;
 	conv->phy = phy;
 
 	conv->clk = phy->clks[RX_SAMPL_CLK];
 	conv->adc_clk = clk_get_rate(conv->clk);
 
-	spi_set_drvdata(spi, conv); /* Take care here */
+	dev_set_drvdata(&spi->dev, conv); /* Take care here */
 
 	return 0;
 out:

--- a/drivers/iio/adc/ad9371_conv.c
+++ b/drivers/iio/adc/ad9371_conv.c
@@ -160,13 +160,13 @@ int ad9371_register_axi_converter(struct ad9371_rf_phy *phy)
 	conv->write_raw = ad9371_write_raw;
 	conv->read_raw = ad9371_read_raw;
 	conv->post_setup = ad9371_post_setup;
-	conv->spi = spi;
+	conv->dev = &spi->dev;
 	conv->phy = phy;
 
 	conv->clk = phy->clks[RX_SAMPL_CLK];
 	conv->adc_clk = clk_get_rate(conv->clk);
 
-	spi_set_drvdata(spi, conv); /* Take care here */
+	dev_set_drvdata(&spi->dev, conv); /* Take care here */
 
 	return 0;
 }

--- a/drivers/iio/adc/ad9467.c
+++ b/drivers/iio/adc/ad9467.c
@@ -218,7 +218,7 @@ static int ad9467_reg_access(struct iio_dev *indio_dev, unsigned int reg,
 			     unsigned int writeval, unsigned int *readval)
 {
 	struct axiadc_converter *conv = iio_device_get_drvdata(indio_dev);
-	struct spi_device *spi = conv->spi;
+	struct spi_device *spi = to_spi_device(conv->dev);
 	int ret;
 
 	if (readval == NULL) {
@@ -254,10 +254,14 @@ static int ad9467_testmode_set(struct iio_dev *indio_dev,
 {
 	struct axiadc_converter *conv = iio_device_get_drvdata(indio_dev);
 
-	ad9467_spi_write(conv->spi, AN877_ADC_REG_CHAN_INDEX, 1 << chan);
-	ad9467_spi_write(conv->spi, AN877_ADC_REG_TEST_IO, mode);
-	ad9467_spi_write(conv->spi, AN877_ADC_REG_CHAN_INDEX, 0x3);
-	ad9467_spi_write(conv->spi, AN877_ADC_REG_TRANSFER, AN877_ADC_TRANSFER_SYNC);
+	ad9467_spi_write(to_spi_device(conv->dev), AN877_ADC_REG_CHAN_INDEX,
+			 1 << chan);
+	ad9467_spi_write(to_spi_device(conv->dev), AN877_ADC_REG_TEST_IO,
+			 mode);
+	ad9467_spi_write(to_spi_device(conv->dev), AN877_ADC_REG_CHAN_INDEX,
+			 0x3);
+	ad9467_spi_write(to_spi_device(conv->dev), AN877_ADC_REG_TRANSFER,
+			 AN877_ADC_TRANSFER_SYNC);
 	conv->testmode[chan] = mode;
 	return 0;
 }
@@ -282,10 +286,12 @@ static int ad9467_set_pnsel(struct iio_dev *indio_dev, unsigned int chan,
 	int ret;
 
 	if (mode == AN877_ADC_TESTMODE_OFF)
-		ret = ad9467_spi_write(conv->spi, AN877_ADC_REG_OUTPUT_MODE,
+		ret = ad9467_spi_write(to_spi_device(conv->dev),
+				       AN877_ADC_REG_OUTPUT_MODE,
 				       conv->adc_output_mode);
 	else
-		ret = ad9467_spi_write(conv->spi, AN877_ADC_REG_OUTPUT_MODE,
+		ret = ad9467_spi_write(to_spi_device(conv->dev),
+				       AN877_ADC_REG_OUTPUT_MODE,
 				       conv->
 				       adc_output_mode &
 				       ~AN877_ADC_OUTPUT_MODE_TWOS_COMPLEMENT);
@@ -306,8 +312,8 @@ static int ad9467_calibrate(struct iio_dev *indio_dev, unsigned chan,
 		 chan_ctrl0, chan_ctrl1, max_val = dco ? 32 : 31;
 	unsigned char err_field[66];
 
-	ret = ad9467_outputmode_set(conv->spi,
-			conv->adc_output_mode & ~AN877_ADC_OUTPUT_MODE_TWOS_COMPLEMENT);
+	ret = ad9467_outputmode_set(to_spi_device(conv->dev),
+				    conv->adc_output_mode & ~AN877_ADC_OUTPUT_MODE_TWOS_COMPLEMENT);
 	if (ret < 0)
 		return ret;
 
@@ -316,9 +322,10 @@ static int ad9467_calibrate(struct iio_dev *indio_dev, unsigned chan,
 
 	do {
 		if (dco && conv->chip_info->id != CHIPID_AD9652) {
-			ad9467_spi_write(conv->spi, AN877_ADC_REG_OUTPUT_PHASE,
-					AN877_ADC_OUTPUT_EVEN_ODD_MODE_EN | (inv_range ?
-						AN877_ADC_INVERT_DCO_CLK : 0));
+			ad9467_spi_write(to_spi_device(conv->dev),
+					 AN877_ADC_REG_OUTPUT_PHASE,
+					 AN877_ADC_OUTPUT_EVEN_ODD_MODE_EN |
+					 (inv_range ?  AN877_ADC_INVERT_DCO_CLK : 0));
 		} else if (!dco) {
 			unsigned reg_cntrl = axiadc_read(st, ADI_REG_CNTRL);
 
@@ -343,11 +350,14 @@ static int ad9467_calibrate(struct iio_dev *indio_dev, unsigned chan,
 
 		for (val = 0; val <= max_val; val++) {
 			if (dco) {
-				ad9467_spi_write(conv->spi, AN877_ADC_REG_OUTPUT_DELAY,
-						val > 0 ? ((val - 1) | dco_en) : 0);
-				ad9467_spi_write(conv->spi, AN877_ADC_REG_TRANSFER,
-						AN877_ADC_TRANSFER_SYNC);
-				ad9467_spi_read(conv->spi, AN877_ADC_REG_OUTPUT_DELAY);
+				ad9467_spi_write(to_spi_device(conv->dev),
+						 AN877_ADC_REG_OUTPUT_DELAY,
+						 val > 0 ? ((val - 1) | dco_en) : 0);
+				ad9467_spi_write(to_spi_device(conv->dev),
+						 AN877_ADC_REG_TRANSFER,
+						 AN877_ADC_TRANSFER_SYNC);
+				ad9467_spi_read(to_spi_device(conv->dev),
+						AN877_ADC_REG_OUTPUT_DELAY);
 			} else {
 				for (lane = 0; lane < nb_lanes; lane++) {
 					axiadc_idelay_set(st, lane, val);
@@ -413,8 +423,10 @@ static int ad9467_calibrate(struct iio_dev *indio_dev, unsigned chan,
 	if (val > max_val) {
 		val -= max_val + 1;
 		if (dco && conv->chip_info->id != CHIPID_AD9652) {
-			ad9467_spi_write(conv->spi, AN877_ADC_REG_OUTPUT_PHASE,
-				 AN877_ADC_OUTPUT_EVEN_ODD_MODE_EN | AN877_ADC_INVERT_DCO_CLK);
+			ad9467_spi_write(to_spi_device(conv->dev),
+					 AN877_ADC_REG_OUTPUT_PHASE,
+					 AN877_ADC_OUTPUT_EVEN_ODD_MODE_EN |
+					 AN877_ADC_INVERT_DCO_CLK);
 		} else if (!dco) {
 			unsigned reg_cntrl = axiadc_read(st, ADI_REG_CNTRL);
 			reg_cntrl |= ADI_DDR_EDGESEL;
@@ -423,8 +435,9 @@ static int ad9467_calibrate(struct iio_dev *indio_dev, unsigned chan,
 		cnt = 1;
 	} else {
 		if (dco && conv->chip_info->id != CHIPID_AD9652) {
-			ad9467_spi_write(conv->spi, AN877_ADC_REG_OUTPUT_PHASE,
-				 AN877_ADC_OUTPUT_EVEN_ODD_MODE_EN);
+			ad9467_spi_write(to_spi_device(conv->dev),
+					 AN877_ADC_REG_OUTPUT_PHASE,
+					 AN877_ADC_OUTPUT_EVEN_ODD_MODE_EN);
 		} else if (!dco) {
 			unsigned reg_cntrl = axiadc_read(st, ADI_REG_CNTRL);
 			reg_cntrl &= ~ADI_DDR_EDGESEL;
@@ -445,9 +458,12 @@ static int ad9467_calibrate(struct iio_dev *indio_dev, unsigned chan,
 	ad9467_testmode_set(indio_dev, 0, AN877_ADC_TESTMODE_OFF);
 	ad9467_testmode_set(indio_dev, 1, AN877_ADC_TESTMODE_OFF);
 	if (dco) {
-		ad9467_spi_write(conv->spi, AN877_ADC_REG_OUTPUT_DELAY,
-				val > 0 ? ((val - 1) | dco_en) : 0);
-		ad9467_spi_write(conv->spi, AN877_ADC_REG_TRANSFER, AN877_ADC_TRANSFER_SYNC);
+		ad9467_spi_write(to_spi_device(conv->dev),
+				 AN877_ADC_REG_OUTPUT_DELAY,
+				 val > 0 ? ((val - 1) | dco_en) : 0);
+		ad9467_spi_write(to_spi_device(conv->dev),
+				 AN877_ADC_REG_TRANSFER,
+				 AN877_ADC_TRANSFER_SYNC);
 	} else {
 		for (lane = 0; lane < nb_lanes; lane++) {
 			axiadc_idelay_set(st, lane, val);
@@ -457,7 +473,8 @@ static int ad9467_calibrate(struct iio_dev *indio_dev, unsigned chan,
 	axiadc_write(st, ADI_REG_CHAN_CNTRL(0), chan_ctrl0);
 	axiadc_write(st, ADI_REG_CHAN_CNTRL(1), chan_ctrl1);
 
-	ret = ad9467_outputmode_set(conv->spi, conv->adc_output_mode);
+	ret = ad9467_outputmode_set(to_spi_device(conv->dev),
+				    conv->adc_output_mode);
 	if (ret < 0)
 		return ret;
 
@@ -887,7 +904,7 @@ static void ad9625_clk_del_provider(void *data)
 {
 	struct axiadc_converter *conv = data;
 
-	of_clk_del_provider(conv->spi->dev.of_node);
+	of_clk_del_provider(to_spi_device(conv->dev)->dev.of_node);
 	clk_unregister_fixed_factor(conv->out_clk);
 }
 
@@ -956,7 +973,7 @@ static int ad9625_setup(struct spi_device *spi)
 
 	ret = clk_set_rate(conv->lane_clk, lane_rate_kHz);
 	if (ret < 0) {
-		dev_err(&conv->spi->dev, "Failed to set lane rate to %lu kHz: %d\n",
+		dev_err(conv->dev, "Failed to set lane rate to %lu kHz: %d\n",
 			lane_rate_kHz, ret);
 		return ret;
 	}
@@ -966,7 +983,7 @@ static int ad9625_setup(struct spi_device *spi)
 		ret = 0;
 
 	if (ret < 0) {
-		dev_err(&conv->spi->dev, "Failed to enable JESD204 link: %d\n", ret);
+		dev_err(conv->dev, "Failed to enable JESD204 link: %d\n", ret);
 		return ret;
 	}
 
@@ -1011,7 +1028,8 @@ static int ad9467_get_scale(struct axiadc_converter *conv, int *val, int *val2)
 		break;
 	}
 
-	vref_val = ad9467_spi_read(conv->spi, AN877_ADC_REG_VREF);
+	vref_val = ad9467_spi_read(to_spi_device(conv->dev),
+				   AN877_ADC_REG_VREF);
 
 	vref_val &= vref_mask;
 
@@ -1047,9 +1065,10 @@ static int ad9467_set_scale(struct axiadc_converter *conv, int val, int val2)
 		if (scale_val[0] != val || scale_val[1] != val2)
 			continue;
 
-		ad9467_spi_write(conv->spi, AN877_ADC_REG_VREF,
+		ad9467_spi_write(to_spi_device(conv->dev), AN877_ADC_REG_VREF,
 				 conv->chip_info->scale_table[i][1]);
-		ad9467_spi_write(conv->spi, AN877_ADC_REG_TRANSFER,
+		ad9467_spi_write(to_spi_device(conv->dev),
+				 AN877_ADC_REG_TRANSFER,
 				 AN877_ADC_TRANSFER_SYNC);
 		return 0;
 	}
@@ -1101,7 +1120,7 @@ static int ad9467_write_raw(struct iio_dev *indio_dev,
 
 		r_clk = clk_round_rate(conv->clk, val);
 		if (r_clk < 0 || r_clk > conv->chip_info->max_rate) {
-			dev_warn(&conv->spi->dev,
+			dev_warn(conv->dev,
 				 "Error setting ADC sample rate %ld", r_clk);
 			return -EINVAL;
 		}
@@ -1151,7 +1170,7 @@ static int ad9467_post_setup(struct iio_dev *indio_dev)
 
 static int ad9467_setup(struct axiadc_converter *st, unsigned int chip_id)
 {
-	struct spi_device *spi = st->spi;
+	struct spi_device *spi = to_spi_device(st->dev);
 	int ret;
 
 	st->adc_output_mode = AN877_ADC_OUTPUT_MODE_TWOS_COMPLEMENT;
@@ -1232,7 +1251,7 @@ static int ad9467_probe(struct spi_device *spi)
 	/* FIXME: remove this asap; it's to make things easier to diff with upstream version */
 	st = conv;
 
-	st->spi = spi;
+	st->dev = &spi->dev;
 
 	st->clk = devm_clk_get(&spi->dev, NULL);
 	if (IS_ERR(st->clk))
@@ -1269,7 +1288,7 @@ static int ad9467_probe(struct spi_device *spi)
 		mdelay(10);
 	}
 
-	spi_set_drvdata(spi, st);
+	dev_set_drvdata(&spi->dev, st);
 
 	conv->chip_info = info;
 

--- a/drivers/iio/adc/ad9680.c
+++ b/drivers/iio/adc/ad9680.c
@@ -153,7 +153,7 @@ static int ad9680_reg_access(struct iio_dev *indio_dev, unsigned int reg,
 	unsigned int writeval, unsigned int *readval)
 {
 	struct axiadc_converter *conv = iio_device_get_drvdata(indio_dev);
-	struct spi_device *spi = conv->spi;
+	struct spi_device *spi = to_spi_device(conv->dev);
 	int ret;
 
 	if (readval == NULL)
@@ -181,10 +181,12 @@ static int ad9680_select_channel(struct axiadc_converter *conv,
 		pair = 0x3;
 	}
 
-	ret = ad9680_spi_write(conv->spi, AD9680_REG_DEVICE_INDEX, device);
+	ret = ad9680_spi_write(to_spi_device(conv->dev),
+			       AD9680_REG_DEVICE_INDEX, device);
 	if (ret < 0)
 		return ret;
-	return ad9680_spi_write(conv->spi, AD9680_REG_PAIR_INDEX, pair);
+	return ad9680_spi_write(to_spi_device(conv->dev),
+				AD9680_REG_PAIR_INDEX, pair);
 }
 
 static int ad9680_channel_write(struct axiadc_converter *conv,
@@ -193,7 +195,7 @@ static int ad9680_channel_write(struct axiadc_converter *conv,
 	int ret;
 
 	ret = ad9680_select_channel(conv, chan);
-	ret |= ad9680_spi_write(conv->spi, reg, val);
+	ret |= ad9680_spi_write(to_spi_device(conv->dev), reg, val);
 	ret |= ad9680_select_channel(conv, -1);
 
 	return ret;
@@ -205,7 +207,7 @@ static int ad9680_channel_read(struct axiadc_converter *conv,
 	int ret;
 
 	ad9680_select_channel(conv, chan);
-	ret = ad9680_spi_read(conv->spi, reg);
+	ret = ad9680_spi_read(to_spi_device(conv->dev), reg);
 	ad9680_select_channel(conv, -1);
 
 	return ret;
@@ -258,7 +260,8 @@ static int ad9680_set_pnsel(struct iio_dev *indio_dev, unsigned int chan,
 	if (mode != AD9680_TESTMODE_OFF)
 		output_mode &= ~AD9680_OUTPUT_MODE_TWOS_COMPLEMENT;
 
-	ret = ad9680_spi_write(conv->spi, AD9680_REG_OUTPUT_MODE, output_mode);
+	ret = ad9680_spi_write(to_spi_device(conv->dev),
+			       AD9680_REG_OUTPUT_MODE, output_mode);
 	if (ret < 0)
 		return ret;
 
@@ -294,7 +297,7 @@ static int ad9680_read_thresh(struct iio_dev *indio_dev,
 	int *val2)
 {
 	struct axiadc_converter *conv = iio_device_get_drvdata(indio_dev);
-	struct spi_device *spi = conv->spi;
+	struct spi_device *spi = to_spi_device(conv->dev);
 	u16 low, high;
 
 	mutex_lock(&conv->lock);
@@ -323,7 +326,7 @@ static int ad9680_read_thresh_en(struct iio_dev *indio_dev,
 	enum iio_event_direction dir)
 {
 	struct axiadc_converter *conv = iio_device_get_drvdata(indio_dev);
-	struct spi_device *spi = conv->spi;
+	struct spi_device *spi = to_spi_device(conv->dev);
 	int ret;
 
 	ret = ad9680_spi_read(spi, AD9680_REG_CHIP_PIN_CTRL);
@@ -339,7 +342,7 @@ static int ad9680_write_thresh(struct iio_dev *indio_dev,
 	int val2)
 {
 	struct axiadc_converter *conv = iio_device_get_drvdata(indio_dev);
-	struct spi_device *spi = conv->spi;
+	struct spi_device *spi = to_spi_device(conv->dev);
 	int ret = 0;
 	int low, high;
 
@@ -392,7 +395,7 @@ static int ad9680_write_thresh_en(struct iio_dev *indio_dev,
 	enum iio_event_direction dir, int state)
 {
 	struct axiadc_converter *conv = iio_device_get_drvdata(indio_dev);
-	struct spi_device *spi = conv->spi;
+	struct spi_device *spi = to_spi_device(conv->dev);
 	int ret;
 
 	mutex_lock(&conv->lock);
@@ -469,7 +472,8 @@ static int ad9680_get_scale(struct axiadc_converter *conv,
 		vref_val = ad9680_channel_read(conv, chan->channel, 0x1910);
 		break;
 	default:
-		vref_val = ad9680_spi_read(conv->spi, AD9680_REG_INPUT_FS_RANGE);
+		vref_val = ad9680_spi_read(to_spi_device(conv->dev),
+					   AD9680_REG_INPUT_FS_RANGE);
 		break;
 	}
 	vref_val &= 0xf;
@@ -505,7 +509,8 @@ static int ad9680_set_scale(struct axiadc_converter *conv,
 					     scale_raw);
 			break;
 		default:
-			ad9680_spi_write(conv->spi, AD9680_REG_INPUT_FS_RANGE,
+			ad9680_spi_write(to_spi_device(conv->dev),
+					 AD9680_REG_INPUT_FS_RANGE,
 					 scale_raw);
 			break;
 		}
@@ -724,7 +729,7 @@ static int ad9680_update_sysref(struct axiadc_converter *conv,
 	}
 
 	if (n == 0) {
-		dev_err(&conv->spi->dev,
+		dev_err(conv->dev,
 			"Could not find suitable SYSREF rate for LMFC of %u\n",
 			lmfc);
 		return -EINVAL;
@@ -745,10 +750,10 @@ static ssize_t ad9680_status_read(struct device *dev,
 	switch (conv->id) {
 	case CHIPID_AD9694:
 	case CHIPID_AD9094:
-		val = ad9680_spi_read(conv->spi, 0x11b);
+		val = ad9680_spi_read(to_spi_device(conv->dev), 0x11b);
 		break;
 	default:
-		val = ad9680_spi_read(conv->spi, 0x11c);
+		val = ad9680_spi_read(to_spi_device(conv->dev), 0x11c);
 		break;
 	}
 
@@ -758,16 +763,16 @@ static ssize_t ad9680_status_read(struct device *dev,
 	if (conv->id == CHIPID_AD9684)
 		return ret;
 
-	val = ad9680_spi_read(conv->spi, 0x56f);
+	val = ad9680_spi_read(to_spi_device(conv->dev), 0x56f);
 	ret += scnprintf(buf + ret, PAGE_SIZE - ret,
 		"JESD204 PLL is %slocked\n",
 		(val & 0x80) ? "" : "not ");
 
-	val = ad9680_spi_read(conv->spi, 0x12a);
+	val = ad9680_spi_read(to_spi_device(conv->dev), 0x12a);
 	ret += scnprintf(buf + ret, PAGE_SIZE - ret,
 		"SYSREF counter: %d\n", val);
 
-	val = ad9680_spi_read(conv->spi, 0x128);
+	val = ad9680_spi_read(to_spi_device(conv->dev), 0x128);
 	hold = (val >> 4) & 0xf;
 	setup = val & 0xf;
 
@@ -804,26 +809,30 @@ static int ad9680_setup_jesd204_link(struct axiadc_converter *conv,
 	lane_rate_kHz = DIV_ROUND_CLOSEST(sample_rate, 100);
 
 	if (lane_rate_kHz < 3125000 || lane_rate_kHz > 12500000) {
-		dev_err(&conv->spi->dev, "Lane rate %lu Mbps out of bounds. Must be between 3125 and 12500 Mbps",
+		dev_err(conv->dev,
+			"Lane rate %lu Mbps out of bounds. Must be between 3125 and 12500 Mbps",
 			lane_rate_kHz / 1000);
 		return -EINVAL;
 	}
 
 	if (lane_rate_kHz < 6250000)
-		ad9680_spi_write(conv->spi, 0x56e, 0x10);	// low line rate mode must be enabled
+		/* low line rate mode must be enabled */
+		ad9680_spi_write(to_spi_device(conv->dev), 0x56e, 0x10);
 	else
-		ad9680_spi_write(conv->spi, 0x56e, 0x00);	// low line rate mode must be disabled
+		/* low line rate mode must be disabled */
+		ad9680_spi_write(to_spi_device(conv->dev), 0x56e, 0x00);
 
 	ret = ad9680_update_sysref(conv, sysref_rate);
 	if (ret < 0) {
-		dev_err(&conv->spi->dev, "Failed to set SYSREF clock to %lu kHz: %d\n",
+		dev_err(conv->dev,
+			"Failed to set SYSREF clock to %lu kHz: %d\n",
 			sysref_rate / 1000, ret);
 		return ret;
 	}
 
 	ret = clk_set_rate(conv->lane_clk, lane_rate_kHz);
 	if (ret < 0) {
-		dev_err(&conv->spi->dev, "Failed to set lane rate to %lu kHz: %d\n",
+		dev_err(conv->dev, "Failed to set lane rate to %lu kHz: %d\n",
 			lane_rate_kHz, ret);
 		return ret;
 	}
@@ -847,7 +856,7 @@ static int ad9680_set_sample_rate(struct axiadc_converter *conv,
 	sample_rate = clk_round_rate(conv->clk, sample_rate);
 
 	/* Disable link */
-	ad9680_spi_write(conv->spi, 0x571, 0x15);
+	ad9680_spi_write(to_spi_device(conv->dev), 0x571, 0x15);
 
 	if (conv->running) {
 		clk_disable_unprepare(conv->lane_clk);
@@ -858,7 +867,8 @@ static int ad9680_set_sample_rate(struct axiadc_converter *conv,
 
 	ret = clk_set_rate(conv->clk, sample_rate);
 	if (ret) {
-		dev_err(&conv->spi->dev, "Failed to set converter clock rate to %u kHz: %d\n",
+		dev_err(conv->dev,
+			"Failed to set converter clock rate to %u kHz: %d\n",
 			sample_rate / 1000, ret);
 		return ret;
 	}
@@ -869,30 +879,31 @@ static int ad9680_set_sample_rate(struct axiadc_converter *conv,
 
 	ret = clk_prepare_enable(conv->clk);
 	if (ret) {
-		dev_err(&conv->spi->dev, "Failed to enable converter clock: %d\n", ret);
+		dev_err(conv->dev, "Failed to enable converter clock: %d\n",
+			ret);
 		return ret;
 	}
 	ret = clk_prepare_enable(conv->sysref_clk);
 	if (ret) {
 		clk_disable_unprepare(conv->clk);
-		dev_err(&conv->spi->dev, "Failed to enable SYSREF clock: %d\n", ret);
+		dev_err(conv->dev, "Failed to enable SYSREF clock: %d\n", ret);
 		return ret;
 	}
 
 	// Enable link
-	ad9680_spi_write(conv->spi, 0x571, 0x14);
+	ad9680_spi_write(to_spi_device(conv->dev), 0x571, 0x14);
 
 	mdelay(20);
-	pll_stat = ad9680_spi_read(conv->spi, 0x56f);
+	pll_stat = ad9680_spi_read(to_spi_device(conv->dev), 0x56f);
 
-	dev_info(&conv->spi->dev, "PLL %s\n",
+	dev_info(conv->dev, "PLL %s\n",
 		 (pll_stat & 0x80) ? "LOCKED" : "UNLOCKED");
 
 	ret = clk_prepare_enable(conv->lane_clk);
 	if (ret < 0) {
 		clk_disable_unprepare(conv->clk);
 		clk_disable_unprepare(conv->sysref_clk);
-		dev_err(&conv->spi->dev, "Failed to enable JESD204 link: %d\n", ret);
+		dev_err(conv->dev, "Failed to enable JESD204 link: %d\n", ret);
 		return ret;
 	}
 
@@ -906,7 +917,7 @@ static int ad9680_request_clks(struct axiadc_converter *conv)
 {
 	int ret;
 
-	conv->sysref_clk = devm_clk_get(&conv->spi->dev, "adc_sysref");
+	conv->sysref_clk = devm_clk_get(conv->dev, "adc_sysref");
 	if (IS_ERR(conv->sysref_clk)) {
 		if (PTR_ERR(conv->sysref_clk) != -ENOENT)
 			return PTR_ERR(conv->sysref_clk);
@@ -917,7 +928,7 @@ static int ad9680_request_clks(struct axiadc_converter *conv)
 			return ret;
 	}
 
-	conv->clk = devm_clk_get(&conv->spi->dev, "adc_clk");
+	conv->clk = devm_clk_get(conv->dev, "adc_clk");
 	if (IS_ERR(conv->clk)) {
 		if (PTR_ERR(conv->clk) != -ENOENT) {
 			clk_disable_unprepare(conv->sysref_clk);
@@ -934,7 +945,7 @@ static int ad9680_request_clks(struct axiadc_converter *conv)
 		conv->adc_clk = clk_get_rate(conv->clk);
 	}
 
-	conv->lane_clk = devm_clk_get(&conv->spi->dev, "jesd_adc_clk");
+	conv->lane_clk = devm_clk_get(conv->dev, "jesd_adc_clk");
 	if (IS_ERR(conv->lane_clk)) {
 		if (PTR_ERR(conv->lane_clk) != -ENOENT) {
 			clk_disable_unprepare(conv->clk);
@@ -1080,9 +1091,9 @@ static int ad9680_setup(struct spi_device *spi, bool ad9234)
 	if (ret < 0)
 		goto err;
 	mdelay(20);
-	pll_stat = ad9680_spi_read(conv->spi, 0x56f);
+	pll_stat = ad9680_spi_read(to_spi_device(conv->dev), 0x56f);
 
-	dev_info(&conv->spi->dev, "AD9680 PLL %s\n",
+	dev_info(conv->dev, "AD9680 PLL %s\n",
 		 pll_stat & 0x80 ? "LOCKED" : "UNLOCKED");
 
 	ret = clk_prepare_enable(conv->lane_clk);
@@ -1140,7 +1151,8 @@ static int ad9694_setup_jesd204_link(struct axiadc_converter *conv,
 	lane_rate_kHz = DIV_ROUND_CLOSEST(sample_rate, 100);
 
 	if (lane_rate_kHz < 1687500 || lane_rate_kHz > 15000000) {
-		dev_err(&conv->spi->dev, "Lane rate %lu Mbps out of bounds. Must be between 1687.5 and 15000 Mbps",
+		dev_err(conv->dev,
+			"Lane rate %lu Mbps out of bounds. Must be between 1687.5 and 15000 Mbps",
 			lane_rate_kHz / 1000);
 		return -EINVAL;;
 	}
@@ -1154,26 +1166,27 @@ static int ad9694_setup_jesd204_link(struct axiadc_converter *conv,
 	else
 		val = 0x3;
 
-	ad9680_spi_write(conv->spi, 0x56e, val << 4);
+	ad9680_spi_write(to_spi_device(conv->dev), 0x56e, val << 4);
 
 	/* Required sequence after link reset */
-	ad9680_spi_write(conv->spi, 0x1228, 0x4f);
-	ad9680_spi_write(conv->spi, 0x1228, 0x0f);
-	ad9680_spi_write(conv->spi, 0x1222, 0x04);
-	ad9680_spi_write(conv->spi, 0x1222, 0x00);
-	ad9680_spi_write(conv->spi, 0x1262, 0x08);
-	ad9680_spi_write(conv->spi, 0x1262, 0x00);
+	ad9680_spi_write(to_spi_device(conv->dev), 0x1228, 0x4f);
+	ad9680_spi_write(to_spi_device(conv->dev), 0x1228, 0x0f);
+	ad9680_spi_write(to_spi_device(conv->dev), 0x1222, 0x04);
+	ad9680_spi_write(to_spi_device(conv->dev), 0x1222, 0x00);
+	ad9680_spi_write(to_spi_device(conv->dev), 0x1262, 0x08);
+	ad9680_spi_write(to_spi_device(conv->dev), 0x1262, 0x00);
 
 	ret = clk_set_rate(conv->sysref_clk, sysref_rate);
 	if (ret < 0) {
-		dev_err(&conv->spi->dev, "Failed to set SYSREF clock to %lu kHz: %d\n",
+		dev_err(conv->dev,
+			"Failed to set SYSREF clock to %lu kHz: %d\n",
 			sysref_rate / 1000, ret);
 		return ret;
 	}
 
 	ret = clk_set_rate(conv->lane_clk, lane_rate_kHz);
 	if (ret < 0) {
-		dev_err(&conv->spi->dev, "Failed to set lane rate to %lu kHz: %d\n",
+		dev_err(conv->dev, "Failed to set lane rate to %lu kHz: %d\n",
 			lane_rate_kHz, ret);
 		return ret;
 	}
@@ -1240,9 +1253,9 @@ static int ad9694_setup(struct spi_device *spi)
 	if (ret < 0)
 		goto err;
 	mdelay(20);
-	pll_stat = ad9680_spi_read(conv->spi, 0x56f);
+	pll_stat = ad9680_spi_read(to_spi_device(conv->dev), 0x56f);
 
-	dev_info(&conv->spi->dev, "%s PLL %s\n",
+	dev_info(conv->dev, "%s PLL %s\n",
 		 (conv->id == CHIPID_AD9094) ? "AD9094" : "AD9694",
 		 pll_stat & 0x80 ? "LOCKED" : "UNLOCKED");
 
@@ -1301,12 +1314,12 @@ static void ad9694_serdes_pll_watchdog(struct work_struct *work)
 	unsigned int clock_detected, serdes_locked;
 	int ret;
 
-	clock_detected = ad9680_spi_read(conv->spi, 0x11b);
-	serdes_locked = ad9680_spi_read(conv->spi, 0x56f);
+	clock_detected = ad9680_spi_read(to_spi_device(conv->dev), 0x11b);
+	serdes_locked = ad9680_spi_read(to_spi_device(conv->dev), 0x56f);
 
 	/* Restart if clock is detected, but SERDES is not locked */
 	if ((clock_detected & 0x01) && !(serdes_locked & 0x80)) {
-		dev_err(&conv->spi->dev, "Lost SERDES PLL lock, re-initializing.");
+		dev_err(conv->dev, "Lost SERDES PLL lock, re-initializing.");
 
 		if (conv->running) {
 			clk_disable_unprepare(conv->lane_clk);
@@ -1314,21 +1327,22 @@ static void ad9694_serdes_pll_watchdog(struct work_struct *work)
 		}
 
 		 /* datapath soft reset */
-		ad9680_spi_write(conv->spi, 0x001, 0x02);
+		ad9680_spi_write(to_spi_device(conv->dev), 0x001, 0x02);
 		mdelay(1);
 
 		/* Required sequence after link reset */
-		ad9680_spi_write(conv->spi, 0x1228, 0x4f);
-		ad9680_spi_write(conv->spi, 0x1228, 0x0f);
-		ad9680_spi_write(conv->spi, 0x1222, 0x04);
-		ad9680_spi_write(conv->spi, 0x1222, 0x00);
-		ad9680_spi_write(conv->spi, 0x1262, 0x08);
-		ad9680_spi_write(conv->spi, 0x1262, 0x00);
+		ad9680_spi_write(to_spi_device(conv->dev), 0x1228, 0x4f);
+		ad9680_spi_write(to_spi_device(conv->dev), 0x1228, 0x0f);
+		ad9680_spi_write(to_spi_device(conv->dev), 0x1222, 0x04);
+		ad9680_spi_write(to_spi_device(conv->dev), 0x1222, 0x00);
+		ad9680_spi_write(to_spi_device(conv->dev), 0x1262, 0x08);
+		ad9680_spi_write(to_spi_device(conv->dev), 0x1262, 0x00);
 
 		mdelay(20);
-		serdes_locked = ad9680_spi_read(conv->spi, 0x56f);
+		serdes_locked = ad9680_spi_read(to_spi_device(conv->dev),
+						0x56f);
 
-		dev_info(&conv->spi->dev, "AD9694 PLL %s\n",
+		dev_info(conv->dev, "AD9694 PLL %s\n",
 			 (serdes_locked & 0x80) ? "LOCKED" : "UNLOCKED");
 
 		ret = clk_prepare_enable(conv->lane_clk);
@@ -1387,7 +1401,7 @@ static int ad9680_write_raw(struct iio_dev *indio_dev,
 
 		r_clk = clk_round_rate(conv->clk, val);
 		if (r_clk < 0 || r_clk > conv->chip_info->max_rate) {
-			dev_warn(&conv->spi->dev,
+			dev_warn(conv->dev,
 				 "Error setting ADC sample rate %ld", r_clk);
 			return -EINVAL;
 		}
@@ -1405,7 +1419,7 @@ static int ad9680_write_raw(struct iio_dev *indio_dev,
 
 static int ad9680_request_fd_irqs(struct axiadc_converter *conv)
 {
-	struct device *dev = &conv->spi->dev;
+	struct device *dev = conv->dev;
 	struct gpio_desc *gpio;
 
 	gpio = devm_gpiod_get(dev, "fastdetect-a", GPIOD_IN);
@@ -1471,8 +1485,8 @@ static int ad9680_probe(struct spi_device *spi)
 
 	INIT_DELAYED_WORK(&conv->watchdog_work, ad9694_serdes_pll_watchdog);
 
-	spi_set_drvdata(spi, conv);
-	conv->spi = spi;
+	dev_set_drvdata(&spi->dev, conv);
+	conv->dev = &spi->dev;
 
 	conv->pwrdown_gpio = devm_gpiod_get_optional(&spi->dev, "powerdown",
 		GPIOD_OUT_LOW);

--- a/drivers/iio/adc/adaq8092.c
+++ b/drivers/iio/adc/adaq8092.c
@@ -399,7 +399,7 @@ static int adaq8092_probe(struct spi_device *spi)
 		return -EINVAL;
 	}
 
-	conv->spi = st->spi;
+	conv->dev = &st->spi->dev;
 	conv->clk = st->clkin;
 	conv->chip_info = &conv_chip_info;
 	conv->adc_output_mode = ADAQ8092_TWOS_COMPLEMENT;
@@ -409,7 +409,7 @@ static int adaq8092_probe(struct spi_device *spi)
 	conv->phy = st;
 
 	/* Without this, the axi_adc won't find the converter data */
-	spi_set_drvdata(st->spi, conv);
+	dev_set_drvdata(&st->spi->dev, conv);
 
 	ret = regmap_write(st->regmap, ADAQ8092_REG_RESET,
 			   FIELD_PREP(ADAQ8092_RESET, 1));

--- a/drivers/iio/adc/adrv9009_conv.c
+++ b/drivers/iio/adc/adrv9009_conv.c
@@ -202,10 +202,10 @@ int adrv9009_register_axi_converter(struct adrv9009_rf_phy *phy)
 	if (conv == NULL)
 		return -ENOMEM;
 
-	conv->spi = spi;
+	conv->dev = &spi->dev;
 	conv->phy = phy;
 
-	spi_set_drvdata(spi, conv); /* Take care here */
+	dev_set_drvdata(&spi->dev, conv); /* Take care here */
 
 	conv->chip_info = &axiadc_chip_info_tbl[phy->spi_device_id];
 	conv->write_raw = adrv9009_write_raw;

--- a/drivers/iio/adc/cf_axi_adc.h
+++ b/drivers/iio/adc/cf_axi_adc.h
@@ -213,7 +213,7 @@ struct axiadc_chip_info {
 };
 
 struct axiadc_converter {
-	struct spi_device 	*spi;
+	struct device *dev;
 	struct clk 		*clk;
 	struct clock_scale		adc_clkscale;
 	struct clk		*lane_clk;

--- a/drivers/iio/adc/cf_axi_adc.h
+++ b/drivers/iio/adc/cf_axi_adc.h
@@ -292,6 +292,8 @@ struct axiadc_converter {
 	int (*post_iio_register)(struct iio_dev *indio_dev);
 	int (*set_pnsel)(struct iio_dev *indio_dev, unsigned chan,
 			enum adc_pn_sel sel);
+	int (*update_scan_mode)(struct iio_dev *indio_dev,
+				const unsigned long *scan_mask);
 };
 
 

--- a/drivers/iio/adc/cf_axi_adc_core.c
+++ b/drivers/iio/adc/cf_axi_adc_core.c
@@ -44,7 +44,7 @@ struct axiadc_core_info {
 };
 
 struct axiadc_state {
-	struct device 			*dev_spi;
+	struct device *conv_dev;
 	struct iio_info			iio_info;
 	struct clk 			*clk;
 	struct gpio_desc		*gpio_decimation;
@@ -67,7 +67,7 @@ struct axiadc_state {
 
 struct axiadc_converter *to_converter(struct device *dev)
 {
-	struct axiadc_converter *conv = spi_get_drvdata(to_spi_device(dev));
+	struct axiadc_converter *conv = dev_get_drvdata(dev);
 
 	if (conv)
 		return conv;
@@ -186,7 +186,7 @@ enum adc_pn_sel axiadc_get_pnsel(struct axiadc_state *st,
 
 static unsigned int axiadc_num_phys_channels(struct axiadc_state *st)
 {
-	struct axiadc_converter *conv = to_converter(st->dev_spi);
+	struct axiadc_converter *conv = to_converter(st->conv_dev);
 	return conv->chip_info->num_channels - st->have_slave_channels;
 }
 
@@ -220,7 +220,7 @@ static ssize_t axiadc_debugfs_pncheck_write(struct file *file,
 {
 	struct iio_dev *indio_dev = file->private_data;
 	struct axiadc_state *st = iio_priv(indio_dev);
-	struct axiadc_converter *conv = to_converter(st->dev_spi);
+	struct axiadc_converter *conv = to_converter(st->conv_dev);
 	enum adc_pn_sel mode;
 	unsigned int i;
 	char buf[80], *p = buf;
@@ -269,7 +269,7 @@ static int axiadc_reg_access(struct iio_dev *indio_dev,
 			      unsigned *readval)
 {
 	struct axiadc_state *st = iio_priv(indio_dev);
-	struct axiadc_converter *conv = to_converter(st->dev_spi);
+	struct axiadc_converter *conv = to_converter(st->conv_dev);
 	int ret;
 
 	/* Check that the register is in range and aligned */
@@ -280,7 +280,7 @@ static int axiadc_reg_access(struct iio_dev *indio_dev,
 	mutex_lock(&conv->lock);
 
 	if (!(reg & DEBUGFS_DRA_PCORE_REG_MAGIC)) {
-		struct axiadc_converter *conv = to_converter(st->dev_spi);
+		struct axiadc_converter *conv = to_converter(st->conv_dev);
 		if (IS_ERR(conv))
 			ret = PTR_ERR(conv);
 		else if (!conv->reg_access)
@@ -331,7 +331,7 @@ static int axiadc_decimation_set(struct axiadc_state *st,
 
 static int axiadc_get_parent_sampling_frequency(struct axiadc_state *st, unsigned long *freq)
 {
-	struct axiadc_converter *conv = to_converter(st->dev_spi);
+	struct axiadc_converter *conv = to_converter(st->conv_dev);
 	int ret = 0;
 
 	if (conv->clk)
@@ -371,7 +371,7 @@ static ssize_t axiadc_sampling_frequency_available(struct device *dev,
 {
 	struct iio_dev *indio_dev = dev_to_iio_dev(dev);
 	struct axiadc_state *st = iio_priv(indio_dev);
-	struct axiadc_converter *conv = to_converter(st->dev_spi);
+	struct axiadc_converter *conv = to_converter(st->conv_dev);
 	unsigned long freq;
 	int i, ret;
 
@@ -406,7 +406,7 @@ static ssize_t axiadc_sync_start_store(struct device *dev,
 {
 	struct iio_dev *indio_dev = dev_to_iio_dev(dev);
 	struct axiadc_state *st = iio_priv(indio_dev);
-	struct axiadc_converter *conv = to_converter(st->dev_spi);
+	struct axiadc_converter *conv = to_converter(st->conv_dev);
 	int ret;
 
 	ret = sysfs_match_string(axiadc_sync_ctrls, buf);
@@ -499,7 +499,7 @@ static int axiadc_read_raw(struct iio_dev *indio_dev,
 			   long m)
 {
 	struct axiadc_state *st = iio_priv(indio_dev);
-	struct axiadc_converter *conv = to_converter(st->dev_spi);
+	struct axiadc_converter *conv = to_converter(st->conv_dev);
 	int ret, sign;
 	unsigned tmp, phase = 0, channel;
 	unsigned long long llval;
@@ -604,7 +604,7 @@ static int axiadc_write_raw(struct iio_dev *indio_dev,
 			       long mask)
 {
 	struct axiadc_state *st = iio_priv(indio_dev);
-	struct axiadc_converter *conv = to_converter(st->dev_spi);
+	struct axiadc_converter *conv = to_converter(st->conv_dev);
 	unsigned fract, tmp, phase = 0, channel;
 	unsigned long long llval;
 
@@ -699,7 +699,7 @@ static int axiadc_read_label(struct iio_dev *indio_dev,
 			     const struct iio_chan_spec *chan, char *label)
 {
 	struct axiadc_state *st = iio_priv(indio_dev);
-	struct axiadc_converter *conv = to_converter(st->dev_spi);
+	struct axiadc_converter *conv = to_converter(st->conv_dev);
 
 	if (conv && conv->read_label)
 		return conv->read_label(indio_dev, chan, label);
@@ -715,7 +715,7 @@ static int axiadc_read_event_value(struct iio_dev *indio_dev,
 	int *val2)
 {
 	struct axiadc_state *st = iio_priv(indio_dev);
-	struct axiadc_converter *conv = to_converter(st->dev_spi);
+	struct axiadc_converter *conv = to_converter(st->conv_dev);
 
 	if (conv->read_event_value)
 		return conv->read_event_value(indio_dev, chan,
@@ -730,7 +730,7 @@ static int axiadc_write_event_value(struct iio_dev *indio_dev,
 	int val2)
 {
 	struct axiadc_state *st = iio_priv(indio_dev);
-	struct axiadc_converter *conv = to_converter(st->dev_spi);
+	struct axiadc_converter *conv = to_converter(st->conv_dev);
 
 	if (conv->write_event_value)
 		return conv->write_event_value(indio_dev, chan,
@@ -745,7 +745,7 @@ static int axiadc_read_event_config(struct iio_dev *indio_dev,
 				    enum iio_event_direction dir)
 {
 	struct axiadc_state *st = iio_priv(indio_dev);
-	struct axiadc_converter *conv = to_converter(st->dev_spi);
+	struct axiadc_converter *conv = to_converter(st->conv_dev);
 
 	if (conv->read_event_config)
 		return conv->read_event_config(indio_dev, chan, type, dir);
@@ -760,7 +760,7 @@ static int axiadc_write_event_config(struct iio_dev *indio_dev,
 				     int state)
 {
 	struct axiadc_state *st = iio_priv(indio_dev);
-	struct axiadc_converter *conv = to_converter(st->dev_spi);
+	struct axiadc_converter *conv = to_converter(st->conv_dev);
 
 	if (conv->write_event_config)
 		return conv->write_event_config(indio_dev,
@@ -853,21 +853,21 @@ static const struct iio_info axiadc_info = {
 	.read_label = &axiadc_read_label,
 };
 
-struct axiadc_spidev {
-	struct device_node *of_nspi;
-	struct device *dev_spi;
+struct axiadc_dev {
+	struct device_node *of_ndev;
+	struct device *dev;
 	struct module *owner;
 };
 
 static int axiadc_attach_spi_client(struct device *dev, void *data)
 {
-	struct axiadc_spidev *axiadc_spidev = data;
+	struct axiadc_dev *axiadc_dev = data;
 	int ret = 0;
 
 	device_lock(dev);
-	if ((axiadc_spidev->of_nspi == dev->of_node) && dev->driver) {
-		axiadc_spidev->dev_spi = dev;
-		axiadc_spidev->owner = dev->driver->owner;
+	if (axiadc_dev->of_ndev == dev->of_node && dev->driver) {
+		axiadc_dev->dev = dev;
+		axiadc_dev->owner = dev->driver->owner;
 		ret = 1;
 	}
 	device_unlock(dev);
@@ -1057,10 +1057,10 @@ int axiadc_append_attrs(struct iio_dev *indio_dev,
 
 static void axiadc_release_converter(void *conv)
 {
-	struct axiadc_spidev *axiadc_spidev = conv;
+	struct axiadc_dev *axiadc_dev = conv;
 
-	put_device(axiadc_spidev->dev_spi);
-	module_put(axiadc_spidev->owner);
+	put_device(axiadc_dev->dev);
+	module_put(axiadc_dev->owner);
 }
 
 /**
@@ -1080,7 +1080,7 @@ static int axiadc_probe(struct platform_device *pdev)
 	struct iio_dev *indio_dev;
 	struct axiadc_state *st;
 	struct resource *mem;
-	struct axiadc_spidev *axiadc_spidev;
+	struct axiadc_dev *axiadc_dev;
 	struct axiadc_converter *conv;
 	unsigned int config, skip = 1;
 	int ret;
@@ -1094,32 +1094,33 @@ static int axiadc_probe(struct platform_device *pdev)
 
 	info = id->data;
 
-	axiadc_spidev = devm_kzalloc(&pdev->dev, sizeof(*axiadc_spidev), GFP_KERNEL);
-	if (!axiadc_spidev)
+	axiadc_dev = devm_kzalloc(&pdev->dev, sizeof(*axiadc_dev), GFP_KERNEL);
+	if (!axiadc_dev)
 		return -ENOMEM;
 
 	/* Defer driver probe until matching spi
 	 * converter driver is registered
 	 */
-	axiadc_spidev->of_nspi = of_parse_phandle(pdev->dev.of_node,
-						  "spibus-connected", 0);
-	if (!axiadc_spidev->of_nspi) {
+	axiadc_dev->of_ndev = of_parse_phandle(pdev->dev.of_node,
+					       "spibus-connected", 0);
+	if (!axiadc_dev->of_ndev) {
 		dev_err(&pdev->dev, "could not find spi node\n");
 		return -ENODEV;
 	}
 
-	ret = bus_for_each_dev(&spi_bus_type, NULL, axiadc_spidev,
+	ret = bus_for_each_dev(&spi_bus_type, NULL, axiadc_dev,
 			       axiadc_attach_spi_client);
-	of_node_put(axiadc_spidev->of_nspi);
+	of_node_put(axiadc_dev->of_ndev);
 	if (ret == 0)
 		return -EPROBE_DEFER;
 
-	if (!try_module_get(axiadc_spidev->owner))
+	if (!try_module_get(axiadc_dev->dev->driver->owner))
 		return -ENODEV;
 
-	get_device(axiadc_spidev->dev_spi);
+	get_device(axiadc_dev->dev);
 
-	ret = devm_add_action_or_reset(&pdev->dev, axiadc_release_converter, axiadc_spidev);
+	ret = devm_add_action_or_reset(&pdev->dev, axiadc_release_converter,
+				       axiadc_dev->dev);
 	if (ret)
 		return ret;
 
@@ -1139,7 +1140,7 @@ static int axiadc_probe(struct platform_device *pdev)
 	if (IS_ERR(st->regs))
 		return PTR_ERR(st->regs);
 
-	st->dev_spi = axiadc_spidev->dev_spi;
+	st->conv_dev = axiadc_dev->dev;
 
 	platform_set_drvdata(pdev, indio_dev);
 
@@ -1147,7 +1148,7 @@ static int axiadc_probe(struct platform_device *pdev)
 	st->ext_sync_avail = !!(config & ADI_EXT_SYNC);
 	st->dp_disable = false; /* FIXME: resolve later which reg & bit to read for this */
 
-	conv = to_converter(st->dev_spi);
+	conv = to_converter(st->conv_dev);
 	if (IS_ERR(conv)) {
 		dev_err(&pdev->dev, "Failed to get converter device: %d\n",
 				(int)PTR_ERR(conv));

--- a/drivers/iio/adc/cf_axi_adc_core.c
+++ b/drivers/iio/adc/cf_axi_adc_core.c
@@ -773,7 +773,11 @@ static int axiadc_update_scan_mode(struct iio_dev *indio_dev,
 	const unsigned long *scan_mask)
 {
 	struct axiadc_state *st = iio_priv(indio_dev);
+	struct axiadc_converter *conv = to_converter(st->conv_dev);
 	unsigned i, ctrl;
+
+	if (conv->update_scan_mode)
+		return conv->update_scan_mode(indio_dev, scan_mask);
 
 	for (i = 0; i < indio_dev->masklength; i++) {
 		if (i > (st->have_slave_channels - 1))

--- a/drivers/iio/adc/cf_axi_adc_core.c
+++ b/drivers/iio/adc/cf_axi_adc_core.c
@@ -1010,6 +1010,7 @@ static const struct of_device_id axiadc_of_match[] = {
 	{ .compatible =	"xlnx,axi-ad9234-1.00.a", .data = &axi_adc_10_0_a_info },
 	{ .compatible =	"xlnx,axi-ad9250-1.00.a", .data = &axi_adc_10_0_a_info },
 	{ .compatible =	"xlnx,axi-ad9434-1.00.a", .data = &axi_adc_10_0_a_info },
+	{ .compatible = "adi,axi-ad7606-1.0", .data = &axi_adc_10_0_a_info },
 	{ .compatible = "adi,axi-ad9643-6.00.a", .data = &axi_adc_10_0_a_info },
 	{ .compatible = "adi,axi-ad9361-6.00.a", .data = &axi_adc_10_0_a_info },
 	{ .compatible = "adi,axi-ad9680-1.0", .data = &axi_adc_10_0_a_info },

--- a/drivers/iio/adc/ltc2358.c
+++ b/drivers/iio/adc/ltc2358.c
@@ -385,14 +385,14 @@ static int ltc235x_probe(struct spi_device *spi)
 	if (ret)
 		return ret;
 
-	conv->spi = st->spi;
+	conv->dev = &st->spi->dev;
 	conv->clk = st->clkin;
 	conv->read_raw = &ltc235x_read_raw;
 	conv->write_raw = &ltc235x_write_raw;
 	conv->reg_access = &ltc235x_reg_access;
 	conv->post_setup = &ltc235x_post_setup;
 	conv->phy = st;
-	spi_set_drvdata(st->spi, conv);
+	dev_set_drvdata(&st->spi->dev, conv);
 
 	return ret;
 }

--- a/drivers/iio/adc/navassa/adrv9002_conv.c
+++ b/drivers/iio/adc/navassa/adrv9002_conv.c
@@ -547,10 +547,10 @@ int adrv9002_register_axi_converter(struct adrv9002_rf_phy *phy)
 	conv->read_raw = adrv9002_read_raw;
 	conv->post_setup = adrv9002_post_setup;
 	conv->reg_access = adrv9002_reg_access;
-	conv->spi = spi;
+	conv->dev = &spi->dev;
 	conv->phy = phy;
 
-	spi_set_drvdata(spi, conv); /* Take care here */
+	dev_set_drvdata(&spi->dev, conv); /* Take care here */
 
 	return 0;
 }


### PR DESCRIPTION
Supported AD7606x family devices in this driver:

Digital interface mode - Parallel:

- ad7606b - [datasheet](https://www.analog.com/media/en/technical-documentation/data-sheets/ad7606b.pdf);
- ad7606c-16 - [datasheet](https://www.analog.com/media/en/technical-documentation/data-sheets/ad7606c-16.pdf);
- ad7606c-18 - [datasheet](https://www.analog.com/media/en/technical-documentation/data-sheets/ad7606c-18.pdf);

Eval boards - digital interface mode - parallel:

- EVAL-AD7606B-FMCZ - [guide](https://www.analog.com/media/en/technical-documentation/user-guides/EVAL-AD7606BFMCZ-UG-1225.pdf), [page](https://www.analog.com/en/design-center/evaluation-hardware-and-software/evaluation-boards-kits/EVAL-AD7606B-FMCZ.html);
- EVAL-AD7606CFMCZ - 16b and 18b variants [guide](https://www.analog.com/media/en/technical-documentation/user-guides/eval-ad7606c-fmcz-ug-1870.pdf), [page](https://www.analog.com/en/design-center/evaluation-hardware-and-software/evaluation-boards-kits/eval-ad7606c-18.html);

HDL project and control module for parallel interface - [link-project](https://github.com/analogdevicesinc/hdl/tree/master/projects/ad7606x_fmc), [link-control_module](https://github.com/analogdevicesinc/hdl/tree/master/library/axi_ad7606x);