### PR TITLE
arch: arm: dts: Updates for the CN0501 on Coraz7s device tree

### DIFF
--- a/arch/arm/boot/dts/zynq-coraz7s-cn0501.dts
+++ b/arch/arm/boot/dts/zynq-coraz7s-cn0501.dts
@@ -31,12 +31,12 @@
 };
 
 &fpga_axi {
-	rx_dma: rx-dmac@7c480000 {
+	rx_dma: rx-dmac@44a30000 {
 		compatible = "adi,axi-dmac-1.00.a";
-		reg = <0x7c480000 0x1000>;
+		reg = <0x44a30000 0x1000>;
 		#dma-cells = <1>;
 		interrupt-parent = <&intc>;
-		interrupts = <0 54 IRQ_TYPE_LEVEL_HIGH>;
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 
 		adi,channels {
@@ -53,9 +53,9 @@
 		};
 	};
 
-	axi_adc_ad7768: cf_axi_adc@43c00000 {
+	axi_adc_ad7768: cf_axi_adc@44a00000 {
 		compatible = "adi,axi-adc-10.0.a";
-		reg = <0x43c00000 0x10000>;
+		reg = <0x44a00000 0x10000>;
 		dmas = <&rx_dma 0>;
 		dma-names = "rx";
 		spibus-connected = <&ad7768>;
@@ -74,5 +74,6 @@
 
 		clocks = <&ad7768_mclk>;
 		clock-names = "mclk";
+		adi,data-lines = <8>;
 	};
 };


### PR DESCRIPTION
The device tree file was updated to match the new version of the CN0501 HDL project.
[HDL address and interrupt values.](https://github.com/analogdevicesinc/hdl/blob/3f0a487b2e8f7425206bed310c45f2f313dee2b8/projects/cn0501/common/cn0501_bd.tcl#L53-L63) 