### PR TITLE
arch: dts: add missing ADI overlays

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -8,6 +8,9 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	adafruit18.dtbo \
 	adau1977-adc.dtbo \
 	adau7002-simple.dtbo \
+	adau7118-simple.dtbo \
+	adis16475.dtbo \
+	adis16480.dtbo \
 	ads1015.dtbo \
 	ads1115.dtbo \
 	ads7846.dtbo \
@@ -193,12 +196,70 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	ramoops.dtbo \
 	ramoops-pi4.dtbo \
 	rotary-encoder.dtbo \
+	rpi-ada4250.dtbo \
+	rpi-adin1110.dtbo \
+	rpi-adin2111.dtbo \
+	rpi-adau1761.dtbo \
+	rpi-adau1472.dtbo \
+	rpi-addi9036.dtbo \
+	rpi-adf4159.dtbo \
+	rpi-adf4371.dtbo \
+	rpi-admv1013.dtbo \
+	rpi-admv1014.dtbo \
+	rpi-admv8818.dtbo \
+	rpi-adrf6780.dtbo \
+	rpi-ad4130.dtbo \
+	rpi-ad5592r.dtbo \
+	rpi-ad5593r.dtbo \
+	rpi-ad5677r.dtbo \
+	rpi-ad5686.dtbo \
+	rpi-ad5679r.dtbo \
+	rpi-ad5766.dtbo \
+	rpi-ad7124.dtbo \
+	rpi-ad7124-8-all-diff-cs0-int25.dtbo \
+	rpi-ad7173.dtbo \
+	rpi-ad7190.dtbo \
+	rpi-ad7293.dtbo \
+	rpi-ad738x.dtbo \
+	rpi-ad7746.dtbo \
+	rpi-ad7768-1.dtbo \
+	rpi-ad74115.dtbo \
+	rpi-ad74413r.dtbo \
+	rpi-ad9545-hmc7044.dtbo \
+	rpi-ad9834.dtbo \
+	rpi-adar1000.dtbo \
+	rpi-adgs1408.dtbo \
+	rpi-adxl313-spi.dtbo \
+	rpi-adxl313-i2c.dtbo \
+	rpi-adxl345.dtbo \
+	rpi-adxl355.dtbo \
+	rpi-adxl367.dtbo \
+	rpi-adxl372.dtbo \
+	rpi-adxl375.dtbo \
+	rpi-adxrs290.dtbo \
+	rpi-ad5770r.dtbo \
+	rpi-ad5791.dtbo \
+	rpi-adt7420.dtbo \
 	rpi-backlight.dtbo \
 	rpi-codeczero.dtbo \
+	rpi-cn0504.dtbo \
+	rpi-cn0508.dtbo \
+	rpi-cn0511.dtbo \
+	rpi-cn0552.dtbo \
+	rpi-cn0554.dtbo \
+	rpi-cn0566.dtbo \
+	rpi-cn0575.dtbo \
 	rpi-dacplus.dtbo \
 	rpi-dacpro.dtbo \
+	rpi-dc1962c.dtbo \
 	rpi-digiampplus.dtbo \
 	rpi-ft5406.dtbo \
+	rpi-lm75.dtbo \
+	rpi-ltc2497.dtbo \
+	rpi-ltc2688.dtbo \
+	rpi-ltc6952.dtbo \
+	rpi-max14830-i2c.dtbo \
+	rpi-max14830-spi.dtbo \
 	rpi-poe.dtbo \
 	rpi-poe-plus.dtbo \
 	rpi-sense.dtbo \

--- a/arch/arm/boot/dts/overlays/adau7118-simple-overlay.dts
+++ b/arch/arm/boot/dts/overlays/adau7118-simple-overlay.dts
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-2.0
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target = <&i2s>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@1 {
+		target = <&i2c1>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			adau7118_codec: adau7118-codec@14 {
+				reg = <0x14>;
+				#sound-dai-cells = <0>;
+				compatible = "adi,adau7118";
+				status = "okay";
+			};
+		};
+	};
+
+	fragment@2 {
+		target = <&sound>;
+		sound_overlay: __overlay__ {
+			compatible = "simple-audio-card";
+			simple-audio-card,format = "i2s";
+			simple-audio-card,name = "adau7118";
+			simple-audio-card,bitclock-slave = <&dailink0_slave>;
+			simple-audio-card,frame-slave = <&dailink0_slave>;
+			simple-audio-card,widgets =
+				"Microphone", "Microphone Jack";
+			simple-audio-card,routing =
+				"PDM_DAT0", "Microphone Jack";
+			status = "okay";
+			simple-audio-card,cpu {
+				/* so that bclk is 64x FS */
+				dai-tdm-slot-num = <2>;
+				dai-tdm-slot-width = <32>;
+				sound-dai = <&i2s>;
+			};
+			dailink0_slave: simple-audio-card,codec {
+				sound-dai = <&adau7118_codec>;
+			};
+		};
+	};
+
+	__overrides__ {
+		card-name = <&sound_overlay>,"simple-audio-card,name";
+	};
+};

