### PR TITLE
[2021_R2] iio: adc: adrv9002: fix ORx port detection

### DIFF
--- a/drivers/iio/adc/navassa/adrv9002.c
+++ b/drivers/iio/adc/navassa/adrv9002.c
@@ -1121,7 +1121,7 @@ static const u32 rx_track_calls[] = {
 };
 
 static int adrv9002_phy_rx_do_write(const struct adrv9002_rf_phy *phy, struct adrv9002_rx_chan *rx,
-				    uintptr_t private, const char *buf)
+				    adi_common_Port_e port, uintptr_t private, const char *buf)
 {
 	struct adi_adrv9001_RxSettings *rx_settings = &phy->curr_profile->rx;
 	struct adi_adrv9001_RxChannelCfg *rx_cfg = &rx_settings->rxChannelCfg[rx->channel.idx];
@@ -1181,7 +1181,7 @@ static int adrv9002_phy_rx_do_write(const struct adrv9002_rf_phy *phy, struct ad
 		return adrv9002_channel_to_state(phy, &rx->channel, rx->channel.cached_state,
 						 false);
 	case RX_BBDC:
-		if (!rx->orx_en && rx->channel.port == ADI_ORX)
+		if (!rx->orx_en && port == ADI_ORX)
 			return -ENODEV;
 
 		ret = kstrtobool(buf, &enable);
@@ -1192,7 +1192,7 @@ static int adrv9002_phy_rx_do_write(const struct adrv9002_rf_phy *phy, struct ad
 		 * value to 0. The difference with the tracking cal is that disabling it, just
 		 * disables the algorithm but the last used correction value is still applied...
 		 */
-		return api_call(phy, adi_adrv9001_bbdc_RejectionEnable_Set, rx->channel.port,
+		return api_call(phy, adi_adrv9001_bbdc_RejectionEnable_Set, port,
 				rx->channel.number, enable);
 	case RX_BBDC_LOOP_GAIN:
 		ret = kstrtou32(buf, 10, &val);
@@ -1212,7 +1212,7 @@ static ssize_t adrv9002_phy_rx_write(struct iio_dev *indio_dev,
 {
 	struct adrv9002_rf_phy *phy = iio_priv(indio_dev);
 	const int channel = ADRV_ADDRESS_CHAN(chan->address);
-	const int port = ADRV_ADDRESS_PORT(chan->address);
+	const adi_common_Port_e port = ADRV_ADDRESS_PORT(chan->address);
 	struct adrv9002_rx_chan *rx = &phy->rx_channels[channel];
 	int ret = -ENODEV;
 
@@ -1220,7 +1220,7 @@ static ssize_t adrv9002_phy_rx_write(struct iio_dev *indio_dev,
 	if (!rx->channel.enabled && port == ADI_RX)
 		goto out_unlock;
 
-	ret = adrv9002_phy_rx_do_write(phy, rx, private, buf);
+	ret = adrv9002_phy_rx_do_write(phy, rx, port, private, buf);
 
 out_unlock:
 	mutex_unlock(&phy->lock);
@@ -1228,7 +1228,8 @@ out_unlock:
 }
 
 static int adrv9002_phy_rx_do_read(const struct adrv9002_rf_phy *phy,
-				   const struct adrv9002_rx_chan *rx, uintptr_t private, char *buf)
+				   const struct adrv9002_rx_chan *rx, adi_common_Port_e port,
+				   uintptr_t private, char *buf)
 {
 	struct adi_adrv9001_RxSettings *rx_settings = &phy->curr_profile->rx;
 	struct adi_adrv9001_RxChannelCfg *rx_cfg = &rx_settings->rxChannelCfg[rx->channel.idx];
@@ -1287,11 +1288,11 @@ static int adrv9002_phy_rx_do_read(const struct adrv9002_rf_phy *phy,
 
 		return sysfs_emit(buf, "%d\n", enable);
 	case RX_BBDC:
-		if (!rx->orx_en && rx->channel.port == ADI_ORX)
+		if (!rx->orx_en && port == ADI_ORX)
 			return -ENODEV;
 
-		ret = api_call(phy, adi_adrv9001_bbdc_RejectionEnable_Get,
-			       rx->channel.port, rx->channel.number, &bbdc);
+		ret = api_call(phy, adi_adrv9001_bbdc_RejectionEnable_Get, port,
+			       rx->channel.number, &bbdc);
 		if (ret)
 			return ret;
 
@@ -1314,7 +1315,7 @@ static ssize_t adrv9002_phy_rx_read(struct iio_dev *indio_dev,
 {
 	struct adrv9002_rf_phy *phy = iio_priv(indio_dev);
 	const int channel = ADRV_ADDRESS_CHAN(chan->address);
-	const int port = ADRV_ADDRESS_PORT(chan->address);
+	const adi_common_Port_e port = ADRV_ADDRESS_PORT(chan->address);
 	struct adrv9002_rx_chan *rx = &phy->rx_channels[channel];
 	int ret = -ENODEV;
 
@@ -1322,7 +1323,7 @@ static ssize_t adrv9002_phy_rx_read(struct iio_dev *indio_dev,
 	if (!rx->channel.enabled && port == ADI_RX)
 		goto out_unlock;
 
-	ret = adrv9002_phy_rx_do_read(phy, rx, private, buf);
+	ret = adrv9002_phy_rx_do_read(phy, rx, port, private, buf);
 
 out_unlock:
 	mutex_unlock(&phy->lock);
@@ -1750,12 +1751,13 @@ static int adrv9002_phy_read_raw_no_rf_chan(const struct adrv9002_rf_phy *phy,
 }
 
 static int adrv9002_hardware_gain_get(const struct adrv9002_rf_phy *phy,
-				      const struct adrv9002_chan *c, int *val, int *val2)
+				      const struct adrv9002_chan *c, adi_common_Port_e port,
+				      int *val, int *val2)
 {
 	int temp, ret;
 	u8 index;
 
-	if (c->port == ADI_TX) {
+	if (port == ADI_TX) {
 		u16 atten_mdb;
 
 		ret = api_call(phy, adi_adrv9001_Tx_Attenuation_Get, c->number, &atten_mdb);
@@ -1770,14 +1772,14 @@ static int adrv9002_hardware_gain_get(const struct adrv9002_rf_phy *phy,
 		return IIO_VAL_INT_PLUS_MICRO_DB;
 	}
 
-	if (c->port == ADI_ORX)
+	if (port == ADI_ORX)
 		ret = api_call(phy, adi_adrv9001_ORx_Gain_Get, c->number, &index);
 	else
 		ret = api_call(phy, adi_adrv9001_Rx_Gain_Get, c->number, &index);
 	if (ret)
 		return ret;
 
-	temp = adrv9002_gainidx_to_gain(index, c->port);
+	temp = adrv9002_gainidx_to_gain(index, port);
 	*val = temp / 1000;
 	*val2 = temp % 1000 * 1000;
 
@@ -1785,17 +1787,17 @@ static int adrv9002_hardware_gain_get(const struct adrv9002_rf_phy *phy,
 }
 
 static int adrv9002_phy_read_raw_rf_chan(const struct adrv9002_rf_phy *phy,
-					 const struct adrv9002_chan *chann, int *val,
-					 int *val2, long m)
+					 const struct adrv9002_chan *chann, adi_common_Port_e port,
+					 int *val, int *val2, long m)
 {
 	switch (m) {
 	case IIO_CHAN_INFO_HARDWAREGAIN:
-		return adrv9002_hardware_gain_get(phy, chann, val, val2);
+		return adrv9002_hardware_gain_get(phy, chann, port, val, val2);
 	case IIO_CHAN_INFO_SAMP_FREQ:
 		*val = clk_get_rate(chann->clk);
 		return IIO_VAL_INT;
 	case IIO_CHAN_INFO_ENABLE:
-		if (chann->port == ADI_ORX) {
+		if (port == ADI_ORX) {
 			struct adrv9002_rx_chan *rx = chan_to_rx(chann);
 
 			if (!rx->orx_gpio)
@@ -1838,7 +1840,7 @@ static int adrv9002_phy_read_raw(struct iio_dev *indio_dev,
 		goto out_unlock;
 	}
 
-	ret = adrv9002_phy_read_raw_rf_chan(phy, chann, val, val2, m);
+	ret = adrv9002_phy_read_raw_rf_chan(phy, chann, port, val, val2, m);
 
 out_unlock:
 	mutex_unlock(&phy->lock);
@@ -1904,13 +1906,14 @@ static bool adrv9002_orx_can_enable(const struct adrv9002_rf_phy *phy,
 }
 
 static int adrv9002_hardware_gain_set(const struct adrv9002_rf_phy *phy,
-				      const struct adrv9002_chan *c, int val, int val2)
+				      const struct adrv9002_chan *c, adi_common_Port_e port,
+				      int val, int val2)
 {
 	int gain;
 	u32 code;
 	u8 idx;
 
-	if (c->port == ADI_TX) {
+	if (port == ADI_TX) {
 		if (val > 0 || (val == 0 && val2 > 0))
 			return -EINVAL;
 
@@ -1919,22 +1922,23 @@ static int adrv9002_hardware_gain_set(const struct adrv9002_rf_phy *phy,
 	}
 
 	gain = val * 1000 + val2 / 1000;
-	idx = adrv9002_gain_to_gainidx(gain, c->port);
+	idx = adrv9002_gain_to_gainidx(gain, port);
 
-	if (c->port == ADI_RX)
+	if (port == ADI_RX)
 		return api_call(phy, adi_adrv9001_Rx_Gain_Set, c->number, idx);
 
 	return api_call(phy, adi_adrv9001_ORx_Gain_Set, c->number, idx);
 }
 
 static int adrv9002_phy_write_raw_rf_chan(const struct adrv9002_rf_phy *phy,
-					  struct adrv9002_chan *chann, int val, int val2, long mask)
+					  struct adrv9002_chan *chann, adi_common_Port_e port,
+					  int val, int val2, long mask)
 {
 	switch (mask) {
 	case IIO_CHAN_INFO_HARDWAREGAIN:
-		return adrv9002_hardware_gain_set(phy, chann, val, val2);
+		return adrv9002_hardware_gain_set(phy, chann, port, val, val2);
 	case IIO_CHAN_INFO_ENABLE:
-		if (chann->port == ADI_ORX) {
+		if (port == ADI_ORX) {
 			struct adrv9002_rx_chan *rx = chan_to_rx(chann);
 
 			if (!rx->orx_gpio)
@@ -1979,7 +1983,7 @@ static int adrv9002_phy_write_raw(struct iio_dev *indio_dev,
 		goto out_unlock;
 	}
 
-	ret = adrv9002_phy_write_raw_rf_chan(phy, chann, val, val2, mask);
+	ret = adrv9002_phy_write_raw_rf_chan(phy, chann, port, val, val2, mask);
 
 out_unlock:
 	mutex_unlock(&phy->lock);


### PR DESCRIPTION
The ORx port does not have it's own struct 'adrv9002_chann' instance since it's a very simple one and we can handle it with a couple of specific 'struct adrv9002_rx' members. That means, that we need to explicitly use the encoded port in 'struct iio_chan_spec::address' to identify an ORx port when dealing with it's IIO attributes so we can actually read and write them (instead of changing RX attributes)

Of course that not having it's own instance can lead to subtle errors like this but I still think it's not really worth it...

While at it, made all the port handling coeherent by always using 'adi_common_Port_e'.

Fixes: 2c490432b857c ("iio: adc: adrv9002: improve IIO read/write() callbacks code flow")

---

Same as #2214 