### PR TITLE
ad9136 fixes

### DIFF
--- a/arch/arm/boot/dts/adi-common-dac-fmc-ebz.dtsi
+++ b/arch/arm/boot/dts/adi-common-dac-fmc-ebz.dtsi
@@ -25,16 +25,15 @@
 
 	spibus-connected = <&dac>;
 	adi,axi-pl-fifo-enable;
+
+	/* jesd204-fsm support */
+	jesd204-device;
+	#jesd204-cells = <2>;
+	jesd204-inputs = <&jesd204_link 0 0>;
 };
 
 &jesd204_link {
 	compatible = "adi,axi-jesd204-tx-1.0";
-
-	adi,octets-per-frame = <1>;
-	adi,frames-per-multiframe = <32>;
-	adi,converter-resolution = <16>;
-	adi,bits-per-sample = <16>;
-	adi,converters-per-device = <2>;
 
 	#clock-cells = <0>;
 	clock-output-names = "jesd_dac_lane_clk";

--- a/arch/arm/boot/dts/adi-xilinx-dac-fmc-ebz.dtsi
+++ b/arch/arm/boot/dts/adi-xilinx-dac-fmc-ebz.dtsi
@@ -17,23 +17,32 @@
 
 		interrupts = <0 54 IRQ_TYPE_LEVEL_HIGH>;
 
-		clocks = <&axi_clk>, <&fpga_device_clk>, <&jesd204_phy 0>;
-		clock-names = "s_axi_aclk", "device_clk", "lane_clk";
+		clocks = <&axi_clk>, <&fpga_device_clk>, <&jesd204_phy 0>, <&ad9516 7>;
+		clock-names = "s_axi_aclk", "device_clk", "lane_clk", "sysref_clk";
+
+		/* jesd204-fsm support */
+		jesd204-device;
+		#jesd204-cells = <2>;
+		jesd204-inputs = <&jesd204_phy 0 0>;
 	};
 
 	jesd204_phy: jesd204-phy@44a60000 {
 		compatible = "adi,axi-adxcvr-1.0";
 		reg = <0x44a60000 0x1000>;
 
-		clocks = <&fpga_device_clk>, <&fpga_device_clk>;
-		clock-names = "conv", "div40";
+		clocks = <&fpga_device_clk>;
+		clock-names = "conv";
 
 		#clock-cells = <1>;
 		clock-output-names = "dac_gt_clk", "tx_out_clk";
 
 		adi,sys-clk-select = <XCVR_QPLL>;
-		adi,out-clk-select = <XCVR_REFCLK_DIV2>;
+		adi,out-clk-select = <XCVR_REFCLK>;
 		adi,use-lpm-enable;
+
+		/* jesd204-fsm support */
+		jesd204-device;
+		#jesd204-cells = <2>;
 	};
 };
 

