### PR TITLE
iio: adc: adrv9002: fix -Wdiscarded-qualifiers warning

### DIFF
--- a/drivers/iio/adc/navassa/adrv9002_conv.c
+++ b/drivers/iio/adc/navassa/adrv9002_conv.c
@@ -271,7 +271,7 @@ static void adrv9002_axi_digital_tune_verbose(const struct adrv9002_rf_phy *phy,
 {
 	int i, j;
 	char c;
-	struct adrv9002_chan *ch;
+	const struct adrv9002_chan *ch;
 
 	if (tx)
 		ch = &phy->tx_channels[channel].channel;


### PR DESCRIPTION
The warning was introduced by
commit cf397097e5848 ("iio: adc: adrv9002: constify where possible") and only triggers when DEBUG is defined...