### PR TITLE
arch: arm: dts: Add ZC706 + AD9082-FMCA-EBZ support

### DIFF
--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad9082.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad9082.dts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD9082-FMC-EBZ
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-mxfe/ad9081
+ * https://wiki.analog.com/resources/eval/user-guides/ad9081_fmca_ebz/ad9081_fmca_ebz_hdl
+ *
+ * hdl_project: <ad9082_fmca_ebz/zc706> Special Synthesis parameters required
+ * board_revision: <>
+ *
+ * Copyright (C) 2023 Analog Devices Inc.
+ */
+
+#include "zynq-zc706-adv7511-ad9081.dts"
+
+&trx0_ad9081 {
+	compatible = "adi,ad9082";
+};


### PR DESCRIPTION
 * JESD_MODE    8B10B
 * RX_LANE_RATE 10
 * TX_LANE_RATE 10
 * RX_JESD_M    8
 * RX_JESD_L    4
 * RX_JESD_S    1
 * RX_JESD_NP   16
 * RX_NUM_LINKS 1
 * TX_JESD_M    8
 * TX_JESD_L    4
 * TX_JESD_S    1
 * TX_JESD_NP   16
 * TX_NUM_LINKS 1

Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>
(cherry picked from commit dd289167670c13fa5fd49d25f6b9aa07ba0c54b0)