### PR TITLE
[adrv9002] frequency hopping fixes

### DIFF
--- a/drivers/iio/adc/navassa/adrv9002.c
+++ b/drivers/iio/adc/navassa/adrv9002.c
@@ -3513,10 +3513,8 @@ static ssize_t adrv9002_fh_bin_table_write(struct adrv9002_rf_phy *phy, char *bu
 					   size_t count, int hop, int table)
 {
 	struct adrv9002_fh_bin_table *tbl = &phy->fh_table_bin_attr[hop * 2 + table];
-	/* this is only static to avoid  -Wframe-larger-than on ARM */
-	static adi_adrv9001_FhHopFrame_t hop_tbl[ADI_ADRV9001_FH_MAX_HOP_TABLE_SIZE];
 	char *p, *line;
-	int entry = 0, ret, max_sz = ARRAY_SIZE(hop_tbl);
+	int entry = 0, ret, max_sz = ARRAY_SIZE(tbl->hop_tbl);
 
 	mutex_lock(&phy->lock);
 	if (!phy->curr_profile->sysConfig.fhModeOn) {
@@ -3572,19 +3570,19 @@ static ssize_t adrv9002_fh_bin_table_write(struct adrv9002_rf_phy *phy, char *bu
 			return -EINVAL;
 		}
 
-		hop_tbl[entry].hopFrequencyHz = lo;
-		hop_tbl[entry].rx1OffsetFrequencyHz = rx10_if;
-		hop_tbl[entry].rx2OffsetFrequencyHz = rx10_if;
-		hop_tbl[entry].rx1GainIndex = rx1_gain;
-		hop_tbl[entry].tx1Attenuation_fifthdB = tx1_atten;
-		hop_tbl[entry].rx2GainIndex = rx1_gain;
-		hop_tbl[entry].tx2Attenuation_fifthdB = tx2_atten;
+		tbl->hop_tbl[entry].hopFrequencyHz = lo;
+		tbl->hop_tbl[entry].rx1OffsetFrequencyHz = rx10_if;
+		tbl->hop_tbl[entry].rx2OffsetFrequencyHz = rx10_if;
+		tbl->hop_tbl[entry].rx1GainIndex = rx1_gain;
+		tbl->hop_tbl[entry].tx1Attenuation_fifthdB = tx1_atten;
+		tbl->hop_tbl[entry].rx2GainIndex = rx1_gain;
+		tbl->hop_tbl[entry].tx2Attenuation_fifthdB = tx2_atten;
 		entry++;
 	}
 
 	dev_dbg(&phy->spi->dev, "Load hop:%d table:%d with %d entries\n", hop, table, entry);
 	ret = api_call(phy, adi_adrv9001_fh_HopTable_Static_Configure,
-		       phy->fh.mode, hop, table, hop_tbl, entry);
+		       phy->fh.mode, hop, table, tbl->hop_tbl, entry);
 	mutex_unlock(&phy->lock);
 
 	return ret ? ret : count;

--- a/drivers/iio/adc/navassa/adrv9002.c
+++ b/drivers/iio/adc/navassa/adrv9002.c
@@ -3531,16 +3531,15 @@ static ssize_t adrv9002_fh_bin_table_write(struct adrv9002_rf_phy *phy, char *bu
 		return -ENOTSUPP;
 	}
 
-	if (!off)
-		memset(tbl->bin_table, 0, sizeof(tbl->bin_table));
-
 	memcpy(tbl->bin_table + off, buf, count);
+	/* The bellow is always safe as @bin_table is bigger (by 1 byte) than the bin attribute */
+	tbl->bin_table[off + count] = '\0';
 
 	if (phy->fh.mode == ADI_ADRV9001_FHMODE_LO_RETUNE_REALTIME_PROCESS_DUAL_HOP)
 		max_sz /= 2;
 
 	p = tbl->bin_table;
-	while ((line = strsep(&p, "\n")) && p) {
+	while ((line = strsep(&p, "\n"))) {
 		u64 lo;
 		u32 rx10_if, rx20_if, rx1_gain, tx1_atten, rx2_gain, tx2_atten;
 

--- a/drivers/iio/adc/navassa/adrv9002.h
+++ b/drivers/iio/adc/navassa/adrv9002.h
@@ -194,8 +194,11 @@ struct adrv9002_gpio {
 };
 
 struct adrv9002_fh_bin_table {
-	/* page size should be more than enough for a max of 64 entries! */
-	u8 bin_table[PAGE_SIZE];
+	/*
+	 * page size should be more than enough for a max of 64 entries!
+	 * +1 so we the table can be properly NULL terminated.
+	 */
+	u8 bin_table[PAGE_SIZE + 1];
 };
 
 #define to_clk_priv(_hw) container_of(_hw, struct adrv9002_clock, hw)

--- a/drivers/iio/adc/navassa/adrv9002.h
+++ b/drivers/iio/adc/navassa/adrv9002.h
@@ -199,6 +199,7 @@ struct adrv9002_fh_bin_table {
 	 * +1 so we the table can be properly NULL terminated.
 	 */
 	u8 bin_table[PAGE_SIZE + 1];
+	adi_adrv9001_FhHopFrame_t hop_tbl[ADI_ADRV9001_FH_MAX_HOP_TABLE_SIZE];
 };
 
 #define to_clk_priv(_hw) container_of(_hw, struct adrv9002_clock, hw)

--- a/drivers/iio/adc/navassa/adrv9002.h
+++ b/drivers/iio/adc/navassa/adrv9002.h
@@ -33,7 +33,6 @@ struct iio_chan_spec;
 #define ADRV_ADDRESS_CHAN(addr)		((addr) & 0xFF)
 #define ADRV9002_FH_HOP_SIGNALS_NR	2
 #define ADRV9002_FH_TABLES_NR		2
-#define ADRV9002_FH_BIN_ATTRS_CNT	(ADRV9002_FH_HOP_SIGNALS_NR * ADRV9002_FH_TABLES_NR)
 #define ADRV9002_RX_MIN_GAIN_IDX	ADI_ADRV9001_RX_GAIN_INDEX_MIN
 #define ADRV9002_RX_MAX_GAIN_IDX	ADI_ADRV9001_RX_GAIN_INDEX_MAX
 
@@ -239,7 +238,7 @@ struct adrv9002_rf_phy {
 	char				*bin_attr_buf;
 	u8				*stream_buf;
 	u16				stream_size;
-	struct adrv9002_fh_bin_table	fh_table_bin_attr[ADRV9002_FH_BIN_ATTRS_CNT];
+	struct adrv9002_fh_bin_table	fh_table_bin_attr;
 	adi_adrv9001_FhCfg_t		fh;
 	struct adrv9002_rx_chan		rx_channels[ADRV9002_CHANN_MAX];
 	struct adrv9002_tx_chan		tx_channels[ADRV9002_CHANN_MAX];


### PR DESCRIPTION
The first two patches are fixes and the last patch is an improvement (forcing the hopping table to be written in one go; might be a controversial change, I know, but I'm still willing to take the risk - more on the commit message)