### PR TITLE
[ADRV9002] support re-running init calls

### DIFF
--- a/drivers/iio/adc/navassa/adrv9002.c
+++ b/drivers/iio/adc/navassa/adrv9002.c
@@ -706,7 +706,7 @@ static int adrv9002_init_cals_set(struct adrv9002_rf_phy *phy, const char *buf)
 
 static int adrv9002_fh_set(const struct adrv9002_rf_phy *phy, const char *buf, u64 address)
 {
-	int tbl;
+	int tbl, ret;
 
 	if (!phy->curr_profile->sysConfig.fhModeOn) {
 		dev_err(&phy->spi->dev, "Frequency hopping not enabled\n");
@@ -723,14 +723,11 @@ static int adrv9002_fh_set(const struct adrv9002_rf_phy *phy, const char *buf, u
 	switch (address) {
 	case ADRV9002_HOP_1_TABLE_SEL:
 	case ADRV9002_HOP_2_TABLE_SEL:
-		for (tbl = 0; tbl < ARRAY_SIZE(adrv9002_hop_table) - 1; tbl++) {
-			if (sysfs_streq(buf, adrv9002_hop_table[tbl]))
-				break;
-		}
-
-		if (tbl == ARRAY_SIZE(adrv9002_hop_table) - 1) {
+		ret = __sysfs_match_string(adrv9002_hop_table,
+					   ARRAY_SIZE(adrv9002_hop_table) - 1, buf);
+		if (ret) {
 			dev_err(&phy->spi->dev, "Unknown table %s\n", buf);
-			return -EINVAL;
+			return ret;
 		}
 
 		return api_call(phy, adi_adrv9001_fh_HopTable_Set, address, tbl);

--- a/drivers/iio/adc/navassa/adrv9002.c
+++ b/drivers/iio/adc/navassa/adrv9002.c
@@ -670,12 +670,81 @@ static int adrv9002_set_ext_lo(const struct adrv9002_chan *c, u64 freq)
 	return clk_set_rate_scaled(c->ext_lo->clk, freq, &c->ext_lo->scale);
 }
 
+static int adrv9002_phy_lo_set(struct adrv9002_rf_phy *phy, struct adrv9002_chan *c, u64 freq)
+{
+	struct adi_adrv9001_Carrier lo_freq;
+	int ret;
+
+	ret = api_call(phy, adi_adrv9001_Radio_Carrier_Inspect, c->port, c->number, &lo_freq);
+	if (ret)
+		return ret;
+
+	ret = adrv9002_set_ext_lo(c, freq);
+	if (ret)
+		return ret;
+
+	lo_freq.carrierFrequency_Hz = freq;
+
+	return api_call(phy, adi_adrv9001_Radio_Carrier_Configure, c->port, c->number, &lo_freq);
+}
+
+static int adrv9002_phy_lo_set_ports(struct adrv9002_rf_phy *phy, struct adrv9002_chan *c, u64 freq)
+{
+	int ret;
+	int tx;
+
+	if (c->port == ADI_RX) {
+		int rx;
+
+		for (rx = 0; rx < ARRAY_SIZE(phy->rx_channels); rx++) {
+			if (c->lo != phy->rx_channels[rx].channel.lo)
+				continue;
+
+			ret = adrv9002_phy_lo_set(phy, &phy->rx_channels[rx].channel, freq);
+			if (ret)
+				return ret;
+		}
+
+		return 0;
+	}
+
+	for (tx = 0; tx < phy->chip->n_tx; tx++) {
+		if (c->lo != phy->tx_channels[tx].channel.lo)
+			continue;
+
+		ret = adrv9002_phy_lo_set(phy, &phy->tx_channels[tx].channel, freq);
+		if (ret)
+			return ret;
+	}
+
+	return 0;
+}
+
+/*
+ * Handling the carrier frequency is not really straight because it looks like we have 4
+ * independent controls when in reality they are not as the device only has 2 LOs. It
+ * all the depends on the LO mappings present in the current profile. First, the only way
+ * a carrier is actually applied (PLL re-tunes) is if all ports on the same LO, are moved
+ * into the calibrated state before changing it. Not doing so means that we may end up in
+ * an inconsistent state. For instance, consider the following steps in a FDD profile where
+ * RX1=RX2=LO1 (assuming both ports start at 2.4GHz):
+ *   1) Move RX1 carrier to 2.45GHz -> LO1 re-tunes
+ *   2) Move RX1 back to 2.4GHz -> LO1 does not re-tune and our carrier is at 2.45GHz
+ * With the above steps we are left with both ports, __apparently__, at 2.4GHz but in __reality__
+ * our carrier is at 2.45GHz.
+ *
+ * Secondly, when both ports of the same type are at the same LO, which happens on FDD and TTD
+ * (with diversity) profiles, we should move the carrier of these ports together, because it's
+ * just not possible to have both ports enabled with different carriers (they are on the same LO!).
+ * On TDD profiles, we never move TX/RX ports together even being on the same LO. The assumption
+ * is that we might have time to re-tune between RX and TX frames. If we don't, we need to manually
+ * set TX and RX carriers to the same value before starting operating...
+ */
 static ssize_t adrv9002_phy_lo_do_write(struct adrv9002_rf_phy *phy, struct adrv9002_chan *c,
 					const char *buf, size_t len)
 {
-	struct adi_adrv9001_Carrier lo_freq;
+	int ret, i;
 	u64 freq;
-	int ret;
 
 	ret = kstrtoull(buf, 10, &freq);
 	if (ret)
@@ -688,23 +757,48 @@ static ssize_t adrv9002_phy_lo_do_write(struct adrv9002_rf_phy *phy, struct adrv
 		goto out_unlock;
 	}
 
-	ret = api_call(phy, adi_adrv9001_Radio_Carrier_Inspect, c->port, c->number, &lo_freq);
-	if (ret)
-		goto out_unlock;
+	/* move all channels on the same lo to the calibrated state */
+	for (i = 0; i < ARRAY_SIZE(phy->channels); i++) {
+		if (phy->channels[i]->lo != c->lo)
+			continue;
 
-	ret = adrv9002_set_ext_lo(c, freq);
-	if (ret)
-		goto out_unlock;
+		ret = adrv9002_channel_to_state(phy, phy->channels[i],
+						ADI_ADRV9001_CHANNEL_CALIBRATED, true);
+		if (ret)
+			goto out_unlock;
+	}
 
-	lo_freq.carrierFrequency_Hz = freq;
-	ret = adrv9002_channel_to_state(phy, c, ADI_ADRV9001_CHANNEL_CALIBRATED, true);
+	ret = adrv9002_phy_lo_set_ports(phy, c, freq);
 	if (ret)
-		goto out_unlock;
+		return ret;
 
-	ret = api_call(phy, adi_adrv9001_Radio_Carrier_Configure, c->port, c->number, &lo_freq);
-	if (ret)
-		goto out_unlock;
+	/* move all channels on the same lo to the cached state */
+	for (i = 0; i < ARRAY_SIZE(phy->channels); i++) {
+		/* If it's me... defer. See below */
+		if (phy->channels[i]->port == c->port && phy->channels[i]->idx == c->idx)
+			continue;
 
+		if (phy->channels[i]->lo != c->lo)
+			continue;
+
+		ret = adrv9002_channel_to_state(phy, phy->channels[i],
+						phy->channels[i]->cached_state, false);
+		if (ret)
+			goto out_unlock;
+	}
+
+	/*
+	 * This is needed so that we are sure that the port where we are changing the
+	 * carrier is the last one to transition state. This might matter in TDD profiles
+	 * because a transition from calibrated to prime also causes the PLL to re-lock
+	 * to the port carrier. So let's say that RX1 and TX1 are both on LO1 and start:
+	 *	1. TX1 carrier set to 2.45GHz and primed
+	 *	2. RX1 carrier set to 2.4GHz and primed
+	 *	3. Change RX1 to rf_enabled and set carrier to 2.5GHz
+	 * With the last steps we end up with 2.4GHz on LO1 which is not expected. The
+	 * reason is that we would move TX1 from calibrated to prime after changing RX1
+	 * which causes a re-lock.
+	 */
 	ret = adrv9002_channel_to_state(phy, c, c->cached_state, false);
 
 out_unlock:
@@ -2569,6 +2663,7 @@ static int adrv9002_validate_profile(struct adrv9002_rf_phy *phy)
 {
 	const struct adi_adrv9001_RxChannelCfg *rx_cfg = phy->curr_profile->rx.rxChannelCfg;
 	const struct adi_adrv9001_TxProfile *tx_cfg = phy->curr_profile->tx.txProfile;
+	struct adi_adrv9001_ClockSettings *clks = &phy->curr_profile->clocks;
 	unsigned long rx_mask = phy->curr_profile->rx.rxInitChannelMask;
 	unsigned long tx_mask = phy->curr_profile->tx.txInitChannelMask;
 	const u32 ports[ADRV9002_CHANN_MAX * 2 + ADI_ADRV9001_MAX_ORX_ONLY] = {
@@ -2628,6 +2723,7 @@ static int adrv9002_validate_profile(struct adrv9002_rf_phy *phy)
 		rx->channel.rate = rx_cfg[i].profile.rxOutputRate_Hz;
 		if (lo < ADI_ADRV9001_LOSEL_LO2)
 			rx->channel.ext_lo = &phy->ext_los[lo];
+		rx->channel.lo = i ? clks->rx2LoSelect : clks->rx1LoSelect;
 tx:
 		/* tx validations*/
 		if (!test_bit(ports[i * 2 + 1], &tx_mask))
@@ -2718,6 +2814,7 @@ tx:
 		tx->rate = tx_cfg[i].txInputRate_Hz;
 		if (lo < ADI_ADRV9001_LOSEL_LO2)
 			tx->ext_lo = &phy->ext_los[lo];
+		tx->lo = i ? clks->tx2LoSelect : clks->tx1LoSelect;
 	}
 
 	return 0;
@@ -3237,8 +3334,10 @@ static void adrv9002_cleanup(struct adrv9002_rf_phy *phy)
 			gpiod_set_value_cansleep(phy->rx_channels[i].orx_gpio, 0);
 		phy->rx_channels[i].channel.enabled = 0;
 		phy->rx_channels[i].channel.ext_lo = NULL;
+		phy->rx_channels[i].channel.lo = 0;
 		phy->tx_channels[i].channel.enabled = 0;
 		phy->tx_channels[i].channel.ext_lo = NULL;
+		phy->tx_channels[i].channel.lo = 0;
 	}
 
 	phy->profile_len = scnprintf(phy->profile_buf, sizeof(phy->profile_buf),

--- a/drivers/iio/adc/navassa/adrv9002.c
+++ b/drivers/iio/adc/navassa/adrv9002.c
@@ -67,8 +67,8 @@
 #define ALL_RX_CHANNEL_MASK	(ADI_ADRV9001_RX1 | ADI_ADRV9001_RX2 | \
 				 ADI_ADRV9001_ORX1 | ADI_ADRV9001_ORX2)
 
-#define ADRV9002_RX_EN(nr)	BIT(((nr) * 2) & 0x3)
-#define ADRV9002_TX_EN(nr)	BIT(((nr) * 2 + 1) & 0x3)
+#define ADRV9002_PORT_BIT(c)	(((c)->idx * 2 + (c)->port) & 0x3)
+#define ADRV9002_PORT_MASK(c)	BIT(ADRV9002_PORT_BIT(c))
 
 #define ADRV9002_RX_MAX_GAIN_mdB	\
 	((ADI_ADRV9001_RX_GAIN_INDEX_MAX - ADI_ADRV9001_RX_GAIN_INDEX_MIN) *	\
@@ -2505,9 +2505,9 @@ static void adrv9002_compute_init_cals(struct adrv9002_rf_phy *phy)
 			continue;
 
 		if (c->port == ADI_RX)
-			pos |= ADRV9002_RX_EN(c->idx);
+			pos |= ADRV9002_PORT_MASK(c);
 		else
-			pos |= ADRV9002_TX_EN(c->idx);
+			pos |= ADRV9002_PORT_MASK(c);
 	}
 
 	phy->init_cals.chanInitCalMask[0] = adrv9002_init_cals_mask[pos][0];

--- a/drivers/iio/adc/navassa/adrv9002.c
+++ b/drivers/iio/adc/navassa/adrv9002.c
@@ -3350,6 +3350,31 @@ static void adrv9002_fill_profile_read(struct adrv9002_rf_phy *phy)
 				     ssi[phy->ssi_type]);
 }
 
+static void adrv9002_port_enable(const struct adrv9002_rf_phy *phy,
+				 const struct adrv9002_chan *c, bool enable)
+{
+	if (c->mux_ctl)
+		gpiod_set_value_cansleep(c->mux_ctl, enable);
+	if (c->mux_ctl_2)
+		gpiod_set_value_cansleep(c->mux_ctl_2, enable);
+	/*
+	 * Nothing to do for channel 2 in rx2tx2 mode. The check is useful to have
+	 * it in here if the outer loop is looping through all the channels.
+	 */
+	if (phy->rx2tx2 && c->idx > ADRV9002_CHANN_1)
+		return;
+	/*
+	 * We always disable but let's not enable a port that is not enable in the profile.
+	 * Same as above, the condition is needed if the outer loop is looping through all
+	 * channels to enable/disable them. Might be a redundant in some cases where the
+	 * caller already knows the state of the port.
+	 */
+	if (enable && !c->enabled)
+		return;
+
+	adrv9002_axi_interface_enable(phy, c->idx, c->port == ADI_TX, enable);
+}
+
 int adrv9002_init(struct adrv9002_rf_phy *phy, struct adi_adrv9001_Init *profile)
 {
 	int ret, c;
@@ -3367,17 +3392,7 @@ int adrv9002_init(struct adrv9002_rf_phy *phy, struct adi_adrv9001_Init *profile
 		if (chan->port == ADI_TX && chan->idx >= phy->chip->n_tx)
 			break;
 
-		if (chan->mux_ctl)
-			gpiod_set_value_cansleep(chan->mux_ctl, 0);
-
-		if (chan->mux_ctl_2)
-			gpiod_set_value_cansleep(chan->mux_ctl_2, 0);
-
-		/* we still need to disable the muxes if the cores are set for rx2tx2 */
-		if (phy->rx2tx2 && chan->idx > ADRV9002_CHANN_1)
-			continue;
-
-		adrv9002_axi_interface_enable(phy, chan->idx, chan->port == ADI_TX, false);
+		adrv9002_port_enable(phy, chan, false);
 	}
 
 	phy->curr_profile = profile;
@@ -3399,20 +3414,7 @@ int adrv9002_init(struct adrv9002_rf_phy *phy, struct adi_adrv9001_Init *profile
 	for (c = 0; c < ARRAY_SIZE(phy->channels); c++) {
 		chan = phy->channels[c];
 
-		if (chan->mux_ctl)
-			gpiod_set_value_cansleep(chan->mux_ctl, 1);
-
-		if (chan->mux_ctl_2)
-			gpiod_set_value_cansleep(chan->mux_ctl_2, 1);
-
-		/* We still need to go through the whole loop to potentially re-enable the muxes */
-		if (phy->rx2tx2 && chan->idx > ADRV9002_CHANN_1)
-			continue;
-
-		if (!chan->enabled)
-			continue;
-
-		adrv9002_axi_interface_enable(phy, chan->idx, chan->port == ADI_TX, true);
+		adrv9002_port_enable(phy, chan, true);
 	}
 
 	ret = adrv9002_intf_tuning(phy);

--- a/drivers/iio/adc/navassa/adrv9002.c
+++ b/drivers/iio/adc/navassa/adrv9002.c
@@ -539,7 +539,8 @@ enum {
 	ADRV9002_HOP_1_TABLE_SEL,
 	ADRV9002_HOP_2_TABLE_SEL,
 	ADRV9002_HOP_1_TRIGGER,
-	ADRV9002_HOP_2_TRIGGER
+	ADRV9002_HOP_2_TRIGGER,
+	ADRV9002_INIT_CALS_RUN,
 };
 
 static const char * const adrv9002_hop_table[ADRV9002_FH_TABLES_NR + 1] = {
@@ -574,6 +575,12 @@ static int adrv9002_fh_table_show(struct adrv9002_rf_phy *phy, char *buf, u64 ad
 	return sysfs_emit(buf, "%s\n", adrv9002_hop_table[table]);
 }
 
+static const char * const adrv9002_init_cals_modes[] = {
+	"off",
+	"auto",
+	"run"
+};
+
 static ssize_t adrv9002_attr_show(struct device *dev, struct device_attribute *attr, char *buf)
 {
 	struct iio_dev *indio_dev = dev_to_iio_dev(dev);
@@ -588,6 +595,9 @@ static ssize_t adrv9002_attr_show(struct device *dev, struct device_attribute *a
 	case ADRV9002_HOP_2_TABLE_SEL:
 		ret = adrv9002_fh_table_show(phy, buf, iio_attr->address);
 		break;
+	case ADRV9002_INIT_CALS_RUN:
+		ret = sysfs_emit(buf, "%s\n", adrv9002_init_cals_modes[phy->run_cals]);
+		break;
 	default:
 		ret = -EINVAL;
 	}
@@ -595,6 +605,103 @@ static ssize_t adrv9002_attr_show(struct device *dev, struct device_attribute *a
 	mutex_unlock(&phy->lock);
 
 	return ret;
+}
+
+static void adrv9002_port_enable(const struct adrv9002_rf_phy *phy,
+				 const struct adrv9002_chan *c, bool enable)
+{
+	if (c->mux_ctl)
+		gpiod_set_value_cansleep(c->mux_ctl, enable);
+	if (c->mux_ctl_2)
+		gpiod_set_value_cansleep(c->mux_ctl_2, enable);
+	/*
+	 * Nothing to do for channel 2 in rx2tx2 mode. The check is useful to have
+	 * it in here if the outer loop is looping through all the channels.
+	 */
+	if (phy->rx2tx2 && c->idx > ADRV9002_CHANN_1)
+		return;
+	/*
+	 * We always disable but let's not enable a port that is not enable in the profile.
+	 * Same as above, the condition is needed if the outer loop is looping through all
+	 * channels to enable/disable them. Might be a redundant in some cases where the
+	 * caller already knows the state of the port.
+	 */
+	if (enable && !c->enabled)
+		return;
+
+	adrv9002_axi_interface_enable(phy, c->idx, c->port == ADI_TX, enable);
+}
+
+static int adrv9002_phy_rerun_cals_setup(struct adrv9002_rf_phy *phy, unsigned long port_mask,
+					 bool after)
+{
+	int ret, c;
+
+	for (c = 0; c < ARRAY_SIZE(phy->channels); c++) {
+		adi_adrv9001_ChannelState_e state = after ? phy->channels[c]->cached_state
+				: ADI_ADRV9001_CHANNEL_CALIBRATED;
+
+		adrv9002_port_enable(phy, phy->channels[c], after);
+
+		/* if the bit is set, then we already moved the port */
+		if (test_bit(ADRV9002_PORT_BIT(phy->channels[c]), &port_mask))
+			continue;
+
+		ret = adrv9002_channel_to_state(phy, phy->channels[c], state, !after);
+		if (ret)
+			return ret;
+	}
+
+	return 0;
+}
+
+static int adrv9002_phy_rerun_cals(struct adrv9002_rf_phy *phy,
+				   struct adi_adrv9001_InitCals *init_cals, unsigned long port_mask)
+{
+	u8 error;
+	int ret;
+
+	if (!init_cals->chanInitCalMask[0] && !init_cals->chanInitCalMask[1])
+		return 0;
+
+	/* move the missing ports to calibrated state and disable all the axi cores */
+	ret = adrv9002_phy_rerun_cals_setup(phy, port_mask, false);
+	if (ret)
+		return ret;
+
+	dev_dbg(&phy->spi->dev, "Re-run init cals: mask: %08X, %08X\n",
+		init_cals->chanInitCalMask[0], init_cals->chanInitCalMask[1]);
+
+	ret = api_call(phy, adi_adrv9001_cals_InitCals_Run, init_cals, 60000, &error);
+	if (ret)
+		return ret;
+
+	/* re-enable cores and re-set port states (those where the carrier is not being changed) */
+	return adrv9002_phy_rerun_cals_setup(phy, port_mask, true);
+}
+
+static int adrv9002_init_cals_set(struct adrv9002_rf_phy *phy, const char *buf)
+{
+	struct adi_adrv9001_InitCals cals = {0};
+	int c, ret;
+
+	ret = sysfs_match_string(adrv9002_init_cals_modes, buf);
+	if (ret < 0)
+		return ret;
+
+	if (strcmp(adrv9002_init_cals_modes[ret], "run")) {
+		if (!strcmp(adrv9002_init_cals_modes[ret], "auto"))
+			phy->run_cals = true;
+		else
+			phy->run_cals = false;
+
+		return 0;
+	}
+
+	for (c = 0; c < ARRAY_SIZE(phy->channels); c++)
+		cals.chanInitCalMask[phy->channels[c]->idx] |= phy->channels[c]->lo_cals;
+
+	return adrv9002_phy_rerun_cals(phy, &cals, 0);
 }
 
 static int adrv9002_fh_set(const struct adrv9002_rf_phy *phy, const char *buf, u64 address)
@@ -645,7 +752,13 @@ static ssize_t adrv9002_attr_store(struct device *dev, struct device_attribute *
 	int ret;
 
 	mutex_lock(&phy->lock);
-	ret = adrv9002_fh_set(phy, buf, iio_attr->address);
+	switch (iio_attr->address) {
+	case ADRV9002_INIT_CALS_RUN:
+		ret = adrv9002_init_cals_set(phy, buf);
+		break;
+	default:
+		ret = adrv9002_fh_set(phy, buf, iio_attr->address);
+	}
 	mutex_unlock(&phy->lock);
 
 	return ret ? ret : len;
@@ -670,7 +783,8 @@ static int adrv9002_set_ext_lo(const struct adrv9002_chan *c, u64 freq)
 	return clk_set_rate_scaled(c->ext_lo->clk, freq, &c->ext_lo->scale);
 }
 
-static int adrv9002_phy_lo_set(struct adrv9002_rf_phy *phy, struct adrv9002_chan *c, u64 freq)
+static int adrv9002_phy_lo_set(struct adrv9002_rf_phy *phy, struct adrv9002_chan *c,
+			       struct adi_adrv9001_InitCals *init_cals, u64 freq)
 {
 	struct adi_adrv9001_Carrier lo_freq;
 	int ret;
@@ -683,12 +797,16 @@ static int adrv9002_phy_lo_set(struct adrv9002_rf_phy *phy, struct adrv9002_chan
 	if (ret)
 		return ret;
 
+	if (abs(freq - lo_freq.carrierFrequency_Hz) >= 100 * MEGA && phy->run_cals)
+		init_cals->chanInitCalMask[c->idx] |= c->lo_cals;
+
 	lo_freq.carrierFrequency_Hz = freq;
 
 	return api_call(phy, adi_adrv9001_Radio_Carrier_Configure, c->port, c->number, &lo_freq);
 }
 
-static int adrv9002_phy_lo_set_ports(struct adrv9002_rf_phy *phy, struct adrv9002_chan *c, u64 freq)
+static int adrv9002_phy_lo_set_ports(struct adrv9002_rf_phy *phy, struct adrv9002_chan *c,
+				     struct adi_adrv9001_InitCals *init_cals, u64 freq)
 {
 	int ret;
 	int tx;
@@ -700,7 +818,8 @@ static int adrv9002_phy_lo_set_ports(struct adrv9002_rf_phy *phy, struct adrv900
 			if (c->lo != phy->rx_channels[rx].channel.lo)
 				continue;
 
-			ret = adrv9002_phy_lo_set(phy, &phy->rx_channels[rx].channel, freq);
+			ret = adrv9002_phy_lo_set(phy, &phy->rx_channels[rx].channel,
+						  init_cals, freq);
 			if (ret)
 				return ret;
 		}
@@ -712,7 +831,7 @@ static int adrv9002_phy_lo_set_ports(struct adrv9002_rf_phy *phy, struct adrv900
 		if (c->lo != phy->tx_channels[tx].channel.lo)
 			continue;
 
-		ret = adrv9002_phy_lo_set(phy, &phy->tx_channels[tx].channel, freq);
+		ret = adrv9002_phy_lo_set(phy, &phy->tx_channels[tx].channel, init_cals, freq);
 		if (ret)
 			return ret;
 	}
@@ -743,6 +862,8 @@ static int adrv9002_phy_lo_set_ports(struct adrv9002_rf_phy *phy, struct adrv900
 static ssize_t adrv9002_phy_lo_do_write(struct adrv9002_rf_phy *phy, struct adrv9002_chan *c,
 					const char *buf, size_t len)
 {
+	struct adi_adrv9001_InitCals init_cals = {0};
+	unsigned long port_mask = 0;
 	int ret, i;
 	u64 freq;
 
@@ -766,11 +887,17 @@ static ssize_t adrv9002_phy_lo_do_write(struct adrv9002_rf_phy *phy, struct adrv
 						ADI_ADRV9001_CHANNEL_CALIBRATED, true);
 		if (ret)
 			goto out_unlock;
+
+		port_mask |= ADRV9002_PORT_MASK(phy->channels[i]);
 	}
 
-	ret = adrv9002_phy_lo_set_ports(phy, c, freq);
+	ret = adrv9002_phy_lo_set_ports(phy, c, &init_cals, freq);
 	if (ret)
-		return ret;
+		goto out_unlock;
+
+	ret = adrv9002_phy_rerun_cals(phy, &init_cals, port_mask);
+	if (ret)
+		goto out_unlock;
 
 	/* move all channels on the same lo to the cached state */
 	for (i = 0; i < ARRAY_SIZE(phy->channels); i++) {
@@ -2340,6 +2467,7 @@ static const struct iio_chan_spec adrv9003_phy_chan[] = {
 };
 
 static IIO_CONST_ATTR(frequency_hopping_hop_table_select_available, "TABLE_A TABLE_B");
+static IIO_CONST_ATTR(initial_calibrations_available, "off auto run");
 static IIO_DEVICE_ATTR(frequency_hopping_hop1_table_select, 0600, adrv9002_attr_show,
 		       adrv9002_attr_store, ADRV9002_HOP_1_TABLE_SEL);
 static IIO_DEVICE_ATTR(frequency_hopping_hop2_table_select, 0600, adrv9002_attr_show,
@@ -2348,13 +2476,17 @@ static IIO_DEVICE_ATTR(frequency_hopping_hop1_signal_trigger, 0200, NULL, adrv90
 		       ADRV9002_HOP_1_TRIGGER);
 static IIO_DEVICE_ATTR(frequency_hopping_hop2_signal_trigger, 0200, NULL, adrv9002_attr_store,
 		       ADRV9002_HOP_2_TRIGGER);
+static IIO_DEVICE_ATTR(initial_calibrations, 0600, adrv9002_attr_show, adrv9002_attr_store,
+		       ADRV9002_INIT_CALS_RUN);
 
 static struct attribute *adrv9002_sysfs_attrs[] = {
+	&iio_const_attr_initial_calibrations_available.dev_attr.attr,
 	&iio_const_attr_frequency_hopping_hop_table_select_available.dev_attr.attr,
 	&iio_dev_attr_frequency_hopping_hop1_table_select.dev_attr.attr,
 	&iio_dev_attr_frequency_hopping_hop2_table_select.dev_attr.attr,
 	&iio_dev_attr_frequency_hopping_hop1_signal_trigger.dev_attr.attr,
 	&iio_dev_attr_frequency_hopping_hop2_signal_trigger.dev_attr.attr,
+	&iio_dev_attr_initial_calibrations.dev_attr.attr,
 	NULL
 };
 
@@ -2724,6 +2856,7 @@ static int adrv9002_validate_profile(struct adrv9002_rf_phy *phy)
 		if (lo < ADI_ADRV9001_LOSEL_LO2)
 			rx->channel.ext_lo = &phy->ext_los[lo];
 		rx->channel.lo = i ? clks->rx2LoSelect : clks->rx1LoSelect;
+		rx->channel.lo_cals = ADI_ADRV9001_INIT_LO_RETUNE & ~ADI_ADRV9001_INIT_CAL_TX_ALL;
 tx:
 		/* tx validations*/
 		if (!test_bit(ports[i * 2 + 1], &tx_mask))
@@ -2815,6 +2948,7 @@ tx:
 		if (lo < ADI_ADRV9001_LOSEL_LO2)
 			tx->ext_lo = &phy->ext_los[lo];
 		tx->lo = i ? clks->tx2LoSelect : clks->tx1LoSelect;
+		tx->lo_cals = ADI_ADRV9001_INIT_LO_RETUNE & ~ADI_ADRV9001_INIT_CAL_RX_ALL;
 	}
 
 	return 0;
@@ -3335,15 +3469,23 @@ static void adrv9002_cleanup(struct adrv9002_rf_phy *phy)
 		phy->rx_channels[i].channel.enabled = 0;
 		phy->rx_channels[i].channel.ext_lo = NULL;
 		phy->rx_channels[i].channel.lo = 0;
+		phy->rx_channels[i].channel.lo_cals = 0;
 		phy->tx_channels[i].channel.enabled = 0;
 		phy->tx_channels[i].channel.ext_lo = NULL;
 		phy->tx_channels[i].channel.lo = 0;
+		phy->tx_channels[i].channel.lo_cals = 0;
 	}
 
 	phy->profile_len = scnprintf(phy->profile_buf, sizeof(phy->profile_buf),
 				     "No profile loaded...\n");
 	memset(&phy->adrv9001->devStateInfo, 0,
 	       sizeof(phy->adrv9001->devStateInfo));
+
+	/*
+	 * By default, let's not run init cals for LO changes >= 100MHz to keep
+	 * the same behavior as before (as doing it automatically is time consuming).
+	 */
+	phy->run_cals = false;
 }
 
 static u32 adrv9002_get_arm_clk(const struct adrv9002_rf_phy *phy)
@@ -3449,31 +3591,6 @@ static void adrv9002_fill_profile_read(struct adrv9002_rf_phy *phy)
 				     rx->rxInitChannelMask, tx->txInitChannelMask,
 				     duplex[sys->duplexMode], sys->fhModeOn, mcs[sys->mcsMode],
 				     ssi[phy->ssi_type]);
-}
-
-static void adrv9002_port_enable(const struct adrv9002_rf_phy *phy,
-				 const struct adrv9002_chan *c, bool enable)
-{
-	if (c->mux_ctl)
-		gpiod_set_value_cansleep(c->mux_ctl, enable);
-	if (c->mux_ctl_2)
-		gpiod_set_value_cansleep(c->mux_ctl_2, enable);
-	/*
-	 * Nothing to do for channel 2 in rx2tx2 mode. The check is useful to have
-	 * it in here if the outer loop is looping through all the channels.
-	 */
-	if (phy->rx2tx2 && c->idx > ADRV9002_CHANN_1)
-		return;
-	/*
-	 * We always disable but let's not enable a port that is not enable in the profile.
-	 * Same as above, the condition is needed if the outer loop is looping through all
-	 * channels to enable/disable them. Might be a redundant in some cases where the
-	 * caller already knows the state of the port.
-	 */
-	if (enable && !c->enabled)
-		return;
-
-	adrv9002_axi_interface_enable(phy, c->idx, c->port == ADI_TX, enable);
 }
 
 int adrv9002_init(struct adrv9002_rf_phy *phy, struct adi_adrv9001_Init *profile)

--- a/drivers/iio/adc/navassa/adrv9002.h
+++ b/drivers/iio/adc/navassa/adrv9002.h
@@ -156,6 +156,7 @@ struct adrv9002_chan {
 	 */
 	struct adi_adrv9001_ChannelEnablementDelays en_delays_ns;
 	unsigned long rate;
+	adi_adrv9001_InitCalibrations_e lo_cals;
 	adi_adrv9001_ChannelState_e cached_state;
 	adi_common_ChannelNumber_e number;
 	adi_adrv9001_LoSel_e lo;
@@ -251,6 +252,7 @@ struct adrv9002_rf_phy {
 	struct adi_adrv9001_Init	*curr_profile;
 	struct adi_adrv9001_Init	profile;
 	struct adi_adrv9001_InitCals	init_cals;
+	bool				run_cals;
 	u32				n_clks;
 	int				ngpios;
 	u8				rx2tx2;

--- a/drivers/iio/adc/navassa/adrv9002.h
+++ b/drivers/iio/adc/navassa/adrv9002.h
@@ -299,7 +299,7 @@ int adrv9002_axi_interface_set(const struct adrv9002_rf_phy *phy, const u8 n_lan
 			       const bool cmos_ddr, const int channel, const bool tx);
 int adrv9002_axi_intf_tune(const struct adrv9002_rf_phy *phy, const bool tx, const int chann,
 			   u8 *clk_delay, u8 *data_delay);
-void adrv9002_axi_interface_enable(struct adrv9002_rf_phy *phy, const int chan, const bool tx,
+void adrv9002_axi_interface_enable(const struct adrv9002_rf_phy *phy, const int chan, const bool tx,
 				   const bool en);
 int adrv9002_axi_tx_test_pattern_cfg(struct adrv9002_rf_phy *phy, const int channel,
 				     const adi_adrv9001_SsiTestModeData_e data);

--- a/drivers/iio/adc/navassa/adrv9002.h
+++ b/drivers/iio/adc/navassa/adrv9002.h
@@ -158,6 +158,7 @@ struct adrv9002_chan {
 	unsigned long rate;
 	adi_adrv9001_ChannelState_e cached_state;
 	adi_common_ChannelNumber_e number;
+	adi_adrv9001_LoSel_e lo;
 	adi_common_Port_e port;
 	u32 power;
 	int nco_freq;

--- a/drivers/iio/adc/navassa/adrv9002_conv.c
+++ b/drivers/iio/adc/navassa/adrv9002_conv.c
@@ -512,7 +512,7 @@ int adrv9002_axi_intf_tune(const struct adrv9002_rf_phy *phy, const bool tx, con
 	return max_cnt ? 0 : -EIO;
 }
 
-void adrv9002_axi_interface_enable(struct adrv9002_rf_phy *phy, const int chan, const bool tx,
+void adrv9002_axi_interface_enable(const struct adrv9002_rf_phy *phy, const int chan, const bool tx,
 				   const bool en)
 {
 	struct axiadc_converter *conv = spi_get_drvdata(phy->spi);


### PR DESCRIPTION
This patch series addresses the issue present in [1](https://ez.analog.com/wide-band-rf-transceivers/design-support-adrv9001-adrv9007/f/q-a/571138/adrv9002-tx-image-rejection/498677).

The first patches are just preparing the real "fix" present in [iio: adc: adrv9002: add initial_calibrations attribute](https://github.com/analogdevicesinc/linux/commit/e0b42f16f76a9880b6c380a869fdeea791863280).

The last patch is a minor improvement that I realized when supporting the new attribute. 