### PR TITLE
CI: moving atrifactory upload to new agent

### DIFF
--- a/azure-pipelines-rpi.yml
+++ b/azure-pipelines-rpi.yml
@@ -103,7 +103,7 @@ stages:
     pool:
       name: Default
       demands:
-        - agent.name -equals lab2_b5
+        - agent.name -equals linux-rpi
     steps:
       - task: DownloadPipelineArtifact@2
         inputs:

--- a/azure-pipelines-rpi.yml
+++ b/azure-pipelines-rpi.yml
@@ -89,8 +89,6 @@ stages:
       - task: DownloadPipelineArtifact@2
         inputs:
           path: $(Build.SourcesDirectory)/bin
-      - bash: ./ci/travis/prepare_artifacts.sh structure
-        displayName: 'Prepare the folder structure'
       - task: DownloadSecureFile@1
         name: key
         displayName: 'Download rsa key'
@@ -110,8 +108,6 @@ stages:
       - task: DownloadPipelineArtifact@2
         inputs:
           path: $(Build.SourcesDirectory)/bin
-      - bash: ./ci/travis/prepare_artifacts.sh structure
-        displayName: 'Prepare the folder structure'
       - bash: ./ci/travis/prepare_artifacts.sh artifactory
         env:
           ARTIFACTORY_PATH: $(PATH)

--- a/ci/travis/prepare_artifacts.sh
+++ b/ci/travis/prepare_artifacts.sh
@@ -31,6 +31,7 @@ artifacts_structure() {
 
 #upload artifacts to Artifactory
 artifacts_artifactory() {
+	artifacts_structure
 	cd ${SOURCE_DIRECTORY}
 	python ../ci/travis/upload_to_artifactory.py --base_path="${ARTIFACTORY_PATH}" \
 		--server_path="linux_rpi/${BUILD_SOURCEBRANCHNAME}" --local_path="${timestamp}" --token="${ARTIFACTORY_TOKEN}"
@@ -38,6 +39,7 @@ artifacts_artifactory() {
 
 #archive artifacts and upload to SWDownloads
 artifacts_swdownloads() {
+	artifacts_structure
 	cd ${SOURCE_DIRECTORY}/${timestamp} || exit 1
 	chmod 600 ${KEY_FILE}
 	scp -2 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o HostKeyAlgorithms=+ssh-dss \

--- a/ci/travis/upload_to_artifactory.py
+++ b/ci/travis/upload_to_artifactory.py
@@ -53,7 +53,7 @@ else:
       API_TOKEN = os.environ['API_TOKEN']
    else:
       print('\nError:Parameter "--token" is not set. This is Artifactory Authentication Token and can be set even using parameter "--token" on upload command, even by exporting API_TOKEN variable in terminal, before calling upload script.')
-      quit()
+      exit(1)
 
 if args.base_path:
    UPLOAD_BASE_PATH = args.base_path
@@ -62,7 +62,7 @@ else:
       UPLOAD_BASE_PATH = os.environ['UPLOAD_BASE_PATH']
    else:
       print('\nError:Parameter "--base_path" is not set. This is ADI Internal Artifactory Server plus first level of folders. It can be set even using parameter "--base_path" on upload command, even by exporting UPLOAD_BASE_PATH variable in terminal, before calling upload script.')
-      quit()
+      exit(1)
 
 
 if args.server_path:
@@ -73,10 +73,10 @@ if args.server_path:
    if SERVER_FOLDER not in SERVER_FOLDERS_LIST:
      print('\nError:Parameter "--server_path" must contain an already existing folder, for example "hdl", "linux", "SD_card_image" etc.' +
      'If you want to add new folders, please edit "upload_to_artifactory.py" or contact script owner.')
-     quit()
+     exit(1)
 else:
    print('\nError:Parameter "--server_path" is required. It should be set to server location where the files/folder will be uploaded. Check help section.')
-   quit()
+   exit(1)
 
 if args.local_path:
    LOCAL_PATH = os.path.abspath(args.local_path) if '../' in args.local_path else args.local_path
@@ -92,10 +92,10 @@ if args.local_path:
       print('IS FILE' + LOCAL_PATHS_LIST)
    else:
       print('\nError:It looks that parameter "--local_path" is wrong defined/does not exists. Plese check: ' + LOCAL_PATH)
-      quit()
+      exit(1)
 else:
    print('\nParameter "--local_path" is required. It should point to local file/folder to upload.')
-   quit()
+   exit(1)
 
 if args.properties:
    PROPS = args.properties


### PR DESCRIPTION
Changing the agent for artifactory upload and eliminating the task regarding restructure of the artifacts, from pipeline due to possible double generating of timestamp folder.
Also changing from quit() to exit(1) so that the exit code in case of error to be different from 0.