--- a/arch/arm/boot/dts/adi-xilinx-dac-fmc-ebz.dtsi
+++ b/arch/arm/boot/dts/adi-xilinx-dac-fmc-ebz.dtsi
@@ -4,18 +4,18 @@
 	dac_dma: dma@7c420000 {
 		reg = <0x7c420000 0x10000>;
 
-		interrupts = <0 56 0>;
+		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&axi_clk>;
 	};
 
 	jesd204_transport: jesd204-transport-layer@44a04000 {
-		reg = <0x44a14000 0x4000>;
+		reg = <0x44a04000 0x4000>;
 	};
 
 	jesd204_link: jesd204-link-layer@44a90000 {
-		reg = <0x44a20000 0x1000>;
+		reg = <0x44a90000 0x1000>;
 
-		interrupts = <0 54 0>;
+		interrupts = <0 54 IRQ_TYPE_LEVEL_HIGH>;
 
 		clocks = <&axi_clk>, <&fpga_device_clk>, <&jesd204_phy 0>;
 		clock-names = "s_axi_aclk", "device_clk", "lane_clk";
@@ -23,7 +23,7 @@
 
 	jesd204_phy: jesd204-phy@44a60000 {
 		compatible = "adi,axi-adxcvr-1.0";
-		reg = <0x44a00000 0x1000>;
+		reg = <0x44a60000 0x1000>;
 
 		clocks = <&fpga_device_clk>, <&fpga_device_clk>;
 		clock-names = "conv", "div40";

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad9136-fmc-ebz.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad9136-fmc-ebz.dts
@@ -1,3 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD9136-FMC-EBZ
+ *
+ * hdl_project: <dac_fmc_ebz/zc706>
+ * board_revision: <>
+ *
+ * HDL Synthesis Parameter:
+ *	make ADI_DAC_DEVICE=AD9136 ADI_DAC_MODE=11
+ *
+ * Copyright (C) 2018-2023 Analog Devices Inc.
+ */
 /dts-v1/;
 
 #include "zynq-zc706.dtsi"

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad9136-fmc-ebz.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad9136-fmc-ebz.dts
@@ -26,3 +26,16 @@
 
 #include "adi-xilinx-dac-fmc-ebz.dtsi"
 #include "adi-ad9136-fmc-ebz.dtsi"
+
+&dac {
+	adi,subclass = <1>;
+	adi,interpolation = <2>;
+	adi,sysref-mode = <1>;
+	adi,jesd-link-mode = <11>;
+
+	jesd204-device;
+	#jesd204-cells = <2>;
+	jesd204-top-device = <0>; /* This is the TOP device */
+	jesd204-link-ids = <0>;
+	jesd204-inputs = <&jesd204_transport 0 0>;
+};

--- a/ci/travis/dtb_build_test_exceptions
+++ b/ci/travis/dtb_build_test_exceptions
@@ -134,7 +134,6 @@ arch/arm/boot/dts/zynq-microzed-cn0363.dts
 arch/arm/boot/dts/zynq-coraz7s.dts
 arch/arm/boot/dts/zynq-zc702-adv7511-adrv9363.dts
 arch/arm/boot/dts/zynq-zc702-adv7511-fmcomms1.dts
-arch/arm/boot/dts/zynq-zc706-adv7511-ad9136-fmc-ebz.dts
 arch/arm/boot/dts/zynq-zc706-adv7511-adrv9363.dts
 arch/arm/boot/dts/zynq-zc706-adv7511-fmcadc4.dts
 arch/arm/boot/dts/zynq-zc706-adv7511-fmcdaq1.dts

--- a/drivers/iio/jesd204/axi_jesd204_rx.c
+++ b/drivers/iio/jesd204/axi_jesd204_rx.c
@@ -86,6 +86,7 @@ struct axi_jesd204_rx {
 	struct clk *device_clk;
 	struct clk *link_clk;
 	struct clk *conv2_clk;
+	struct clk *sysref_clk;
 
 	struct jesd204_dev *jdev;
 
@@ -928,12 +929,16 @@ static int axi_jesd204_rx_jesd204_clks_enable(struct jesd204_dev *jdev,
 	case JESD204_STATE_OP_REASON_INIT:
 		break;
 	case JESD204_STATE_OP_REASON_UNINIT:
-		if (__clk_is_enabled(jesd->device_clk))
-			clk_disable_unprepare(jesd->device_clk);
 		if (!IS_ERR_OR_NULL(jesd->link_clk)) {
 			if (__clk_is_enabled(jesd->link_clk))
 				clk_disable_unprepare(jesd->link_clk);
 		}
+		if (!IS_ERR_OR_NULL(jesd->sysref_clk)) {
+			if (__clk_is_enabled(jesd->sysref_clk))
+				clk_disable_unprepare(jesd->sysref_clk);
+		}
+		if (__clk_is_enabled(jesd->device_clk))
+			clk_disable_unprepare(jesd->device_clk);
 		return JESD204_STATE_CHANGE_DONE;
 	default:
 		return JESD204_STATE_CHANGE_DONE;
@@ -944,6 +949,15 @@ static int axi_jesd204_rx_jesd204_clks_enable(struct jesd204_dev *jdev,
 		dev_err(dev, "%s: Link%u enable device clock failed (%d)\n",
 			__func__, lnk->link_id, ret);
 		return ret;
+	}
+
+	if (!IS_ERR_OR_NULL(jesd->sysref_clk)) {
+		ret = clk_prepare_enable(jesd->sysref_clk);
+		if (ret) {
+			dev_err(dev, "%s: Link%u enable sysref clock failed (%d)\n",
+				__func__, lnk->link_id, ret);
+			return ret;
+		}
 	}
 
 	if (!IS_ERR_OR_NULL(jesd->link_clk)) {
@@ -1175,6 +1189,10 @@ static int axi_jesd204_rx_probe(struct platform_device *pdev)
 	jesd->link_clk = devm_clk_get_optional(&pdev->dev, "link_clk");
 	if (IS_ERR(jesd->link_clk))
 		return PTR_ERR(jesd->link_clk);
+
+	jesd->sysref_clk = devm_clk_get_optional(&pdev->dev, "sysref_clk");
+	if (IS_ERR(jesd->sysref_clk))
+		return PTR_ERR(jesd->sysref_clk);
 
 	ret = clk_prepare_enable(jesd->axi_clk);
 	if (ret)


### PR DESCRIPTION
The ad9136 devicetree was completely outdated and that was brought to our attention in:

https://ez.analog.com/linux-software-drivers/f/q-a/569459/kernel-boot-failure-when-adding-a-new-custom-devicetree-with-petalinux/492733

This PULL should fix those issues...