### PR TITLE
pluto adrv9002 rx muxes

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-pluto-ng.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-pluto-ng.dts
@@ -280,7 +280,8 @@
 &zynqmp_dpsub {
 	status = "okay";
 	phy-names = "dp-phy0";
-	phys = <&psgtr 1 PHY_TYPE_DP 0 1>;
+	phys = <&psgtr 3 PHY_TYPE_DP 0 1>,
+		<&psgtr 2 PHY_TYPE_DP 1 1>;
 };
 
 &zynqmp_dp_snd_codec0 {
@@ -314,7 +315,7 @@
 	ceva,p1-burst-params = /bits/ 8 <0x13 0x08 0x4A 0x06>;
 	ceva,p1-retry-params = /bits/ 16 <0x96A4 0x3FFC>;
 	phy-names = "sata-phy";
-	phys = <&psgtr 3 PHY_TYPE_SATA 1 2>;
+	phys = <&psgtr 1 PHY_TYPE_SATA 1 2>;
 };
 
 &usb0 {

--- a/arch/arm64/boot/dts/xilinx/zynqmp-pluto-ng.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-pluto-ng.dts
@@ -348,16 +348,30 @@
 
 	usb_reset {
 		gpio-hog;
-		gpios = <13 0>;
+		gpios = <13 GPIO_ACTIVE_HIGH>;
 		output-high;
 		line-name = "usb-reset";
 	};
 
 	adrv9002_clksrc {
 		gpio-hog;
-		gpios = <79 0>;
+		gpios = <79 GPIO_ACTIVE_HIGH>;
 		output-high;
 		line-name = "adrv9002-clksrc";
+	};
+
+	fan_en {
+		gpio-hog;
+		gpios = <144 GPIO_ACTIVE_HIGH>;
+		output-high;
+		line-name = "fan-en";
+	};
+
+	fan_ctl {
+		gpio-hog;
+		gpios = <145 GPIO_ACTIVE_HIGH>;
+		output-low;
+		line-name = "fan-ctl";
 	};
 };
 

--- a/arch/arm64/boot/dts/xilinx/zynqmp-pluto-ng.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-pluto-ng.dts
@@ -359,55 +359,6 @@
 		output-high;
 		line-name = "adrv9002-clksrc";
 	};
