### PR TITLE
iio: frequency: ad9783: fix DAC channel gain get/set

### DIFF
--- a/drivers/iio/frequency/ad9783.c
+++ b/drivers/iio/frequency/ad9783.c
@@ -90,6 +90,11 @@
 #define AD9783_DAC1FSC_MSB              GENMASK(1, 0)
 /* AD9783_REG_DAC2_FSC_MSBS */
 #define AD9783_DAC2FSC_MSB              GENMASK(1, 0)
+#define AD9783_DAC_FSC_MIN              8660000U
+#define AD9783_DAC_FSC_MAX              31660000U
+#define AD9783_DAC_FSC_MAX_REG_VAL      GENMASK(9, 0)
+/* (FSC_MAX - FSC_MIN) / FSC_MAX_REG_VAL */
+#define AD9783_DAC_FSC_STEP             22483U
 /* AD9783_REG_BIST_CONTROL */
 #define AD9783_BISTEN                   BIT(7)
 #define AD9783_BISTRD                   BIT(6)
@@ -398,9 +403,9 @@ static int ad9783_set_chan_gain(struct ad9783_phy *phy, int ch,
 	int ret;
 
 	val = val_int * 1000 * 1000 + val_frac;
-	val = clamp(val, 8660000U, 31660000U);
-	val = (val * 10) - 86600000;
-	val = DIV_ROUND_CLOSEST(val, 220000);
+	val = clamp(val, AD9783_DAC_FSC_MIN, AD9783_DAC_FSC_MAX);
+	val = val - AD9783_DAC_FSC_MIN;
+	val = DIV_ROUND_CLOSEST(val, AD9783_DAC_FSC_STEP);
 
 	mutex_lock(&phy->lock);
 	ret = regmap_update_bits(phy->regmap, AD9783_REG_DAC_MSB(ch),
@@ -428,7 +433,8 @@ static int ad9783_get_chan_gain(struct ad9783_phy *phy, int ch,
 	if (ret < 0)
 		goto err_get_chan_gain;
 	data |= (reg & 0x03) << 8;
-	*val = DIV_ROUND_CLOSEST((data * 10 - 86600000), 220000);
+
+	*val = AD9783_DAC_FSC_MIN + (data * AD9783_DAC_FSC_STEP);
 	*val2 = 1000000;
 err_get_chan_gain:
 	mutex_unlock(&phy->lock);


### PR DESCRIPTION
DAC1/DAC2 full scale adjustment is possible in range of 8.66-31.66mA. Fix setting and reading of channel full scale value. Note that scaling documented in datasheet is not fully linear, as value of 0x200 will set slightly different value than 20mA.

According to [datasheet](https://www.analog.com/media/en/technical-documentation/data-sheets/AD9780_9781_9783.pdf) DAC1 FSC and DAC2 FSC take values from 0-0x3FF which corresponds to full scale output between 8.66-31.66mA. The current driver sysfs interface for controlling the values did work as expected. This PR provides a fix for setting and getting DAC1/DAC2 gain through the iio sysfs interface.

**Testing details:**
Before applying fix:
~~~~
# register default value is as expected 0x1F9
/sys/kernel/debug/iio/iio:device1 # echo 0xc > direct_reg_access 
/sys/kernel/debug/iio/iio:device1 # cat direct_reg_access 
0x1
/sys/kernel/debug/iio/iio:device1 # echo 0xb > direct_reg_access 
/sys/kernel/debug/iio/iio:device1 # cat direct_reg_access 
0xF9
~~~~
however the value cannot be changed from the sysfs interface
~~~~
iio:device1 # cat out_voltage0_TX_I_hardwaregain
0.019129000
iio:device1 # echo 0.020 > out_voltage0_TX_I_hardwaregain
iio:device1 # cat out_voltage0_TX_I_hardwaregain
0.019129000
iio:device1 # echo 0.0336 > out_voltage0_TX_I_hardwaregain
iio:device1 # cat out_voltage0_TX_I_hardwaregain
0.019129000
iio:device1 # echo 33.6 > out_voltage0_TX_I_hardwaregain
iio:device1 # cat out_voltage0_TX_I_hardwaregain
0.019129000
iio:device1 # echo 33600 > out_voltage0_TX_I_hardwaregain
iio:device1 # cat out_voltage0_TX_I_hardwaregain
0.019129000
~~~~

After applying fix:
~~~~
iio:device1 # echo 31.66 > out_voltage0_TX_I_hardwaregain
iio:device1 # cat out_voltage0_TX_I_hardwaregain
31.660109000
iio:device1 # echo 20.0 > out_voltage0_TX_I_hardwaregain
iio:device1 # cat out_voltage0_TX_I_hardwaregain
19.991432000
iio:device1 # echo 8.66 > out_voltage0_TX_I_hardwaregain
iio:device1 # cat out_voltage0_TX_I_hardwaregain
8.660000000
~~~~
It is clear that the value follows request. This can also be verified by checking the actual underlying register values. (note; switching dirs debug/iio:device omitted for brevity)
~~~~
# with 8.66 set as above 
device1 # echo 0xc > direct_reg_access 
device1 # cat direct_reg_access 
0x0
iio:device1 # echo 0xb > direct_reg_access 
iio:device1 # cat direct_reg_access 
0x0
# now set maximum
iio:device1 # echo 31.66 >  out_voltage0_TX_I_hardwaregain
iio:device1 # echo 0xc > direct_reg_access
iio:device1 # cat direct_reg_access 
0x3
iio:device1 # echo 0xb > direct_reg_access 
iio:device1 # cat direct_reg_access 
0xFF
~~~~