--- a/arch/arm/boot/dts/overlays/adis16475-overlay.dts
+++ b/arch/arm/boot/dts/overlays/adis16475-overlay.dts
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/interrupt-controller/irq.h>
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target = <&spi0>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@1 {
+		target = <&spidev0>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@2 {
+		target = <&spidev1>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	 fragment@3 {
+		target = <&gpio>;
+		__overlay__ {
+			adis16475_pins: adis16475_pins {
+				brcm,pins = <4 12>; // interrupt and reset
+				brcm,function = <0 1>; // in out
+			};
+		};
+	};
+	fragment@4 {
+		target = <&spi0>;
+		__overlay__ {
+			/* needed to avoid dtc warning */
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			adis16475: adis16475@0 {
+				reg = <0>;
+				pinctrl-names = "default";
+				pinctrl-0 = <&adis16475_pins>;
+				spi-cpha;
+				spi-cpol;
+				reset-gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+				spi-max-frequency = <2000000>;
+				interrupts = <4 IRQ_TYPE_EDGE_RISING>;
+				interrupt-parent = <&gpio>;
+			};
+		};
+	};
+
+	__overrides__ {
+		/*
+		 * This gives an option to use the gpio25 as the data ready pin. This
+		 * must be used for the adis16465/7 families as these devices use the
+		 * 14 pin connector where DR is using gpio25. Note that this should
+		 * not be used for the other devices as the gpio25 is both connected to
+		 * the sync selector and to the sync pin (because the sync and DR pins
+		 * are swapped in the 16 pin connector).
+		 */
+		drdy_gpio25 = <&adis16475_pins>,"brcm,pins:0=25",
+				<&adis16475>,"interrupts:0=25";
+		device = <&adis16475>,"compatible";
+	};
+};

--- a/arch/arm/boot/dts/overlays/adis16480-overlay.dts
+++ b/arch/arm/boot/dts/overlays/adis16480-overlay.dts
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/interrupt-controller/irq.h>
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target = <&spi0>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@1 {
+		target = <&spidev0>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@2 {
+		target = <&spidev1>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	 fragment@3 {
+		target = <&gpio>;
+		__overlay__ {
+			adis16480_pins: adis16480_pins {
+				brcm,pins = <6 12>; // interrupt and reset
+				brcm,function = <0 1>; // in out
+			};
+		};
+	};
+	fragment@4 {
+		target = <&spi0>;
+		__overlay__ {
+			/* needed to avoid dtc warning */
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			adis16480: adis16480@0 {
+				reg = <0>;
+				pinctrl-names = "default";
+				pinctrl-0 = <&adis16480_pins>;
+				spi-cpha;
+				spi-cpol;
+				reset-gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+				spi-max-frequency = <15000000>;
+				/* use DIO1 as data ready by default */
+				interrupts = <6 IRQ_TYPE_EDGE_RISING>;
+				interrupt-parent = <&gpio>;
+			};
+		};
+	};
+
+	__overrides__ {
+		device = <&adis16480>,"compatible";
+		drdy_dio2 = <&adis16480_pins>,"brcm,pins:0=25",
+				<&adis16480>,"interrupts:0=25",
+				<&adis16480>,"interrupt-names=DIO2";
+		drdy_dio3 = <&adis16480_pins>,"brcm,pins:0=4",
+				<&adis16480>,"interrupts:0=4",
+				<&adis16480>,"interrupt-names=DIO3";
+		drdy_dio4 = <&adis16480_pins>,"brcm,pins:0=5",
+				<&adis16480>,"interrupts:0=5",
+				<&adis16480>,"interrupt-names=DIO4";
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-ad4130-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ad4130-overlay.dts
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-2.0
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+
+/ {
+	compatible = "brcm,bcm2835", "brcm,bcm2711";
+};
+
+&spi0 {
+	cs-gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+	status = "okay";
+
+	ad4130@0 {
+		compatible = "adi,ad4130";
+		reg = <0>;
+
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		spi-max-frequency = <5000000>;
+		interrupts = <27 IRQ_TYPE_EDGE_FALLING>;
+		interrupt-parent = <&gpio>;
+
+		channel@0 {
+			reg = <0>;
+
+			adi,reference-select = <2>;
+
+			/* AIN8, AIN9 */
+			diff-channels = <8 9>;
+		};
+
+		channel@1 {
+			reg = <1>;
+
+			adi,reference-select = <2>;
+
+			/* AIN10, AIN11 */
+			diff-channels = <10 11>;
+		};
+
+		channel@2 {
+			reg = <2>;
+
+			adi,reference-select = <2>;
+
+			/* Temperature Sensor, DGND */
+			diff-channels = <16 19>;
+		};
+
+		channel@3 {
+			reg = <3>;
+
+			adi,reference-select = <2>;
+
+			/* Internal reference, DGND */
+			diff-channels = <18 19>;
+		};
+
+		channel@4 {
+			reg = <4>;
+
+			adi,reference-select = <2>;
+
+			/* DGND, DGND */
+			diff-channels = <19 19>;
+		};
+	};
+};
+
+&spidev0 {
+	status = "disabled";
+};
+
+&spidev1 {
+	status = "disabled";
+};

--- a/arch/arm/boot/dts/overlays/rpi-ad5592r-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ad5592r-overlay.dts
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/iio/adi,ad5592r.h>
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target = <&spidev0>;
+
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@1 {
+		target = <&spi0>;
+		__overlay__ {
+			#size-cells = <0>;
+			#address-cells = <1>;
+			status = "okay";
+
+			ad5592r: ad5592r@0 {
+				compatible = "adi,ad5592r";
+				reg = <0>;
+
+				spi-max-frequency = <1000000>;
+				spi-cpol;
+
+				channel@0 {
+					reg = <0>;
+					adi,mode = <CH_MODE_DAC>;
+				};
+				channel@1 {
+					reg = <1>;
+					adi,mode = <CH_MODE_ADC>;
+				};
+				channel@2 {
+					reg = <2>;
+					adi,mode = <CH_MODE_DAC_AND_ADC>;
+				};
+				channel@3 {
+					reg = <3>;
+					adi,mode = <CH_MODE_DAC_AND_ADC>;
+					adi,off-state = <CH_OFFSTATE_PULLDOWN>;
+				};
+				channel@4 {
+					reg = <4>;
+					adi,mode = <CH_MODE_UNUSED>;
+					adi,off-state = <CH_OFFSTATE_PULLDOWN>;
+				};
+				channel@5 {
+					reg = <5>;
+					adi,mode = <CH_MODE_GPIO>;
+					adi,off-state = <CH_OFFSTATE_PULLDOWN>;
+				};
+				channel@6 {
+					reg = <6>;
+					adi,mode = <CH_MODE_GPIO>;
+					adi,off-state = <CH_OFFSTATE_PULLDOWN>;
+				};
+				channel@7 {
+					reg = <7>;
+					adi,mode = <CH_MODE_GPIO>;
+					adi,off-state = <CH_OFFSTATE_PULLDOWN>;
+				};
+			};
+		};
+	};
+	__overrides__ {
+		cs_pin = <&ad5592r>,"reg:0";
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-ad5593r-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ad5593r-overlay.dts
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/iio/adi,ad5592r.h>
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@1 {
+		target = <&i2c1>;
+		__overlay__ {
+			#size-cells = <0>;
+			#address-cells = <1>;
+			status = "okay";
+
+			clock-frequency = <400000>;
+
+			ad5593r: ad5593r@10 {
+				compatible = "adi,ad5593r";
+				reg = <0x10>;
+
+				channel@0 {
+					reg = <0>;
+					adi,mode = <CH_MODE_DAC>;
+					adi,off-state = <CH_OFFSTATE_PULLDOWN>;
+				};
+				channel@1 {
+					reg = <1>;
+					adi,mode = <CH_MODE_ADC>;
+					adi,off-state = <CH_OFFSTATE_PULLDOWN>;
+				};
+				channel@2 {
+					reg = <2>;
+					adi,mode = <CH_MODE_DAC_AND_ADC>;
+					adi,off-state = <CH_OFFSTATE_PULLDOWN>;
+				};
+				channel@6 {
+					reg = <6>;
+					adi,mode = <CH_MODE_GPIO>;
+					adi,off-state = <CH_OFFSTATE_PULLDOWN>;
+				};
+			};
+		};
+	};
+	__overrides__ {
+		addr = <&ad5593r>,"reg:0";
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-ad5677r-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ad5677r-overlay.dts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2708";
+
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			adc_vref: fixedregulator@0 {
+				compatible = "regulator-fixed";
+				regulator-name = "fixed-supply";
+				regulator-min-microvolt = <2500000>;
+				regulator-max-microvolt = <2500000>;
+				regulator-boot-on;
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&i2c1>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			ad5677r@0f{
+				compatible = "adi,ad5677r";
+				reg = <0x0f>;
+				vcc-supply = <&adc_vref>;
+			};
+		};
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-ad5679r-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ad5679r-overlay.dts
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/interrupt-controller/irq.h>
+
+/ {
+	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709", "brcm,bcm2711";
+
+	fragment@0 {
+		target = <&gpio>;
+		__overlay__ {
+			pwm_pins: pwm_pins {
+				brcm,pins = <18>;
+				brcm,function = <2>; /* Alt5 */
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&pwm>;
+		frag1: __overlay__ {
+			pinctrl-names = "default";
+			pinctrl-0 = <&pwm_pins>;
+			assigned-clock-rates = <100000000>;
+			status = "okay";
+		};
+	};
+
+	__overrides__ {
+		pin   = <&pwm_pins>,"brcm,pins:0";
+		func  = <&pwm_pins>,"brcm,function:0";
+		clock = <&frag1>,"assigned-clock-rates:0";
+	};
+
+	fragment@2 {
+		target-path = "/";
+		__overlay__ {
+			adc_vref: fixedregulator@0 {
+				compatible = "regulator-fixed";
+				regulator-name = "fixed-supply";
+				regulator-min-microvolt = <2500000>;
+				regulator-max-microvolt = <2500000>;
+				regulator-boot-on;
+			};
+		};
+	};
+
+	fragment@3 {
+		target = <&spi0>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			ad5679r@0{
+				compatible = "adi,ad5679r";
+				reg = <0>;
+				spi-max-frequency = <50000000>;
+				spi-cpha;
+				vcc-supply = <&adc_vref>;
+
+				interrupts = <25 IRQ_TYPE_EDGE_RISING>;
+				interrupt-parent = <&gpio>;
+
+				pwms = <&pwm 0 100>;
+				pwm-names = "pwm-trigger";
+			};
+		};
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-ad5686-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ad5686-overlay.dts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2708";
+
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			adc_vref: fixedregulator@0 {
+				compatible = "regulator-fixed";
+				regulator-name = "fixed-supply";
+				regulator-min-microvolt = <2500000>;
+				regulator-max-microvolt = <2500000>;
+				regulator-boot-on;
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&spi0>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			ad5686r@0{
+				compatible = "adi,ad5686r";
+				reg = <0>;
+				spi-max-frequency = <1000000>;
+				spi-cpha;
+				vcc-supply = <&adc_vref>;
+			};
+		};
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-ad5766-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ad5766-overlay.dts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2708", "brcm,bcm2837";
+
+	fragment@0 {
+		target = <&spi0>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			ad5766@0{
+				compatible = "adi,ad5766";
+				reg = <0>;
+				spi-cpol;
+				spi-max-frequency = <1000000>;
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&spidev0>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@2 {
+		target = <&spidev1>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-ad5770r-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ad5770r-overlay.dts
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2708";
+
+	fragment@0 {
+		target = <&spi0>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			ad5770r@0 {
+				compatible = "ad5770r";
+				reg = <0>;
+				spi-max-frequency = <1000000>;
+				vref-supply = <&vref>;
+
+				reset-gpios = <&gpio 22 0>;
+
+				channel@0 {
+					num = <0>;
+					adi,range-microamp = <(-60000) 300000>;
+				};
+
+				channel@1 {
+					num = <1>;
+					adi,range-microamp = <0 140000>;
+				};
+
+				channel@2 {
+					num = <2>;
+					adi,range-microamp = <0 55000>;
+				};
+
+				channel@3 {
+					num = <3>;
+					adi,range-microamp = <0 45000>;
+				};
+
+				channel@4 {
+					num = <4>;
+					adi,range-microamp = <0 45000>;
+				};
+
+				channel@5 {
+					num = <5>;
+					adi,range-microamp = <0 45000>;
+				};
+			};
+		};
+	};
+
+	fragment@1 {
+		target-path = "/";
+		__overlay__ {
+		vref: fixedregulator@0 {
+				compatible = "regulator-fixed";
+				regulator-name = "fixed-supply";
+				regulator-min-microvolt = <1250000>;
+				regulator-max-microvolt = <1250000>;
+			};
+		};
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-ad5791-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ad5791-overlay.dts
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709", "brcm,bcm2711";
+
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			vdd: fixedregulator@0 {
+				compatible = "regulator-fixed";
+				regulator-name = "fixed-supply";
+				regulator-min-microvolt = <2500000>;
+				regulator-max-microvolt = <2500000>;
+				regulator-boot-on;
+			};
+		};
+	};
+
+	fragment@1 {
+		target-path = "/";
+		__overlay__ {
+			vss: fixedregulator@1 {
+				compatible = "regulator-fixed";
+				regulator-name = "fixed-supply";
+				regulator-min-microvolt = <2500000>;
+				regulator-max-microvolt = <2500000>;
+				regulator-boot-on;
+			};
+		};
+	};
+
+	fragment@2 {
+		target = <&spi0>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			ad5791@1 {
+				compatible = "adi,ad5791";
+				reg = <1>;
+				spi-max-frequency = <5000000>;
+				spi-cpha;
+				vdd-supply = <&vdd>;
+				vss-supply = <&vss>;
+			};
+		};
+	};
+
+	fragment@3 {
+		target = <&spidev0>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@4 {
+		target = <&spidev1>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-ad7124-8-all-diff-cs0-int25-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ad7124-8-all-diff-cs0-int25-overlay.dts
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709";
+
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			vref: fixedregulator@0 {
+				compatible = "regulator-fixed";
+				regulator-name = "fixed-supply";
+				regulator-min-microvolt = <2500000>;
+				regulator-max-microvolt = <2500000>;
+				regulator-boot-on;
+			};
+		};
+	};
+
+	fragment@1 {
+		target-path = "/";
+		__overlay__ {
+			clocks {
+				ad7124_mclk: clock@0 {
+					#clock-cells = <0>;
+					compatible = "fixed-clock";
+					clock-frequency = <614400>;
+				};
+			};
+		};
+	};
+
+	fragment@2 {
+		target = <&spi0>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			ad7124@0 {
+				compatible = "adi,ad7124-8";
+				reg = <0>;
+				spi-max-frequency = <5000000>;
+				interrupts = <25 2>;
+				interrupt-parent = <&gpio>;
+				refin1-supply = <&vref>;
+				clocks = <&ad7124_mclk>;
+				clock-names = "mclk";
+
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				channel@0 {
+					reg = <0>;
+					diff-channels = <0 1>;
+				};
+
+				channel@1 {
+					reg = <1>;
+					diff-channels = <2 3>;
+				};
+
+				channel@2 {
+					reg = <2>;
+					diff-channels = <4 5>;
+				};
+
+				channel@3 {
+					reg = <3>;
+					diff-channels = <6 7>;
+				};
+
+				channel@4 {
+					reg = <4>;
+					diff-channels = <8 9>;
+				};
+
+				channel@5 {
+					reg = <5>;
+					diff-channels = <10 11>;
+				};
+
+				channel@6 {
+					reg = <6>;
+					diff-channels = <12 13>;
+				};
+
+				channel@7 {
+					reg = <7>;
+					diff-channels = <14 15>;
+				};
+			};
+		};
+	};
+
+	fragment@3 {
+		target = <&spidev0>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@4 {
+		target = <&spidev1>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-ad7124-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ad7124-overlay.dts
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709";
+
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			vref: fixedregulator@0 {
+				compatible = "regulator-fixed";
+				regulator-name = "fixed-supply";
+				regulator-min-microvolt = <2500000>;
+				regulator-max-microvolt = <2500000>;
+				regulator-boot-on;
+			};
+		};
+	};
+
+	fragment@1 {
+		target-path = "/";
+		__overlay__ {
+			clocks {
+				ad7124_mclk: clock@0 {
+					#clock-cells = <0>;
+					compatible = "fixed-clock";
+					clock-frequency = <614400>;
+				};
+			};
+		};
+	};
+
+	fragment@2 {
+		target = <&spi0>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			ad7124@0 {
+				compatible = "adi,ad7124-4";
+				reg = <0>;
+				spi-max-frequency = <5000000>;
+				interrupts = <25 2>;
+				interrupt-parent = <&gpio>;
+				refin1-supply = <&vref>;
+				clocks = <&ad7124_mclk>;
+				clock-names = "mclk";
+
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				channel@0 {
+					reg = <0>;
+					diff-channels = <0 19>;
+					adi,reference-select = <0>;
+				};
+
+				channel@1 {
+					reg = <1>;
+					diff-channels = <1 19>;
+					adi,reference-select = <0>;
+				};
+
+				channel@2 {
+					reg = <2>;
+					diff-channels = <2 19>;
+					adi,reference-select = <0>;
+				};
+
+				channel@3 {
+					reg = <3>;
+					diff-channels = <3 19>;
+					adi,reference-select = <0>;
+				};
+
+				channel@4 {
+					reg = <4>;
+					diff-channels = <4 19>;
+					adi,reference-select = <0>;
+				};
+
+				channel@5 {
+					reg = <5>;
+					diff-channels = <5 19>;
+					adi,reference-select = <0>;
+				};
+
+				channel@6 {
+					reg = <6>;
+					diff-channels = <6 19>;
+					adi,reference-select = <0>;
+				};
+
+				channel@7 {
+					reg = <7>;
+					diff-channels = <7 19>;
+					adi,reference-select = <0>;
+				};
+			};
+		};
+	};
+
+	fragment@3 {
+		target = <&spidev0>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@4 {
+		target = <&spidev1>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-ad7173-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ad7173-overlay.dts
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709", "brcm,bcm2711";
+
+	fragment@0 {
+		target = <&spi0>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			ad7173@0 {
+				compatible = "adi,ad7173-8";
+				reg = <0>;
+				interrupts = <25 2>;
+				interrupt-parent = <&gpio>;
+				spi-max-frequency = <100000>;
+				spi-cpol;
+				spi-cpha;
+
+				adi,channels {
+					#address-cells = <2>;
+					#size-cells = <0>;
+
+					channel@0,1 {
+						reg = <0 1>;
+						adi,bipolar;
+					};
+
+					channel@2,3 {
+						reg = <2 3>;
+						adi,bipolar;
+					};
+					channel@4,5 {
+						reg = <4 5>;
+						adi,bipolar;
+					};
+					channel@6,7 {
+						reg = <6 7>;
+						adi,bipolar;
+					};
+					channel@8,9 {
+						reg = <8 9>;
+						adi,bipolar;
+					};
+					channel@10,11 {
+						reg = <10 11>;
+						adi,bipolar;
+					};
+					channel@12,13 {
+						reg = <12 13>;
+						adi,bipolar;
+					};
+					channel@14,15 {
+						reg = <14 15>;
+						adi,bipolar;
+					};
+				};
+			};
+		};
+	};
+
+	fragment@3 {
+		target = <&spidev0>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@4 {
+		target = <&spidev1>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-ad7190-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ad7190-overlay.dts
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709";
+
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			dvdd: fixedregulator@0 {
+				compatible = "regulator-fixed";
+				regulator-name = "fixed-supply";
+				regulator-min-microvolt = <3300000>;
+				regulator-max-microvolt = <3300000>;
+				regulator-boot-on;
+			};
+		};
+	};
+
+	fragment@1 {
+		target-path = "/";
+		__overlay__ {
+			avdd: fixedregulator@1 {
+				compatible = "regulator-fixed";
+				regulator-name = "fixed-supply2";
+				regulator-min-microvolt = <3300000>;
+				regulator-max-microvolt = <3300000>;
+				regulator-boot-on;
+			};
+		};
+	};
+
+	fragment@3 {
+		target = <&spi0>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			ad7190@0 {
+				compatible = "adi,ad7190";
+				reg = <0>;
+				spi-max-frequency = <1000000>;
+				spi-cpol;
+				spi-cpha;
+				#interrupt-cells = <2>;
+				interrupts = <25 0x2>;
+				interrupt-parent = <&gpio>;
+				dvdd-supply = <&dvdd>;
+				avdd-supply = <&avdd>;
+
+				adi,reference-voltage-mv = /bits/ 16  <3300>;
+				adi,clock-source-select = [02];
+				adi,refin2-pins-enable;
+				adi,rejection-60-Hz-enable;
+				adi,chop-enable;
+				adi,buffer-enable;
+				adi,burnout-currents-enable;
+				adi,sinc3-filter-enable;
+				adi,unipolar-enable;
+			};
+		};
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-ad7293-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ad7293-overlay.dts
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target = <&spidev0>;
+
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@1 {
+		target-path = "/";
+		__overlay__ {
+			avdd: fixedregulator@0 {
+				compatible = "regulator-fixed";
+				regulator-name = "avdd";
+				regulator-min-microvolt = <5000000>;
+				regulator-max-microvolt = <5000000>;
+				regulator-boot-on;
+			};
+			vdrive: fixedregulator@1 {
+				compatible = "regulator-fixed";
+				regulator-name = "vdrive";
+				regulator-min-microvolt = <3300000>;
+				regulator-max-microvolt = <3300000>;
+				regulator-boot-on;
+			};
+		};
+	};
+
+	fragment@2 {
+		target = <&spi0>;
+
+		__overlay__{
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			ad7293@0{
+				compatible = "adi,ad7293";
+				reg = <0>;
+				spi-max-frequency = <1000000>;
+				avdd-supply = <&avdd>;
+				vdrive-supply = <&vdrive>;
+			};
+		};
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-ad738x-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ad738x-overlay.dts
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2708";
+
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			adc_vref: fixedregulator@0 {
+				compatible = "regulator-fixed";
+				regulator-name = "fixed-supply";
+				regulator-min-microvolt = <2500000>;
+				regulator-max-microvolt = <2500000>;
+				regulator-boot-on;
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&spi0>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			ad7380@0 {
+				compatible = "ad7380";
+				reg = <0>;
+				spi-max-frequency = <1000000>;
+				spi-cpol;
+				interrupts = <25 2>;
+				interrupt-parent = <&gpio>;
+				vref-supply = <&adc_vref>;
+			};
+		};
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-ad74115-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ad74115-overlay.dts
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-2.0
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+
+/ {
+	compatible = "brcm,bcm2835", "brcm,bcm2711";
+};
+
+&{/} {
+	ad74115_avdd: fixed-regulator@1 {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-supply";
+		regulator-min-microvolt = <24000000>;
+		regulator-max-microvolt = <24000000>;
+		regulator-boot-on;
+	};
+};
+
+&spi0 {
+	cs-gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+	status = "okay";
+
+	ad74115h@0 {
+		compatible = "adi,ad74115h";
+		reg = <0>;
+
+		spi-max-frequency = <12000000>;
+		spi-cpol;
+
+		reset-gpios = <&gpio 27 GPIO_ACTIVE_LOW>;
+
+		interrupt-parent = <&gpio>;
+		interrupts = <26 IRQ_TYPE_EDGE_FALLING>;
+		interrupt-names = "adc_rdy";
+
+		avdd-supply = <&ad74115_avdd>;
+
+		adi,ch-func = <1>;
+		adi,conv2-mux = <2>;
+		adi,conv2-range-microvolt = <(-12000000) 12000000>;
+
+		adi,gpio0-mode = <1>;
+		adi,gpio1-mode = <1>;
+		adi,gpio2-mode = <1>;
+		adi,gpio3-mode = <1>;
+
+		adi,dac-bipolar;
+	};
+};
+
+&spidev0 {
+	status = "disabled";
+};
+
+&spidev1 {
+	status = "disabled";
+};

--- a/arch/arm/boot/dts/overlays/rpi-ad74413r-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ad74413r-overlay.dts
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+#include <dt-bindings/iio/addac/adi,ad74413r.h>
+
+/ {
+	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709", "brcm,bcm2711";
+
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			ad74413r_refin: fixedregulator@0 {
+				compatible = "regulator-fixed";
+				regulator-name = "fixed-supply";
+				regulator-min-microvolt = <2500000>;
+				regulator-max-microvolt = <2500000>;
+				regulator-boot-on;
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&spi0>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			cs-gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			status = "okay";
+
+			ad74413r@0 {
+				compatible = "adi,ad74413r";
+				reg = <0>;
+
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				spi-max-frequency = <1000000>;
+				spi-cpol;
+
+				interrupt-parent = <&gpio>;
+				interrupts = <26 IRQ_TYPE_EDGE_FALLING>;
+
+				refin-supply = <&ad74413r_refin>;
+
+				channel@0 {
+					reg = <0>;
+
+					adi,ch-func = <CH_FUNC_VOLTAGE_OUTPUT>;
+				};
+
+				channel@1 {
+					reg = <1>;
+
+					adi,ch-func = <CH_FUNC_CURRENT_OUTPUT>;
+				};
+
+				channel@2 {
+					reg = <2>;
+
+					adi,ch-func = <CH_FUNC_VOLTAGE_INPUT>;
+				};
+
+				channel@3 {
+					reg = <3>;
+
+					adi,ch-func = <CH_FUNC_CURRENT_INPUT_EXT_POWER>;
+				};
+			};
+		};
+	};
+
+	fragment@2 {
+		target = <&gpio>;
+		__overlay__ {
+			ad74413r_eval_reset_gpio {
+				gpio-hog;
+				gpios = <27 GPIO_ACTIVE_LOW>;
+				output-low;
+			};
+		};
+	};
+
+	fragment@3 {
+		target = <&spidev0>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@4 {
+		target = <&spidev1>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-ad7746-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ad7746-overlay.dts
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target = <&i2c1>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			ad7746: ad7746@48 {
+				compatible = "adi,ad7746";
+				clock-frequency = <400000>;
+				reg = <0x48>;
+				label = "my_ad7746";
+			};
+		};
+	};
+
+	__overrides__ {
+		addr = <&ad7746>,"reg:0";
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-ad7768-1-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ad7768-1-overlay.dts
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2708";
+
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			adc_vref: fixedregulator@0 {
+				compatible = "regulator-fixed";
+				regulator-name = "fixed-supply";
+				regulator-min-microvolt = <4096000>;
+				regulator-max-microvolt = <4096000>;
+				regulator-boot-on;
+			};
+		};
+	};
+
+	fragment@1 {
+		target-path = "/";
+		__overlay__ {
+			clocks {
+				ad7768_mclk: clock@0 {
+					     #clock-cells = <0>;
+					     compatible = "fixed-clock";
+					     clock-frequency = <16384000>;
+				};
+			};
+		};
+	};
+
+	fragment@2 {
+		target = <&spi0>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			ad7768@0{
+				compatible = "ad7768-1";
+				reg = <0>;
+				spi-max-frequency = <16000000>;
+				spi-cpol;
+				spi-cpha;
+				#interrupt-cells = <2>;
+				interrupts = <25 0x2>;
+				interrupt-parent = <&gpio>;
+				vref-supply = <&adc_vref>;
+				adi,sync-in-gpios = <&gpio 22 1>;
+				reset-gpios = <&gpio 27 1>;
+				clocks = <&ad7768_mclk>;
+				clock-names = "mclk";
+			};
+		};
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-ad9545-hmc7044-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ad9545-hmc7044-overlay.dts
@@ -1,0 +1,565 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR BSD-3-Clause)
+/* Overlay for AD-SYNCHRONA14-EBZ Rev. B
+ *
+ * Copyright 2021 Analog Devices Inc.
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	#include <dt-bindings/clock/ad9545.h>
+	#include <dt-bindings/iio/frequency/hmc7044.h>
+	#include <dt-bindings/gpio/gpio.h>
+
+	compatible = "brcm,bcm2835", "brcm,bcm2709", "brcm,bcm2711";
+
+	fragment@0 {
+
+		target-path = "/";
+		__overlay__ {
+
+			ref_clk2: ref_clk_2 {
+				compatible = "fixed-clock";
+				#clock-cells = <1>;
+
+				clock-frequency  = <10000000>;
+				clock-output-names = "Ref-B";
+			};
+
+			ref_clk3: ref_clk_3 {
+				compatible = "fixed-clock";
+				#clock-cells = <1>;
+
+				clock-frequency  = <1>;
+				clock-output-names = "Ref-BB";
+			};
+
+			ref_m1: ref_m1_clk {
+				compatible = "fixed-clock";
+				#clock-cells = <1>;
+
+				clock-frequency  = <50000000>;
+				clock-output-names = "Ref-M1";
+			};
+
+			hmc_ref_clk0: hmc_ref_clk_0 {
+				compatible = "fixed-clock";
+				#clock-cells = <1>;
+
+				clock-frequency  = <10000000>;
+				clock-output-names = "HMC-REF_CLKIN0";
+			};
+
+			hmc_ref_clk1: hmc_ref_clk_1 {
+				compatible = "fixed-clock";
+				#clock-cells = <1>;
+
+				clock-frequency  = <10000000>;
+				clock-output-names = "HMC-REF_CLKIN1";
+			};
+
+			hmc_ref_clk3: hmc_ref_clk_3 {
+				compatible = "fixed-clock";
+				#clock-cells = <1>;
+
+				clock-frequency  = <40000000>;
+				clock-output-names = "HMC-REF_CLKIN3";
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&spidev0>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@2 {
+		target = <&spidev1>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@3 {
+		target = <&gpio>;
+		__overlay__ {
+			gpio_overrides: gpio_overrides {
+				/* GPIO_4_HMC7044_CAR - 4
+				 * GPIO_1_HMC7044_CAR - 17
+				 * GPIO_2_HMC7044_CAR - 27
+				 * GPIO_3_HMC7044_CAR - 22
+				 * RESETB_AD9545_PI - 25
+				 * RESET_HMC7044_CAR_PI - 5
+				 * VCXO_SELECT_PI - 6
+				 * GPIO19_PI - 19
+				 * GPIO26_PI - 26
+				 * GPIO23_PI - 16 - SYNC Enable
+				 */
+
+				pin-25-reset-high {
+					pins = "gpio25";
+					function = "gpio_out";
+					bias-pull-up;
+					output-high;
+					export;
+				};
+
+				pin-5-reset-low {
+					pins = "gpio5";
+					function = "gpio_out";
+					bias-pull-down;
+				};
+
+				pin-6-vcxo-select {
+					pins = "gpio6";
+					function = "gpio_out";
+					/* GPIO 6:
+					 * 0 - For the 100 MHz VCXO to HMC7044:
+					 * bias-pull-down;
+					 *
+					 * 1 - For the 122.88 MHz VCXO to HMC7044:
+					 * bias-pull-up;
+					 * output-high;
+					 */
+
+					bias-pull-down;
+
+					export;
+				};
+
+				pin-32-red_led {
+					pins = "gpio12";
+					function = "gpio_out";
+					bias-pull-up;
+					output-high;
+					export;
+				};
+
+				pin-36-green_led {
+					pins = "gpio16";
+					function = "gpio_out";
+					bias-pull-up;
+					export;
+				};
+
+				pin-16-sync-en {
+					pins = "gpio23";
+					function = "gpio_out";
+					bias-pull-down;
+					export;
+				};
+			};
+		};
+	};
+
+	fragment@4 {
+		target = <&spi0>;
+		__overlay__ {
+			compatible = "brcm,bcm2835-spi";
+
+			#address-cells = <0x1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			ad9545_clock: ad9545@0 {
+				compatible = "adi,ad9545";
+				reg = <0>;
+
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				/*
+				 * Bind our pinctrl state to the first clock
+				 * provider we probe so it's applied before them.
+				 */
+				pinctrl-0 = <&gpio_overrides>;
+				pinctrl-names = "default";
+
+				adi,ref-crystal;
+				adi,ref-frequency-hz = <49152000>;
+				spi-max-frequency = <1000000>;
+
+				clock-names = "Ref-B", "Ref-BB", "Ref-M1";
+				clocks = <&ref_clk2 2>, <&ref_clk3 3>, <&ref_m1 1>;
+
+				#clock-cells = <2>;
+				assigned-clocks = <&ad9545_clock AD9545_CLK_NCO AD9545_NCO0>,
+						  <&ad9545_clock AD9545_CLK_PLL AD9545_PLL0>,
+						  <&ad9545_clock AD9545_CLK_PLL AD9545_PLL1>,
+						  <&ad9545_clock AD9545_CLK_OUT AD9545_Q0A>,
+						  <&ad9545_clock AD9545_CLK_OUT AD9545_Q0B>,
+						  <&ad9545_clock AD9545_CLK_OUT AD9545_Q1A>,
+						  <&ad9545_clock AD9545_CLK_OUT AD9545_Q1B>,
+						  <&ad9545_clock AD9545_CLK_AUX_TDC AD9545_CLK_AUX_TDC0>;
+				assigned-clock-rates = <10000>,
+						       <1400000000>,
+						       <1800000000>,
+						       <10000000>,
+						       <10000000>,
+						       <10000000>,
+						       <10000000>,
+						       <200000>;
+				assigned-clock-nshot = <0>, <0>, <0>, <0>, <0>, <0>, <1>, <0>;
+
+				aux-tdc-clk@0 {
+					reg = <0>;
+					adi,pin-nr = <1>;
+				};
+
+				aux-dpll@0 {
+					reg = <0>;
+					adi,compensation-source = <4>;
+					adi,aux-dpll-bw-mhz = <50000>;
+				};
+
+				/* Ref B*/
+				ref-input-clk@2 {
+					reg = <2>;
+					adi,single-ended-mode = <DRIVER_MODE_AC_COUPLED>;
+					adi,r-divider-ratio = <50>;
+					adi,ref-dtol-pbb = <10000000>;
+					adi,ref-monitor-hysteresis-pbb = <87500>;
+					adi,ref-validation-timer-ms = <10>;
+					adi,freq-lock-threshold-ps = <2000>;
+					adi,phase-lock-threshold-ps = <2000>;
+					adi,freq-lock-fill-rate = <20>;
+					adi,freq-lock-drain-rate = <20>;
+					adi,phase-lock-fill-rate = <20>;
+					adi,phase-lock-drain-rate = <20>;
+				};
+
+				/* Ref BB*/
+				ref-input-clk@3 {
+					reg = <3>;
+					adi,single-ended-mode = <DRIVER_MODE_DC_COUPLED_1V8>;
+					adi,r-divider-ratio = <1>;
+					adi,ref-dtol-pbb = <100000>;
+					adi,ref-monitor-hysteresis-pbb = <12500>;
+					adi,ref-validation-timer-ms = <1000>;
+					adi,freq-lock-threshold-ps = <2000>;
+					adi,phase-lock-threshold-ps = <2000>;
+					adi,freq-lock-fill-rate = <100>;
+					adi,freq-lock-drain-rate = <10>;
+					adi,phase-lock-fill-rate = <100>;
+					adi,phase-lock-drain-rate = <10>;
+				};
+
+				aux-nco-clk@AD9545_NCO0 {
+					reg = <AD9545_NCO0>;
+					adi,freq-lock-threshold-ps = <0xFFFFFF>;
+					adi,phase-lock-threshold-ps = <0xFFFFFF>;
+				};
+
+				ad9545_apll0: pll-clk@AD9545_PLL0 {
+					reg = <AD9545_PLL0>;
+
+					#address-cells = <1>;
+					#size-cells = <0>;
+
+					/* Uncoment below for Internal Zero-Delay operation: */
+					/*
+					 * adi,pll-internal-zero-delay-feedback = <AD9545_Q0A>;
+					 * adi,pll-internal-zero-delay-feedback-hz = <10000000>;
+					 * adi,pll-slew-rate-limit-ps = <4000000000>;
+					 */
+					profile@0 {
+						reg = <0>;
+						adi,pll-source = <3>;
+						adi,profile-priority = <0>;
+						adi,pll-loop-bandwidth-uhz = <50000>;
+
+						adi,fast-acq-excess-bw = <8>;
+						adi,fast-acq-timeout-ms = <10000>;
+						adi,fast-acq-lock-settle-ms = <1000>;
+					};
+
+					profile@1 {
+						reg = <1>;
+						adi,pll-source = <2>;
+						adi,profile-priority = <10>;
+						adi,pll-loop-bandwidth-uhz = <200000000>;
+					};
+
+				};
+
+				ad9545_apll1: pll-clk@AD9545_PLL1 {
+					reg = <AD9545_PLL1>;
+
+					#address-cells = <1>;
+					#size-cells = <0>;
+
+					/* Uncoment below for internal zero-delay operation */
+					/*
+					 * adi,pll-internal-zero-delay-feedback = <AD9545_Q1A>;
+					 * adi,pll-internal-zero-delay-feedback-hz = <10000000>;
+					 * adi,pll-slew-rate-limit-ps = <4000000000>;
+					 */
+					profile@0 {
+						reg = <0>;
+						adi,pll-source = <3>;
+						adi,profile-priority = <0>;
+						adi,pll-loop-bandwidth-uhz = <50000>;
+
+						adi,fast-acq-excess-bw = <8>;
+						adi,fast-acq-timeout-ms = <10000>;
+						adi,fast-acq-lock-settle-ms = <1000>;
+					};
+
+					profile@1 {
+						reg = <1>;
+						adi,pll-source = <2>;
+						adi,profile-priority = <10>;
+						adi,pll-loop-bandwidth-uhz = <200000000>;
+					};
+				};
+
+				/* Output Q0A CML -> J27 J28 */
+				output-clk@AD9545_Q0A {
+					reg = <AD9545_Q0A>;
+					adi,output-mode = <DRIVER_MODE_SINGLE_DIV_DIF>;
+					adi,current-source-microamp = <15000>;
+				};
+
+				output-clk@AD9545_Q0B {
+					reg = <AD9545_Q0B>;
+					adi,output-mode = <DRIVER_MODE_SINGLE_DIV_DIF>;
+					adi,current-source-microamp = <15000>;
+				};
+
+				/* Output Q1A -> CLK_IN 2 of HMC7044 */
+				output-clk@AD9545_Q1A {
+					reg = <AD9545_Q1A>;
+					adi,output-mode = <DRIVER_MODE_SINGLE_DIV_DIF>;
+					adi,current-source-microamp = <15000>;
+				};
+
+				/* Output Q1B -> SYNC of HMC7044 */
+				output-clk@AD9545_Q1B {
+					reg = <AD9545_Q1B>;
+					adi,output-mode = <DRIVER_MODE_SINGLE_DIV_DIF>;
+					adi,current-source-microamp = <15000>;
+				};
+			};
+
+			hmc7044_fmc: hmc7044@1 {
+				reg = <0x1>;
+
+				#address-cells = <1>;
+				#size-cells = <0>;
+				#clock-cells = <1>;
+
+				compatible = "adi,hmc7044";
+				spi-max-frequency = <1000000>;
+
+				adi,pll1-clkin-frequencies = <10000000 10000000 10000000 40000000>;
+
+				/*
+				 *	HMC7044 Input Clocking Priorities:
+				 *	CLKIN2 -> CLKIN0 -> CLKIN1 -> CLKIN3
+				 *	Where:
+				 *		- CLKIN2 - AD9545
+				 *		- CLKIN0 - J23/J24
+				 *		- CLKIN1 - J25/J26
+				 *		- CLKIN3 - 40 MHz or 38.4 MHz TCXO
+				 */
+				adi,pll1-ref-prio-ctrl = <0xD2>;
+				adi,pll1-ref-autorevert-enable;
+
+				adi,pll1-loop-bandwidth-hz = <200>;
+
+				/* All HMC7044 inputs are AC Coupled */
+				adi,clkin0-buffer-mode = <0x07>;
+				adi,clkin1-buffer-mode  = <0x07>;
+				adi,clkin2-buffer-mode  = <0x07>;
+				adi,clkin3-buffer-mode  = <0x07>;
+
+				clocks = <&hmc_ref_clk0 0>,
+					 <&hmc_ref_clk1 0>,
+					 <&ad9545_clock AD9545_CLK_OUT AD9545_Q1A>,
+					 <&hmc_ref_clk3 0>,
+					 <&ad9545_clock AD9545_CLK_OUT AD9545_Q1B>;
+				clock-names = "clkin0", "clkin1", "clkin2", "clkin3", "sync_clk";
+
+				/* depends on VCXO_SELECT_PI */
+				adi,vcxo-frequency = <100000000>;
+				adi,pll2-output-frequency = <2600000000>;
+				adi,sysref-timer-divider = <1024>;
+				adi,pulse-generator-mode = <HMC7044_PULSE_GEN_CONT_PULSE>;
+
+				adi,oscin-buffer-mode = <0x15>;
+				adi,sync-pin-mode = <HMC7044_SYNC_PIN_SYNC>;
+
+				adi,gpi-controls = <0x00 0x00 0x00 0x00>;
+				adi,gpo-controls = <0x1f 0x2b 0x00 0x00>;
+
+				clock-output-names = "HMC7044_OUT0", "HMC7044_OUT1",
+						     "HMC7044_OUT2", "HMC7044_OUT3",
+						     "HMC7044_OUT4", "HMC7044_OUT5",
+						     "HMC7044_OUT6", "HMC7044_OUT7",
+						     "HMC7044_OUT8", "HMC7044_OUT9",
+						     "HMC7044_OUT10", "HMC7044_OUT11",
+						     "HMC7044_OUT12", "HMC7044_OUT13";
+
+				/*
+				 * Channels in CMOS mode should configure
+				 * adi,driver-impedance-mode to:
+				 * 0 - no output
+				 * 1 - N output
+				 * 2 - P ourput
+				 * 3 - both
+				 * Depending on the desired output pin.
+				 */
+				channel@0 {
+					reg = <0>;
+					adi,extended-name = "HMC7044_OUT0";
+					adi,divider = <260>;
+					adi,driver-mode = <HMC7044_DRIVER_MODE_LVPECL>;
+				};
+
+				channel@1 {
+					reg = <1>;
+					adi,extended-name = "HMC7044_OUT1";
+					adi,divider = <260>;
+					adi,driver-mode = <HMC7044_DRIVER_MODE_LVPECL>;
+				};
+
+				channel@2 {
+					reg = <2>;
+					adi,extended-name = "HMC7044_OUT2";
+					adi,divider = <260>;
+					adi,driver-mode = <HMC7044_DRIVER_MODE_LVPECL>;
+				};
+
+				channel@3 {
+					reg = <3>;
+					adi,extended-name = "HMC7044_OUT3";
+					adi,divider = <260>;
+					adi,driver-mode = <HMC7044_DRIVER_MODE_LVPECL>;
+				};
+
+				channel@4 {
+					reg = <4>;
+					adi,extended-name = "HMC7044_OUT4";
+					adi,divider = <260>;
+					adi,driver-mode = <HMC7044_DRIVER_MODE_CMOS>;
+					adi,driver-impedance-mode = <3>;
+				};
+
+				channel@5 {
+					reg = <5>;
+					adi,extended-name = "HMC7044_OUT5";
+					adi,divider = <260>;
+					adi,driver-mode = <HMC7044_DRIVER_MODE_LVPECL>;
+				};
+
+				channel@6 {
+					reg = <6>;
+					adi,extended-name = "HMC7044_OUT6";
+					adi,divider = <260>;
+					adi,driver-mode = <HMC7044_DRIVER_MODE_CMOS>;
+					adi,driver-impedance-mode = <3>;
+				};
+
+				channel@7 {
+					reg = <7>;
+					adi,extended-name = "HMC7044_OUT7";
+					adi,divider = <260>;
+					adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
+				};
+
+				channel@8 {
+					reg = <8>;
+					adi,extended-name = "HMC7044_OUT8";
+					adi,divider = <260>;
+					adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
+				};
+
+				channel@9 {
+					reg = <9>;
+					adi,extended-name = "HMC7044_OUT9";
+					adi,divider = <260>;
+					adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
+				};
+
+				channel@10 {
+					reg = <10>;
+					adi,extended-name = "HMC7044_OUT10";
+					adi,divider = <260>;
+					adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
+				};
+
+				channel@11 {
+					reg = <11>;
+					adi,extended-name = "HMC7044_OUT11";
+					adi,divider = <260>;
+					adi,driver-mode = <HMC7044_DRIVER_MODE_CMOS>;
+					adi,driver-impedance-mode = <3>;
+				};
+
+				channel@12 {
+					reg = <12>;
+					adi,extended-name = "HMC7044_OUT12";
+					adi,divider = <260>;
+					adi,driver-mode = <HMC7044_DRIVER_MODE_LVPECL>;
+				};
+
+				channel@13 {
+					reg = <13>;
+					adi,extended-name = "HMC7044_OUT13";
+					adi,divider = <260>;
+					adi,driver-mode = <HMC7044_DRIVER_MODE_CMOS>;
+					adi,driver-impedance-mode = <3>;
+				};
+			};
+		};
+	};
+
+	fragment@5 {
+		target-path = "/";
+		__overlay__ {
+			power_ctrl: power_ctrl {
+				compatible = "gpio-poweroff";
+				gpios = <&gpio 21 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+				input;
+				force;
+			};
+		};
+	};
+
+	fragment@6 {
+		target-path = "/soc";
+		__overlay__ {
+			shutdown_button: shutdown_button@3 {
+				compatible = "gpio-keys";
+				status = "okay";
+
+				button: shutdown {
+					label = "shutdown";
+					linux,code = <116>; /* KEY_POWER */
+					gpios = <&gpio 20 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+					debounce-interval = <100>;
+				};
+			};
+		};
+	};
+
+	fragment@7 {
+		target = <&i2c1>;
+		__overlay__ {
+			compatible = "brcm,bcm2711-i2c";
+			status = "okay";
+
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			/* Temperature sensor that monitors HMC7044 */
+			adt7422@48 {
+				compatible = "adi,adt7422";
+				reg = <0x48>;
+			};
+		};
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-ad9834-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ad9834-overlay.dts
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2708", "brcm,bcm2709";
+
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			vcc: fixedregulator@0 {
+				compatible = "regulator-fixed";
+				regulator-name = "fixed-supply";
+				regulator-min-microvolt = <2500000>;
+				regulator-max-microvolt = <2500000>;
+				regulator-boot-on;
+			};
+
+			osc: oscillator {
+				#clock-cells = <0>;
+				compatible = "fixed-clock";
+				clock-frequency = <25000000>;
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&spi0>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			ad9833@0{
+				#clock-cells = <0>;
+				compatible = "ad9833";
+				reg = <0>;
+				spi-max-frequency = <1000000>;
+				spi-cpol;
+				clocks = <&osc>;
+				vcc-supply = <&vcc>;
+			};
+		};
+	};
+};
+

--- a/arch/arm/boot/dts/overlays/rpi-ada4250-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ada4250-overlay.dts
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target = <&spidev0>;
+
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@1 {
+		target-path = "/";
+		__overlay__ {
+			avdd: fixedregulator@0 {
+				compatible = "regulator-fixed";
+				regulator-name = "avdd";
+				regulator-min-microvolt = <5000000>;
+				regulator-max-microvolt = <5000000>;
+				regulator-boot-on;
+			};
+		};
+	};
+
+	fragment@2 {
+		target = <&spi0>;
+
+		__overlay__{
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			ada4250@0{
+				compatible = "adi,ada4250";
+				reg = <0>;
+				spi-max-frequency = <1000000>;
+				avdd-supply = <&avdd>;
+			};
+		};
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-adar1000-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-adar1000-overlay.dts
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709";
+
+	fragment@0 {
+		target = <&spi0>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			adar1000@0 {
+				compatible = "adi,adar1000";
+				reg = <0>;
+				spi-max-frequency = <1000000>;
+
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				adar1000_0@0 {
+					reg = <0>;
+					label = "BEAM0";
+					adi,phasetable-name = "adar1000_std_phasetable";
+				};
+				adar1000_1@1 {
+					reg = <1>;
+					label = "BEAM1";
+				};
+				adar1000_2@2 {
+					reg = <2>;
+					label = "BEAM2";
+				};
+				adar1000_3@3 {
+					reg = <3>;
+					label = "BEAM3";
+				};
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&spidev0>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@2 {
+		target = <&spidev1>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-adau1472-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-adau1472-overlay.dts
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: GPL-2.0
+
+/dts-v1/;
+/plugin/;
+
+/*
+ * Device Tree Overlay for generic I2S audio input and output on RaspberryPi
+ * with ADAU1472 master
+ */
+
+/ {
+	compatible = "brcm,bcm2835", "brcm,bcm2711";
+
+	fragment@0 {
+		target = <&sound>;
+		__overlay__ {
+			compatible = "simple-audio-card";
+			simple-audio-card,name = "ADAU1472";
+
+			status="okay";
+
+			capture_link: simple-audio-card,dai-link@0 {
+				format = "i2s";
+
+				bitclock-master = <&r_codec_dai>;
+				frame-master = <&r_codec_dai>;
+
+				r_cpu_dai: cpu {
+					sound-dai = <&i2s>;
+					/*
+					 * TDM slot configuration
+					 * BCLK ratio: 64 x Fs (2 x 32 bit)
+					 */
+					dai-tdm-slot-num = <2>;
+					dai-tdm-slot-width = <32>;
+				};
+
+				r_codec_dai: codec {
+					sound-dai = <&codec_in>;
+				};
+			};
+
+			playback_link: simple-audio-card,dai-link@1 {
+				format = "i2s";
+
+				bitclock-master = <&p_codec_dai>;
+				frame-master = <&p_codec_dai>;
+
+				p_cpu_dai: cpu {
+					sound-dai = <&i2s>;
+					/*
+					 * TDM slot configuration
+					 * BCLK ratio: 64 x Fs (2 x 32 bit)
+					 */
+					dai-tdm-slot-num = <2>;
+					dai-tdm-slot-width = <32>;
+				};
+
+				p_codec_dai: codec {
+					sound-dai = <&codec_out>;
+				};
+			};
+		};
+	};
+
+	fragment@1 {
+		target-path = "/";
+		__overlay__ {
+			codec_in: spdif_receiver {
+				#address-cells = <0>;
+				#size-cells = <0>;
+				#sound-dai-cells = <0>;
+				compatible = "linux,spdif-dir";
+				status = "okay";
+			};
+
+			codec_out: spdif-transmitter {
+				#address-cells = <0>;
+				#size-cells = <0>;
+				#sound-dai-cells = <0>;
+				compatible = "linux,spdif-dit";
+				status = "okay";
+			};
+		};
+	};
+
+	fragment@2 {
+		target = <&i2s>;
+		__overlay__ {
+			#sound-dai-cells = <0>;
+			status = "okay";
+		};
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-adau1761-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-adau1761-overlay.dts
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: GPL-2.0
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target = <&clocks>;
+		__overlay__ {
+			adau1761_mclk: oscillator {
+				compatible = "fixed-clock";
+				status = "okay";
+				#clock-cells=<0>;
+				clock-frequency = <12288000>;
+				clock-output-names = "adau1761_mclk";
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&i2s>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@2 {
+		target = <&i2c1>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			adau1761_codec: adau1761-codec@38 {
+				compatible = "adi,adau1761";
+				status = "okay";
+				reg = <0x38>;
+				#sound-dai-cells = <0>;
+				clock-names = "mclk";
+				clocks = <&adau1761_mclk>;
+			};
+		};
+	};
+
+	fragment@3 {
+		target = <&sound>;
+		sound_overlay: __overlay__ {
+			compatible = "simple-audio-card";
+			status = "okay";
+			simple-audio-card,format = "i2s";
+			simple-audio-card,name = "EVAL-ADAU1761Z";
+			simple-audio-card,bitclock-master = <&dailink0_master>;
+			simple-audio-card,frame-master = <&dailink0_master>;
+			simple-audio-card,widgets =
+				"Microphone", "Mic In",
+				"Headphone", "Headphone Out",
+				"Line", "Line In",
+				"Line", "Line Out";
+			simple-audio-card,routing =
+				"Line Out", "LOUT",
+				"Line Out", "ROUT",
+				"Headphone Out", "LHP",
+				"Headphone Out", "RHP",
+				"Mic In", "MICBIAS",
+				"LINN", "Mic In",
+				"RINN", "Mic In",
+				"LINP", "Mic In",
+				"RINP", "Mic In",
+				"LAUX", "Line In",
+				"RAUX", "Line In";
+			simple-audio-card,cpu {
+				/* so that bclk is 64x FS */
+				dai-tdm-slot-num = <2>;
+				dai-tdm-slot-width = <32>;
+				sound-dai = <&i2s>;
+			};
+			dailink0_master: simple-audio-card,codec {
+				sound-dai = <&adau1761_codec>;
+			};
+		};
+	};
+
+	__overrides__ {
+		card-name = <&sound_overlay>,"simple-audio-card,name";
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-addi9036-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-addi9036-overlay.dts
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: GPL-2.0
+// Definitions for ADDI9036 camera module
+/dts-v1/;
+/plugin/;
+
+/{
+	compatible = "brcm,bcm2708";
+
+	fragment@0 {
+		target = <&i2c_vc>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			camera_front@64 {
+				compatible = "adi,addi9036";
+				reg = <0x64>;
+
+				reset-gpios = <&gpio 41 1>;
+
+				port {
+					addi9036_ep: endpoint {
+						remote-endpoint = <&csi1_ep>;
+						clock-lanes = <0>;
+						data-lanes = <1 2>;
+					};
+				};
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&csi1>;
+		__overlay__ {
+			status = "okay";
+
+			port {
+				csi1_ep: endpoint {
+					remote-endpoint = <&addi9036_ep>;
+				};
+			};
+		};
+	};
+
+	fragment@2 {
+		target = <&i2c0_pins>;
+		__overlay__ {
+			brcm,pins = <44 45>;
+			brcm,function = <5>; /* alt1 */
+		};
+	};
+
+	fragment@3 {
+		target = <&i2c_vc>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@4 {
+		target = <&i2c1>;
+		__dormant__ {
+			pinctrl-0 = <&i2c1_pins>;
+			status = "okay";
+		};
+	};
+
+/* Fragment valid only for ADI ToF REV B */
+	fragment@5 {
+		target = <&i2c1>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			eeprom_i2c1: eeprom@56 {
+				compatible = "atmel,24c1024";
+				reg = <0x56>;
+				pagesize = <32>;
+			};
+		};
+	};
+
+/* Fragment valid only for ADI ToF REV C */
+	fragment@6 {
+		target = <&i2c_vc>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			eeprom_i2c_vc: eeprom@56 {
+				compatible = "atmel,24c1024";
+				reg = <0x56>;
+				pagesize = <32>;
+			};
+		};
+	};
+
+	fragment@7 {
+		target = <&i2c1_pins>;
+		__dormant__ {
+			brcm,pins = <2 3>;
+			brcm,function = <4>; /* alt 0 */
+		};
+	};
+
+/* Fragment valid only for Chicony */
+	fragment@8 {
+		target = <&i2c_vc>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			tmp102_i2c_vc: temp@48 {
+				compatible = "ti,tmp102";
+				reg = <0x48>;
+			};
+		};
+	};
+
+/* Fragment valid only for Foxconn */
+	fragment@9 {
+		target = <&i2c_vc>;
+		__dormant__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			tmp103_i2c_vc: temp@73 {
+				compatible = "ti,tmp103";
+				reg = <0x73>;
+			};
+		};
+	};
+
+	__overrides__ {
+		revb = <0>,"+4+5-6+7-8-9";
+		revc = <0>,"-4-5+6-7-8-9";
+		chicony = <0>,"-4-5+6-7+8-9";
+		foxconn = <0>,"-4-5+6-7-8+9";
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-adf4159-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-adf4159-overlay.dts
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * ADF4159 SPI Wideband Synthesizer example devicetree
+ *
+ * Copyright 2021 Analog Devices Inc.
+ *
+ */
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/iio/frequency/adf4159.h>
+
+/ {
+	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709";
+
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			clkin: clock@0 {
+				compatible = "fixed-clock";
+				clock-frequency = <100000000>;
+				clock-output-names = "adf4159_ext_refclk";
+				#clock-cells = <0>;
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&spi0>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			adf4159@0 {
+				compatible = "adi,adf4159";
+				reg = <0x0>;
+				spi-max-frequency = <12500000>;
+				/* Clocks */
+				clocks = <&clkin>;
+				clock-names = "clkin";
+				clock-output-names = "rf_out";
+				#clock-cells = <0>;
+				adi,power-up-frequency-hz = /bits/ 64 <6000000000>;
+				adi,charge-pump-current-microamp = <900>;
+				//adi,charge-pump-negative-bleed-enable;
+				adi,clk1-div = <100>;
+				adi,clk2-timer-div = <0>;
+				adi,clk2-timer-div-2 = <0>;
+				adi,clk-div-mode = <0>;
+				//adi,cycle-slip-reduction-enable;
+				//adi,delay-clk-sel-pfd-x-clk1-enable;
+				//adi,delay-start-enable;
+				adi,delay-start-word = <0>;
+				adi,deviation = <1000>;
+				adi,deviation-2 = <0>;
+				adi,deviation-offset = <1>;
+				//adi,dual-ramp-enable;
+				//adi,fast-ramp-enable;
+				//adi,fsk-modulation-enable;
+				//adi,fsk-ramp-enable;
+				adi,interrupt-mode-select = <0>;
+				//adi,le-sync-refin-enable;
+				//adi,lock-detect-precision-6ns-enable;
+				adi,muxout-select = <MUXOUT_READBACK_TO_MUXOUT>;
+				adi,negative-bleed-current-microamp = <0>;
+				//adi,parabolic-ramp-enable;
+				adi,phase = <0>;
+				//adi,phase-detector-polarity-positive-enable;
+				//adi,powerdown-enable;
+				//adi,psk-modulation-enable;
+				//adi,ramp-dealy-fl-enable;
+				//adi,ramp-delay-enable;
+				//adi,ramp-enable;
+				adi,ramp-mode-select = <0>;
+				adi,ramp-status-mode = <RAMP_STATUS_RAMP_COMPLETE_TO_MUXOUT>;
+				//adi,reference-div2-enable;
+				adi,reference-div-factor = <1>;
+				//adi,reference-doubler-enable;
+				//adi,single-full-triangle-enable;
+				adi,step-word = <0>;
+				adi,step-word-2 = <0>;
+				//adi,txdata-invert-enable;
+				//adi,txdata-ramp-clk-txdata-enable;
+				//adi,txdata-trigger-delay-enable;
+				//adi,txdata-trigger-enable;
+			};
+		};
+	};
+
+	fragment@2 {
+		target = <&spidev0>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@3 {
+		target = <&spidev1>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-adf4371-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-adf4371-overlay.dts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+/ {
+
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			clocks {
+				adf4371_clkin: clock@0 {
+					     #clock-cells = <0>;
+					     compatible = "fixed-clock";
+					     clock-frequency = <100000000>; // 100MHz
+				};
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&spi0>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			adf4371@0 {
+				compatible = "adi,adf4371";
+				reg = <0>;
+				spi-max-frequency = <1000000>;
+				clocks = <&adf4371_clkin>;
+				clock-names = "clkin";
+			};
+		};
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-adgs1408-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-adgs1408-overlay.dts
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+#include "../../../include/dt-bindings/mux/mux.h"
+
+/ {
+	compatible = "brcm,bcm2708";
+
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			adc-mux@3 {
+				compatible = "io-channel-mux";
+				io-channels = <&adc 1>;
+				io-channel-names = "parent";
+				mux-controls = <&mux>;
+
+				channels = "out_a0", "out_a1", "test0", "test1",
+				"out_b0", "out_b1", "testb0", "testb1";
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&spi0>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			mux: mux-controller@2 {
+				compatible = "adi,adgs1408";
+				reg = <0>;
+				spi-max-frequency = <1000000>;
+				#mux-control-cells = <0>;
+			};
+
+			adc: ad7298@3 {
+				compatible = "ad7298";
+				#io-channel-cells = <1>;
+				spi-max-frequency = <1000000>;
+				reg = <1>;
+			};
+		};
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-adin1110-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-adin1110-overlay.dts
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR BSD-3-Clause)
+/* Overlay for EVAL-ADIN1110EBZ Rev. B
+ *
+ * Copyright 2022 Analog Devices Inc.
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/interrupt-controller/irq.h>
+
+&spidev0 {
+	status = "disabled";
+};
+
+&spidev1 {
+	status = "disabled";
+};
+
+&spi0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	ethernet@0 {
+		compatible = "adi,adin1110";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		adi,spi-crc;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		interrupt-parent = <&gpio>;
+		interrupts = <25 IRQ_TYPE_LEVEL_LOW>;
+		mac-address = [ CA 2F B7 10 23 63 ];
+
+		phy@0 {
+			compatible = "ethernet-phy-id0283.bc91";
+			reg = <0x0>;
+		};
+	};
+};
+
+&gpio {
+	gpio_overrides: gpio_overrides {
+		pin-13-reset-high {
+			pins = "gpio27";
+			function = "gpio_out";
+			bias-pull-up;
+			output-high;
+			export;
+		};
+	};
+};
+

--- a/arch/arm/boot/dts/overlays/rpi-adin2111-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-adin2111-overlay.dts
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR BSD-3-Clause)
+/* Overlay for EVAL-ADIN2111EBZ Rev. B
+ *
+ * Copyright 2022 Analog Devices Inc.
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/interrupt-controller/irq.h>
+
+&spidev0 {
+	status = "disabled";
+};
+
+&spidev1 {
+	status = "disabled";
+};
+
+&spi0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	ethernet@0 {
+		compatible = "adi,adin2111";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		interrupt-parent = <&gpio>;
+		interrupts = <25 IRQ_TYPE_LEVEL_LOW>;
+		mac-address = [ CA 2F B7 10 23 63 ];
+
+		phy@0 {
+			compatible = "ethernet-phy-id0283.bca1";
+			reg = <0x0>;
+		};
+
+		phy@1 {
+			compatible = "ethernet-phy-id0283.bca1";
+			reg = <0x1>;
+		};
+	};
+};
+
+&gpio {
+	gpio_overrides: gpio_overrides {
+		pin-13-reset-high {
+			pins = "gpio27";
+			function = "gpio_out";
+			bias-pull-up;
+			output-high;
+			export;
+		};
+	};
+};
+

--- a/arch/arm/boot/dts/overlays/rpi-admv1013-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-admv1013-overlay.dts
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target = <&spidev0>;
+
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@1 {
+		target-path = "/";
+		__overlay__ {
+			clocks {
+				admv1013_lo: clock@0 {
+					compatible = "fixed-clock";
+
+					clock-frequency = <100000000>;
+					clock-output-names = "lo_in";
+					#clock-cells = <0>;
+				};
+			};
+		};
+	};
+
+	fragment@2 {
+		target-path = "/";
+		__overlay__ {
+			vcm: fixedregulator@0 {
+				compatible = "regulator-fixed";
+				regulator-name = "vcm";
+				regulator-min-microvolt = <0>;
+				regulator-max-microvolt = <0>;
+				regulator-boot-on;
+			};
+		};
+	};
+
+	fragment@3 {
+		target = <&spi0>;
+
+		__overlay__{
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			admv1013@0{
+				compatible = "adi,admv1013";
+				reg = <0>;
+				spi-max-frequency = <1000000>;
+				clocks = <&admv1013_lo>;
+				clock-names = "lo_in";
+				clock-scales = <1 5>;
+				vcm-supply = <&vcm>;
+				adi,quad-se-mode = <12>;
+				adi,parity-en;
+			};
+		};
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-admv1014-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-admv1014-overlay.dts
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target = <&spidev0>;
+
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@1 {
+		target-path = "/";
+		__overlay__ {
+			clocks {
+				admv1014_lo: clock@0 {
+					compatible = "fixed-clock";
+
+					clock-frequency = <1000000000>;
+					clock-output-names = "lo_in";
+					#clock-cells = <0>;
+				};
+			};
+		};
+	};
+
+	fragment@2 {
+		target-path = "/";
+		__overlay__ {
+			vcm: fixedregulator@0 {
+				compatible = "regulator-fixed";
+				regulator-name = "vcm";
+				regulator-min-microvolt = <1500000>;
+				regulator-max-microvolt = <1500000>;
+				regulator-boot-on;
+			};
+		};
+	};
+
+	fragment@3 {
+		target = <&spi0>;
+
+		__overlay__{
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			admv1014@0{
+				compatible = "adi,admv1014";
+				reg = <0>;
+				spi-max-frequency = <1000000>;
+				clocks = <&admv1014_lo>;
+				clock-names = "lo_in";
+				clock-scales = <1 8>;
+				vcm-supply = <&vcm>;
+				adi,quad-se-mode = <0>;
+				adi,parity-en;
+				adi,p1db-comp = <3>;
+				adi,det-prog = <4>;
+				adi,bb-amp-gain-ctrl = <0>;
+			};
+		};
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-admv8818-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-admv8818-overlay.dts
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target = <&spidev0>;
+
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@1 {
+		target-path = "/";
+		__overlay__ {
+			clocks {
+				admv8818_rfin: clock@0 {
+					compatible = "fixed-clock";
+
+					clock-frequency = <100000000>;
+					clock-output-names = "rf_in";
+					#clock-cells = <0>;
+				};
+			};
+		};
+	};
+
+	fragment@2 {
+		target = <&spi0>;
+
+		__overlay__{
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			admv8818@0{
+				compatible = "adi,admv8818";
+				reg = <0>;
+				spi-max-frequency = <10000000>;
+				clocks = <&admv8818_rfin>;
+				clock-scales = <1 50>;
+				clock-names = "rf_in";
+				adi,bw-hz = /bits/ 64 <600000000>;
+			};
+		};
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-adrf6780-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-adrf6780-overlay.dts
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target = <&spidev0>;
+
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@1 {
+		target-path = "/";
+		__overlay__ {
+			clocks {
+				adrf6780_lo: clock@0 {
+					compatible = "fixed-clock";
+
+					clock-frequency = <100000000>;
+					clock-output-names = "lo_in";
+					#clock-cells = <0>;
+				};
+			};
+		};
+	};
+
+	fragment@2 {
+		target = <&spi0>;
+
+		__overlay__{
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			adrf6780@0{
+				compatible = "adi,adrf6780";
+				reg = <0>;
+				spi-max-frequency = <1000000>;
+				clocks = <&adrf6780_lo>;
+				clock-names = "lo_in";
+			};
+		};
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-adt7420-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-adt7420-overlay.dts
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709", "brcm,bcm2711";
+
+	fragment@1 {
+		target = <&i2c1>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			adt7420@4b {
+				compatible = "adt7420";
+				reg = <0x4b>;
+			};
+		};
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-adxl313-i2c-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-adxl313-i2c-overlay.dts
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-2.0
+/* Overlay for ADXL312, ADXL313, ADXL314
+ *
+ * Copyright 2022 Analog Devices Inc.
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+
+&gpio {
+	adxl313_pins: adxl313_pins {
+		brcm,pins = <25>; // interrupt
+		brcm,function = <0>; // in
+	};
+};
+
+&i2c1 {
+	status = "okay";
+
+	adxl313_i2c: adxl313@1d {
+		compatible = "adi,adxl313";
+		reg = <0x1d>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&adxl313_pins>;
+		interrupt-parent = <&gpio>;
+		interrupts = <25 IRQ_TYPE_EDGE_RISING>;
+		interrupt-names = "DRDY";
+	};
+};
+
+/ {
+	__overrides__ {
+		addr = <&adxl313_i2c>,"reg:0";
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-adxl313-spi-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-adxl313-spi-overlay.dts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-2.0
+/* Overlay for ADXL312, ADXL313, ADXL314
+ *
+ * Copyright 2022 Analog Devices Inc.
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+
+&spidev0 {
+	status = "disabled";
+};
+
+&gpio {
+	adxl313_pins: adxl313_pins {
+		brcm,pins = <25>; // interrupt
+		brcm,function = <0>; // in
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	adxl313@0 {
+		compatible = "adi,adxl313";
+		reg = <0>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&adxl313_pins>;
+		spi-max-frequency = <5000000>;
+		interrupt-parent = <&gpio>;
+		interrupts = <25 IRQ_TYPE_EDGE_RISING>;
+		interrupt-names = "DRDY";
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-adxl345-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-adxl345-overlay.dts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/interrupt-controller/irq.h>
+
+/ {
+	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709";
+
+	fragment@0 {
+		target = <&spi0>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			adxl345@0 {
+				compatible = "adi,adxl345";
+				reg = <0>;
+				spi-max-frequency = <1000000>;
+				spi-cpha;
+				spi-cpol;
+				interrupts = <19 IRQ_TYPE_LEVEL_HIGH>;
+				interrupt-parent = <&gpio>;
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&spidev0>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+};
+

--- a/arch/arm/boot/dts/overlays/rpi-adxl355-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-adxl355-overlay.dts
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+
+/ {
+
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target = <&spidev0>;
+
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@1 {
+		target = <&gpio>;
+		__overlay__ {
+			adxl355_pins: adxl355_pins {
+				brcm,pins = <25>; // interrupt
+				brcm,function = <0>; // in
+			};
+		};
+	};
+
+	fragment@2 {
+		target = <&spi0>;
+		__overlay__ {
+			#address-cells = <1>;
+			status = "okay";
+			#size-cells = <0>;
+
+			adxl355@0 {
+				compatible = "adi,adxl355";
+				reg = <0>;
+				pinctrl-names = "default";
+				pinctrl-0 = <&adxl355_pins>;
+				spi-max-frequency = <1000000>;
+				interrupt-parent = <&gpio>;
+				interrupts = <25 IRQ_TYPE_EDGE_RISING>;
+				interrupt-names = "DRDY";
+			};
+		};
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-adxl367-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-adxl367-overlay.dts
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-2.0
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+
+/ {
+	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709", "brcm,bcm2711";
+
+	fragment@0 {
+		target = <&spi0>;
+
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			cs-gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			status = "okay";
+
+			adxl367@0 {
+				compatible = "adi,adxl367";
+				reg = <0>;
+				spi-max-frequency = <1000000>;
+				interrupts = <26 IRQ_TYPE_EDGE_RISING>;
+				interrupt-parent = <&gpio>;
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&spidev0>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@2 {
+		target = <&spidev1>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-adxl372-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-adxl372-overlay.dts
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2708";
+
+	fragment@0 {
+		target = <&spi0>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			adxl372@0 {
+				compatible = "adi,adxl372";
+				reg = <0>;
+				spi-max-frequency = <1000000>;
+				interrupts = <25 2>;
+				interrupt-parent = <&gpio>;
+			};
+		};
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-adxl375-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-adxl375-overlay.dts
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2708", "brcm,bcm2709";
+
+	fragment@0 {
+		target = <&i2c1>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			adxl375@053 {
+				compatible = "adi,adxl375";
+				reg = <0x53>;
+				interrupt-parent = <&gpio>;
+				interrupts = <25 2>;
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&spi0>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			adxl375@0 {
+				compatible = "adi,adxl375";
+				reg = <0>;
+				spi-max-frequency = <1000000>;
+				spi-cpha;
+				spi-cpol;
+				interrupts = <25 2>;
+				interrupt-parent = <&gpio>;
+			};
+		};
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-adxrs290-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-adxrs290-overlay.dts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2836", "brcm,bcm2835";
+
+	fragment@0 {
+		target = <&spi0>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			adxrs290@0 {
+				compatible = "adi,adxrs290";
+				reg = <0>;
+				spi-max-frequency = <1000000>;
+				spi-cpha;
+				spi-cpol;
+				interrupts = <19 1>;
+				interrupt-parent = <&gpio>;
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&spidev0>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-cn0504-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-cn0504-overlay.dts
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709", "brcm,bcm2711";
+
+	fragment@0 {
+		target = <&ethernet>;
+		__overlay__ {
+			#address-cells = <2>;
+			#size-cells = <0>;
+
+			/* this works on RPi3 */
+			usb_eth_interface: usb_eth_interface@0 {
+				reg = <0 1>;
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&i2c1>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			ltc2945@6f{
+				compatible = "adi,ltc2945";
+				reg = <0x6f>;
+
+				shunt-resistor-micro-ohms = <20000>;
+			};
+		};
+	};
+
+	fragment@2 {
+		target = <&spi0>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			ksz9477@0 {
+				compatible = "microchip,ksz9477";
+				reg = <0>;
+				spi-max-frequency = <500000>;
+
+				ports {
+					#address-cells = <1>;
+					#size-cells = <0>;
+					/**
+					 * LAN1 should be connected via an ethernet
+					 * cable to the RPi's ethernet jack
+					 */
+					port@0 {
+						reg = <0>;
+						label = "lan1";
+						ethernet = <&usb_eth_interface>;
+					};
+					port@1 {
+						reg = <1>;
+						label = "lan2";
+					};
+					port@2 {
+						reg = <2>;
+						label = "lan3";
+					};
+				};
+			};
+		};
+	};
+
+	fragment@3 {
+		target = <&spidev0>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@4 {
+		target = <&spidev1>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-cn0508-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-cn0508-overlay.dts
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709";
+
+	fragment@0 {
+		target = <&spi0_cs_pins>;
+		frag0: __overlay__ {
+			brcm,pins = <22 27 8 7>;
+			brcm,function = <1>; /* output */
+		};
+	};
+
+	fragment@1 {
+		target = <&spi0>;
+		frag1: __overlay__ {
+			cs-gpios = <&gpio 22 1>, <&gpio 27 1>,
+				<&gpio 8 1>, <&gpio 7 1>;
+			status = "okay";
+		};
+	};
+
+	__overrides__ {
+		cs0_pin  = <&frag0>,"brcm,pins:0",
+			   <&frag1>,"cs-gpios:4";
+		cs1_pin  = <&frag0>,"brcm,pins:4",
+			   <&frag1>,"cs-gpios:16";
+		cs2_pin	=  <&frag0>,"brcm,pins:8",
+			   <&frag1>,"cs-gpios:28";
+		cs3_pin	=  <&frag0>,"brcm,pins:12",
+			   <&frag1>,"cs-gpios:40";
+
+		speed =   <&pitft>,"spi-max-frequency:0";
+		rotate =  <&pitft>,"rotate:0";
+		fps =     <&pitft>,"fps:0";
+		debug =   <&pitft>,"debug:0";
+	};
+
+	fragment@2 {
+		target-path = "/";
+		__overlay__ {
+			vref: fixedregulator@0 {
+				compatible = "regulator-fixed";
+				regulator-name = "fixed-supply";
+				regulator-min-microvolt = <2500000>;
+				regulator-max-microvolt = <2500000>;
+				regulator-boot-on;
+			};
+		};
+	};
+
+	fragment@3 {
+		target-path = "/";
+		__overlay__ {
+			clocks {
+				ad7124_mclk: clock@0 {
+					#clock-cells = <0>;
+					compatible = "fixed-clock";
+					clock-frequency = <614400>;
+				};
+			};
+		};
+	};
+
+	fragment@4 {
+		target = <&spi0>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			ad5686r@0{
+				compatible = "adi,ad5683r";
+				reg = <0>;
+				spi-max-frequency = <1000000>;
+				spi-cpha;
+				vcc-supply = <&vref>;
+			};
+		};
+	};
+
+	fragment@5 {
+		target = <&spi0>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			ad7124@1 {
+				compatible = "adi,ad7124-4";
+				reg = <1>;
+				spi-max-frequency = <5000000>;
+				interrupts = <23 2>;
+				interrupt-parent = <&gpio>;
+				refin1-supply = <&vref>;
+				clocks = <&ad7124_mclk>;
+				clock-names = "mclk";
+
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				channel@0 {
+					reg = <0>;
+					diff-channels = <0 19>;
+					adi,reference-select = <0>;
+				};
+
+				channel@1 {
+					reg = <1>;
+					diff-channels = <1 19>;
+					adi,reference-select = <0>;
+				};
+
+				channel@2 {
+					reg = <2>;
+					diff-channels = <2 19>;
+					adi,reference-select = <0>;
+				};
+
+				channel@3 {
+					reg = <3>;
+					diff-channels = <3 19>;
+					adi,reference-select = <0>;
+				};
+
+				channel@4 {
+					reg = <4>;
+					diff-channels = <4 19>;
+					adi,reference-select = <0>;
+				};
+
+				channel@5 {
+					reg = <5>;
+					diff-channels = <5 19>;
+					adi,reference-select = <0>;
+				};
+
+				channel@6 {
+					reg = <6>;
+					diff-channels = <6 19>;
+					adi,reference-select = <0>;
+				};
+
+				channel@7 {
+					reg = <7>;
+					diff-channels = <7 19>;
+					adi,reference-select = <0>;
+				};
+			};
+		};
+	};
+
+	fragment@6 {
+		target = <&spidev0>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@7 {
+		target = <&spidev1>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@8 {
+		target = <&gpio>;
+		__overlay__ {
+			pitft_pins: pitft_pins {
+				brcm,pins = <24 25>;
+				brcm,function = <0 1>; /* in out */
+				brcm,pull = <2 0>; /* pullup none */
+			};
+		};
+	};
+
+	fragment@9 {
+		target = <&spi0>;
+		__overlay__ {
+			/* needed to avoid dtc warning */
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			pitft: pitft@2{
+				compatible = "ilitek,ili9340";
+				reg = <2>;
+				pinctrl-names = "default";
+				pinctrl-0 = <&pitft_pins>;
+
+				spi-max-frequency = <32000000>;
+				rotate = <90>;
+				fps = <25>;
+				bgr;
+				buswidth = <8>;
+				dc-gpios = <&gpio 25 0>;
+				debug = <0>;
+			};
+
+			pitft_ts@3 {
+				compatible = "st,stmpe610";
+				reg = <3>;
+
+				spi-max-frequency = <500000>;
+				irq-gpio = <&gpio 24 0x2>; /* IRQF_TRIGGER_FALLING */
+				interrupts = <24 2>; /* high-to-low edge triggered */
+				interrupt-parent = <&gpio>;
+				interrupt-controller;
+
+				stmpe_touchscreen {
+					compatible = "st,stmpe-ts";
+					st,sample-time = <4>;
+					st,mod-12b = <1>;
+					st,ref-sel = <0>;
+					st,adc-freq = <2>;
+					st,ave-ctrl = <3>;
+					st,touch-det-delay = <4>;
+					st,settling = <2>;
+					st,fraction-z = <7>;
+					st,i-drive = <0>;
+				};
+
+				stmpe_gpio: stmpe_gpio {
+					#gpio-cells = <2>;
+					compatible = "st,stmpe-gpio";
+					/*
+					 * only GPIO2 is wired/available
+					 * and it is wired to the backlight
+					 */
+					st,norequest-mask = <0x7b>;
+				};
+			};
+		};
+	};
+
+	fragment@10 {
+		target-path = "/soc";
+		__overlay__ {
+			backlight {
+				compatible = "gpio-backlight";
+				gpios = <&stmpe_gpio 2 0>;
+				default-on;
+			};
+		};
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-cn0511-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-cn0511-overlay.dts
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2836", "brcm,bcm2835";
+
+	fragment@0 {
+		target-path = "/clocks";
+		__overlay__ {
+			adf4372_clkin: clock@0 {
+				compatible = "fixed-clock";
+				#clock-cells = <0>;
+				clock-frequency = <122880000>;
+				clock-output-names = "clkin";
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&spi0_cs_pins>;
+		frag0: __overlay__ {
+				brcm,pins = <8 7 25>;
+				brcm,function = <1>; //output
+		};
+	};
+
+	fragment@2 {
+		target = <&spi0>;
+		frag1: __overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			cs-gpios = <&gpio 8 1>, <&gpio 7 1>, <&gpio 25 1>;
+			status = "okay";
+
+			dac0_ad9166: ad9166@0 {
+				compatible = "adi,ad9166";
+				reg = <0>;
+				spi-max-frequency = <1000000>;
+				clocks = <&adf4372_clk 0>;
+				clock-names = "dac_clk";
+				spi-cpha;
+				spi-cpol;
+				adi,standalone-probe;
+				adi,dc-test-en;
+				dac_clk-clock-scales = <1 10>;
+			};
+
+			adf4372_clk: adf4372@1 {
+				compatible = "adi,adf4372";
+				reg = <1>;
+
+				#address-cells = <1>;
+				#clock-cells = <1>;
+				#size-cells = <0>;
+
+				spi-max-frequency = <1000000>;
+				spi-3wire;
+				clocks = <&adf4372_clkin>;
+				clock-names = "clkin";
+				clock-output-names = "clk-rf8", "clk-rfaux8",
+						"clk-rf16";
+
+				adi,muxout-select = <1>;
+
+				channel@0 {
+					reg = <0>;
+					adi,power-up-frequency = /bits/ 64
+								<6000000000>;
+				};
+			};
+
+			ad9166_amp: ad9166-amp@2 {
+				compatible = "adi,ad9166-amp";
+				reg = <2>;	// CE2 - gpio25
+				spi-cpha;
+				spi-cpol;
+				spi-max-frequency = <1000000>;
+			};
+		};
+	};
+
+	fragment@3 {
+		target = <&spidev0>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@4 {
+		target = <&spidev1>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@5 {
+		target = <&i2c1>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			ad5696r@4c {
+				compatible = "adi,ad5693r";
+				clock-frequency = <400000>;
+				reg = <0x4c>;
+			};
+
+			eeprom@51 {
+				compatible = "atmel,24c32";
+				reg = <0x51>;
+			};
+		};
+	};
+
+	fragment@6 {
+		target = <&i2c0>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+		};
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-cn0552-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-cn0552-overlay.dts
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-2.0
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2708";
+
+	fragment@0 {
+		target = <&i2c_arm>;
+		__overlay__ {
+			status = "okay";
+
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			adc: ad7746@48 {
+				compatible = "adi,ad7746";
+				reg = <0x48>;
+			};
+		};
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-cn0554-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-cn0554-overlay.dts
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Overlay for the CN0554 Mixed Signal Hat
+ *
+ * Copyright 2023 Analog Devices Inc.
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709";
+};
+
+&{/} {
+	vref: fixedregulator@0 {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-supply";
+		regulator-min-microvolt = <2500000>;
+		regulator-max-microvolt = <2500000>;
+		regulator-boot-on;
+	};
+	vcc: fixedregulator@1 {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc-supply";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+	};
+};
+
+&{/clocks} {
+	ad7124_mclk: clock@0 {
+		#clock-cells = <0>;
+		compatible = "fixed-clock";
+		clock-frequency = <614400>;
+	};
+
+	ltc2688_tgp1: clock@1 {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-frequency = <262144>;
+		clock-output-names = "TGP1";
+	};
+
+	ltc2688_tgp2: clock@2 {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-frequency = <131072>;
+		clock-output-names = "TGP2";
+	};
+};
+
+&spidev0 {
+	status = "disabled";
+};
+
+&spidev1 {
+	status = "disabled";
+};
+
+&spi0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	adc7214: ad7124@0 {
+		compatible = "adi,ad7124-8";
+		reg = <0>;
+		spi-max-frequency = <5000000>;
+
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		clocks = <&ad7124_mclk>;
+		clock-names = "mclk";
+
+		interrupts = <25 2>;
+		interrupt-parent = <&gpio>;
+
+		refin1-supply = <&vref>;
+
+		channel@0 {
+			reg = <0>;
+			diff-channels = <0 1>;
+		};
+
+		channel@1 {
+			reg = <1>;
+			diff-channels = <2 3>;
+		};
+
+		channel@2 {
+			reg = <2>;
+			diff-channels = <4 5>;
+		};
+
+		channel@3 {
+			reg = <3>;
+			diff-channels = <6 7>;
+		};
+
+		channel@4 {
+			reg = <4>;
+			diff-channels = <8 9>;
+		};
+
+		channel@5 {
+			reg = <5>;
+			diff-channels = <10 11>;
+		};
+
+		channel@6 {
+			reg = <6>;
+			diff-channels = <12 13>;
+		};
+
+		channel@7 {
+			reg = <7>;
+			diff-channels = <14 15>;
+		};
+	};
+
+	ltc2688: ltc2688@1 {
+		compatible = "adi,ltc2688";
+		reg = <1>;
+		spi-max-frequency = <5000000>;
+
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		vcc-supply = <&vcc>;
+		iovcc-supply = <&vcc>;
+
+		channel@0 {
+			reg = <0>;
+			adi,output-range-microvolt = <(-15000000) 15000000>;
+		};
+
+		channel@1 {
+			reg = <1>;
+			adi,output-range-microvolt = <(-15000000) 15000000>;
+		};
+
+		channel@2 {
+			reg = <2>;
+			adi,output-range-microvolt = <(-15000000) 15000000>;
+		};
+
+		channel@3 {
+			reg = <3>;
+			adi,output-range-microvolt = <(-15000000) 15000000>;
+		};
+
+		channel@4 {
+			reg = <4>;
+			adi,output-range-microvolt = <(-15000000) 15000000>;
+		};
+
+		channel@5 {
+			reg = <5>;
+			adi,output-range-microvolt = <(-15000000) 15000000>;
+		};
+
+		channel@6 {
+			reg = <6>;
+			adi,output-range-microvolt = <(-15000000) 15000000>;
+		};
+
+		channel@7 {
+			reg = <7>;
+			adi,output-range-microvolt = <(-15000000) 15000000>;
+		};
+
+		channel@8 {
+			reg = <8>;
+			adi,output-range-microvolt = <(-15000000) 15000000>;
+		};
+
+		channel@9 {
+			reg = <9>;
+			adi,output-range-microvolt = <(-15000000) 15000000>;
+		};
+
+		channel@10 {
+			reg = <10>;
+			adi,output-range-microvolt = <(-15000000) 15000000>;
+		};
+
+		channel@11 {
+			reg = <11>;
+			adi,output-range-microvolt = <(-15000000) 15000000>;
+		};
+
+		channel@12 {
+			reg = <12>;
+			adi,output-range-microvolt = <(-15000000) 15000000>;
+		};
+
+		channel@13 {
+			reg = <13>;
+			adi,output-range-microvolt = <(-15000000) 15000000>;
+		};
+
+		channel@14 {
+			reg = <14>;
+			adi,output-range-microvolt = <(-15000000) 15000000>;
+		};
+
+		channel@15 {
+			reg = <15>;
+			adi,output-range-microvolt = <(-15000000) 15000000>;
+		};
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-cn0566-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-cn0566-overlay.dts
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2836", "brcm,bcm2835", "brcm,bcm2709";
+
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			clkin: clock@0 {
+				compatible = "fixed-clock";
+				clock-frequency = <100000000>;
+				clock-output-names = "adf4159_ext_refclk";
+				#clock-cells = <0>;
+			};
+		};
+	};
+
+	/* We have 2 spidev */
+	fragment@1 {
+		target = <&spi0_cs_pins>;
+		frag0: __overlay__ {
+			brcm,pins = <8 7 27>;
+			brcm,function = <1>; //output
+		};
+	};
+
+	fragment@2 {
+		target = <&spi0>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			cs-gpios = <&gpio 8 1>,  <&gpio 7 1>,  <&gpio 27 1>;
+			status = "okay";
+
+			adar1000@0 {
+				compatible = "adi,adar1000";
+				reg = <0>;
+				spi-max-frequency = <3600000>;
+
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				adar1000_0@0 {
+					reg = <0>;
+					label = "BEAM0";
+					adi,phasetable-name = "adar1000_std_phasetable";
+				};
+
+			};
+
+			adar1000@1 {
+				compatible = "adi,adar1000";
+				reg = <1>;
+				spi-max-frequency = <3600000>;
+
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				adar1000_1@0 {
+					reg = <0>;
+					label = "BEAM1";
+					adi,phasetable-name = "adar1000_std_phasetable";
+				};
+			};
+
+			adf4159@2 {
+				compatible = "adi,adf4159";
+				reg = <2>;
+				label = "pll0";
+				spi-max-frequency = <3600000>;
+				/* Clocks */
+				clocks = <&clkin>;
+				clock-names = "clkin";
+				clock-output-names = "rf_out";
+				#clock-cells = <0>;
+				adi,power-up-frequency-hz = /bits/ 64 <3000000000>;
+				adi,charge-pump-current-microamp = <900>;
+				adi,clk1-div = <100>;
+				adi,clk2-timer-div = <0>;
+				adi,clk2-timer-div-2 = <0>;
+				adi,clk-div-mode = <0>;
+				adi,delay-start-word = <0>;
+				adi,deviation = <1000>;
+				adi,deviation-2 = <0>;
+				adi,deviation-offset = <1>;
+				adi,interrupt-mode-select = <0>;
+				adi,muxout-select = <15>;
+				adi,negative-bleed-current-microamp = <0>;
+				adi,phase = <0>;
+				adi,ramp-mode-select = <0>;
+				adi,ramp-status-mode = <3>;
+				adi,reference-div-factor = <1>;
+				adi,step-word = <0>;
+				adi,step-word-2 = <0>;
+			};
+		};
+	};
+
+	fragment@3 {
+		target-path = "/";
+		__overlay__ {
+			one-bit-adc-dac@0 {
+				compatible = "adi,one-bit-adc-dac";
+				label = "gpios";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				in-gpios = <&gpio 25 0>;
+				out-gpios = <&gpio 4 0>, <&gpio 17 0>, <&gpio 22 0>, <&gpio 5 0>,
+					    <&gpio 6 0>, <&gpio 13 0>, <&gpio 18 0>, <&gpio 24 0>,
+					    <&gpio 12 0>, <&gpio 23 0>;
+				status = "okay";
+				channel@0 {
+					reg = <0>;
+					label = "MUXOUT";
+				};
+				channel@1 {
+					reg = <1>;
+					label = "DIV_S0";
+				};
+				channel@2 {
+					reg = <2>;
+					label = "RX_LOAD";
+				};
+				channel@3 {
+					reg = <3>;
+					label = "TR";
+				};
+				channel@4 {
+					reg = <4>;
+					label = "DIV_S1";
+				};
+				channel@5 {
+					reg = <5>;
+					label = "DIV_S2";
+				};
+				channel@6 {
+					reg = <6>;
+					label = "DIV_MR";
+				};
+				channel@7 {
+					reg = <7>;
+					label = "VCTRL_1";
+				};
+				channel@8 {
+					reg = <8>;
+					label = "VCTRL_2";
+				};
+				channel@9 {
+					reg = <9>;
+					label = "TX_SW";
+				};
+				channel@10 {
+					reg = <10>;
+					label = "BURST";
+				};
+			};
+		};
+	};
+
+	fragment@4 {
+		target = <&i2c1>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+			ad7291@2f {
+				compatible = "adi,ad7291";
+				label = "housekeeping_adc";
+				clock-frequency = <400000>;
+				reg = <0x2a>;
+			};
+
+			eeprom@50 {
+				compatible = "at24,24c32";
+				clock-frequency = <400000>;
+				reg = <0x57>;
+			};
+		};
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-cn0575-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-cn0575-overlay.dts
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR BSD-3-Clause)
+/* Overlay for EVAL-CN0575-RPIZ Rev. A
+ *
+ * Copyright 2022 Analog Devices Inc.
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/interrupt-controller/irq.h>
+
+&spidev0 {
+	status = "disabled";
+};
+
+&spidev1 {
+	status = "disabled";
+};
+
+&spi0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	ethernet@0 {
+		compatible = "adi,adin1110";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		interrupt-parent = <&gpio>;
+		interrupts = <25 IRQ_TYPE_LEVEL_LOW>;
+		mac-address = [ CA 2F B7 10 23 63 ];
+
+		phy@0 {
+			compatible = "ethernet-phy-id0283.bc91";
+			reg = <0x0>;
+		};
+	};
+};
+
+&i2c1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	adt75@48 {
+		reg = <0x48>;
+		compatible = "adi,adt75";
+	};
+};
+
+&gpio {
+	gpio_overrides: gpio_overrides {
+		pin-13-reset-high {
+			pins = "gpio27";
+			function = "gpio_out";
+			bias-pull-up;
+			output-high;
+			export;
+		};
+	};
+};
+
+&{/} {
+	#include <dt-bindings/gpio/gpio.h>
+
+	one-bit-adc-dac {
+		compatible = "adi,one-bit-adc-dac";
+		label = "gpios";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		in-gpios = <&gpio 16 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+		out-gpios = <&gpio 26 GPIO_ACTIVE_HIGH>;
+		status = "okay";
+
+		channel@0 {
+			reg = <0>;
+			label = "EXT_BTN";
+		};
+
+		channel@1 {
+			reg = <1>;
+			label = "EXT_LED";
+		};
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-dc1962c-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-dc1962c-overlay.dts
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm, bcm2835";
+
+	fragment@0 {
+		target = <&i2c_arm>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			reg0: ltc3880@30 {
+				compatible = "lltc,ltc3880";
+				reg = <0x30>;
+				regulators {
+					vout0 {
+						regulator-name = "VOUT 0";
+						regulator-boot-on;
+						regulator-always-on;
+					};
+					vout1 {
+						regulator-name = "VOUT 1";
+						regulator-boot-on;
+						regulator-always-on;
+					};
+				};
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&i2c_arm>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			reg1: ltc2974@32 {
+				compatible = "lltc,ltc2974";
+				reg = <0x32>;
+				regulators {
+					vout0 {
+						regulator-name = "VOUT 2";
+						regulator-boot-on;
+						regulator-always-on;
+					};
+					vout1 {
+						regulator-name = "VOUT 3";
+						regulator-boot-on;
+						regulator-always-on;
+					};
+					vout2 {
+						regulator-name = "VOUT 4";
+						regulator-boot-on;
+						regulator-always-on;
+					};
+					vout3 {
+						regulator-name = "VOUT 5";
+						regulator-boot-on;
+						regulator-always-on;
+					};
+				};
+			};
+		};
+	};
+
+	fragment@2 {
+		target = <&i2c_arm>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			reg2: ltc2977@33 {
+				compatible = "lltc,ltc2977";
+				reg = <0x33>;
+				regulators {
+					vout0 {
+						regulator-name = "VOUT 6";
+						regulator-boot-on;
+						regulator-always-on;
+					};
+					vout1 {
+						regulator-name = "VOUT 7";
+						regulator-boot-on;
+						regulator-always-on;
+					};
+					vout2 {
+						regulator-name = "VOUT 8";
+						regulator-boot-on;
+						regulator-always-on;
+					};
+					vout3 {
+						regulator-name = "VOUT 9";
+						regulator-boot-on;
+						regulator-always-on;
+					};
+					vout4 {
+						regulator-name = "VOUT 10";
+						regulator-boot-on;
+						regulator-always-on;
+					};
+					vout5 {
+						regulator-name = "VOUT 11";
+						regulator-boot-on;
+						regulator-always-on;
+					};
+					vout6 {
+						regulator-name = "VOUT 12";
+						regulator-boot-on;
+						regulator-always-on;
+					};
+					vout7 {
+						regulator-name = "VOUT 13";
+						regulator-boot-on;
+						regulator-always-on;
+					};
+				};
+			};
+		};
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-lm75-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-lm75-overlay.dts
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target = <&i2c1>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			lm75: lm75@4c{
+				compatible = "lm75";
+				reg = <0x4c>;
+				label = "my_lm75";
+			};
+
+		};
+	};
+
+	__overrides__ {
+		addr = <&lm75>,"reg:0";
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-ltc2497-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ltc2497-overlay.dts
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target-path = "/";
+
+		__overlay__ {
+
+			vref: fixedregulator@0 {
+				compatible = "regulator-fixed";
+				regulator-name = "vref";
+				regulator-min-microvolt = <2500000>;
+				regulator-max-microvolt = <2500000>;
+				phandle = <0x1>;
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&i2c1>;
+		__overlay__ {
+			#address-cells = <0x1>;
+			#size-cells = <0x0>;
+			status = "okay";
+			ltc2497: ltc2497@76 {
+				compatible = "lltc,ltc2497";
+				reg = <0x76>;
+				label = "my_ltc2497";
+				vref-supply = <&vref>;
+				clock-frequency = <400000>;
+				status = "okay";
+			};
+		};
+	};
+
+	__overrides__ {
+		addr = <&ltc2497>,"reg:0";
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-ltc2688-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ltc2688-overlay.dts
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Overlay for the 16 channel LTC2688 DAC
+ *
+ * Copyright 2022 Analog Devices Inc.
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709";
+};
+
+&{/} {
+	vcc: fixedregulator@1 {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc-supply";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+	};
+};
+
+&{/clocks} {
+	ltc2688_tgp1: clock@0 {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+
+		clock-frequency = <262144>;
+		clock-output-names = "TGP1";
+	};
+
+	ltc2688_tgp2: clock@1 {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+
+		clock-frequency = <131072>;
+		clock-output-names = "TGP2";
+	};
+};
+
+&spidev0 {
+	status = "disabled";
+};
+
+&spidev1 {
+	status = "disabled";
+};
+
+&spi0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	ltc2688: ltc2688@0 {
+		compatible = "adi,ltc2688";
+		reg = <0>;
+		spi-max-frequency = <5000000>;
+
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		vcc-supply = <&vcc>;
+		iovcc-supply = <&vcc>;
+
+		channel@0 {
+			reg = <0>;
+			adi,toggle-dither-input = <1>;
+			clocks = <&ltc2688_tgp2>;
+		};
+
+		channel@1 {
+			reg = <1>;
+			adi,overrange;
+			adi,output-range-microvolt = <(-5000000) 5000000>;
+		};
+
+		channel@2 {
+			reg = <2>;
+			adi,toggle-mode;
+			adi,toggle-dither-input = <0>;
+			clocks = <&ltc2688_tgp1>;
+		};
+
+		channel@3 {
+			reg = <3>;
+			adi,toggle-dither-input = <1>;
+			clocks = <&ltc2688_tgp2>;
+			adi,output-range-microvolt = <(-15000000) 15000000>;
+		};
+
+		channel@7 {
+			reg = <7>;
+			adi,toggle-mode;
+		};
+	};
+};
+
+/ {
+	__overrides__ {
+		cs_pin = <&ltc2688>,"reg:0";
+		tgp1_rate = <&ltc2688_tgp1>,"clock-frequency:0";
+		tgp2_rate = <&ltc2688_tgp2>,"clock-frequency:0";
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-ltc6952-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ltc6952-overlay.dts
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709";
+
+	fragment@0 {
+		target = <&spi0>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			clk0_ltc6952: ltc6952@0 {
+				compatible = "adi,ltc6952";
+				reg = <0>;
+
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				spi-max-frequency = <10000000>;
+
+				clock-output-names = "ltc6952_out0", "ltc6952_out1", "ltc6952_out2",
+					"ltc6952_out3", "ltc6952_out4", "ltc6952_out5", "ltc6952_out6",
+					"ltc6952_out7", "ltc6952_out8", "ltc6952_out9", "ltc6952_out10",
+					"ltc6952_out11";
+				#clock-cells = <1>;
+
+				adi,vco-frequency-hz = <4000000000>;
+				adi,ref-frequency-hz = <100000000>;
+
+				ltc6952_0_c0: channel@0 {
+					reg = <0>;
+					adi,extended-name = "REF_CLK";
+					adi,divider = <10>;
+					adi,digital-delay = <0>;
+					adi,analog-delay = <0>;
+				};
+
+				ltc6952_0_c1: channel@1 {
+					reg = <1>;
+					adi,extended-name = "TEST_CLK";
+					adi,divider = <10>;
+					adi,digital-delay = <0>;
+					adi,analog-delay = <0>;
+				};
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&spidev0>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-max14830-i2c-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-max14830-i2c-overlay.dts
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-2.0
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+
+/ {
+	compatible = "brcm,bcm2835", "brcm,bcm2711";
+
+	fragment@0 {
+		target-path = "/clocks";
+
+		__overlay__ {
+			max14830_xtal: max14830_xtal {
+				compatible = "fixed-clock";
+				#clock-cells = <0>;
+				clock-frequency = <3686400>;
+			};
+		};
+
+	};
+
+	fragment@1 {
+		target = <&i2c1>;
+
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			status = "okay";
+
+			max14830@6c {
+				compatible = "maxim,max14830";
+				reg = <0x6c>;
+
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				gpio-controller;
+				#gpio-cells = <2>;
+
+				interrupts = <27 IRQ_TYPE_EDGE_FALLING>;
+				interrupt-parent = <&gpio>;
+
+				clocks = <&max14830_xtal>;
+				clock-names = "xtal";
+			};
+		};
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-max14830-spi-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-max14830-spi-overlay.dts
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-2.0
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+
+/ {
+	compatible = "brcm,bcm2835", "brcm,bcm2711";
+
+	fragment@0 {
+		target-path = "/clocks";
+
+		__overlay__ {
+			max14830_xtal: max14830_xtal {
+				compatible = "fixed-clock";
+				#clock-cells = <0>;
+				clock-frequency = <3686400>;
+			};
+		};
+
+	};
+
+	fragment@1 {
+		target = <&spi0>;
+
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			cs-gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			status = "okay";
+
+			max14830@0 {
+				compatible = "maxim,max14830";
+				reg = <0>;
+
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				gpio-controller;
+				#gpio-cells = <2>;
+
+				spi-max-frequency = <5000000>;
+				interrupts = <27 IRQ_TYPE_EDGE_FALLING>;
+				interrupt-parent = <&gpio>;
+
+				clocks = <&max14830_xtal>;
+				clock-names = "xtal";
+			};
+		};
+	};
+
+	fragment@2 {
+		target = <&spidev0>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@3 {
+		target = <&spidev1>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+};


### PR DESCRIPTION
Bring all the ADI custom overlays from the rpi-5.10.y branch to the new one.


(We might need to think in a better way of pushing the overlays so this does not happen again)
