### PR TITLE
Dev/adaq4224

### DIFF
--- a/Documentation/devicetree/bindings/iio/adc/adi,ad4630.yaml
+++ b/Documentation/devicetree/bindings/iio/adc/adi,ad4630.yaml
@@ -16,6 +16,9 @@ description: |
   https://www.analog.com/media/en/technical-documentation/data-sheets/ad4630-24_ad4632-24.pdf
   https://www.analog.com/media/en/technical-documentation/data-sheets/ad4630-16-4632-16.pdf
   https://www.analog.com/media/en/technical-documentation/data-sheets/ad4030-24-4032-24.pdf
+  https://www.analog.com/media/en/technical-documentation/data-sheets/adaq4216.pdf
+  https://www.analog.com/media/en/technical-documentation/data-sheets/adaq4220.pdf
+  https://www.analog.com/media/en/technical-documentation/data-sheets/adaq4224.pdf
 
 properties:
 
@@ -25,6 +28,9 @@ properties:
       - adi,ad4630-16
       - adi,ad4630-24
       - adi,ad463x
+      - adi,adaq4216
+      - adi,adaq4220
+      - adi,adaq4224
 
   reg:
     maxItems: 1
@@ -120,6 +126,13 @@ properties:
     enum: [0, 1, 2, 3]
     default: 0
 
+  adi,pga-gpios:
+    description:
+      Device tree identifier of the PGA/PGIA control pins.
+      The PGA input pins are used to configure the gain applied to the input
+      signal pior to ADC sampling.
+    maxItems: 1
+
 required:
   - compatible
   - reg
@@ -191,6 +204,40 @@ examples:
             adi,clock-mode = <1>;
             adi,dual-data-rate;
             adi,out-data-mode = <3>;
+        };
+    };
+  - |
+    #include <dt-bindings/gpio/gpio.h>
+
+    spi {
+        #address-cells = <1>;
+        #size-cells = <0>;
+
+        adaq4224: adaq4224@0 {
+            compatible = "adi,adaq4224";
+            reg = <0>;
+            vdd-supply = <&vref>;
+            vdd_1_8-supply = <&vdd_1_8>;
+            vio-supply = <&vio>;
+            vref-supply = <&vref>;
+            spi-max-frequency = <80000000>;
+            reset-gpios = <&gpio0 86 GPIO_ACTIVE_LOW>;
+            adi,pga-gpios = <&gpio0 87 GPIO_ACTIVE_HIGH>,
+                            <&gpio0 88 GPIO_ACTIVE_HIGH>;
+            adi,lane-mode = <1>;
+            adi,clock-mode = <1>;
+            adi,out-data-mode = <0>;
+            adi,dual-data-rate;
+            adi,spi-trigger;
+
+            clocks = <&cnv_ext_clk>;
+            clock-names = "trigger_clock";
+
+            dmas = <&rx_dma 0>;
+            dma-names = "rx";
+
+            pwm-names = "spi_trigger", "cnv";
+            pwms = <&axi_pwm_gen 0 0>, <&axi_pwm_gen 1 0>;
         };
     };
 ...

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad4630-24.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad4630-24.dts
@@ -110,7 +110,9 @@
 			vref-supply = <&vref>;
 			spi-max-frequency = <80000000>;
 			reset-gpios = <&gpio0 86 GPIO_ACTIVE_LOW>;
-			adi,lane-mode = <1>;
+			adi,lane-mode = <0>;
+			adi,clock-mode = <0>;
+			adi,out-data-mode = <0>;
 			adi,spi-trigger;
 			clocks = <&cnv_ext_clk>;
 			clock-names = "trigger_clock";

