### PR TITLE
Change ad9081 default modes for vck190, add default mode for ad9082 for vck190

### DIFF
--- a/arch/arm64/boot/dts/xilinx/versal-vck190-reva-ad9081-204c-txmode23-rxmode25.dts
+++ b/arch/arm64/boot/dts/xilinx/versal-vck190-reva-ad9081-204c-txmode23-rxmode25.dts
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD9081-FMC-EBZ
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-mxfe/ad9081
+ * https://wiki.analog.com/resources/eval/user-guides/ad9081_fmca_ebz/ad9081_fmca_ebz_hdl
+ *
+ * hdl_project: <ad9081_fmca_ebz/vck190>
+ * board_revision: <>
+ *
+ * Copyright (C) 2019-2023 Analog Devices Inc.
+ */
+
+/*
+ * 204C use case with Subclass 0,
+ * Med. lane rate, using gearbox and PRGOGDIV
+ *   1Txs / 1Rxs per MxFE
+ *   DAC_CLK = 12.00 GSPS
+ *   ADC_CLK = 4.00 GSPS
+ *   Tx I/Q Rate: 2000 MSPS (Interpolation of 6x1)
+ *   Rx I/Q Rate: 2000 MSPS (Decimation of 2x1)
+ *   DAC JESD204C: Mode 23, L=4, M=4, N=N'=12
+ *   ADC JESD204C: Mode 25.00, L=4, M=4, N=N'=12
+ *   DAC-Side JESD204C Lane Rate: 24.75 Gbps
+ *   ADC-Side JESD204C Lane Rate: 24.75 Gbps
+ */
+
+#include "versal-vck190-reva-ad9081.dts"
+
+/ {
+	fpga_axi: fpga-axi@0 {
+		clocks {
+			rx_fixed_linerate: clock@0 {
+				#clock-cells = <0>;
+				compatible = "fixed-clock";
+				clock-frequency = <24750000>;
+				clock-output-names = "rx_lane_clk";
+			};
+
+			tx_fixed_linerate: clock@1 {
+				#clock-cells = <0>;
+				compatible = "fixed-clock";
+				clock-frequency = <24750000>;
+				clock-output-names = "tx_lane_clk";
+			};
+
+			rx_fixed_link_clk: clock@2 {
+				#clock-cells = <0>;
+				compatible = "fixed-clock";
+				clock-frequency = <375000000>;
+				clock-output-names = "rx_link_clk";
+			};
+
+			tx_fixed_link_clk: clock@3 {
+				#clock-cells = <0>;
+				compatible = "fixed-clock";
+				clock-frequency = <375000000>;
+				clock-output-names = "tx_link_clk";
+			};
+		};
+	};
+};
+
+&fmc_spi {
+	/delete-node/ ad9081@0;
+
+	trx0_ad9081: ad9081@0 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "adi,ad9081";
+		reg = <0>;
+		spi-max-frequency = <5000000>;
+
+		reset-gpios = <&axi_gpio 23 0>;
+
+		/* Clocks */
+		clocks = <&hmc7044 2>;
+		clock-names = "dev_clk";
+
+		clock-output-names = "rx_sampl_clk", "tx_sampl_clk";
+		#clock-cells = <1>;
+
+		jesd204-device;
+		#jesd204-cells = <2>;
+		jesd204-top-device = <0>; /* This is the TOP device */
+		jesd204-link-ids = <FRAMER_LINK0_RX DEFRAMER_LINK0_TX>;
+
+		jesd204-inputs =
+			<&axi_ad9081_core_rx 0 FRAMER_LINK0_RX>,
+			<&axi_ad9081_core_tx 0 DEFRAMER_LINK0_TX>;
+
+		adi,continuous-sysref-mode-disable;
+
+		adi,tx-dacs {
+			#size-cells = <0>;
+			#address-cells = <1>;
+			adi,dac-frequency-hz = /bits/ 64 <12000000000>;
+
+			adi,main-data-paths {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				adi,interpolation = <6>;
+
+				ad9081_dac0: dac@0 {
+					reg = <0>;
+					adi,crossbar-select = <&ad9081_tx_fddc_chan0>;
+					adi,nco-frequency-shift-hz = /bits/ 64 <1000000000>; /* 100 MHz */
+				};
+
+				ad9081_dac1: dac@1 {
+					reg = <1>;
+					adi,crossbar-select = <&ad9081_tx_fddc_chan1>;
+					adi,nco-frequency-shift-hz = /bits/ 64 <1100000000>; /* 1100 MHz */
+				};
+			};
+
+			adi,channelizer-paths {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				adi,interpolation = <1>;
+
+				ad9081_tx_fddc_chan0: channel@0 {
+					reg = <0>;
+					adi,gain = <2048>; /* 2048 * 10^(gain_dB/20) */
+					adi,nco-frequency-shift-hz =  /bits/ 64 <0>;
+				};
+
+				ad9081_tx_fddc_chan1: channel@1 {
+					reg = <1>;
+					adi,gain = <2048>; /* 2048 * 10^(gain_dB/20) */
+					adi,nco-frequency-shift-hz =  /bits/ 64 <0>;
+				};
+			};
+
+			adi,jesd-links {
+				#size-cells = <0>;
+				#address-cells = <1>;
+
+				ad9081_tx_jesd_l0: link@0 {
+					#address-cells = <1>;
+					#size-cells = <0>;
+					reg = <0>;
+					adi,logical-lane-mapping = /bits/ 8 <0 2 7 6 1 5 4 3>;
+					adi,link-mode = <23>;			/* JESD Quick Configuration Mode */
+					adi,subclass = <1>;			/* JESD SUBCLASS 0,1,2 */
+					adi,version = <2>;			/* JESD VERSION 0=204A,1=204B,2=204C */
+					adi,dual-link = <0>;			/* JESD Dual Link Mode */
+					adi,converters-per-device = <4>;	/* JESD M */
+					adi,octets-per-frame = <3>;		/* JESD F */
+					adi,frames-per-multiframe = <256>;	/* JESD K */
+					adi,converter-resolution = <12>;	/* JESD N */
+					adi,bits-per-sample = <12>;		/* JESD NP' */
+					adi,control-bits-per-sample = <0>;	/* JESD CS */
+					adi,lanes-per-device = <4>;		/* JESD L */
+					adi,samples-per-converter-per-frame = <2>; /* JESD S */
+					adi,high-density = <0>;			/* JESD HD */
+
+					adi,tpl-phase-adjust = <0x3b>;
+				};
+			};
+		};
+
+		adi,rx-adcs {
+			#size-cells = <0>;
+			#address-cells = <1>;
+			adi,adc-frequency-hz = /bits/ 64 <4000000000>;
+
+			adi,main-data-paths {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				ad9081_adc0: adc@0 {
+					reg = <0>;
+					adi,decimation = <2>;
+					adi,nco-frequency-shift-hz =  /bits/ 64 <400000000>;
+					adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
+				};
+
+				ad9081_adc1: adc@1 {
+					reg = <1>;
+					adi,decimation = <2>;
+					adi,nco-frequency-shift-hz =  /bits/ 64 <(-400000000)>;
+					adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
+				};
+			};
+
+			adi,channelizer-paths {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				ad9081_rx_fddc_chan0: channel@0 {
+					reg = <0>;
+					adi,decimation = <1>;
+					adi,gain = <2048>; /* 2048 * 10^(gain_dB/20) */
+					adi,nco-frequency-shift-hz =  /bits/ 64 <0>;
+				};
+
+				ad9081_rx_fddc_chan1: channel@1 {
+					reg = <1>;
+					adi,decimation = <1>;
+					adi,gain = <2048>; /* 2048 * 10^(gain_dB/20) */
+					adi,nco-frequency-shift-hz =  /bits/ 64 <0>;
+				};
+			};
+
+			adi,jesd-links {
+				#size-cells = <0>;
+				#address-cells = <1>;
+
+				ad9081_rx_jesd_l0: link@0 {
+					reg = <0>;
+					adi,converter-select =
+						<&ad9081_rx_fddc_chan0 FDDC_I>, <&ad9081_rx_fddc_chan0 FDDC_Q>,
+						<&ad9081_rx_fddc_chan1 FDDC_I>, <&ad9081_rx_fddc_chan1 FDDC_Q>;
+					adi,logical-lane-mapping = /bits/ 8 <2 0 7 6 5 4 3 1>;
+					adi,link-mode = <25>;			/* JESD Quick Configuration Mode */
+					adi,subclass = <1>;			/* JESD SUBCLASS 0,1,2 */
+					adi,version = <2>;			/* JESD VERSION 0=204A,1=204B,2=204C */
+					adi,dual-link = <0>;			/* JESD Dual Link Mode */
+					adi,converters-per-device = <4>;	/* JESD M */
+					adi,octets-per-frame = <3>;		/* JESD F */
+					adi,frames-per-multiframe = <256>;	/* JESD K */
+					adi,converter-resolution = <12>;	/* JESD N */
+					adi,bits-per-sample = <12>;		/* JESD NP' */
+					adi,control-bits-per-sample = <0>;	/* JESD CS */
+					adi,lanes-per-device = <4>;		/* JESD L */
+					adi,samples-per-converter-per-frame = <2>; /* JESD S */
+					adi,high-density = <0>;			/* JESD HD */
+				};
+			};
+		};
+	};
+};

