### PR TITLE
add admfm2000 microwave down converter

### DIFF
--- a/Documentation/devicetree/bindings/iio/frequency/adi,admfm2000.yaml
+++ b/Documentation/devicetree/bindings/iio/frequency/adi,admfm2000.yaml
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+# Copyright 2023 Analog Devices Inc.
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/iio/frequency/adi,admfm2000.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
+
+title: ADMFM2000 Dual Microwave Down Converter
+
+maintainers:
+  - Kim Seer Paller <kimseer.paller@analog.com>
+
+description: |
+    Dual microwave down converter module with input RF and LO frequency ranges
+    from 0.5 to 32 GHz and an output IF frequency range from 0.1 to 8 GHz.
+    It consists of a LNA, mixer, IF filter, DSA, and IF amplifier for each down
+    conversion path.
+
+properties:
+  compatible:
+    enum:
+      - adi,admfm2000
+
+  vcc-supply: true
+
+  switch1-gpios:
+    description:
+      Must contain an array of 2 GPIO specifiers, referring to the GPIO pins
+      connected to the channel 1 switch controls.
+    minItems: 2
+    maxItems: 2
+
+  switch2-gpios:
+    description:
+      Must contain an array of 2 GPIO specifiers, referring to the GPIO pins
+      connected to the channel 2 switch controls.
+    minItems: 2
+    maxItems: 2
+
+  attenuation1-gpios:
+    description:
+      Must contain an array of 5 GPIO specifiers, referring to the GPIO pins
+      connected to the channel 1 DSA attenuation controls.
+    minItems: 5
+    maxItems: 5
+
+  attenuation2-gpios:
+    description:
+      Must contain an array of 5 GPIO specifiers, referring to the GPIO pins
+      connected to the channel 2 DSA attenuation controls.
+    minItems: 5
+    maxItems: 5
+
+  '#address-cells':
+    const: 1
+
+  '#size-cells':
+    const: 0
+
+patternProperties:
+  "^channel@[0-1]$":
+    type: object
+    description: Represents a channel of the device.
+
+    properties:
+      reg:
+        description:
+          The channel number.
+        minimum: 0
+        maximum: 1
+
+      adi,direct-if-mode:
+        description:
+          Bypass mixer mode.
+        type: boolean
+
+    required:
+      - reg
+
+required:
+  - compatible
+  - switch1-gpios
+  - switch2-gpios
+  - attenuation1-gpios
+  - attenuation2-gpios
+
+additionalProperties: false
+
+examples:
+  - |
+    #include <dt-bindings/gpio/gpio.h>
+    admfm2000 {
+      compatible = "adi,admfm2000";
+
+      switch1-gpios = <&gpio 1 GPIO_ACTIVE_LOW>,
+        <&gpio 2 GPIO_ACTIVE_HIGH>;
+
+      switch2-gpios = <&gpio 3 GPIO_ACTIVE_LOW>,
+        <&gpio 4 GPIO_ACTIVE_HIGH>;
+
+      attenuation1-gpios = <&gpio 17 GPIO_ACTIVE_LOW>,
+        <&gpio 22 GPIO_ACTIVE_LOW>,
+        <&gpio 23 GPIO_ACTIVE_LOW>,
+        <&gpio 24 GPIO_ACTIVE_LOW>,
+        <&gpio 25 GPIO_ACTIVE_LOW>;
+
+      attenuation2-gpios = <&gpio 0 GPIO_ACTIVE_LOW>,
+        <&gpio 5 GPIO_ACTIVE_LOW>,
+        <&gpio 6 GPIO_ACTIVE_LOW>,
+        <&gpio 16 GPIO_ACTIVE_LOW>,
+        <&gpio 26 GPIO_ACTIVE_LOW>;
+
+      #address-cells = <1>;
+      #size-cells = <0>;
+
+      channel@0 {
+        reg = <0>;
+        adi,direct-if-mode;
+      };
+
+      channel@1 {
+        reg = <1>;
+      };
+    };
+...

--- a/drivers/iio/Kconfig.adi
+++ b/drivers/iio/Kconfig.adi
@@ -123,6 +123,7 @@ config IIO_ALL_ADI_DRIVERS
 	imply ADF4377
 	imply ADF5355
 	imply ADL5960
+	imply ADMFM2000
 	imply ADMV1013
 	imply ADMV1014
 	imply ADMV4420

--- a/drivers/iio/frequency/Kconfig
+++ b/drivers/iio/frequency/Kconfig
@@ -64,6 +64,16 @@ config AD9517
 	  To compile this driver as a module, choose M here: the
 	  module will be called ad9517.
 
