### PR TITLE
Add AD40xx parts and enable dynamic sampling freq

### DIFF
--- a/Documentation/devicetree/bindings/iio/adc/ad400x.txt
+++ b/Documentation/devicetree/bindings/iio/adc/ad400x.txt
@@ -21,6 +21,8 @@ Required properties for the AD400X:
 	- dmas: DMA specifier, consisting of a phandle to DMA controller node.
 	- dma-names: Must be "rx".
 	- vref-supply: phandle to the regulator for ADC reference voltage.
+	- pwms: phandle to pwm device used to drive the CNV input signal
+	- pwm-names: pwm named "cnv" used for the CNV input signal
 
 Example:
 
@@ -31,6 +33,8 @@ ad4020: adc@0 {
 
 	dmas = <&rx_dma 0>;
 	dma-names = "rx";
+	pwms = <&axi_pwm_gen 1 0>;
+	pwm-names = "cnv";
 
 	vref-supply = <&vref>;
 	#io-channel-cells = <1>;

--- a/Documentation/devicetree/bindings/iio/adc/ad400x.txt
+++ b/Documentation/devicetree/bindings/iio/adc/ad400x.txt
@@ -2,10 +2,20 @@ Analog Devices AD400X ADC device driver
 
 Required properties for the AD400X:
 	- compatible: Must be one of
+		* "adi,ad4000"
+		* "adi,ad4001"
+		* "adi,ad4002"
 		* "adi,ad4003"
+		* "adi,ad4004"
+		* "adi,ad4005"
+		* "adi,ad4006"
 		* "adi,ad4007"
+		* "adi,ad4008"
+		* "adi,ad4010"
 		* "adi,ad4011"
 		* "adi,ad4020"
+		* "adi,ad4021"
+		* "adi,ad4022"
 	- reg: SPI chip select number for the device.
 	- spi-max-frequency: See Documentation/devicetree/bindings/spi/spi-bus.txt.
 	- dmas: DMA specifier, consisting of a phandle to DMA controller node.

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad4020.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad4020.dts
@@ -22,16 +22,6 @@
 		regulator-max-microvolt = <2500000>;
 		regulator-always-on;
 	};
-
-	clocks {
-		cnv_ext_clk: ext-clk {
-			#clock-cells = <0x0>;
-			compatible = "fixed-clock";
-			clock-frequency = <100000000>;
-			clock-output-names = "cnv_ext_clk";
-		};
-	};
-
 };
 
 &fpga_axi {
@@ -61,10 +51,10 @@
 		reg = <0x44b00000 0x1000>;
 		label = "cnv";
 		#pwm-cells = <2>;
-		clocks = <&cnv_ext_clk>;
+		clocks = <&spi_clk>;
 	};
 
-	spi_clk: axi-clkgen@0x44a70000 {
+	spi_clk: axi-clkgen@44a70000 {
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x44a70000 0x10000>;
 		#clock-cells = <0>;
@@ -78,7 +68,7 @@
 		reg = <0x44a00000 0x1000>;
 		interrupt-parent = <&intc>;
 		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
-		clocks = <&clkc 15 &spi_clk 17>;
+		clocks = <&clkc 15 &spi_clk>;
 		clock-names = "s_axi_aclk", "spi_clk";
 		num-cs = <1>;
 
@@ -86,9 +76,9 @@
 		#size-cells = <0x0>;
 
 		ad4020: adc@0 {
-			compatible = "ad4020";
+			compatible = "adi,ad4020";
 			reg = <0>;
-			spi-max-frequency = <71000000>;
+			spi-max-frequency = <102000000>;
 
 			dmas = <&rx_dma 0>;
 			dma-names = "rx";

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad4020.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad4020.dts
@@ -64,12 +64,21 @@
 		clocks = <&cnv_ext_clk>;
 	};
 
+	spi_clk: axi-clkgen@0x44a70000 {
+		compatible = "adi,axi-clkgen-2.00.a";
+		reg = <0x44a70000 0x10000>;
+		#clock-cells = <0>;
+		clocks = <&clkc 15>, <&clkc 15>;
+		clock-names = "s_axi_aclk", "clkin1";
+		clock-output-names = "spi_clk";
+	};
+
 	axi_spi_engine_0: spi@44a00000 {
 		compatible = "adi,axi-spi-engine-1.00.a";
 		reg = <0x44a00000 0x1000>;
 		interrupt-parent = <&intc>;
 		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
-		clocks = <&clkc 15 &clkc 17>;
+		clocks = <&clkc 15 &spi_clk 17>;
 		clock-names = "s_axi_aclk", "spi_clk";
 		num-cs = <1>;
 

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad4020.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad4020.dts
@@ -22,6 +22,16 @@
 		regulator-max-microvolt = <2500000>;
 		regulator-always-on;
 	};
+
+	clocks {
+		cnv_ext_clk: ext-clk {
+			#clock-cells = <0x0>;
+			compatible = "fixed-clock";
+			clock-frequency = <100000000>;
+			clock-output-names = "cnv_ext_clk";
+		};
+	};
+
 };
 
 &fpga_axi {
@@ -44,6 +54,14 @@
 				adi,destination-bus-type = <0>;
 			};
 		};
