### PR TITLE
Fix Azure CI - dt_binding_check job

### DIFF
--- a/ci/travis/run-build.sh
+++ b/ci/travis/run-build.sh
@@ -315,7 +315,7 @@ build_dt_binding_check() {
 	fi
 
 	# install dt_binding_check dependencies
-	pip3 install git+https://github.com/devicetree-org/dt-schema.git@master
+	pip3 install dtschema
 
 	__update_git_ref "${ref_branch}" "${ref_branch}"
 


### PR DESCRIPTION
Install dtschema package using pip instead of getting latest from GitHub since the master may contain bugs that will fail our CIs.