### PR TITLE
dts: overlays: add RPi 4 overlay for MAX31827

### DIFF
--- a/arch/arm/boot/dts/overlays/max31827-overlay.dts
+++ b/arch/arm/boot/dts/overlays/max31827-overlay.dts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: (GPL-2.0+)
+/* Overlay for MAX31827EVKIT
+ *
+ * Copyright 2023 Analog Devices Inc.
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "bcrm, bcm2711";
+
+	reg_vdd: regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "vdd";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+};
+
+&i2c_arm {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	temperature-sensor@42 {
+		compatible = "adi,max31827";
+		reg = <0x42>;
+		vref-supply = <&reg_vdd>;
+	};
+};


### PR DESCRIPTION
MAX31827 is a low-power temperature switch with I2C interface.

The device is a ±1°C accuracy from -40°C to +125°C (12 bits) local temperature switch and sensor with I2C/SM- Bus interface. The combination of small 6-bump wafer-lev- el package (WLP) and high accuracy makes this temper- ature sensor/switch ideal for a wide range of applications.

For now only the overlay is ready. The driver is still being reviewed by the linux-hwmon community.