-
-	rf_rx1a_mux_ctl {
-		gpio-hog;
-		gpios = <86 0>;
-		output-high;
-		line-name = "rf_rx1a_mux_ctl";
-	};
-	rf_rx1b_mux_ctl {
-		gpio-hog;
-		gpios = <87 0>;
-		output-high;
-		line-name = "rf_rx1b_mux_ctl";
-	};
-	rf_rx2a_mux_ctl {
-		gpio-hog;
-		gpios = <88 0>;
-		output-high;
-		line-name = "rf_rx2a_mux_ctl";
-	};
-	rf_rx2b_mux_ctl {
-		gpio-hog;
-		gpios = <89 0>;
-		output-high;
-		line-name = "rf_rx2b_mux_ctl";
-	};
-	rf_tx1_mux_ctl1 {
-		gpio-hog;
-		gpios = <90 0>;
-		output-high;
-		line-name = "rf_tx1_mux_ctl1";
-	};
-	rf_tx1_mux_ctl2 {
-		gpio-hog;
-		gpios = <91 0>;
-		output-low;
-		line-name = "rf_tx1_mux_ctl2";
-	};
-	rf_tx2_mux_ctl1 {
-		gpio-hog;
-		gpios = <92 0>;
-		output-low;
-		line-name = "rf_tx2_mux_ctl1";
-	};
-	rf_tx2_mux_ctl2 {
-		gpio-hog;
-		gpios = <93 0>;
-		output-high;
-		line-name = "rf_tx2_mux_ctl2";
-	};
 };
 
 &spi0 {
@@ -594,4 +545,26 @@
 &adc0_adrv9002 {
 	reset-gpios = <&gpio 81 GPIO_ACTIVE_LOW>;
 	interrupts = <78 IRQ_TYPE_EDGE_RISING>;
+
+	adi,channels {
+		rx@0 {
+			mux-ctl-gpios = <&gpio 86 GPIO_ACTIVE_HIGH>;
+			mux-ctl2-gpios = <&gpio 87 GPIO_ACTIVE_LOW>;
+		};
+
+		rx@1 {
+			mux-ctl-gpios = <&gpio 88 GPIO_ACTIVE_HIGH>;
+			mux-ctl2-gpios = <&gpio 89 GPIO_ACTIVE_LOW>;
+		};
+
+		tx@0 {
+			mux-ctl-gpios = <&gpio 90 GPIO_ACTIVE_HIGH>;
+			mux-ctl2-gpios = <&gpio 91 GPIO_ACTIVE_LOW>;
+		};
+
+		tx@1 {
+			mux-ctl-gpios = <&gpio 92 GPIO_ACTIVE_LOW>;
+			mux-ctl2-gpios = <&gpio 93 GPIO_ACTIVE_HIGH>;
+		};
+	};
 };

--- a/drivers/iio/adc/navassa/adrv9002.h
+++ b/drivers/iio/adc/navassa/adrv9002.h
@@ -148,6 +148,8 @@ struct adrv9002_clock {
 
 struct adrv9002_chan {
 	struct clk *clk;
+	struct gpio_desc *mux_ctl;
+	struct gpio_desc *mux_ctl_2;
 	struct adrv9002_ext_lo *ext_lo;
 	/*
 	 * These values are in nanoseconds. They need to be converted with

--- a/drivers/iio/adc/navassa/adrv9002.h
+++ b/drivers/iio/adc/navassa/adrv9002.h
@@ -222,6 +222,7 @@ struct adrv9002_rf_phy {
 	struct iio_dev			*indio_dev;
 	struct gpio_desc		*reset_gpio;
 	struct gpio_desc		*ssi_sync;
+	struct iio_chan_spec		*iio_chan;
 	/* Protect against concurrent accesses to the device */
 	struct mutex			lock;
 	struct clk			*clks[NUM_ADRV9002_CLKS];

--- a/drivers/iio/adc/navassa/adrv9002_of.c
+++ b/drivers/iio/adc/navassa/adrv9002_of.c
@@ -519,6 +519,8 @@ of_pinctrl_put:
 static int adrv9002_parse_tx_dt(struct adrv9002_rf_phy *phy,
 				struct device_node *node, const int channel)
 {
+	const char *mux_label_2 = channel ? "tx2-mux-ctl2" : "tx1-mux-ctl2";
+	const char *mux_label = channel ? "tx2-mux-ctl" : "tx1-mux-ctl";
 	struct adrv9002_tx_chan *tx = &phy->tx_channels[channel];
 	int ret;
 
@@ -533,6 +535,16 @@ static int adrv9002_parse_tx_dt(struct adrv9002_rf_phy *phy,
 	ret = adrv9002_parse_en_delays(phy, node, &tx->channel);
 	if (ret)
 		return ret;
+
+	tx->channel.mux_ctl = devm_fwnode_gpiod_get_optional(&phy->spi->dev, node, "mux-ctl",
+							     GPIOD_OUT_HIGH, mux_label);
+	if (IS_ERR(tx->channel.mux_ctl))
+		return PTR_ERR(tx->channel.mux_ctl);
+
+	tx->channel.mux_ctl_2 = devm_fwnode_gpiod_get_optional(&phy->spi->dev, node, "mux-ctl2",
+							       GPIOD_OUT_HIGH, mux_label_2);
+	if (IS_ERR(tx->channel.mux_ctl_2))
+		return PTR_ERR(tx->channel.mux_ctl_2);
 
 	return adrv9002_parse_tx_pin_dt(phy, node, tx);
 }
@@ -814,6 +826,8 @@ static int adrv9002_parse_rx_dt(struct adrv9002_rf_phy *phy,
 				struct device_node *node,
 				const int channel)
 {
+	const char *rxb_mux_label = channel ? "rx2b-mux-ctl" : "rx1b-mux-ctl";
+	const char *mux_label = channel ? "rx2a-mux-ctl" : "rx1a-mux-ctl";
 	const char *gpio_label = channel ? "orx2" : "orx1";
 	struct adrv9002_rx_chan *rx = &phy->rx_channels[channel];
 	int ret;
@@ -860,6 +874,16 @@ static int adrv9002_parse_rx_dt(struct adrv9002_rf_phy *phy,
 						      gpio_label);
 	if (IS_ERR(rx->orx_gpio))
 		return PTR_ERR(rx->orx_gpio);
+
+	rx->channel.mux_ctl = devm_fwnode_gpiod_get_optional(&phy->spi->dev, node, "mux-ctl",
+							     GPIOD_OUT_HIGH, mux_label);
+	if (IS_ERR(rx->channel.mux_ctl))
+		return PTR_ERR(rx->channel.mux_ctl);
+
+	rx->channel.mux_ctl_2 = devm_fwnode_gpiod_get_optional(&phy->spi->dev, node, "mux-ctl2",
+							       GPIOD_OUT_HIGH, rxb_mux_label);
+	if (IS_ERR(rx->channel.mux_ctl_2))
+		return PTR_ERR(rx->channel.mux_ctl_2);
 
 	return 0;
 }

--- a/drivers/iio/adc/navassa/adrv9002_of.c
+++ b/drivers/iio/adc/navassa/adrv9002_of.c
@@ -799,6 +799,7 @@ static int adrv9002_parse_rx_dt(struct adrv9002_rf_phy *phy,
 				struct device_node *node,
 				const int channel)
 {
+	const char *gpio_label = channel ? "orx2" : "orx1";
 	struct adrv9002_rx_chan *rx = &phy->rx_channels[channel];
 	int ret;
 	u32 min_gain, max_gain;
@@ -840,9 +841,8 @@ static int adrv9002_parse_rx_dt(struct adrv9002_rf_phy *phy,
 	}
 
 	/* there's no optional variant for this, so we need to check for -ENOENT */
-	rx->orx_gpio = devm_fwnode_get_index_gpiod_from_child(&phy->spi->dev, "orx", 0,
-							      of_fwnode_handle(node),
-							      GPIOD_OUT_LOW, NULL);
+	rx->orx_gpio = devm_fwnode_gpiod_get(&phy->spi->dev, of_fwnode_handle(node),
+					     "orx", GPIOD_OUT_LOW, gpio_label);
 	if (IS_ERR(rx->orx_gpio)) {
 		if (PTR_ERR(rx->orx_gpio) != -ENOENT)
 			return PTR_ERR(rx->orx_gpio);


### PR DESCRIPTION
The main goal of this PR is to support adrv9002 port muxes (when available) so that we can make sure all the ports are duly terminated during init calls. It's now possible to select between TX_A and TX_B for transmission. Some devices might re-route TX (through eg: an amplifier) so we can select between those two options.

While doing the above:

* Some cleanups were done;
* Supported GPIOs hogs for fanctl;
* Cherry-picked a missing dts patch.