### PR TITLE
adrv9009: check validity of the link_clk pointer before accessing it

### DIFF
--- a/drivers/iio/adc/adrv9009.c
+++ b/drivers/iio/adc/adrv9009.c
@@ -301,7 +301,7 @@ static int adrv9009_set_jesd_lanerate(struct adrv9009_rf_phy *phy,
 				      taliseJesd204bDeframerConfig_t *deframer,
 				      u32 *lmfc)
 {
-	bool clk_enable = __clk_is_enabled(link_clk);
+	bool clk_enable;
 	unsigned long lane_rate_kHz;
 	u32 m, l, k, f, lmfc_tmp;
 	int ret;
@@ -311,6 +311,8 @@ static int adrv9009_set_jesd_lanerate(struct adrv9009_rf_phy *phy,
 
 	if (IS_ERR_OR_NULL(link_clk))
 		return 0;
+
+	clk_enable = __clk_is_enabled(link_clk);
 
 	if (framer) {
 		m = framer->M;


### PR DESCRIPTION
This bug was found in an ADRV9009 design with the transmit chain removed, including removal of the jesd_tx_clk from the device tree.  The change updates the adrv9009_set_jesd_lanerate function to properly check the validity of the link_clk pointer before using it.

Related forum post: https://ez.analog.com/linux-software-drivers/f/q-a/571070/adrv9009-kernel-driver-errors-when-removing-tx-components