### PR TITLE
iio: adc: adrv9009: Update cached ORX enable and framerB M/F vales

### DIFF
--- a/drivers/iio/adc/adrv9009.c
+++ b/drivers/iio/adc/adrv9009.c
@@ -3680,6 +3680,10 @@ static int adrv9009_restart(struct adrv9009_rf_phy *phy)
 {
 	int ret;
 
+	phy->framer_b_m = phy->talInit.jesd204Settings.framerB.M;
+	phy->framer_b_f = phy->talInit.jesd204Settings.framerB.F;
+	phy->orx_channel_enabled = phy->talInit.obsRx.obsRxChannelsEnable;
+
 	if (phy->jdev) {
 		if(jesd204_dev_is_top(phy->jdev)) {
 			int retry = 1;


### PR DESCRIPTION
Update cached ORX enable and framerB M/F vales after restart. This allows the debugfs dts emulation to update those values.