### PR TITLE
ci: run-build.sh: install xz-utils

### DIFF
--- a/ci/travis/run-build.sh
+++ b/ci/travis/run-build.sh
@@ -56,7 +56,7 @@ adjust_kcflags_against_gcc() {
 	export KCFLAGS
 }
 
-APT_LIST="make bc u-boot-tools flex bison libssl-dev tar kmod"
+APT_LIST="make bc u-boot-tools flex bison libssl-dev tar kmod xz-utils"
 
 if [ "$ARCH" = "arm64" ] ; then
 	if [ -z "$CROSS_COMPILE" ] ; then


### PR DESCRIPTION
Make sure xz-utils are installed for the build jobs. This matters for the rpi branch (linux 6.1).