### PR TITLE
fixing the refcount overlay error for ad9361

### DIFF
--- a/drivers/iio/adc/ad9361.c
+++ b/drivers/iio/adc/ad9361.c
@@ -9607,6 +9607,7 @@ static int ad9361_remove(struct spi_device *spi)
 	clk_notifier_unregister(phy->clks[RX_RFPLL], &phy->clk_nb_rx);
 	clk_notifier_unregister(phy->clks[TX_RFPLL], &phy->clk_nb_tx);
 	ad9361_clks_disable(phy);
+    udelay(100);
 
 	return 0;
 }

--- a/drivers/iio/adc/ad9361_ext_band_ctrl.c
+++ b/drivers/iio/adc/ad9361_ext_band_ctrl.c
@@ -365,18 +365,21 @@ static int ad9361_populate_settings(struct device *dev,
 			break;
 
 		new = devm_kzalloc(dev, sizeof(*new), GFP_KERNEL);
-		if (!new)
+		if (!new){
+            of_node_put(child);
 			return -ENOMEM;
-
+        }
 		dev_dbg(dev, "Found '%s'\n", child->name);
 		ret = ad9361_parse_setting_with_freq_range(dev, child,
 						ctl, new);
 		if (ret < 0) {
 			dev_err(dev, "Error while parsing '%s': %d\n",
 				child->name, ret);
+            of_node_put(child);
 			return ret;
 		}
 		list_add_tail(&new->list, lst);
+        of_node_put(child);
 	}
 
 	return cnt;
@@ -400,10 +403,12 @@ static int ad9361_populate_hooks(struct device *dev,
 
 		ctl->hooks[i] = devm_kzalloc(dev, sizeof(*ctl->hooks[i]),
 					     GFP_KERNEL);
-		if (!ctl->hooks[i])
+		if (!ctl->hooks[i]) {
+            of_node_put(child);
 			return -ENOMEM;
-
+        }
 		ret = ad9361_parse_setting(dev, child, ctl, ctl->hooks[i], NULL);
+        of_node_put(child);
 		if (ret < 0)
 			return ret;
 	}

--- a/drivers/iio/adc/cf_axi_adc_core.c
+++ b/drivers/iio/adc/cf_axi_adc_core.c
@@ -1084,6 +1084,7 @@ static int axiadc_probe(struct platform_device *pdev)
 	unsigned int config, skip = 1;
 	int ret;
 
+    udelay(100);
 	dev_dbg(&pdev->dev, "Device Tree Probing \'%s\'\n",
 		 pdev->dev.of_node->name);
 
@@ -1105,7 +1106,10 @@ static int axiadc_probe(struct platform_device *pdev)
 
 	ret = bus_for_each_dev(&spi_bus_type, NULL, &axiadc_spidev,
 			       axiadc_attach_spi_client);
-	if (ret == 0)
+    
+    of_node_put(axiadc_spidev.of_nspi);
+    
+    if (ret == 0)
 		return -EPROBE_DEFER;
 
 	if (!try_module_get(axiadc_spidev.dev_spi->driver->owner))
@@ -1233,7 +1237,7 @@ static int axiadc_probe(struct platform_device *pdev)
 		return ret;
 	}
 
-	ret = iio_device_register(indio_dev);
+	ret = devm_iio_device_register(&pdev->dev,indio_dev);
 	if (ret)
 		return ret;
 


### PR DESCRIPTION
This patch is to fix errors experienced when trying to perform device overlay removal/ load a new device tree.
OF: ERROR: memory leak, expected refcount 1 instead of 2, of_node_get()/of_node_put() unbalanced - destroy cset entry: attach overlay node /axi/cf-ad9361-lpc-a@79020000
OF: ERROR: memory leak, expected refcount 1 instead of 2, of_node_get()/of_node_put() unbalanced - destroy cset entry: attach overlay node /axi/spi@e0007000/ad9361-phy-a@0

  The ndelay were added to fix a race condition experienced when quickly unloading/loading devicetree overlays, which would frequently result in kernel panic /sometimes a a full system crash