### PR TITLE
Log file as parameter in upload script

### DIFF
--- a/ci/travis/prepare_artifacts.sh
+++ b/ci/travis/prepare_artifacts.sh
@@ -34,7 +34,8 @@ artifacts_artifactory() {
 	artifacts_structure
 	cd ${SOURCE_DIRECTORY}
 	python ../ci/travis/upload_to_artifactory.py --base_path="${ARTIFACTORY_PATH}" \
-		--server_path="linux_rpi/${BUILD_SOURCEBRANCHNAME}" --local_path="${timestamp}" --token="${ARTIFACTORY_TOKEN}"
+		--server_path="linux_rpi/${BUILD_SOURCEBRANCHNAME}" --local_path="${timestamp}" \
+		--token="${ARTIFACTORY_TOKEN}" --log_file="upload_to_artifactory.log"
 }
 
 #archive artifacts and upload to SWDownloads

--- a/ci/travis/upload_to_artifactory.py
+++ b/ci/travis/upload_to_artifactory.py
@@ -7,7 +7,7 @@
 #
 # This script is used to upload files to ADI internal artifactory server
 #
-# Copyright (C) 2019-2022 Analog Devices Inc.
+# Copyright (C) 2019-2023 Analog Devices Inc.
 #
 #######################################################################
 
@@ -42,6 +42,7 @@ parser.add_argument("--properties",  help="Properties to be added to file/folder
 parser.add_argument("--no_rel_path", help="If this exists, the relative path until local file will be appended to artifactory path", action="store_true")
 parser.add_argument("--props_level", help="Set for how many levels of folders to set specified properties, by default just on file.")
 parser.add_argument("--token",       help="Artifactory authentication token. Otherwise you can export API_TOKEN in terminal before calling this script.")
+parser.add_argument("--log_file",    help="Local file where to save the logs from curl command, if no file is specified the logs will be printed in terminal")
 args = parser.parse_args()
 parser.parse_args()
 
@@ -112,6 +113,11 @@ if args.props_level:
 else:
    PROP_LEVEL = 0
 
+if args.log_file:
+   LOG_FILE = ">> " + args.log_file
+else:
+   LOG_FILE = ''
+
 ########## Upload files ##########
 # If files with same name already exists at specified server path, they will be overwritten
 
@@ -121,7 +127,7 @@ for FILE in LOCAL_PATHS_LIST:
         ART_PATH = UPLOAD_BASE_PATH + "/" + SERVER_PATH + "/" + FILE_NAME
    else:
         ART_PATH = UPLOAD_BASE_PATH + "/" + SERVER_PATH + "/" + FILE
-   upload_cmd = "curl -H \"X-JFrog-Art-Api:" + API_TOKEN + "\" -X PUT \"" + ART_PATH + ";" + PROPS + "\" -T \"" + FILE + "\" >> upload_kernel_log.txt"
+   upload_cmd = "curl -H \"X-JFrog-Art-Api:" + API_TOKEN + "\" -X PUT \"" + ART_PATH + ";" + PROPS + "\" -T \"" + FILE + "\" " + LOG_FILE
    os.system(upload_cmd)
 
 ########## Upload properties on folders #########
@@ -133,7 +139,7 @@ else:
 
 i = 0
 while ( i < int(PROP_LEVEL)):
-   set_folder_props_cmd = "curl -H \"X-JFrog-Art-Api:" + API_TOKEN + "\" -X PUT \"" + ART_PATH + "/;" + PROPS + "\" >> upload_kernel_log.txt"
+   set_folder_props_cmd = "curl -H \"X-JFrog-Art-Api:" + API_TOKEN + "\" -X PUT \"" + ART_PATH + "/;" + PROPS + "\" " + LOG_FILE
    os.system(set_folder_props_cmd)
    i = i + 1
    ART_PATH = os.path.split(ART_PATH)[0]


### PR DESCRIPTION
In case we want to save the log on a local file we need to specify the file as input parameter when the script is run otherwise the logs are displayed on terminal.