### PR TITLE
arch: arm: boot: dts: overlays: Rename rpi-ad7124-8-all-diff-cs0-int25-overlay

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -217,7 +217,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	rpi-ad5679r.dtbo \
 	rpi-ad5766.dtbo \
 	rpi-ad7124.dtbo \
-	rpi-ad7124-8-all-diff-cs0-int25.dtbo \
+	rpi-ad7124-8-all-diff.dtbo \
 	rpi-ad7173.dtbo \
 	rpi-ad7190.dtbo \
 	rpi-ad7293.dtbo \

--- a/arch/arm/boot/dts/overlays/rpi-ad7124-8-all-diff-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ad7124-8-all-diff-overlay.dts
@@ -38,11 +38,11 @@
 			#size-cells = <0>;
 			status = "okay";
 
-			ad7124@0 {
+			ad7124: ad7124@0 {
 				compatible = "adi,ad7124-8";
-				reg = <0>;
+				reg = <0>; //CS0 default
 				spi-max-frequency = <5000000>;
-				interrupts = <25 2>;
+				interrupts = <19 2>; // interrupt, Default to PMD-RPI-INTZ P1
 				interrupt-parent = <&gpio>;
 				refin1-supply = <&vref>;
 				clocks = <&ad7124_mclk>;
@@ -106,5 +106,10 @@
 		__overlay__ {
 			status = "disabled";
 		};
+	};
+
+	__overrides__ {
+			cs_pin	= <&ad7124>,"reg:0";
+			irq_gpio = <&ad7124>,"interrupts:0";
 	};
 };


### PR DESCRIPTION
Update rpi-ad7124-8-all-diff-cso-int25-overlay to include overrides for CS and INT lines.
Defaulted CS and INT lines to match P1 on PMD-RPI-INTZ adapter. 
Renamed to rpi-ad7124-8-all-diff to account the dt change.