### PR TITLE
Staging/fix ad9081 versal dts

### DIFF
--- a/arch/arm64/boot/dts/xilinx/versal-vck190-reva-ad9081.dts
+++ b/arch/arm64/boot/dts/xilinx/versal-vck190-reva-ad9081.dts
@@ -89,12 +89,6 @@
 	status = "okay";
 };
 
-&sysmon {
-	#address-cells = <1>;
-	#size-cells = <0>;
-	xlnx,numchannels = /bits/8 <0>;
-};
-
 &serial0 {
 	cts-override ;
 	device_type = "serial";

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -94,6 +94,7 @@ jobs:
     DTS_FILES: "arch/arm/boot/dts/zynq-*.dts
                 arch/arm/boot/dts/socfpga_*.dts
                 arch/arm64/boot/dts/xilinx/zynqmp-*.dts
+                arch/arm64/boot/dts/xilinx/versal-*.dts
                 arch/microblaze/boot/dts/*.dts
                 arch/nios2/boot/dts/*.dts"
   steps:

--- a/ci/travis/dtb_build_test_exceptions
+++ b/ci/travis/dtb_build_test_exceptions
@@ -79,6 +79,46 @@ arch/arm64/boot/dts/xilinx/zynqmp-vpk120-revA.dts
 arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev1.1.dts
 arch/arm64/boot/dts/xilinx/zynqmp-zcu670-revA.dts
 arch/arm64/boot/dts/xilinx/zynqmp-zcu670-revB.dts
+arch/arm64/boot/dts/xilinx/versal-net-emu-rev1.9.dts
+arch/arm64/boot/dts/xilinx/versal-net-ipp-rev1.9.dts
+arch/arm64/boot/dts/xilinx/versal-net-ipp-rev1.9-ospi.dts
+arch/arm64/boot/dts/xilinx/versal-v350-revA.dts
+arch/arm64/boot/dts/xilinx/versal-vck190-rev1.1.dts
+arch/arm64/boot/dts/xilinx/versal-vck190-rev1.1-x-ebm-01-revA.dts
+arch/arm64/boot/dts/xilinx/versal-vck190-rev1.1-x-ebm-02-revA.dts
+arch/arm64/boot/dts/xilinx/versal-vck190-rev1.1-x-ebm-03-revA.dts
+arch/arm64/boot/dts/xilinx/versal-vck190-reva.dts
+arch/arm64/boot/dts/xilinx/versal-vck190-revA.dts
+arch/arm64/boot/dts/xilinx/versal-vck190-revA-x-ebm-01-revA.dts
+arch/arm64/boot/dts/xilinx/versal-vck190-revA-x-ebm-02-revA.dts
+arch/arm64/boot/dts/xilinx/versal-vck190-revA-x-ebm-03-revA.dts
+arch/arm64/boot/dts/xilinx/versal-vck5000-revA.dts
+arch/arm64/boot/dts/xilinx/versal-vc-p-a2197-00-revA.dts
+arch/arm64/boot/dts/xilinx/versal-vc-p-a2197-00-revA-x-prc-01-revA.dts
+arch/arm64/boot/dts/xilinx/versal-vc-p-a2197-00-revA-x-prc-01-revA-ospi.dts
+arch/arm64/boot/dts/xilinx/versal-vc-p-a2197-00-revA-x-prc-02-revA.dts
+arch/arm64/boot/dts/xilinx/versal-vc-p-a2197-00-revA-x-prc-03-revA.dts
+arch/arm64/boot/dts/xilinx/versal-vc-p-a2197-00-revA-x-prc-04-revA.dts
+arch/arm64/boot/dts/xilinx/versal-vc-p-a2197-00-revA-x-prc-04-revA-ospi.dts
+arch/arm64/boot/dts/xilinx/versal-vc-p-a2197-00-revA-x-prc-05-revA.dts
+arch/arm64/boot/dts/xilinx/versal-vek280-revA.dts
+arch/arm64/boot/dts/xilinx/versal-vhk158-revA.dts
+arch/arm64/boot/dts/xilinx/versal-vmk180-rev1.1.dts
+arch/arm64/boot/dts/xilinx/versal-vmk180-rev1.1-x-ebm-01-revA.dts
+arch/arm64/boot/dts/xilinx/versal-vmk180-rev1.1-x-ebm-02-revA.dts
+arch/arm64/boot/dts/xilinx/versal-vmk180-rev1.1-x-ebm-03-revA.dts
+arch/arm64/boot/dts/xilinx/versal-vmk180-reva.dts
+arch/arm64/boot/dts/xilinx/versal-vmk180-revA.dts
+arch/arm64/boot/dts/xilinx/versal-vmk180-revA-x-ebm-01-revA.dts
+arch/arm64/boot/dts/xilinx/versal-vmk180-revA-x-ebm-02-revA.dts
+arch/arm64/boot/dts/xilinx/versal-vmk180-revA-x-ebm-03-revA.dts
+arch/arm64/boot/dts/xilinx/versal-vpk120-revA.dts
+arch/arm64/boot/dts/xilinx/versal-vpk120-revB.dts
+arch/arm64/boot/dts/xilinx/versal-vpk180-revA.dts
+arch/arm64/boot/dts/xilinx/versal-vp-x-a2785-00-revA.dts
+arch/arm64/boot/dts/xilinx/versal-x-ebm-01-revA.dts
+arch/arm64/boot/dts/xilinx/versal-x-ebm-02-revA.dts
+arch/arm64/boot/dts/xilinx/versal-x-ebm-03-revA.dts
 
 # Anything belonging to ADI, goes here
 


### PR DESCRIPTION
This fixes the devicetree for mxfe on versal. On top of it, it makes sure those devicetree are being build by CI.