### PR TITLE
[2021_R2] iio: adc: ad4630: fix pm runtime unbalanced refcounts

### DIFF
--- a/drivers/iio/adc/ad4630.c
+++ b/drivers/iio/adc/ad4630.c
@@ -554,7 +554,7 @@ static int ad4630_buffer_preenable(struct iio_dev *indio_dev)
 	struct ad4630_state *st = iio_priv(indio_dev);
 	int ret;
 
-	ret = pm_runtime_get_sync(&st->spi->dev);
+	ret = pm_runtime_resume_and_get(&st->spi->dev);
 	if (ret < 0)
 		return ret;
 


### PR DESCRIPTION
pm_runtime_get_sync() will increment the refcount but it will not release it if it fails to resume the device. Hence, use pm_runtime_resume_and_get() which properly handles the this.

Fixes: 04ff9ea893f9 ("drivers: iio: adc: add support for ad4630")