--- a/arch/arm64/boot/dts/xilinx/versal-vck190-reva-ad9081.dts
+++ b/arch/arm64/boot/dts/xilinx/versal-vck190-reva-ad9081.dts
@@ -370,25 +370,30 @@
 		#size-cells = <0>;
 		#address-cells = <1>;
 		adi,dac-frequency-hz = /bits/ 64 <4000000000>;
+
 		adi,main-data-paths {
 			#address-cells = <1>;
 			#size-cells = <0>;
 			adi,interpolation = <2>;
+
 			ad9081_dac0: dac@0 {
 				reg = <0>;
 				adi,crossbar-select = <&ad9081_tx_fddc_chan0>;
 				adi,nco-frequency-shift-hz = /bits/ 64 <1000000000>; /* 100 MHz */
 			};
+
 			ad9081_dac1: dac@1 {
 				reg = <1>;
 				adi,crossbar-select = <&ad9081_tx_fddc_chan1>;
 				adi,nco-frequency-shift-hz = /bits/ 64 <1100000000>; /* 1100 MHz */
 			};
+
 			ad9081_dac2: dac@2 {
 				reg = <2>;
 				adi,crossbar-select = <&ad9081_tx_fddc_chan2>; /* All 4 channels @ dac2 */
 				adi,nco-frequency-shift-hz = /bits/ 64 <1200000000>;  /* 300 MHz */
 			};
+
 			ad9081_dac3: dac@3 {
 				reg = <3>;
 				adi,crossbar-select = <&ad9081_tx_fddc_chan3>; /* All 4 channels @ dac2 */
@@ -400,21 +405,25 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			adi,interpolation = <1>;
+
 			ad9081_tx_fddc_chan0: channel@0 {
 				reg = <0>;
 				adi,gain = <2048>; /* 2048 * 10^(gain_dB/20) */
 				adi,nco-frequency-shift-hz =  /bits/ 64 <0>;
 			};
+
 			ad9081_tx_fddc_chan1: channel@1 {
 				reg = <1>;
 				adi,gain = <2048>; /* 2048 * 10^(gain_dB/20) */
 				adi,nco-frequency-shift-hz =  /bits/ 64 <0>;
 			};
+
 			ad9081_tx_fddc_chan2: channel@2 {
 				reg = <2>;
 				adi,gain = <2048>; /* 2048 * 10^(gain_dB/20) */
 				adi,nco-frequency-shift-hz =  /bits/ 64 <0>;
 			};
+
 			ad9081_tx_fddc_chan3: channel@3 {
 				reg = <3>;
 				adi,gain = <2048>; /* 2048 * 10^(gain_dB/20) */
@@ -425,6 +434,7 @@
 		adi,jesd-links {
 			#size-cells = <0>;
 			#address-cells = <1>;
+
 			ad9081_tx_jesd_l0: link@0 {
 				#address-cells = <1>;
 				#size-cells = <0>;
@@ -448,31 +458,37 @@
 			};
 		};
 	};
+
 	adi,rx-adcs {
 		#size-cells = <0>;
 		#address-cells = <1>;
 		adi,adc-frequency-hz = /bits/ 64 <2000000000>;
+
 		adi,main-data-paths {
 			#address-cells = <1>;
 			#size-cells = <0>;
+
 			ad9081_adc0: adc@0 {
 				reg = <0>;
 				adi,decimation = <1>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <400000000>;
 				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 			};
+
 			ad9081_adc1: adc@1 {
 				reg = <1>;
 				adi,decimation = <1>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <(-400000000)>;
 				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 			};
+
 			ad9081_adc2: adc@2 {
 				reg = <2>;
 				adi,decimation = <1>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <100000000>;
 				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 			};
+
 			ad9081_adc3: adc@3 {
 				reg = <3>;
 				adi,decimation = <1>;
@@ -480,27 +496,32 @@
 				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 			};
 		};
+
 		adi,channelizer-paths {
 			#address-cells = <1>;
 			#size-cells = <0>;
+
 			ad9081_rx_fddc_chan0: channel@0 {
 				reg = <0>;
 				adi,decimation = <1>;
 				adi,gain = <2048>; /* 2048 * 10^(gain_dB/20) */
 				adi,nco-frequency-shift-hz =  /bits/ 64 <0>;
 			};
+
 			ad9081_rx_fddc_chan1: channel@1 {
 				reg = <1>;
 				adi,decimation = <1>;
 				adi,gain = <2048>; /* 2048 * 10^(gain_dB/20) */
 				adi,nco-frequency-shift-hz =  /bits/ 64 <0>;
 			};
+
 			ad9081_rx_fddc_chan4: channel@4 {
 				reg = <4>;
 				adi,decimation = <1>;
 				adi,gain = <2048>; /* 2048 * 10^(gain_dB/20) */
 				adi,nco-frequency-shift-hz =  /bits/ 64 <0>;
 			};
+
 			ad9081_rx_fddc_chan5: channel@5 {
 				reg = <5>;
 				adi,decimation = <1>;
@@ -508,9 +529,11 @@
 				adi,nco-frequency-shift-hz =  /bits/ 64 <0>;
 			};
 		};
+
 		adi,jesd-links {
 			#size-cells = <0>;
 			#address-cells = <1>;
+
 			ad9081_rx_jesd_l0: link@0 {
 				reg = <0>;
 				adi,converter-select =

--- a/arch/arm64/boot/dts/xilinx/versal-vck190-reva-ad9081.dts
+++ b/arch/arm64/boot/dts/xilinx/versal-vck190-reva-ad9081.dts
@@ -7,7 +7,7 @@
  * hdl_project: <ad9081_fmca_ebz/vck190>
  * board_revision: <>
  *
- * Copyright (C) 2019-2020 Analog Devices Inc.
+ * Copyright (C) 2019-2023 Analog Devices Inc.
  */
 
 #include "versal-vck190-reva.dts"
@@ -323,7 +323,7 @@
 	hmc7044_c2: channel@2 {
 		reg = <2>;
 		adi,extended-name = "DEV_REFCLK";
-		adi,divider = <12>;	// 250
+		adi,divider = <8>;	// 375
 		adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;	// LVDS
 	};
 
@@ -369,11 +369,11 @@
 	adi,tx-dacs {
 		#size-cells = <0>;
 		#address-cells = <1>;
-		adi,dac-frequency-hz = /bits/ 64 <12000000000>;
+		adi,dac-frequency-hz = /bits/ 64 <4000000000>;
 		adi,main-data-paths {
 			#address-cells = <1>;
 			#size-cells = <0>;
-			adi,interpolation = <6>;
+			adi,interpolation = <2>;
 			ad9081_dac0: dac@0 {
 				reg = <0>;
 				adi,crossbar-select = <&ad9081_tx_fddc_chan0>;
@@ -383,6 +383,16 @@
 				reg = <1>;
 				adi,crossbar-select = <&ad9081_tx_fddc_chan1>;
 				adi,nco-frequency-shift-hz = /bits/ 64 <1100000000>; /* 1100 MHz */
+			};
+			ad9081_dac2: dac@2 {
+				reg = <2>;
+				adi,crossbar-select = <&ad9081_tx_fddc_chan2>; /* All 4 channels @ dac2 */
+				adi,nco-frequency-shift-hz = /bits/ 64 <1200000000>;  /* 300 MHz */
+			};
+			ad9081_dac3: dac@3 {
+				reg = <3>;
+				adi,crossbar-select = <&ad9081_tx_fddc_chan3>; /* All 4 channels @ dac2 */
+				adi,nco-frequency-shift-hz = /bits/ 64 <1300000000>; /* 400 MHz */
 			};
 		};
 
@@ -400,6 +410,16 @@
 				adi,gain = <2048>; /* 2048 * 10^(gain_dB/20) */
 				adi,nco-frequency-shift-hz =  /bits/ 64 <0>;
 			};
+			ad9081_tx_fddc_chan2: channel@2 {
+				reg = <2>;
+				adi,gain = <2048>; /* 2048 * 10^(gain_dB/20) */
+				adi,nco-frequency-shift-hz =  /bits/ 64 <0>;
+			};
+			ad9081_tx_fddc_chan3: channel@3 {
+				reg = <3>;
+				adi,gain = <2048>; /* 2048 * 10^(gain_dB/20) */
+				adi,nco-frequency-shift-hz =  /bits/ 64 <0>;
+			};
 		};
 
 		adi,jesd-links {
@@ -410,19 +430,19 @@
 				#size-cells = <0>;
 				reg = <0>;
 				adi,logical-lane-mapping = /bits/ 8 <0 2 7 6 1 5 4 3>;
-				adi,link-mode = <23>;			/* JESD Quick Configuration Mode */
+				adi,link-mode = <24>;			/* JESD Quick Configuration Mode */
 				adi,subclass = <1>;			/* JESD SUBCLASS 0,1,2 */
 				adi,version = <2>;			/* JESD VERSION 0=204A,1=204B,2=204C */
 				adi,dual-link = <0>;			/* JESD Dual Link Mode */
-				adi,converters-per-device = <4>;	/* JESD M */
+				adi,converters-per-device = <8>;	/* JESD M */
 				adi,octets-per-frame = <3>;		/* JESD F */
 				adi,frames-per-multiframe = <256>;	/* JESD K */
 				adi,converter-resolution = <12>;	/* JESD N */
 				adi,bits-per-sample = <12>;		/* JESD NP' */
 				adi,control-bits-per-sample = <0>;	/* JESD CS */
-				adi,lanes-per-device = <4>;		/* JESD L */
+				adi,lanes-per-device = <8>;		/* JESD L */
 				adi,samples-per-converter-per-frame = <2>; /* JESD S */
-				adi,high-density = <1>;			/* JESD HD */
+				adi,high-density = <0>;			/* JESD HD */
 
 				adi,tpl-phase-adjust = <0x3b>;
 			};
@@ -431,20 +451,32 @@
 	adi,rx-adcs {
 		#size-cells = <0>;
 		#address-cells = <1>;
-		adi,adc-frequency-hz = /bits/ 64 <4000000000>;
+		adi,adc-frequency-hz = /bits/ 64 <2000000000>;
 		adi,main-data-paths {
 			#address-cells = <1>;
 			#size-cells = <0>;
 			ad9081_adc0: adc@0 {
 				reg = <0>;
-				adi,decimation = <2>;
+				adi,decimation = <1>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <400000000>;
 				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 			};
 			ad9081_adc1: adc@1 {
 				reg = <1>;
-				adi,decimation = <2>;
+				adi,decimation = <1>;
 				adi,nco-frequency-shift-hz =  /bits/ 64 <(-400000000)>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
+			};
+			ad9081_adc2: adc@2 {
+				reg = <2>;
+				adi,decimation = <1>;
+				adi,nco-frequency-shift-hz =  /bits/ 64 <100000000>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
+			};
+			ad9081_adc3: adc@3 {
+				reg = <3>;
+				adi,decimation = <1>;
+				adi,nco-frequency-shift-hz =  /bits/ 64 <100000000>;
 				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
 			};
 		};
@@ -463,6 +495,18 @@
 				adi,gain = <2048>; /* 2048 * 10^(gain_dB/20) */
 				adi,nco-frequency-shift-hz =  /bits/ 64 <0>;
 			};
+			ad9081_rx_fddc_chan4: channel@4 {
+				reg = <4>;
+				adi,decimation = <1>;
+				adi,gain = <2048>; /* 2048 * 10^(gain_dB/20) */
+				adi,nco-frequency-shift-hz =  /bits/ 64 <0>;
+			};
+			ad9081_rx_fddc_chan5: channel@5 {
+				reg = <5>;
+				adi,decimation = <1>;
+				adi,gain = <2048>; /* 2048 * 10^(gain_dB/20) */
+				adi,nco-frequency-shift-hz =  /bits/ 64 <0>;
+			};
 		};
 		adi,jesd-links {
 			#size-cells = <0>;
@@ -471,21 +515,23 @@
 				reg = <0>;
 				adi,converter-select =
 					<&ad9081_rx_fddc_chan0 FDDC_I>, <&ad9081_rx_fddc_chan0 FDDC_Q>,
-					<&ad9081_rx_fddc_chan1 FDDC_I>, <&ad9081_rx_fddc_chan1 FDDC_Q>;
+					<&ad9081_rx_fddc_chan1 FDDC_I>, <&ad9081_rx_fddc_chan1 FDDC_Q>,
+					<&ad9081_rx_fddc_chan4 FDDC_I>, <&ad9081_rx_fddc_chan4 FDDC_Q>,
+					<&ad9081_rx_fddc_chan5 FDDC_I>, <&ad9081_rx_fddc_chan5 FDDC_Q>;
 				adi,logical-lane-mapping = /bits/ 8 <2 0 7 6 5 4 3 1>;
-				adi,link-mode = <25>;			/* JESD Quick Configuration Mode */
+				adi,link-mode = <26>;			/* JESD Quick Configuration Mode */
 				adi,subclass = <1>;			/* JESD SUBCLASS 0,1,2 */
 				adi,version = <2>;			/* JESD VERSION 0=204A,1=204B,2=204C */
 				adi,dual-link = <0>;			/* JESD Dual Link Mode */
-				adi,converters-per-device = <4>;	/* JESD M */
+				adi,converters-per-device = <8>;	/* JESD M */
 				adi,octets-per-frame = <3>;		/* JESD F */
 				adi,frames-per-multiframe = <256>;	/* JESD K */
 				adi,converter-resolution = <12>;	/* JESD N */
 				adi,bits-per-sample = <12>;		/* JESD NP' */
 				adi,control-bits-per-sample = <0>;	/* JESD CS */
-				adi,lanes-per-device = <4>;		/* JESD L */
+				adi,lanes-per-device = <8>;		/* JESD L */
 				adi,samples-per-converter-per-frame = <2>; /* JESD S */
-				adi,high-density = <1>;			/* JESD HD */
+				adi,high-density = <0>;			/* JESD HD */
 			};
 		};
 	};

--- a/arch/arm64/boot/dts/xilinx/versal-vck190-reva-ad9082.dts
+++ b/arch/arm64/boot/dts/xilinx/versal-vck190-reva-ad9082.dts
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD9081-FMC-EBZ
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-mxfe/ad9081
+ * https://wiki.analog.com/resources/eval/user-guides/ad9081_fmca_ebz/ad9081_fmca_ebz_hdl
+ *
+ * hdl_project: <ad9081_fmca_ebz/vck190>
+ * board_revision: <>
+ *
+ * Copyright (C) 2019-2023 Analog Devices Inc.
+ */
+
+/*
+ * 204C use case with Subclass 0,
+ * Med. lane rate, using gearbox and PRGOGDIV
+ *   1Txs / 1Rxs per MxFE
+ *   DAC_CLK = 4.00 GSPS
+ *   ADC_CLK = 4.00 GSPS
+ *   Tx I/Q Rate: 4000 MSPS (Interpolation of 1x1)
+ *   Rx I/Q Rate: 4000 MSPS (Decimation of 1x1)
+ *   DAC JESD204C: Mode 35, L=8, M=4, N=N'=12
+ *   ADC JESD204C: Mode 27.00, L=8, M=4, N=N'=12
+ *   DAC-Side JESD204C Lane Rate: 24.75 Gbps
+ *   ADC-Side JESD204C Lane Rate: 24.75 Gbps
+ */
+
+#include "versal-vck190-reva-ad9081.dts"
+
+&trx0_ad9081 {
+	compatible = "adi,ad9082";
+
+	adi,tx-dacs {
+		#size-cells = <0>;
+		#address-cells = <1>;
+		adi,dac-frequency-hz = /bits/ 64 <4000000000>;
+
+		adi,main-data-paths {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			adi,interpolation = <1>;
+
+			ad9081_dac0: dac@0 {
+				reg = <0>;
+				adi,crossbar-select = <&ad9081_tx_fddc_chan0>;
+				adi,nco-frequency-shift-hz = /bits/ 64 <1000000000>; /* 100 MHz */
+			};
+
+			ad9081_dac1: dac@1 {
+				reg = <1>;
+				adi,crossbar-select = <&ad9081_tx_fddc_chan1>;
+				adi,nco-frequency-shift-hz = /bits/ 64 <1100000000>; /* 1100 MHz */
+			};
+		};
+
+		adi,channelizer-paths {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			adi,interpolation = <1>;
+
+			ad9081_tx_fddc_chan0: channel@0 {
+				reg = <0>;
+				adi,gain = <2048>; /* 2048 * 10^(gain_dB/20) */
+				adi,nco-frequency-shift-hz =  /bits/ 64 <0>;
+			};
+
+			ad9081_tx_fddc_chan1: channel@1 {
+				reg = <1>;
+				adi,gain = <2048>; /* 2048 * 10^(gain_dB/20) */
+				adi,nco-frequency-shift-hz =  /bits/ 64 <0>;
+			};
+		};
+
+		adi,jesd-links {
+			#size-cells = <0>;
+			#address-cells = <1>;
+
+			ad9081_tx_jesd_l0: link@0 {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				reg = <0>;
+				adi,logical-lane-mapping = /bits/ 8 <0 2 7 6 1 5 4 3>;
+				adi,link-mode = <35>;			/* JESD Quick Configuration Mode */
+				adi,subclass = <1>;			/* JESD SUBCLASS 0,1,2 */
+				adi,version = <2>;			/* JESD VERSION 0=204A,1=204B,2=204C */
+				adi,dual-link = <0>;			/* JESD Dual Link Mode */
+				adi,converters-per-device = <4>;	/* JESD M */
+				adi,octets-per-frame = <3>;		/* JESD F */
+				adi,frames-per-multiframe = <256>;	/* JESD K */
+				adi,converter-resolution = <12>;	/* JESD N */
+				adi,bits-per-sample = <12>;		/* JESD NP' */
+				adi,control-bits-per-sample = <0>;	/* JESD CS */
+				adi,lanes-per-device = <8>;		/* JESD L */
+				adi,samples-per-converter-per-frame = <4>; /* JESD S */
+				adi,high-density = <0>;			/* JESD HD */
+
+				adi,tpl-phase-adjust = <0x3b>;
+			};
+		};
+	};
+
+	adi,rx-adcs {
+		#size-cells = <0>;
+		#address-cells = <1>;
+		adi,adc-frequency-hz = /bits/ 64 <4000000000>;
+
+		adi,main-data-paths {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			ad9081_adc0: adc@0 {
+				reg = <0>;
+				adi,decimation = <1>;
+				adi,nco-frequency-shift-hz =  /bits/ 64 <400000000>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
+			};
+
+			ad9081_adc1: adc@1 {
+				reg = <1>;
+				adi,decimation = <1>;
+				adi,nco-frequency-shift-hz =  /bits/ 64 <(-400000000)>;
+				adi,nco-mixer-mode = <AD9081_ADC_NCO_VIF>;
+			};
+		};
+
+		adi,channelizer-paths {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			ad9081_rx_fddc_chan0: channel@0 {
+				reg = <0>;
+				adi,decimation = <1>;
+				adi,gain = <2048>; /* 2048 * 10^(gain_dB/20) */
+				adi,nco-frequency-shift-hz =  /bits/ 64 <0>;
+			};
+
+			ad9081_rx_fddc_chan1: channel@1 {
+				reg = <1>;
+				adi,decimation = <1>;
+				adi,gain = <2048>; /* 2048 * 10^(gain_dB/20) */
+				adi,nco-frequency-shift-hz =  /bits/ 64 <0>;
+			};
+		};
+
+		adi,jesd-links {
+			#size-cells = <0>;
+			#address-cells = <1>;
+
+			ad9081_rx_jesd_l0: link@0 {
+				reg = <0>;
+				adi,converter-select =
+					<&ad9081_rx_fddc_chan0 FDDC_I>, <&ad9081_rx_fddc_chan0 FDDC_Q>,
+					<&ad9081_rx_fddc_chan1 FDDC_I>, <&ad9081_rx_fddc_chan1 FDDC_Q>;
+				adi,logical-lane-mapping = /bits/ 8 <2 0 7 6 5 4 3 1>;
+				adi,link-mode = <27>;			/* JESD Quick Configuration Mode */
+				adi,subclass = <1>;			/* JESD SUBCLASS 0,1,2 */
+				adi,version = <2>;			/* JESD VERSION 0=204A,1=204B,2=204C */
+				adi,dual-link = <0>;			/* JESD Dual Link Mode */
+				adi,converters-per-device = <4>;	/* JESD M */
+				adi,octets-per-frame = <3>;		/* JESD F */
+				adi,frames-per-multiframe = <256>;	/* JESD K */
+				adi,converter-resolution = <12>;	/* JESD N */
+				adi,bits-per-sample = <12>;		/* JESD NP' */
+				adi,control-bits-per-sample = <0>;	/* JESD CS */
+				adi,lanes-per-device = <8>;		/* JESD L */
+				adi,samples-per-converter-per-frame = <4>; /* JESD S */
+				adi,high-density = <0>;			/* JESD HD */
+			};
+		};
+	};
+};


### PR DESCRIPTION
- Updates the default modes for the AD9081 for the VCK190 carrier now that the HDL supports more than 4 lanes and the high lane rates issues have been fixed
- The old AD9081 modes have been added to a different devicetree
- Adds the default modes for AD9082 for the VCK190 carrier