### PR TITLE
[2021_R2] iio: frequency: ad9783: fix DAC channel gain get/set

### DIFF
--- a/drivers/iio/frequency/ad9783.c
+++ b/drivers/iio/frequency/ad9783.c
@@ -90,6 +90,11 @@
 #define AD9783_DAC1FSC_MSB              GENMASK(1, 0)
 /* AD9783_REG_DAC2_FSC_MSBS */
 #define AD9783_DAC2FSC_MSB              GENMASK(1, 0)
+#define AD9783_DAC_FSC_MIN              8660000U
+#define AD9783_DAC_FSC_MAX              31660000U
+#define AD9783_DAC_FSC_MAX_REG_VAL      GENMASK(9, 0)
+/* (FSC_MAX - FSC_MIN) / FSC_MAX_REG_VAL */
+#define AD9783_DAC_FSC_STEP             22483U
 /* AD9783_REG_BIST_CONTROL */
 #define AD9783_BISTEN                   BIT(7)
 #define AD9783_BISTRD                   BIT(6)
@@ -398,9 +403,9 @@ static int ad9783_set_chan_gain(struct ad9783_phy *phy, int ch,
 	int ret;
 
 	val = val_int * 1000 * 1000 + val_frac;
-	val = clamp(val, 8660000U, 31660000U);
-	val = (val * 10) - 86600000;
-	val = DIV_ROUND_CLOSEST(val, 220000);
+	val = clamp(val, AD9783_DAC_FSC_MIN, AD9783_DAC_FSC_MAX);
+	val = val - AD9783_DAC_FSC_MIN;
+	val = DIV_ROUND_CLOSEST(val, AD9783_DAC_FSC_STEP);
 
 	mutex_lock(&phy->lock);
 	ret = regmap_update_bits(phy->regmap, AD9783_REG_DAC_MSB(ch),
@@ -428,7 +433,8 @@ static int ad9783_get_chan_gain(struct ad9783_phy *phy, int ch,
 	if (ret < 0)
 		goto err_get_chan_gain;
 	data |= (reg & 0x03) << 8;
-	*val = DIV_ROUND_CLOSEST((data * 10 - 86600000), 220000);
+
+	*val = AD9783_DAC_FSC_MIN + (data * AD9783_DAC_FSC_STEP);
 	*val2 = 1000000;
 err_get_chan_gain:
 	mutex_unlock(&phy->lock);


### PR DESCRIPTION
DAC1/DAC2 full scale adjustment is possible in range of 8.66-31.66mA. Fix setting and reading of channel full scale value. Note that scaling documented in datasheet is not fully linear, as value of 0x200 will set slightly different value than 20mA.

Define new constants related to DAC_FSC for better code readability.

Fixes: abdceca3a01972 ("drivers: iio: adc: Add support for AD978")

(cherry picked from commit 8deea8b8a2357c104ca7b545045ba385c9d6bf02)