### PR TITLE
add ltc2358 support

### DIFF
--- a/Documentation/devicetree/bindings/iio/adc/adi,ltc2358.yaml
+++ b/Documentation/devicetree/bindings/iio/adc/adi,ltc2358.yaml
@@ -1,0 +1,165 @@
+# SPDX-License-Identifier: (GPL-2.0 OR BSD-2-Clause)
+# Copyright 2023 Analog Devices Inc.
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/iio/adc/adi,ltc2358.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
+
+title: Analog Devices LTC235X Family
+
+maintainers:
+  - Kim Seer Paller <kimseer.paller@analog.com>
+
+description: |
+    The LTC235X family consist of buffered ADCs with differential ±10.24V inputs
+    and 30VP-P common mode range.
+    https://www.analog.com/media/en/technical-documentation/data-sheets/235316f.pdf
+    https://www.analog.com/media/en/technical-documentation/data-sheets/235316f.pdf
+    https://www.analog.com/media/en/technical-documentation/data-sheets/235716f.pdf
+    https://www.analog.com/media/en/technical-documentation/data-sheets/235716f.pdf
+    https://www.analog.com/media/en/technical-documentation/data-sheets/235816f.pdf
+    https://www.analog.com/media/en/technical-documentation/data-sheets/235818f.pdf
+
+properties:
+  compatible:
+    enum:
+      - adi,ltc2353-16
+      - adi,ltc2353-18
+      - adi,ltc2357-16
+      - adi,ltc2357-18
+      - adi,ltc2358-16
+      - adi,ltc2358-18
+
+  reg:
+    maxItems: 1
+
+  spi-max-frequency:
+    maximum: 100000000
+
+  vref-supply:
+    description: Voltage reference to establish input scaling.
+
+  clocks:
+    description: The clock for the ADC. This is the system clock.
+
+  clock-names:
+    items:
+      - const: clkin
+
+  pwms:
+    maxItems: 1
+
+  pwm-names:
+    items:
+      - const: cnv
+
+  '#address-cells':
+    const: 1
+
+  '#size-cells':
+    const: 0
+
+patternProperties:
+  "^channel@[0-7]$":
+    type: object
+    description: Represents the external channels which are connected to the ADC.
+
+    properties:
+      reg:
+        description: Channel number.
+        minimum: 0
+        maximum: 7
+
+      adi,softspan-code:
+        $ref: /schemas/types.yaml#/definitions/uint32
+        enum: [1, 2, 3, 4, 5, 6, 7]
+        default: 7
+        description: |
+          The softspan code is used to set the input range of the ADC.
+          The input range is set by the following formula:
+          1: 0V to 1.25V * Vref
+          2: ±1.25V *  Vref / 1.024
+          3: ±1.25V * Vref
+          4: 0V to 2.5V * Vref / 1.024
+          5: 0V to 2.5V * Vref
+          6: ±2.5V * Vref / 1.024
+          7: ±2.5V * Vref
+
+    required:
+      - reg
+
+required:
+  - compatible
+  - reg
+  - clocks
+  - clock-names
+  - pwms
+  - pwm-names
+
+allOf:
+  - $ref: /schemas/spi/spi-peripheral-props.yaml#
+
+additionalProperties: false
+
+examples:
+  - |
+    spi {
+        #address-cells = <1>;
+        #size-cells = <0>;
+
+        adc@0 {
+            compatible = "adi,ltc2358-18";
+            reg = <0>;
+            spi-max-frequency = <10000000>;
+
+            #address-cells = <1>;
+            #size-cells = <0>;
+
+            clocks = <&sys_clk>;
+            clock-names = "clkin";
+
+            pwms = <&axi_pwm_gen 0 0>;
+            pwm-names = "cnv";
+
+            channel@0 {
+                reg = <0>;
+                adi,softspan-code = <1>;
+            };
+
+            channel@1 {
+                reg = <1>;
+                adi,softspan-code = <1>;
+            };
+
+            channel@2 {
+                reg = <2>;
+                adi,softspan-code = <2>;
+            };
+
+            channel@3 {
+                reg = <3>;
+                adi,softspan-code = <2>;
+            };
+
+            channel@4 {
+                reg = <4>;
+                adi,softspan-code = <3>;
+            };
+
+            channel@5 {
+                reg = <5>;
+                adi,softspan-code = <3>;
+            };
+
+            channel@6 {
+                reg = <6>;
+                adi,softspan-code = <4>;
+            };
+
+            channel@7 {
+                reg = <7>;
+                adi,softspan-code = <4>;
+            };
+        };
+    };
+...

