### PR TITLE
iio: frequency: ad9783: fix ad9780 and ad9781 channel ref

### DIFF
--- a/drivers/iio/frequency/ad9783.c
+++ b/drivers/iio/frequency/ad9783.c
@@ -707,6 +707,18 @@ static const struct iio_info ad9783_info = {
 	}
 
 static const struct iio_chan_spec ad9783_channels[][4] = {
+	[ID_DEV_AD9780] = {
+		AD9783_CHANNEL_DAC("TX_I", 0),
+		AD9783_CHANNEL_DAC("TX_Q", 1),
+		AD9783_CHANNEL_AUXDAC("AUX1", 2),
+		AD9783_CHANNEL_AUXDAC("AUX2", 3),
+	},
+	[ID_DEV_AD9781] = {
+		AD9783_CHANNEL_DAC("TX_I", 0),
+		AD9783_CHANNEL_DAC("TX_Q", 1),
+		AD9783_CHANNEL_AUXDAC("AUX1", 2),
+		AD9783_CHANNEL_AUXDAC("AUX2", 3),
+	},
 	[ID_DEV_AD9783] = {
 		AD9783_CHANNEL_DAC("TX_I", 0),
 		AD9783_CHANNEL_DAC("TX_Q", 1),


### PR DESCRIPTION
Add channel specifications for ad9780 and ad9781.
device_id points to the enumerated index in ad9783_channels based on the compatible string,
but since the index was empty the channel initialisation failed.