--- a/arch/arm/boot/dts/zynq-zed-adv7511-adaq4224-24.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-adaq4224-24.dts
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices ADAQ4224
+ *
+ * hdl_project: <ad4630_fmc/zed>
+ * board_revision: <B>
+ *
+ * Copyright (C) 2023 Analog Devices Inc.
+ */
+/dts-v1/;
+
+#include "zynq-zed.dtsi"
+#include "zynq-zed-adv7511.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/pwm/pwm.h>
+
+/ {
+	vref: regulator-vref {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-supply";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		regulator-always-on;
+	};
+
+	vdd_1_8: regulator-vdd-1-8 {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-supply";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+		regulator-always-on;
+	};
+
+	vio: regulator-vio {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-supply";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+		regulator-always-on;
+	};
+
+	clocks {
+		cnv_ext_clk: ext-clk {
+			#clock-cells = <0x0>;
+			compatible = "fixed-clock";
+			clock-frequency = <100000000>;
+			clock-output-names = "cnv_ext_clk";
+		};
+	};
+};
+
+&fpga_axi {
+	i2c@44c00000 {
+		compatible = "xlnx,axi-iic-1.01.b", "xlnx,xps-iic-2.00.a";
+		reg = <0x44c00000 0x10000>;
+		interrupt-parent = <&intc>;
+		interrupts = <0 54 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&clkc 15>;
+		clock-names = "pclk";
+
+		#size-cells = <0>;
+		#address-cells = <1>;
+
+		max31827: max31827@5f {
+			compatible = "adi,max31827";
+			reg = <0x5f>;
+			vref-supply = <&vio>;
+		};
+	};
+	rx_dma: rx-dmac@44a30000 {
+		compatible = "adi,axi-dmac-1.00.a";
+		reg = <0x44a30000 0x1000>;
+		#dma-cells = <1>;
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&clkc 15>;
+
+		adi,channels {
+			#size-cells = <0>;
+			#address-cells = <1>;
+
+			dma-channel@0 {
+				reg = <0>;
+				adi,source-bus-width = <64>;
+				adi,source-bus-type = <1>;
+				adi,destination-bus-width = <64>;
+				adi,destination-bus-type = <0>;
+			};
+		};
+	};
+
+	spi_clk: axi-clkgen@0x44a70000 {
+		compatible = "adi,axi-clkgen-2.00.a";
+		reg = <0x44a70000 0x10000>;
+		#clock-cells = <0>;
+		clocks = <&clkc 15>, <&clkc 15>;
+		clock-names = "s_axi_aclk", "clkin1";
+		clock-output-names = "spi_clk";
+	};
+
+	axi_pwm_gen: axi-pwm-gen@ {
+		compatible = "adi,axi-pwmgen";
+		reg = <0x44b00000 0x1000>;
+		label = "ad463x_cnv";
+		#pwm-cells = <2>;
+		clocks = <&cnv_ext_clk>;
+
+	};
+
+	axi_spi_engine: spi@44a00000 {
+		compatible = "adi,axi-spi-engine-1.00.a";
+		reg = <0x44a00000 0x1FF>;
+		interrupt-parent = <&intc>;
+		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&clkc 15>, <&spi_clk>;
+		clock-names = "s_axi_aclk", "spi_clk";
+		num-cs = <1>;
+
+		#address-cells = <0x1>;
+		#size-cells = <0x0>;
+
+		adaq4224: adaq4224@0 {
+			compatible = "adi,adaq4224";
+			reg = <0>;
+			vdd-supply = <&vref>;
+			vdd_1_8-supply = <&vdd_1_8>;
+			vio-supply = <&vio>;
+			vref-supply = <&vref>;
+			spi-max-frequency = <80000000>;
+			reset-gpios = <&gpio0 86 GPIO_ACTIVE_LOW>;
+			adi,pga-gpios = <&gpio0 87 GPIO_ACTIVE_HIGH>,
+					<&gpio0 88 GPIO_ACTIVE_HIGH>;
+			adi,lane-mode = <1>;
+			adi,clock-mode = <1>;
+			adi,out-data-mode = <0>;
+			adi,dual-data-rate;
+			adi,spi-trigger;
+
+			clocks = <&cnv_ext_clk>;
+			clock-names = "trigger_clock";
+
+			dmas = <&rx_dma 0>;
+			dma-names = "rx";
+
+			pwm-names = "spi_trigger", "cnv";
+			pwms = <&axi_pwm_gen 0 0>, <&axi_pwm_gen 1 0>;
+		};
+	};
+};