--- a/arch/arm/boot/dts/socfpga_cyclone5_sockit_dc2677a.dts
+++ b/arch/arm/boot/dts/socfpga_cyclone5_sockit_dc2677a.dts
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * DC2677A HSMC board
+ *
+ * hdl_project: <dc2677a/c5soc>
+ * board_revision: <>
+ *
+ * Copyright 2023 Analog Devices Inc.
+ */
+#include <dt-bindings/interrupt-controller/irq.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/pwm/pwm.h>
+#include "socfpga_cyclone5.dtsi"
+
+/ {
+	model = "Terasic SoCkit";
+	compatible = "altr,socfpga-cyclone5", "altr,socfpga";
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	memory {
+		name = "memory";
+		device_type = "memory";
+		reg = <0x0 0x40000000>;
+	};
+
+	aliases {
+		ethernet0 = &gmac1;
+	};
+
+	sys_clk: sys_clk {
+		#clock-cells = <0x0>;
+		compatible = "fixed-clock";
+		clock-frequency = <50000000>;
+		clock-output-names = "sys_clk";
+	};
+
+	soc {
+		clkmgr@ffd04000 {
+			clocks {
+				osc1 {
+					clock-frequency = <25000000>;
+				};
+			};
+		};
+
+		gmac1: ethernet@ff702000 {
+			phy-mode = "rgmii";
+			phy-addr = <0xffffffff>; /* probe for phy addr */
+			status = "okay";
+
+			rxd0-skew-ps = <0>;
+			rxd1-skew-ps = <0>;
+			rxd2-skew-ps = <0>;
+			rxd3-skew-ps = <0>;
+			txen-skew-ps = <0>;
+			txc-skew-ps = <2600>;
+			rxdv-skew-ps = <0>;
+			rxc-skew-ps = <2000>;
+		};
+
+		timer0: timer0@ffc08000 {
+			clock-frequency = <100000000>;
+		};
+
+		timer1: timer1@ffc09000 {
+			clock-frequency = <100000000>;
+		};
+
+		timer2: timer2@ffd00000 {
+			clock-frequency = <25000000>;
+		};
+
+		timer3: timer3@ffd01000 {
+			clock-frequency = <25000000>;
+		};
+
+		uart0: serial0@ffc02000 {
+			clock-frequency = <100000000>;
+		};
+
+		uart1: serial1@ffc03000 {
+			clock-frequency = <100000000>;
+		};
+
+		mmc: dwmmc0@ff704000 {
+			status = "okay";
+			supports-highspeed;
+			altr,dw-mshc-ciu-div = <0x3>;
+			altr,dw-mshc-sdr-timing = <0x0 0x3>;
+			slot@0 {
+				reg = <0x0>;
+				bus-width = <0x4>;
+			};
+		};
+
+		usb1: usb@ffb40000 {
+			status = "okay";
+			enable-dynamic-fifo = <1>;
+			host-rx-fifo-size = <0xa00>;
+			host-perio-tx-fifo-size = <0xa00>;
+			host-nperio-tx-fifo-size = <0xa00>;
+			dma-desc-enable = <0>;
+			dr_mode = "host";
+		};
+
+		sys_hps_bridges: bridge@c0000000 {
+			compatible = "simple-bus";
+			reg = <0xc0000000 0x20000000>,
+				<0xff200000 0x00200000>;
+			reg-names = "axi_h2f", "axi_h2f_lw";
+			#address-cells = <2>;
+			#size-cells = <1>;
+			ranges = <0x00000000 0x00000000 0xc0000000 0x00010000>,
+				<0x00000001 0x00100000 0xff300000 0x00100000>;
+
+			c5soc_sys_cpu_interconnect: bridge@100100000 {
+				compatible = "simple-bus";
+				reg = <0x00000001 0x00100000 0x00100000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
+				ranges = <0x00020000 0x00000001 0x00120000 0x00010000>,
+					<0x00000000 0x00000001 0x00100000 0x00004000>,
+					<0x00040000 0x00000001 0x00140000 0x00001000>,
+					<0x00009000 0x00000001 0x00109000 0x00000010>;
+
+				rx_dma: dma@0 {
+					compatible = "adi,axi-dmac-1.00.a";
+					reg = <0x00000000 0x00004000>;
+					interrupt-parent = <&intc>;
+					interrupts = <0 42 4>;
+					#dma-cells = <1>;
+					clocks = <&sys_clk>;
+
+					adi,channels {
+						#size-cells = <0>;
+						#address-cells = <1>;
+
+						dma-channel@0 {
+							reg = <0>;
+							adi,source-bus-width = <256>;
+							adi,source-bus-type = <2>;
+							adi,destination-bus-width = <64>;
+							adi,destination-bus-type = <0>;
+						};
+					};
+				};
+
+				axi_pwm_gen: axi-pwm-gen@40000 {
+					compatible = "adi,axi-pwmgen";
+					reg = <0x00040000 0x1000>;
+					#pwm-cells = <2>;
+					clocks = <&sys_clk>;
+				};
+
+				gpio: gpio@9000 {
+					compatible = "altr,pio-1.0";
+					reg = <0x00020000 0x00010000>;
+					altr,gpio-bank-width = <5>;
+					resetvalue = <0>;
+					#gpio-cells = <2>;
+					gpio-controller;
+				};
+
+				axi_ltc235x_adc_core: axi-ltc235x@20000 {
+					compatible = "adi,axi-adc-10.0.a";
+					reg = <0x00020000 0x00010000>;
+					dmas = <&rx_dma 0>;
+					dma-names = "rx";
+					spibus-connected = <&ltc2358>;
+				};
+			};
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	ltc2358: adc@0 {
+		compatible = "adi,ltc2358-18";
+		reg = <0>;
+		spi-max-frequency = <1000000>;
+
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		clocks = <&sys_clk>;
+		clock-names = "clkin";
+
+		pwms = <&axi_pwm_gen 0 0>;
+		pwm-names = "cnv";
+
+		channel@0 {
+			reg = <0>;
+			adi,softspan-code = <1>;
+		};
+
+		channel@1 {
+			reg = <1>;
+			adi,softspan-code = <3>;
+		};
+
+		channel@2 {
+			reg = <2>;
+			adi,softspan-code = <2>;
+		};
+
+		channel@3 {
+			reg = <3>;
+			adi,softspan-code = <4>;
+		};
+
+		channel@4 {
+			reg = <4>;
+			adi,softspan-code = <5>;
+		};
+
+		channel@5 {
+			reg = <5>;
+			adi,softspan-code = <7>;
+		};
+
+		channel@6 {
+			reg = <6>;
+			adi,softspan-code = <6>;
+		};
+
+		channel@7 {
+			reg = <7>;
+			adi,softspan-code = <2>;
+		};
+	};
+};

--- a/drivers/iio/Kconfig.adi
+++ b/drivers/iio/Kconfig.adi
@@ -81,6 +81,7 @@ config IIO_ALL_ADI_DRIVERS
 	imply XILINX_XADC if (ARCH_ZYNQ || ARCH_ZYNQMP || MICROBLAZE)
 	imply LTC2497
 	imply LTC2308
+	imply LTC2358
 	imply LTC2387
 	imply AD8366
 	imply ADA4250

--- a/drivers/iio/adc/Kconfig
+++ b/drivers/iio/adc/Kconfig
@@ -865,6 +865,17 @@ config LTC2308
 	  This driver can also be built as a module. If so, the module will
 	  be called ltc2308.
 
+config LTC2358
+	tristate "Analog Devices LTC2358 ADC driver"
+	depends on PWM && SPI
+	select IIO_BUFFER
+	help
+	  Say yes here to build support for Analog Devices LTC2358
+	  Buffered Octal, 18-Bit, 200ksps/Ch Differential ±10.24V ADC.
+
+	  This driver can also be built as a module. If so, the module will
+	  be called ltc2358.
+
 config LTC2387
 	tristate "Linear Technology LTC2387 ADC driver"
 	depends on PWM

--- a/drivers/iio/adc/Makefile
+++ b/drivers/iio/adc/Makefile
@@ -128,6 +128,7 @@ obj-$(CONFIG_LP8788_ADC) += lp8788_adc.o
 obj-$(CONFIG_LPC18XX_ADC) += lpc18xx_adc.o
 obj-$(CONFIG_LPC32XX_ADC) += lpc32xx_adc.o
 obj-$(CONFIG_LTC2308) += ltc2308.o
+obj-$(CONFIG_LTC2358) += ltc2358.o
 obj-$(CONFIG_LTC2387) += ltc2387.o
 obj-$(CONFIG_LTC2471) += ltc2471.o
 obj-$(CONFIG_LTC2485) += ltc2485.o

--- a/drivers/iio/adc/cf_axi_adc.h
+++ b/drivers/iio/adc/cf_axi_adc.h
@@ -123,6 +123,8 @@
 #define ADI_PN_OOS			(1 << 1)
 #define ADI_OVER_RANGE			(1 << 0)
 
+#define ADI_REG_CHAN_RAW_DATA(c)	(0x0408 + (c) * 0x40)
+
 #define ADI_REG_CHAN_CNTRL_1(c)		(0x0410 + (c) * 0x40)
 #define ADI_DCFILT_OFFSET(x)		(((x) & 0xFFFF) << 16)
 #define ADI_TO_DCFILT_OFFSET(x)		(((x) >> 16) & 0xFFFF)
@@ -140,6 +142,8 @@
 #define ADI_TO_ADC_PN_SEL(x)		(((x) >> 16) & 0xF)
 #define ADI_ADC_DATA_SEL(x)		(((x) & 0xF) << 0)
 #define ADI_TO_ADC_DATA_SEL(x)		(((x) >> 0) & 0xF)
+
+#define ADI_SOFTSPAN(c)			(0x0428 + (c) * 0x40)
 
 enum adc_pn_sel {
 	ADC_PN9 = 0,
@@ -198,6 +202,7 @@ struct axiadc_chip_info {
 	const unsigned long 	*scan_masks;
 	const int			(*scale_table)[2];
 	int				num_scales;
+	int				resolution;
 	int				max_testmode;
 	unsigned long			max_rate;
 	struct iio_chan_spec		channel[AXIADC_MAX_CHANNEL];

--- a/drivers/iio/adc/ltc2358.c
+++ b/drivers/iio/adc/ltc2358.c
@@ -1,0 +1,440 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices LTC235x ADC driver
+ *
+ * Copyright 2023 Analog Devices Inc.
+ * Authors:
+ *	Kim Seer Paller <kimseer.paller@analog.com>
+ *	John Erasmus Mari Geronimo <johnerasmusmari.geronimo@analog.com>
+ */
+
+#include <linux/clk.h>
+#include <linux/device.h>
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/property.h>
+#include <linux/pwm.h>
+#include <linux/regulator/consumer.h>
+#include <linux/spi/spi.h>
+#include <linux/units.h>
+
+#include "cf_axi_adc.h"
+
+#define LTC235X_MAX_SOFTSPAN		7
+#define LTC235X_TCNVH_NS		40
+#define LTC235X_MIN_SAMP_FREQ		100000
+
+enum ltc235x_supported_device_ids {
+	ID_LTC2353_16,
+	ID_LTC2353_18,
+	ID_LTC2357_16,
+	ID_LTC2357_18,
+	ID_LTC2358_16,
+	ID_LTC2358_18,
+};
+
+struct ltc235x_state {
+	struct spi_device		*spi;
+	struct clk			*clkin;
+	struct pwm_device		*cnv_pwm;
+	unsigned int			softspan[8];
+	int				vref_mv;
+	int				num_channels;
+};
+
+static struct ltc235x_state *ltc235x_get_data(struct iio_dev *indio_dev)
+{
+	struct axiadc_converter *conv;
+
+	conv = iio_device_get_drvdata(indio_dev);
+
+	return conv->phy;
+}
+
+static int __ltc235x_set_sampling_freq(struct ltc235x_state *st,
+					unsigned int freq)
+{
+	struct pwm_state cnv_state;
+
+	pwm_get_state(st->cnv_pwm, &cnv_state);
+	cnv_state.duty_cycle = LTC235X_TCNVH_NS;
+	cnv_state.period = DIV_ROUND_CLOSEST_ULL(NANO, freq);
+	cnv_state.time_unit = PWM_UNIT_NSEC;
+
+	return pwm_apply_state(st->cnv_pwm, &cnv_state);
+}
+
+static int ltc235x_set_sampling_freq(struct iio_dev *indio_dev,
+					unsigned int freq)
+{
+	struct ltc235x_state *st = ltc235x_get_data(indio_dev);
+	struct axiadc_converter *conv = iio_device_get_drvdata(indio_dev);
+	struct device *dev = &st->spi->dev;
+	int ret, num_chan, max_freq;
+
+	num_chan = conv->chip_info->num_channels;
+
+	/*
+	 * Determine the maximum sampling frequency based on the
+	 * number of channels.
+	 */
+	switch (num_chan) {
+	case 2:
+		max_freq = 550000;
+		break;
+	case 4:
+		max_freq = 350000;
+		break;
+	case 8:
+		max_freq = 200000;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	if (freq < LTC235X_MIN_SAMP_FREQ || freq > max_freq) {
+		dev_err(dev, "Sampling frequency out of range\n");
+		return -EINVAL;
+	}
+
+	ret = iio_device_claim_direct_mode(indio_dev);
+	if (ret)
+		return ret;
+
+	ret = __ltc235x_set_sampling_freq(st, freq);
+
+	iio_device_release_direct_mode(indio_dev);
+
+	return ret;
+}
+
+static void ltc235x_get_sampling_freq(struct iio_dev *indio_dev,
+				      unsigned int *freq)
+{
+	struct ltc235x_state *st = ltc235x_get_data(indio_dev);
+	struct pwm_state cnv_state;
+
+	pwm_get_state(st->cnv_pwm, &cnv_state);
+	*freq = DIV_ROUND_CLOSEST_ULL(NANO, cnv_state.period);
+}
+
+static int ltc235x_read_raw(struct iio_dev *indio_dev,
+			     struct iio_chan_spec const *chan,
+			     int *val, int *val2, long mask)
+{
+	struct axiadc_state *axiadc_st = iio_priv(indio_dev);
+	struct ltc235x_state *st = ltc235x_get_data(indio_dev);
+	struct axiadc_converter *conv = iio_device_get_drvdata(indio_dev);
+
+	switch (mask) {
+	case IIO_CHAN_INFO_RAW:
+		*val = axiadc_read(axiadc_st, ADI_REG_CHAN_RAW_DATA(chan->channel));
+
+		return IIO_VAL_INT;
+	case IIO_CHAN_INFO_SCALE:
+		*val = st->vref_mv * 2;
+		*val2 = conv->chip_info->resolution;
+
+		return IIO_VAL_FRACTIONAL_LOG2;
+	case IIO_CHAN_INFO_SAMP_FREQ:
+		ltc235x_get_sampling_freq(indio_dev, val);
+
+		return IIO_VAL_INT;
+	default:
+		return -EINVAL;
+	}
+}
+
+static int ltc235x_write_raw(struct iio_dev *indio_dev,
+				struct iio_chan_spec const *chan,
+				int val, int val2, long mask)
+{
+	switch (mask) {
+	case IIO_CHAN_INFO_SAMP_FREQ:
+		return ltc235x_set_sampling_freq(indio_dev, val);
+	default:
+		return -EINVAL;
+	}
+}
+
+static int ltc235x_reg_access(struct iio_dev *indio_dev, unsigned int reg,
+				unsigned int writeval, unsigned int *readval)
+{
+	struct axiadc_state *axiadc_st = iio_priv(indio_dev);
+
+	if (readval)
+		*readval = axiadc_read(axiadc_st, reg);
+	else
+		axiadc_write(axiadc_st, reg, writeval);
+
+	return 0;
+}
+
+#define LTC235X_CHAN(_chan, _idx) {					\
+	.type = IIO_VOLTAGE,						\
+	.indexed = 1,							\
+	.channel = _chan,						\
+	.info_mask_separate = BIT(IIO_CHAN_INFO_RAW) |			\
+			BIT(IIO_CHAN_INFO_SCALE),			\
+	.info_mask_shared_by_all = BIT(IIO_CHAN_INFO_SAMP_FREQ),	\
+	.scan_index = _idx,						\
+	.scan_type = {							\
+		.sign = 'u',						\
+		.realbits = 24,						\
+		.storagebits = 32,					\
+	},								\
+}
+
+static const struct axiadc_chip_info ltc235x_chip_info[] = {
+	[ID_LTC2353_16] = {
+		.name = "ltc2353-16",
+		.resolution = 16,
+		.num_channels = 2,
+		.channel[0] = LTC235X_CHAN(0, 0),
+		.channel[1] = LTC235X_CHAN(1, 1),
+	},
+	[ID_LTC2353_18] = {
+		.name = "ltc2353-18",
+		.resolution = 18,
+		.num_channels = 2,
+		.channel[0] = LTC235X_CHAN(0, 0),
+		.channel[1] = LTC235X_CHAN(1, 1),
+	},
+	[ID_LTC2357_16] = {
+		.name = "ltc2357-16",
+		.resolution = 16,
+		.num_channels = 4,
+		.channel[0] = LTC235X_CHAN(0, 0),
+		.channel[1] = LTC235X_CHAN(1, 1),
+		.channel[2] = LTC235X_CHAN(2, 2),
+		.channel[3] = LTC235X_CHAN(3, 3),
+	},
+	[ID_LTC2357_18] = {
+		.name = "ltc2357-18",
+		.resolution = 18,
+		.num_channels = 4,
+		.channel[0] = LTC235X_CHAN(0, 0),
+		.channel[1] = LTC235X_CHAN(1, 1),
+		.channel[2] = LTC235X_CHAN(2, 2),
+		.channel[3] = LTC235X_CHAN(3, 3),
+	},
+	[ID_LTC2358_16] = {
+		.name = "ltc2358-16",
+		.resolution = 16,
+		.num_channels = 8,
+		.channel[0] = LTC235X_CHAN(0, 0),
+		.channel[1] = LTC235X_CHAN(1, 1),
+		.channel[2] = LTC235X_CHAN(2, 2),
+		.channel[3] = LTC235X_CHAN(3, 3),
+		.channel[4] = LTC235X_CHAN(4, 4),
+		.channel[5] = LTC235X_CHAN(5, 5),
+		.channel[6] = LTC235X_CHAN(6, 6),
+		.channel[7] = LTC235X_CHAN(7, 7),
+	},
+	[ID_LTC2358_18] = {
+		.name = "ltc2358-18",
+		.resolution = 18,
+		.num_channels = 8,
+		.channel[0] = LTC235X_CHAN(0, 0),
+		.channel[1] = LTC235X_CHAN(1, 1),
+		.channel[2] = LTC235X_CHAN(2, 2),
+		.channel[3] = LTC235X_CHAN(3, 3),
+		.channel[4] = LTC235X_CHAN(4, 4),
+		.channel[5] = LTC235X_CHAN(5, 5),
+		.channel[6] = LTC235X_CHAN(6, 6),
+		.channel[7] = LTC235X_CHAN(7, 7),
+	},
+};
+
+static int ltc235x_channel_config(struct ltc235x_state *st)
+{
+	struct device *dev = &st->spi->dev;
+	struct fwnode_handle *child;
+	unsigned int reg;
+	int ret;
+
+	device_for_each_child_node(dev, child) {
+		ret = fwnode_property_read_u32(child, "reg", &reg);
+		if (ret) {
+			fwnode_handle_put(child);
+			return dev_err_probe(dev, -EINVAL,
+					     "Missing channel number\n");
+		}
+
+		if (reg >= st->num_channels) {
+			fwnode_handle_put(child);
+			return dev_err_probe(dev, -EINVAL,
+					     "Invalid channel number\n");
+		}
+
+		st->softspan[reg] = 7;
+		ret = fwnode_property_read_u32(child, "adi,softspan-code",
+					       &st->softspan[reg]);
+		if (!ret) {
+			if (st->softspan[reg] > LTC235X_MAX_SOFTSPAN ||
+						st->softspan[reg] < 0) {
+				fwnode_handle_put(child);
+				return dev_err_probe(dev, -EINVAL,
+						     "Invalid softspan code\n");
+			}
+		}
+	}
+
+	return 0;
+}
+
+static int ltc235x_post_setup(struct iio_dev *indio_dev)
+{
+	struct axiadc_state *axiadc_st = iio_priv(indio_dev);
+	struct axiadc_converter *conv = iio_device_get_drvdata(indio_dev);
+	struct ltc235x_state *st = ltc235x_get_data(indio_dev);
+	int i;
+
+	for (i = 0; i < conv->chip_info->num_channels; i++) {
+		axiadc_write(axiadc_st, ADI_SOFTSPAN(i), st->softspan[i]);
+		axiadc_write(axiadc_st, ADI_REG_CHAN_CNTRL(i), ADI_ENABLE);
+	}
+
+	return 0;
+}
+
+static void ltc235x_regulator_disable(void *data)
+{
+	regulator_disable(data);
+}
+
+static void ltc235x_clk_disable(void *data)
+{
+	clk_disable_unprepare(data);
+}
+
+static int ltc235x_probe(struct spi_device *spi)
+{
+	struct ltc235x_state *st;
+	struct axiadc_converter *conv;
+	struct regulator *vref;
+	struct device *dev = &spi->dev;
+	unsigned int samp_freq;
+	int ret;
+
+	st = devm_kzalloc(dev, sizeof(*st), GFP_KERNEL);
+	if (!st)
+		return -ENOMEM;
+
+	conv = devm_kzalloc(dev, sizeof(*conv), GFP_KERNEL);
+	if (!conv)
+		return -ENOMEM;
+
+	st->spi = spi;
+
+	conv->chip_info = device_get_match_data(dev);
+	if (!conv->chip_info)
+		return dev_err_probe(dev, -EINVAL, "Failed to get chip info\n");
+
+	st->num_channels = conv->chip_info->num_channels;
+
+	ret = ltc235x_channel_config(st);
+	if (ret)
+		return ret;
+
+	ret = clk_prepare_enable(st->clkin);
+	if (ret)
+		return dev_err_probe(dev, ret, "Failed to enable clkin\n");
+
+	ret = devm_add_action_or_reset(dev, ltc235x_clk_disable, st->clkin);
+	if (ret)
+		return ret;
+
+	vref = devm_regulator_get_optional(dev, "vref");
+	if (IS_ERR(vref)) {
+		if (PTR_ERR(vref) != -ENODEV)
+			return dev_err_probe(dev, PTR_ERR(vref),
+					     "Failed to get vref regulator\n");
+
+		/* internal reference */
+		st->vref_mv = 2048;
+	} else {
+		ret = regulator_enable(vref);
+		if (ret)
+			return dev_err_probe(dev, ret,
+					"Failed to enable vref regulator\n");
+
+		ret = devm_add_action_or_reset(dev, ltc235x_regulator_disable,
+					       vref);
+		if (ret)
+			return ret;
+
+		ret = regulator_get_voltage(vref);
+		if (ret < 0)
+			return dev_err_probe(dev, ret, "Failed to get vref\n");
+
+		if (ret < 1250000 || ret > 2200000)
+			return dev_err_probe(dev, -EINVAL,
+						"Invalid vref voltage\n");
+
+		st->vref_mv = ret * 2 / 1000;
+	}
+
+	samp_freq = LTC235X_MIN_SAMP_FREQ;
+	st->cnv_pwm = devm_pwm_get(dev, "cnv");
+	if (IS_ERR(st->cnv_pwm))
+		return dev_err_probe(dev, PTR_ERR(st->cnv_pwm),
+					"Failed to get CNV PWM\n");
+
+	ret = __ltc235x_set_sampling_freq(st, samp_freq);
+	if (ret)
+		return ret;
+
+	conv->spi = st->spi;
+	conv->clk = st->clkin;
+	conv->read_raw = &ltc235x_read_raw;
+	conv->write_raw = &ltc235x_write_raw;
+	conv->reg_access = &ltc235x_reg_access;
+	conv->post_setup = &ltc235x_post_setup;
+	conv->phy = st;
+	spi_set_drvdata(st->spi, conv);
+
+	return ret;
+}
+
+static const struct spi_device_id ltc235x_id[] = {
+	{ "ltc2353-16", (kernel_ulong_t)&ltc235x_chip_info[ID_LTC2353_16] },
+	{ "ltc2353-18", (kernel_ulong_t)&ltc235x_chip_info[ID_LTC2353_18] },
+	{ "ltc2357-16", (kernel_ulong_t)&ltc235x_chip_info[ID_LTC2357_16] },
+	{ "ltc2357-18", (kernel_ulong_t)&ltc235x_chip_info[ID_LTC2357_18] },
+	{ "ltc2358-16", (kernel_ulong_t)&ltc235x_chip_info[ID_LTC2358_16] },
+	{ "ltc2358-18", (kernel_ulong_t)&ltc235x_chip_info[ID_LTC2358_18] },
+	{ },
+};
+MODULE_DEVICE_TABLE(spi, ltc2358_id);
+
+static const struct of_device_id ltc235x_of_match[] = {
+	{ .compatible = "adi,ltc2353-16",
+			.data = &ltc235x_chip_info[ID_LTC2353_16] },
+	{ .compatible = "adi,ltc2353-18",
+			.data = &ltc235x_chip_info[ID_LTC2353_18] },
+	{ .compatible = "adi,ltc2357-16",
+			.data = &ltc235x_chip_info[ID_LTC2357_16] },
+	{ .compatible = "adi,ltc2357-18",
+			.data = &ltc235x_chip_info[ID_LTC2357_18] },
+	{ .compatible = "adi,ltc2358-16",
+			.data = &ltc235x_chip_info[ID_LTC2358_16] },
+	{ .compatible = "adi,ltc2358-18",
+			.data = &ltc235x_chip_info[ID_LTC2358_18] },
+	{ },
+};
+MODULE_DEVICE_TABLE(of, ltc235x_of_match);
+
+static struct spi_driver ltc235x_driver = {
+	.driver = {
+		.name = "ltc235x",
+		.of_match_table = ltc235x_of_match,
+	},
+	.probe = ltc235x_probe,
+	.id_table = ltc235x_id,
+};
+module_spi_driver(ltc235x_driver);
+
+MODULE_AUTHOR("Kim Seer Paller <kimseer.paller@nalog.com>");
+MODULE_DESCRIPTION("Analog Devices LTC235X ADC");
+MODULE_LICENSE("GPL v2");


### PR DESCRIPTION
This PR enables the integration of the DC2677A board with the SoC FPGA Cyclone 5 FPGA. 
The setup involves utilizing the [axi-dc2677a-hdl-project](https://github.com/analogdevicesinc/hdl/pull/1130) repository for the required HDL project.
