### PR TITLE
dts: adi-adrv9009.dtsi: Set ORX JESD204 Par M=2, F=2 and chanORXen=ORX1

### DIFF
--- a/arch/arm/boot/dts/adi-adrv9009.dtsi
+++ b/arch/arm/boot/dts/adi-adrv9009.dtsi
@@ -154,7 +154,7 @@
 		adi,jesd204-framer-b-lane0-id = <0>;
 		adi,jesd204-framer-b-m = <2>;
 		adi,jesd204-framer-b-k = <32>;
-		adi,jesd204-framer-b-f = <4>;
+		adi,jesd204-framer-b-f = <2>;
 		adi,jesd204-framer-b-np = <16>;
 		adi,jesd204-framer-b-scramble = <1>;
 		adi,jesd204-framer-b-external-sysref = <1>;
@@ -256,7 +256,7 @@
 		adi,orx-gain-control-orx2-min-gain-index = <195>;
 
 		adi,obs-settings-framer-sel = <1>;
-		adi,obs-settings-obs-rx-channels-enable = <3>;
+		adi,obs-settings-obs-rx-channels-enable = <1>;
 		adi,obs-settings-obs-rx-lo-source = <0>;
 
 		/* TX */

--- a/arch/arm64/boot/dts/xilinx/adi-adrv9009.dtsi
+++ b/arch/arm64/boot/dts/xilinx/adi-adrv9009.dtsi
@@ -152,9 +152,9 @@
 		adi,jesd204-framer-b-bank-id = <0>;
 		adi,jesd204-framer-b-device-id = <0>;
 		adi,jesd204-framer-b-lane0-id = <0>;
-		adi,jesd204-framer-b-m = <4>;
+		adi,jesd204-framer-b-m = <2>;
 		adi,jesd204-framer-b-k = <32>;
-		adi,jesd204-framer-b-f = <4>;
+		adi,jesd204-framer-b-f = <2>;
 		adi,jesd204-framer-b-np = <16>;
 		adi,jesd204-framer-b-scramble = <1>;
 		adi,jesd204-framer-b-external-sysref = <1>;
@@ -256,7 +256,7 @@
 		adi,orx-gain-control-orx2-min-gain-index = <195>;
 
 		adi,obs-settings-framer-sel = <1>;
-		adi,obs-settings-obs-rx-channels-enable = <3>;
+		adi,obs-settings-obs-rx-channels-enable = <1>;
 		adi,obs-settings-obs-rx-lo-source = <0>;
 
 		/* TX */


### PR DESCRIPTION
M=2, F=2 are the default HDL synthesis parameters.