### PR TITLE
dts: zynq-zc706-adv7511-ad9136-fmc-ebz.dts: Fix TXEN GPIO assignments

### DIFF
--- a/arch/arm/boot/dts/adi-ad9136-fmc-ebz.dtsi
+++ b/arch/arm/boot/dts/adi-ad9136-fmc-ebz.dtsi
@@ -75,7 +75,7 @@
 
 		spi-max-frequency = <1000000>;
 
-		txen-gpios = <&fmc_gpio (fmc_gpio_base + 0) 0>, <&fmc_gpio (fmc_gpio_base + 1) 0>;
+		txen-gpios = <&fmc_gpio (fmc_gpio_base + 0) 0>, <&fmc_gpio (fmc_gpio_base + 3) 0>;
 
 		clocks = <&jesd204_link>, <&ad9516 1>, <&ad9516 6>;
 		clock-names = "jesd_dac_clk", "dac_clk", "dac_sysref";

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad9136-fmc-ebz.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad9136-fmc-ebz.dts
@@ -33,7 +33,7 @@
 #define axi_clk clkc 16
 #define fpga_device_clk ad9516 9
 
-#define fmc_gpio_base 86
+#define fmc_gpio_base 75
 #define fmc_gpio gpio0
 
 #include "adi-xilinx-dac-fmc-ebz.dtsi"


### PR DESCRIPTION
DAC control GPIO base must be 54 + 21.
While the EVAL board uses LA07P and LA07N and those map to an offset of 0 and 3.

Fixes: 310ac9d ("dts: Add devicetree for AD9136-FMC-EBZ + ZC706")