### PR TITLE
ADRV9009: make jesd clocks optional

### DIFF
--- a/drivers/clk/clk.c
+++ b/drivers/clk/clk.c
@@ -3108,7 +3108,7 @@ static void clk_dump_one(struct seq_file *s, struct clk_core *c, int level)
 	phase = clk_core_get_phase(c);
 	if (phase >= 0)
 		seq_printf(s, "\"phase\": %d,", phase);
-	seq_printf(s, "\"duty_cycle\": %u",
+	seq_printf(s, "\"duty_cycle\": %u,",
 		   clk_core_get_scaled_duty_cycle(c, 100000));
 	seq_printf(s, "\"nshot\": %d", clk_core_get_nshot(c));
 }

--- a/drivers/iio/adc/adrv9009.c
+++ b/drivers/iio/adc/adrv9009.c
@@ -301,9 +301,9 @@ static int adrv9009_set_jesd_lanerate(struct adrv9009_rf_phy *phy,
 				      taliseJesd204bDeframerConfig_t *deframer,
 				      u32 *lmfc)
 {
-	bool clk_enable = __clk_is_enabled(link_clk);
 	unsigned long lane_rate_kHz;
 	u32 m, l, k, f, lmfc_tmp;
+	bool clk_enable;
 	int ret;
 
 	if (!lmfc)
@@ -311,6 +311,8 @@ static int adrv9009_set_jesd_lanerate(struct adrv9009_rf_phy *phy,
 
 	if (IS_ERR_OR_NULL(link_clk))
 		return 0;
+
+	clk_enable = __clk_is_enabled(link_clk);
 
 	if (framer) {
 		m = framer->M;

--- a/drivers/iio/adc/adrv9009.c
+++ b/drivers/iio/adc/adrv9009.c
@@ -921,8 +921,6 @@ static int adrv9009_do_setup(struct adrv9009_rf_phy *phy)
 	}
 
 	/*** < User Sends SYSREF Here > ***/
-
-
 	adrv9009_sysref_req(phy, SYSREF_CONT_ON);
 
 	if (has_rx_and_en(phy)) {
@@ -954,9 +952,8 @@ static int adrv9009_do_setup(struct adrv9009_rf_phy *phy)
 		adrv9009_spi_write(phy->spi, TALISE_ADDR_DES_PHY_GENERAL_CTL_1, phy_ctrl);
 	}
 
-	adrv9009_sysref_req(phy, SYSREF_CONT_OFF);
-
 	/*** < User Sends SYSREF Here > ***/
+	adrv9009_sysref_req(phy, SYSREF_CONT_OFF);
 
 	/*** < Insert User JESD204B Sync Verification Code Here > ***/
 

--- a/drivers/iio/adc/adrv9009.c
+++ b/drivers/iio/adc/adrv9009.c
@@ -6535,17 +6535,26 @@ static int adrv9009_probe(struct spi_device *spi)
 					      GPIOD_OUT_HIGH);
 
 	if (!phy->jdev) {
-		if (has_tx(phy))
+		if (has_tx(phy)) {
 			phy->jesd_tx_clk =
-				devm_clk_get(&spi->dev, "jesd_tx_clk");
+				devm_clk_get_optional(&spi->dev, "jesd_tx_clk");
+			if (IS_ERR(phy->jesd_tx_clk))
+				return PTR_ERR(phy->jesd_tx_clk);
+		}
 
-		if (has_rx(phy))
+		if (has_rx(phy)) {
 			phy->jesd_rx_clk =
-				devm_clk_get(&spi->dev, "jesd_rx_clk");
+				devm_clk_get_optional(&spi->dev, "jesd_rx_clk");
+			if (IS_ERR(phy->jesd_rx_clk))
+				return PTR_ERR(phy->jesd_rx_clk);
+		}
 
-		if (has_obs(phy))
+		if (has_obs(phy)) {
 			phy->jesd_rx_os_clk =
-				devm_clk_get(&spi->dev, "jesd_rx_os_clk");
+				devm_clk_get_optional(&spi->dev, "jesd_rx_os_clk");
+			if (IS_ERR(phy->jesd_rx_os_clk))
+				return PTR_ERR(phy->jesd_rx_os_clk);
+		}
 
 		phy->dev_clk = devm_clk_get(&spi->dev, "dev_clk");
 		if (IS_ERR(phy->dev_clk))

--- a/drivers/iio/adc/adrv9009.h
+++ b/drivers/iio/adc/adrv9009.h
@@ -258,9 +258,14 @@ static inline bool has_tx_and_en(struct adrv9009_rf_phy *phy)
 		(!IS_ERR_OR_NULL(phy->jesd_tx_clk) || phy->jdev);
 }
 
+static inline bool has_obs(struct adrv9009_rf_phy *phy)
+{
+	return has_tx(phy);
+}
+
 static inline bool has_obs_and_en(struct adrv9009_rf_phy *phy)
 {
-	return has_tx(phy) &&
+	return has_obs(phy) &&
 		(phy->talInit.obsRx.obsRxChannelsEnable != TAL_ORXOFF) &&
 		!IS_ERR_OR_NULL(phy->jesd_rx_os_clk);
 }


### PR DESCRIPTION
In some cases transmit/receive chains can be disabled even if the chip supports it. Make the clocks optional so that we get a NULL reference instead of ENOENT.

This PR is related to https://github.com/analogdevicesinc/linux/pull/2219.