+config ADMFM2000
+	tristate "Analog Devices ADMFM2000 Dual Microwave Down Converter"
+	depends on GPIOLIB
+	help
+	  Say yes here to build support for Analog Devices ADMFM2000 Dual
+	  Microwave Down Converter.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called admfm2000.
+
 config ADMV1013
 	tristate "Analog Devices ADMV1013 Microwave Upconverter"
 	depends on SPI

--- a/drivers/iio/frequency/Makefile
+++ b/drivers/iio/frequency/Makefile
@@ -16,6 +16,7 @@ obj-$(CONFIG_ADF4371) += adf4371.o
 obj-$(CONFIG_ADF4377) += adf4377.o
 obj-$(CONFIG_ADF5355) += adf5355.o
 obj-$(CONFIG_ADL5960) += adl5960.o
+obj-$(CONFIG_ADMFM20000) += admfm2000.o
 obj-$(CONFIG_ADMV1013) += admv1013.o
 obj-$(CONFIG_ADMV1014) += admv1014.o
 obj-$(CONFIG_ADMV1014) += admv4420.o

--- a/drivers/iio/frequency/admfm2000.c
+++ b/drivers/iio/frequency/admfm2000.c
@@ -1,0 +1,344 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * ADMFM2000 Dual Microwave Down Converter
+ *
+ * Copyright 2023 Analog Devices Inc.
+ */
+
+#include <linux/device.h>
+#include <linux/err.h>
+#include <linux/gpio/consumer.h>
+#include <linux/iio/iio.h>
+#include <linux/iio/sysfs.h>
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/of_device.h>
+#include <linux/of_platform.h>
+#include <linux/platform_device.h>
+#include <linux/slab.h>
+#include <linux/regulator/consumer.h>
+#include <linux/sysfs.h>
+
+struct admfm2000_chip_info {
+	const char			*name;
+	const struct iio_chan_spec	*channels;
+	unsigned int			num_channels;
+	unsigned int			mode_gpios;
+	unsigned int			dsa_gpios;
+	int				gain_min;
+	int				gain_max;
+	int				default_gain;
+};
+
+struct admfm2000_state {
+	struct regulator		*reg;
+	struct mutex			lock; /* protect sensor state */
+	struct admfm2000_chip_info	*chip_info;
+	struct gpio_descs		*sw_ch[2];
+	struct gpio_descs		*dsa_gpios[2];
+	u32				gain[2];
+};
+
+static int admfm2000_mode(struct iio_dev *indio_dev, u32 reg, u32 mode)
+{
+	struct admfm2000_state *st = iio_priv(indio_dev);
+	DECLARE_BITMAP(values, 2);
+
+	switch (mode) {
+	case 0:
+		values[0] = (reg == 0) ? 1 : 2;
+		gpiod_set_array_value_cansleep(st->sw_ch[reg]->ndescs,
+					       st->sw_ch[reg]->desc,
+					       NULL, values);
+		break;
+	case 1:
+		values[0] = (reg == 0) ? 2 : 1;
+		gpiod_set_array_value_cansleep(st->sw_ch[reg]->ndescs,
+					       st->sw_ch[reg]->desc,
+					       NULL, values);
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+static int admfm2000_attenuation(struct iio_dev *indio_dev, u32 chan,
+				 u32 value)
+{
+	struct admfm2000_state *st = iio_priv(indio_dev);
+	DECLARE_BITMAP(values, BITS_PER_TYPE(value));
+
+	values[0] = value;
+
+	gpiod_set_array_value_cansleep(st->dsa_gpios[chan]->ndescs,
+				       st->dsa_gpios[chan]->desc,
+				       NULL, values);
+	return 0;
+}
+
+static int admfm2000_read_raw(struct iio_dev *indio_dev,
+			      struct iio_chan_spec const *chan, int *val,
+			      int *val2, long mask)
+{
+	struct admfm2000_state *st = iio_priv(indio_dev);
+	int gain = 0;
+	int ret;
+
+	mutex_lock(&st->lock);
+	switch (mask) {
+	case IIO_CHAN_INFO_HARDWAREGAIN:
+		gain = ~(st->gain[chan->channel]) * -1000;
+		*val = gain / 1000;
+		*val2 = (gain % 1000) * 1000;
+
+		ret =  IIO_VAL_INT_PLUS_MICRO_DB;
+		break;
+	default:
+		ret = -EINVAL;
+	}
+	mutex_unlock(&st->lock);
+
+	return ret;
+};
+
+static int admfm2000_write_raw(struct iio_dev *indio_dev,
+			     struct iio_chan_spec const *chan, int val,
+			     int val2, long mask)
+{
+	struct admfm2000_state *st = iio_priv(indio_dev);
+	struct admfm2000_chip_info *info = st->chip_info;
+	int gain;
+	int ret;
+
+	if (val < 0)
+		gain = (val * 1000) - (val2 / 1000);
+	else
+		gain = (val * 1000) + (val2 / 1000);
+
+	if (gain > info->gain_max || gain < info->gain_min)
+		return -EINVAL;
+
+	mutex_lock(&st->lock);
+	switch (mask) {
+	case IIO_CHAN_INFO_HARDWAREGAIN:
+		st->gain[chan->channel] = ~((abs(gain) / 1000) & 0x1F);
+
+		ret = admfm2000_attenuation(indio_dev, chan->channel,
+					    st->gain[chan->channel]);
+		if (ret)
+			return ret;
+		break;
+	default:
+		ret = -EINVAL;
+	}
+	mutex_unlock(&st->lock);
+
+	return ret;
+}
+
+static int admfm2000_write_raw_get_fmt(struct iio_dev *indio_dev,
+				       struct iio_chan_spec const *chan,
+				       long mask)
+{
+	switch (mask) {
+	case IIO_CHAN_INFO_HARDWAREGAIN:
+		return IIO_VAL_INT_PLUS_MICRO_DB;
+	default:
+		return -EINVAL;
+	}
+}
+
+static const struct iio_info admfm2000_info = {
+	.read_raw = &admfm2000_read_raw,
+	.write_raw = &admfm2000_write_raw,
+	.write_raw_get_fmt = &admfm2000_write_raw_get_fmt,
+};
+
+#define ADMFM2000_CHAN(_channel) {					\
+	.type = IIO_VOLTAGE,						\
+	.output = 1,							\
+	.indexed = 1,							\
+	.channel = _channel,						\
+	.info_mask_separate = BIT(IIO_CHAN_INFO_HARDWAREGAIN),		\
+}
+
+static const struct iio_chan_spec admfm2000_channels[] = {
+	ADMFM2000_CHAN(0),
+	ADMFM2000_CHAN(1),
+};
+
+static int admfm2000_channel_config(struct admfm2000_state *st,
+				    struct iio_dev *indio_dev)
+{
+	struct platform_device *pdev = to_platform_device(indio_dev->dev.parent);
+	struct device *dev = &pdev->dev;
+	struct fwnode_handle *child;
+	u32 reg, mode;
+	int ret;
+
+	device_for_each_child_node(dev, child) {
+		ret = fwnode_property_read_u32(child, "reg", &reg);
+		if (ret) {
+			fwnode_handle_put(child);
+			return dev_err_probe(dev, ret,
+					     "Failed to get reg property\n");
+		}
+
+		if (reg >= indio_dev->num_channels) {
+			fwnode_handle_put(child);
+			return dev_err_probe(dev, -EINVAL, "reg bigger than: %d\n",
+					     indio_dev->num_channels);
+		}
+
+		mode = fwnode_property_read_bool(child, "adi,direct-if-mode");
+		ret = admfm2000_mode(indio_dev, reg, mode);
+		if (ret) {
+			fwnode_handle_put(child);
+			return ret;
+		}
+	}
+
+	return 0;
+}
+
+static void admfm2000_reg_disable(void *data)
+{
+	struct admfm2000_state *st = data;
+
+	regulator_disable(st->reg);
+}
+
+static struct admfm2000_chip_info admfm2000_chip_info_tbl = {
+	.name = "admfm2000",
+	.channels = admfm2000_channels,
+	.num_channels = ARRAY_SIZE(admfm2000_channels),
+	.dsa_gpios = 5,
+	.mode_gpios = 2,
+	.gain_min = -31000,
+	.gain_max = 0,
+	.default_gain = -0x20, /* set default gain -31db */
+};
+
+static int admfm2000_setup(struct admfm2000_state *st,
+			   struct iio_dev *indio_dev)
+{
+	struct platform_device *pdev = to_platform_device(indio_dev->dev.parent);
+	struct device *dev = &pdev->dev;
+
+	st->sw_ch[0] = devm_gpiod_get_array(dev, "switch1", GPIOD_OUT_LOW);
+	if (IS_ERR(st->sw_ch[0]))
+		return dev_err_probe(dev, PTR_ERR(st->sw_ch[0]),
+				     "Failed to get gpios\n");
+
+	if (st->sw_ch[0]->ndescs != st->chip_info->mode_gpios) {
+		dev_err(dev, "%d GPIOs needed to operate\n",
+			st->chip_info->mode_gpios);
+		return -ENODEV;
+	}
+
+	st->sw_ch[1] = devm_gpiod_get_array(dev, "switch2", GPIOD_OUT_LOW);
+	if (IS_ERR(st->sw_ch[1]))
+		return dev_err_probe(dev, PTR_ERR(st->sw_ch[1]),
+				     "Failed to get gpios\n");
+
+	if (st->sw_ch[1]->ndescs != st->chip_info->mode_gpios) {
+		dev_err(dev, "%d GPIOs needed to operate\n",
+			st->chip_info->mode_gpios);
+		return -ENODEV;
+	}
+
+	st->dsa_gpios[0] = devm_gpiod_get_array(dev, "attenuation1",
+						GPIOD_OUT_LOW);
+	if (IS_ERR(st->dsa_gpios[0]))
+		return dev_err_probe(dev, PTR_ERR(st->dsa_gpios[0]),
+				     "Failed to get gpios\n");
+
+	if (st->dsa_gpios[0]->ndescs != st->chip_info->dsa_gpios) {
+		dev_err(dev, "%d GPIOs needed to operate\n",
+			st->chip_info->dsa_gpios);
+		return -ENODEV;
+	}
+
+	st->dsa_gpios[1] = devm_gpiod_get_array(dev, "attenuation2",
+						GPIOD_OUT_LOW);
+	if (IS_ERR(st->dsa_gpios[1]))
+		return dev_err_probe(dev, PTR_ERR(st->dsa_gpios[1]),
+				     "Failed to get gpios\n");
+
+	if (st->dsa_gpios[1]->ndescs != st->chip_info->dsa_gpios) {
+		dev_err(dev, "%d GPIOs needed to operate\n",
+			st->chip_info->dsa_gpios);
+		return -ENODEV;
+	}
+
+	return 0;
+}
+
+static int admfm2000_probe(struct platform_device *pdev)
+{
+	struct device *dev = &pdev->dev;
+	struct iio_dev *indio_dev;
+	struct admfm2000_state *st;
+	int ret;
+
+	indio_dev = devm_iio_device_alloc(dev, sizeof(*st));
+	if (!indio_dev)
+		return -ENOMEM;
+
+	st = iio_priv(indio_dev);
+
+	st->chip_info = &admfm2000_chip_info_tbl;
+	indio_dev->num_channels = st->chip_info->num_channels;
+	indio_dev->channels = st->chip_info->channels;
+	indio_dev->name = st->chip_info->name;
+	indio_dev->info = &admfm2000_info;
+	indio_dev->modes = INDIO_DIRECT_MODE;
+
+	st->gain[0] = st->chip_info->default_gain;
+	st->gain[1] = st->chip_info->default_gain;
+
+	st->reg = devm_regulator_get(dev, "vcc-supply");
+	if (IS_ERR(st->reg))
+		return PTR_ERR(st->reg);
+
+	ret = regulator_enable(st->reg);
+	if (ret)
+		return ret;
+
+	ret = devm_add_action_or_reset(dev, admfm2000_reg_disable, st);
+	if (ret)
+		return ret;
+
+	mutex_init(&st->lock);
+
+	ret = admfm2000_setup(st, indio_dev);
+	if (ret)
+		return ret;
+
+	ret = admfm2000_channel_config(st, indio_dev);
+	if (ret)
+		return ret;
+
+	return devm_iio_device_register(dev, indio_dev);
+}
+
+static const struct of_device_id admfm2000_of_match[] = {
+	{ .compatible = "adi,admfm2000" },
+	{ }
+};
+MODULE_DEVICE_TABLE(of, admfm2000_of_match);
+
+static struct platform_driver admfm2000_driver = {
+	.driver = {
+		.name = "admfm2000",
+		.of_match_table = admfm2000_of_match,
+	},
+	.probe = admfm2000_probe,
+};
+module_platform_driver(admfm2000_driver);
+
+MODULE_AUTHOR("Kim Seer Paller <kimseer.paller@analog.com>");
+MODULE_DESCRIPTION("ADMFM2000 Dual Microwave Down Converter");
+MODULE_LICENSE("GPL v2");


### PR DESCRIPTION
Dual microwave down converter module with input RF and LO frequency ranges
from 0.5 to 32 GHz and an output IF frequency range from 0.1 to 8 GHz.
It consists of a LNA, mixer, IF filter, DSA, and IF amplifier for each down
conversion path.

Datasheet is not publicly available but can be requested through support personnel.