+	};
+
+	axi_pwm_gen: axi-pwm-gen@ {
+		compatible = "adi,axi-pwmgen";
+		reg = <0x44b00000 0x1000>;
+		label = "cnv";
+		#pwm-cells = <2>;
+		clocks = <&cnv_ext_clk>;
 	};
 
 	axi_spi_engine_0: spi@44a00000 {

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad4020.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad4020.dts
@@ -92,6 +92,8 @@
 
 			dmas = <&rx_dma 0>;
 			dma-names = "rx";
+			pwms = <&axi_pwm_gen 0 0>;
+			pwm-names = "cnv";
 
 			vref-supply = <&vref>;
 			#io-channel-cells = <1>;

--- a/drivers/iio/adc/ad400x.c
+++ b/drivers/iio/adc/ad400x.c
@@ -432,6 +432,7 @@ static int ad400x_buffer_postenable(struct iio_dev *indio_dev)
 {
 	struct ad400x_state *st = iio_priv(indio_dev);
 	int ret;
+	struct pwm_state conv_state;
 
 	memset(&st->spi_transfer, 0, sizeof(st->spi_transfer));
 	st->spi_transfer.rx_buf = (void *)-1;
@@ -449,15 +450,23 @@ static int ad400x_buffer_postenable(struct iio_dev *indio_dev)
 
 	spi_engine_offload_enable(st->spi, true);
 
+	pwm_get_state(st->conv_trigger, &conv_state);
+	conv_state.enabled = true;
+	ret = pwm_apply_state(st->conv_trigger, &conv_state);
 	return 0;
 }
 
 static int ad400x_buffer_postdisable(struct iio_dev *indio_dev)
 {
 	struct ad400x_state *st = iio_priv(indio_dev);
+	struct pwm_state conv_state;
+	int ret;
 
 	spi_engine_offload_enable(st->spi, false);
 
+	pwm_get_state(st->conv_trigger, &conv_state);
+	conv_state.enabled = false;
+	ret = pwm_apply_state(st->conv_trigger, &conv_state);
 	st->bus_locked = false;
 	return spi_bus_unlock(st->spi->master);
 }

--- a/drivers/iio/adc/ad400x.c
+++ b/drivers/iio/adc/ad400x.c
@@ -55,12 +55,23 @@ enum ad400x_ids {
 	ID_AD4020,
 };
 
-static const struct iio_chan_spec ad400x_channels[] = {
-	AD400X_CHANNEL(18),
+struct ad400x_chip_info {
+	struct iio_chan_spec chan_spec;
 };
 
-static const struct iio_chan_spec ad4020_channel[] = {
-	AD400X_CHANNEL(20),
+static const struct ad400x_chip_info ad400x_chips[] = {
+	[ID_AD4003] = {
+		.chan_spec = AD400X_CHANNEL(18),
+	},
+	[ID_AD4007] = {
+		.chan_spec = AD400X_CHANNEL(18),
+	},
+	[ID_AD4011] = {
+		.chan_spec = AD400X_CHANNEL(18),
+	},
+	[ID_AD4020] = {
+		.chan_spec = AD400X_CHANNEL(20),
+	},
 };
 
 struct ad400x_state {
@@ -372,10 +383,7 @@ static int ad400x_probe(struct spi_device *spi)
 	indio_dev->setup_ops = &ad400x_buffer_setup_ops;
 	indio_dev->info = &ad400x_info;
 
-	if (dev_id == ID_AD4020)
-		indio_dev->channels = ad4020_channel;
-	else
-		indio_dev->channels = ad400x_channels;
+	indio_dev->channels = &ad400x_chips[dev_id].chan_spec;
 
 	indio_dev->num_channels = 1;
 	st->num_bits = indio_dev->channels->scan_type.realbits;

--- a/drivers/iio/adc/ad400x.c
+++ b/drivers/iio/adc/ad400x.c
@@ -49,10 +49,20 @@
 	}								\
 
 enum ad400x_ids {
+	ID_AD4000,
+	ID_AD4001,
+	ID_AD4002,
 	ID_AD4003,
+	ID_AD4004,
+	ID_AD4005,
+	ID_AD4006,
 	ID_AD4007,
+	ID_AD4008,
+	ID_AD4010,
 	ID_AD4011,
 	ID_AD4020,
+	ID_AD4021,
+	ID_AD4022,
 };
 
 struct ad400x_chip_info {
@@ -60,16 +70,46 @@ struct ad400x_chip_info {
 };
 
 static const struct ad400x_chip_info ad400x_chips[] = {
+	[ID_AD4000] = {
+		.chan_spec = AD400X_CHANNEL(16),
+	},
+	[ID_AD4001] = {
+		.chan_spec = AD400X_CHANNEL(16),
+	},
+	[ID_AD4002] = {
+		.chan_spec = AD400X_CHANNEL(18),
+	},
 	[ID_AD4003] = {
 		.chan_spec = AD400X_CHANNEL(18),
 	},
+	[ID_AD4004] = {
+		.chan_spec = AD400X_CHANNEL(16),
+	},
+	[ID_AD4005] = {
+		.chan_spec = AD400X_CHANNEL(16),
+	},
+	[ID_AD4006] = {
+		.chan_spec = AD400X_CHANNEL(18),
+	},
 	[ID_AD4007] = {
+		.chan_spec = AD400X_CHANNEL(18),
+	},
+	[ID_AD4008] = {
+		.chan_spec = AD400X_CHANNEL(16),
+	},
+	[ID_AD4010] = {
 		.chan_spec = AD400X_CHANNEL(18),
 	},
 	[ID_AD4011] = {
 		.chan_spec = AD400X_CHANNEL(18),
 	},
 	[ID_AD4020] = {
+		.chan_spec = AD400X_CHANNEL(20),
+	},
+	[ID_AD4021] = {
+		.chan_spec = AD400X_CHANNEL(20),
+	},
+	[ID_AD4022] = {
 		.chan_spec = AD400X_CHANNEL(20),
 	},
 };
@@ -284,10 +324,20 @@ static const struct iio_info ad400x_info = {
 };
 
 static const struct spi_device_id ad400x_id[] = {
+	{"ad4000", ID_AD4000},
+	{"ad4001", ID_AD4001},
+	{"ad4002", ID_AD4002},
 	{"ad4003", ID_AD4003},
+	{"ad4004", ID_AD4004},
+	{"ad4005", ID_AD4005},
+	{"ad4006", ID_AD4006},
 	{"ad4007", ID_AD4007},
+	{"ad4008", ID_AD4008},
+	{"ad4010", ID_AD4010},
 	{"ad4011", ID_AD4011},
 	{"ad4020", ID_AD4020},
+	{"ad4021", ID_AD4021},
+	{"ad4022", ID_AD4022},
 	{}
 };
 MODULE_DEVICE_TABLE(spi, ad400x_id);
@@ -405,10 +455,19 @@ static int ad400x_probe(struct spi_device *spi)
 }
 
 static const struct of_device_id ad400x_of_match[] = {
+	{ .compatible = "adi,ad4000" },
+	{ .compatible = "adi,ad4001" },
+	{ .compatible = "adi,ad4002" },
 	{ .compatible = "adi,ad4003" },
+	{ .compatible = "adi,ad4004" },
+	{ .compatible = "adi,ad4005" },
+	{ .compatible = "adi,ad4006" },
 	{ .compatible = "adi,ad4007" },
+	{ .compatible = "adi,ad4008" },
 	{ .compatible = "adi,ad4011" },
 	{ .compatible = "adi,ad4020" },
+	{ .compatible = "adi,ad4021" },
+	{ .compatible = "adi,ad4022" },
 	{ },
 };
 MODULE_DEVICE_TABLE(of, ad400x_of_match);

--- a/drivers/iio/adc/ad400x.c
+++ b/drivers/iio/adc/ad400x.c
@@ -67,50 +67,65 @@ enum ad400x_ids {
 
 struct ad400x_chip_info {
 	struct iio_chan_spec chan_spec;
+	int max_rate;
 };
 
 static const struct ad400x_chip_info ad400x_chips[] = {
 	[ID_AD4000] = {
 		.chan_spec = AD400X_CHANNEL(16),
+		.max_rate  = 2000000,
 	},
 	[ID_AD4001] = {
 		.chan_spec = AD400X_CHANNEL(16),
+		.max_rate  = 2000000,
 	},
 	[ID_AD4002] = {
 		.chan_spec = AD400X_CHANNEL(18),
+		.max_rate  = 2000000,
 	},
 	[ID_AD4003] = {
 		.chan_spec = AD400X_CHANNEL(18),
+		.max_rate  = 2000000,
 	},
 	[ID_AD4004] = {
 		.chan_spec = AD400X_CHANNEL(16),
+		.max_rate  = 1000000,
 	},
 	[ID_AD4005] = {
 		.chan_spec = AD400X_CHANNEL(16),
+		.max_rate  = 1000000,
 	},
 	[ID_AD4006] = {
 		.chan_spec = AD400X_CHANNEL(18),
+		.max_rate  = 1000000,
 	},
 	[ID_AD4007] = {
 		.chan_spec = AD400X_CHANNEL(18),
+		.max_rate  = 1000000,
 	},
 	[ID_AD4008] = {
 		.chan_spec = AD400X_CHANNEL(16),
+		.max_rate  =  500000,
 	},
 	[ID_AD4010] = {
 		.chan_spec = AD400X_CHANNEL(18),
+		.max_rate  =  500000,
 	},
 	[ID_AD4011] = {
 		.chan_spec = AD400X_CHANNEL(18),
+		.max_rate  =  500000,
 	},
 	[ID_AD4020] = {
 		.chan_spec = AD400X_CHANNEL(20),
+		.max_rate  = 1800000,
 	},
 	[ID_AD4021] = {
 		.chan_spec = AD400X_CHANNEL(20),
+		.max_rate  = 1000000,
 	},
 	[ID_AD4022] = {
 		.chan_spec = AD400X_CHANNEL(20),
+		.max_rate  =  500000,
 	},
 };
 

--- a/drivers/iio/adc/ad400x.c
+++ b/drivers/iio/adc/ad400x.c
@@ -33,11 +33,34 @@
 #define AD400X_TURBO_MODE(x)	FIELD_PREP(BIT_MASK(1), x)
 #define AD400X_HIGH_Z_MODE(x)	FIELD_PREP(BIT_MASK(2), x)
 
+#define AD400X_CHANNEL(real_bits)					\
+	{								\
+		.type = IIO_VOLTAGE,					\
+		.indexed = 1,						\
+		.info_mask_separate = BIT(IIO_CHAN_INFO_RAW) |		\
+			BIT(IIO_CHAN_INFO_SCALE) |			\
+			BIT(IIO_CHAN_INFO_OFFSET),			\
+		.info_mask_shared_by_all = BIT(IIO_CHAN_INFO_SAMP_FREQ),\
+		.scan_type = {						\
+			.sign = 's',					\
+			.realbits = real_bits,				\
+			.storagebits = 32,				\
+		},							\
+	}								\
+
 enum ad400x_ids {
 	ID_AD4003,
 	ID_AD4007,
 	ID_AD4011,
 	ID_AD4020,
+};
+
+static const struct iio_chan_spec ad400x_channels[] = {
+	AD400X_CHANNEL(18),
+};
+
+static const struct iio_chan_spec ad4020_channel[] = {
+	AD400X_CHANNEL(20),
 };
 
 struct ad400x_state {
@@ -155,29 +178,6 @@ static int ad400x_set_mode(struct ad400x_state *st)
 
 	return ret;
 }
-
-#define AD400X_CHANNEL(real_bits)					\
-	{								\
-		.type = IIO_VOLTAGE,					\
-		.indexed = 1,						\
-		.info_mask_separate = BIT(IIO_CHAN_INFO_RAW) |		\
-			BIT(IIO_CHAN_INFO_SCALE) |			\
-			BIT(IIO_CHAN_INFO_OFFSET),			\
-		.info_mask_shared_by_all = BIT(IIO_CHAN_INFO_SAMP_FREQ),\
-		.scan_type = {						\
-			.sign = 's',					\
-			.realbits = real_bits,				\
-			.storagebits = 32,				\
-		},							\
-	}								\
-
-static const struct iio_chan_spec ad400x_channels[] = {
-	AD400X_CHANNEL(18),
-};
-
-static const struct iio_chan_spec ad4020_channel[] = {
-	AD400X_CHANNEL(20),
-};
 
 static int ad400x_single_conversion(struct iio_dev *indio_dev,
 	const struct iio_chan_spec *chan, int *val)


### PR DESCRIPTION
* Add support for additional AD40xx parts:
  * AD4000/AD4001/AD4002/AD4004/AD4005/AD4006/AD4008/AD4010/AD4021/AD4022
* Add support to get and set sampling freq    
  * This is achieved by configuring a PWM output to drive the start-conversion (CNV) input signal in the ADC.

* Notes:
  * GitHub issue: [Extend support for AD40xx with variable sample frequency #2239](https://github.com/analogdevicesinc/linux/issues/2239)
  *  Requires PWM peripheral in the updated BOOT.BIN (from @acostina in https://github.com/adi-ses/sea-misc/pull/27) that will be merged into the public HDL project
   * Conflicts with #2171 by @machschmitt which adds ADAQ4003 support. We should discuss how to best integrate both efforts.