--- a/arch/arm/boot/dts/zynq-zed-adv7511-adaq4224-24_cm0_sdi4_cz2.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-adaq4224-24_cm0_sdi4_cz2.dts
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD4630-24
+ *
+ * hdl_project: <ad4630_fmc/zed>
+ * board_revision: <B>
+ *
+ * Copyright (C) 2022 Analog Devices Inc.
+ */
+/dts-v1/;
+
+#include "zynq-zed.dtsi"
+#include "zynq-zed-adv7511.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/pwm/pwm.h>
+
+/ {
+	vref: regulator-vref {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-supply";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		regulator-always-on;
+	};
+
+	vdd_1_8: regulator-vdd-1-8 {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-supply";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+		regulator-always-on;
+	};
+
+	vio: regulator-vio {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-supply";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+		regulator-always-on;
+	};
+
+	clocks {
+		cnv_ext_clk: ext-clk {
+			#clock-cells = <0x0>;
+			compatible = "fixed-clock";
+			clock-frequency = <100000000>;
+			clock-output-names = "cnv_ext_clk";
+		};
+	};
+
+	max17687_control@0 {
+		compatible = "adi,one-bit-adc-dac";
+
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		in-gpios = <&gpio0 89 GPIO_ACTIVE_HIGH>;
+
+		channel@0 {
+			reg = <0>;
+			label = "MAX17687_RST";
+		};
+	};
+};
+
+&fpga_axi {
+	rx_dma: rx-dmac@44a30000 {
+		compatible = "adi,axi-dmac-1.00.a";
+		reg = <0x44a30000 0x1000>;
+		#dma-cells = <1>;
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&clkc 15>;
+
+		adi,channels {
+			#size-cells = <0>;
+			#address-cells = <1>;
+
+			dma-channel@0 {
+				reg = <0>;
+				adi,source-bus-width = <64>;
+				adi,source-bus-type = <1>;
+				adi,destination-bus-width = <64>;
+				adi,destination-bus-type = <0>;
+			};
+		};
+	};
+
+	spi_clk: axi-clkgen@0x44a70000 {
+		compatible = "adi,axi-clkgen-2.00.a";
+		reg = <0x44a70000 0x10000>;
+		#clock-cells = <0>;
+		clocks = <&clkc 15>, <&clkc 15>;
+		clock-names = "s_axi_aclk", "clkin1";
+		clock-output-names = "spi_clk";
+	};
+
+	axi_pwm_gen: axi-pwm-gen@ {
+		compatible = "adi,axi-pwmgen";
+		reg = <0x44b00000 0x1000>;
+		label = "ad463x_cnv";
+		#pwm-cells = <2>;
+		clocks = <&cnv_ext_clk>;
+
+	};
+
+	i2c@41620000 {
+		compatible = "xlnx,axi-iic-1.01.b", "xlnx,xps-iic-2.00.a";
+		reg = <0x41620000 0x10000>;
+		interrupt-parent = <&intc>;
+		interrupts = <0 55 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&clkc 15>;
+		clock-names = "pclk";
+
+		#size-cells = <0>;
+		#address-cells = <1>;
+
+		eeprom@50 {
+			compatible = "at24,24c02";
+			reg = <0x50>;
+		};
+
+		max31827@5f {
+			compatible = "adi,max31827";
+			reg = <0x5f>;
+			vref-supply = <&vio>;
+
+			adi,comp-int;
+			adi,alarm-pol = <0>;
+			adi,fault-q = <1>;
+			adi,timeout-enable;
+		};
+	};
+
+	axi_spi_engine: spi@44a00000 {
+		compatible = "adi,axi-spi-engine-1.00.a";
+		reg = <0x44a00000 0x1FF>;
+		interrupt-parent = <&intc>;
+		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&clkc 15>, <&spi_clk>;
+		clock-names = "s_axi_aclk", "spi_clk";
+		num-cs = <1>;
+
+		#address-cells = <0x1>;
+		#size-cells = <0x0>;
+
+		adaq4224: adaq4224@0 {
+			compatible = "adi,adaq4224";
+			reg = <0>;
+			vdd-supply = <&vref>;
+			vdd_1_8-supply = <&vdd_1_8>;
+			vio-supply = <&vio>;
+			vref-supply = <&vref>;
+			spi-max-frequency = <80000000>;
+			reset-gpios = <&gpio0 86 GPIO_ACTIVE_LOW>;
+			adi,pga-gpios = <&gpio0 87 GPIO_ACTIVE_HIGH>,
+					<&gpio0 88 GPIO_ACTIVE_HIGH>;
+			adi,lane-mode = <2>;
+			adi,clock-mode = <0>;
+			adi,out-data-mode = <0>;
+			adi,spi-trigger;
+
+			clocks = <&cnv_ext_clk>;
+			clock-names = "trigger_clock";
+
+			dmas = <&rx_dma 0>;
+			dma-names = "rx";
+
+			pwm-names = "spi_trigger", "cnv";
+			pwms = <&axi_pwm_gen 0 0>, <&axi_pwm_gen 1 0>;
+		};
+	};
+};

--- a/drivers/iio/adc/ad4630.c
+++ b/drivers/iio/adc/ad4630.c
@@ -1315,9 +1315,9 @@ static const struct spi_device_id ad4630_id_table[] = {
 MODULE_DEVICE_TABLE(spi, ad4630_id_table);
 
 static const struct of_device_id ad4630_of_match[] = {
-	{ .compatible = "adi,ad4630-24", .data = &ad4630_chip_info[ID_AD4030_24] },
+	{ .compatible = "adi,ad4030-24", .data = &ad4630_chip_info[ID_AD4030_24] },
 	{ .compatible = "adi,ad4630-16", .data = &ad4630_chip_info[ID_AD4630_16] },
-	{ .compatible = "adi,ad4030-24", .data = &ad4630_chip_info[ID_AD4630_24] },
+	{ .compatible = "adi,ad4630-24", .data = &ad4630_chip_info[ID_AD4630_24] },
 	{ .compatible = "adi,ad463x", .data = &ad463x_chip_info},
 	{}
 };


### PR DESCRIPTION
Add support for ADAQ4224 Data Acquisition micro module.

The ADAQ4224 is a micro module precision data acquisition (DAQ) signal chain solution.
The internal ADC is an AD4030-24 so this set leverages the driver that already supports AD4030-24 by expanding it to also support ADAQ4216, ADAQ4220, and ADAQ4224.
