### PR TITLE
iio: adc: adrv9009: Add support for Serializer/PHY PRBS generation

### DIFF
--- a/drivers/iio/adc/adrv9009.c
+++ b/drivers/iio/adc/adrv9009.c
@@ -3752,6 +3752,18 @@ static ssize_t adrv9009_debugfs_write(struct file *file,
 
 		entry->val = val;
 		return count;
+	case DBGFS_BIST_SERIALIZER_A_PRBS:
+	case DBGFS_BIST_SERIALIZER_B_PRBS:
+		mutex_lock(&phy->lock);
+		ret = TALISE_enableFramerTestData(phy->talDevice,
+			entry->cmd == DBGFS_BIST_SERIALIZER_A_PRBS ? TAL_FRAMER_A : TAL_FRAMER_B,
+			val, TAL_FTD_SERIALIZER);
+		mutex_unlock(&phy->lock);
+		if (ret)
+			return ret;
+
+		entry->val = val;
+		return count;
 	case DBGFS_BIST_FRAMER_A_LOOPBACK:
 	case DBGFS_BIST_FRAMER_B_LOOPBACK:
 		mutex_lock(&phy->lock);
@@ -3884,6 +3896,8 @@ static int adrv9009_register_debugfs(struct iio_dev *indio_dev)
 	adrv9009_add_debugfs_entry(phy, "initialize", DBGFS_INIT);
 	adrv9009_add_debugfs_entry(phy, "bist_framer_a_prbs", DBGFS_BIST_FRAMER_A_PRBS);
 	adrv9009_add_debugfs_entry(phy, "bist_framer_b_prbs", DBGFS_BIST_FRAMER_B_PRBS);
+	adrv9009_add_debugfs_entry(phy, "bist_serializer_a_prbs", DBGFS_BIST_SERIALIZER_A_PRBS);
+	adrv9009_add_debugfs_entry(phy, "bist_serializer_b_prbs", DBGFS_BIST_SERIALIZER_B_PRBS);
 	adrv9009_add_debugfs_entry(phy, "bist_framer_a_loopback", DBGFS_BIST_FRAMER_A_LOOPBACK);
 	adrv9009_add_debugfs_entry(phy, "bist_framer_b_loopback", DBGFS_BIST_FRAMER_B_LOOPBACK);
 	adrv9009_add_debugfs_entry(phy, "bist_tone", DBGFS_BIST_TONE);

--- a/drivers/iio/adc/adrv9009.h
+++ b/drivers/iio/adc/adrv9009.h
@@ -38,6 +38,8 @@ enum debugfs_cmd {
 	DBGFS_INIT,
 	DBGFS_BIST_FRAMER_A_PRBS,
 	DBGFS_BIST_FRAMER_B_PRBS,
+	DBGFS_BIST_SERIALIZER_A_PRBS,
+	DBGFS_BIST_SERIALIZER_B_PRBS,
 	DBGFS_BIST_FRAMER_A_LOOPBACK,
 	DBGFS_BIST_FRAMER_B_LOOPBACK,
 	DBGFS_BIST_TONE,
@@ -214,7 +216,7 @@ struct adrv9009_rf_phy {
 	struct clk 		*clks[NUM_ADRV9009_CLKS];
 	struct adrv9009_clock	clk_priv[NUM_ADRV9009_CLKS];
 	struct clk_onecell_data	clk_data;
-	struct adrv9009_debugfs_entry debugfs_entry[342];
+	struct adrv9009_debugfs_entry debugfs_entry[344];
 	struct bin_attribute 	bin;
 	struct bin_attribute 	bin_gt;
 	struct iio_dev 		*indio_dev;


### PR DESCRIPTION
This patch adds support for Serializer/PHY PRBS generation. This is in addition to the existing Framer PRBS support. The main difference is the injection point.
TAL_FTD_FRAMERINPUT vs. TAL_FTD_SERIALIZER.