### PR TITLE
drivers: hwmon: max31827: handle vref regulator

### DIFF
--- a/drivers/hwmon/max31827.c
+++ b/drivers/hwmon/max31827.c
@@ -427,6 +427,10 @@ static int max31827_probe(struct i2c_client *client)
 		return dev_err_probe(dev, PTR_ERR(st->regmap),
 				     "Failed to allocate regmap.\n");
 
+	err = devm_regulator_get_enable(dev, "vref");
+	if (err)
+		return dev_err_probe(dev, err, "failed to enable regulator\n");
+
 	err = max31827_init_client(st);
 	if (err)
 		return err;


### PR DESCRIPTION
Add missing implementation for the max31827 supply regulator.
This is a hardware required property that is not handled.

Link: https://lore.kernel.org/r/20230925122929.10610-1-antoniu.miclaus@analog.com/
Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>