### PR TITLE
jesd204: remove useless 'state_ops' check

### DIFF
--- a/drivers/jesd204/jesd204-core.c
+++ b/drivers/jesd204/jesd204-core.c
@@ -887,7 +887,6 @@ static int jesd204_dev_init_links_data(struct device *parent,
 	 * or a link init op/callback which should do JESD204 link init.
 	 */
 	if (!init->links &&
-	    !init->state_ops &&
 	    !init->state_ops[JESD204_OP_LINK_INIT].per_link) {
 		jesd204_err(jdev,
 			    "num_links is non-zero, but no links data provided\n");

--- a/drivers/jesd204/jesd204-fsm.c
+++ b/drivers/jesd204/jesd204-fsm.c
@@ -1121,9 +1121,6 @@ static int jesd204_fsm_table_entry_cb(struct jesd204_dev *jdev,
 
 	jesd204_fsm_handle_stop_state(jdev, link_idx, fsm_data);
 
-	if (!jdev->dev_data->state_ops)
-		return JESD204_STATE_CHANGE_DONE;
-
 	state_op = &jdev->dev_data->state_ops[it->table[0].op];
 
 	if (fsm_data->rollback)


### PR DESCRIPTION
There's no point in checking for a null pointer in 'struct jesd204_dev_data::state_ops' since state_ops is an array and will never be NULL.

On more recent compilers, this fixes the following warning:

"warning: the comparison will always evaluate as ‘true’ for the address of ‘state_ops’ will never be NULL [-Waddress]"