### PR TITLE
Move upload logs to a file on server

### DIFF
--- a/ci/travis/upload_to_artifactory.py
+++ b/ci/travis/upload_to_artifactory.py
@@ -121,7 +121,7 @@ for FILE in LOCAL_PATHS_LIST:
         ART_PATH = UPLOAD_BASE_PATH + "/" + SERVER_PATH + "/" + FILE_NAME
    else:
         ART_PATH = UPLOAD_BASE_PATH + "/" + SERVER_PATH + "/" + FILE
-   upload_cmd = "curl -v -s -H \"X-JFrog-Art-Api:" + API_TOKEN + "\" -X PUT \"" + ART_PATH + ";" + PROPS + "\" -T \"" + FILE + "\""
+   upload_cmd = "curl -H \"X-JFrog-Art-Api:" + API_TOKEN + "\" -X PUT \"" + ART_PATH + ";" + PROPS + "\" -T \"" + FILE + "\" >> upload_kernel_log.txt"
    os.system(upload_cmd)
 
 ########## Upload properties on folders #########
@@ -133,7 +133,7 @@ else:
 
 i = 0
 while ( i < int(PROP_LEVEL)):
-   set_folder_props_cmd = "curl -H \"X-JFrog-Art-Api:" + API_TOKEN + "\" -X PUT \"" + ART_PATH + "/;" + PROPS + "\""
+   set_folder_props_cmd = "curl -H \"X-JFrog-Art-Api:" + API_TOKEN + "\" -X PUT \"" + ART_PATH + "/;" + PROPS + "\" >> upload_kernel_log.txt"
    os.system(set_folder_props_cmd)
    i = i + 1
    ART_PATH = os.path.split(ART_PATH)[0]


### PR DESCRIPTION
To avoid exposing the link of artifactory server the logs regarding uploading of files to artifactory were moved to a local file.