### PR TITLE
Add support for AD7944, AD7985, AD7986

### DIFF
--- a/Documentation/devicetree/bindings/iio/adc/adi,pulsar.yaml
+++ b/Documentation/devicetree/bindings/iio/adc/adi,pulsar.yaml
@@ -13,11 +13,14 @@ description: |
   Analog Devices PulSAR family Analog to Digital Converters with SPI support
     https://www.analog.com/en/products/ad7988-5.html
     https://www.analog.com/en/products/ad7988-1.html
+    https://www.analog.com/en/products/ad7986.html
+    https://www.analog.com/en/products/ad7985.html
     https://www.analog.com/en/products/ad7984.html
     https://www.analog.com/en/products/ad7983.html
     https://www.analog.com/en/products/ad7982.html
     https://www.analog.com/en/products/ad7980.html
     https://www.analog.com/en/products/ad7949.html
+    https://www.analog.com/en/products/ad7944.html
     https://www.analog.com/en/products/ad7946.html
     https://www.analog.com/en/products/ad7942.html
     https://www.analog.com/en/products/ad7699.html
@@ -45,12 +48,15 @@ properties:
     enum:
       - adi,pulsar,ad7988-5
       - adi,pulsar,ad7988-1
+      - adi,pulsar,ad7986
+      - adi,pulsar,ad7985
       - adi,pulsar,ad7984
       - adi,pulsar,ad7983
       - adi,pulsar,ad7982
       - adi,pulsar,ad7980
       - adi,pulsar,ad7949
       - adi,pulsar,ad7946
+      - adi,pulsar,ad7944
       - adi,pulsar,ad7942
       - adi,pulsar,ad7699
       - adi,pulsar,ad7693
@@ -103,6 +109,12 @@ properties:
 
   vref-supply:
     description: Voltage regulator for the reference voltage.
+
+  turbo-gpios:
+    maxItems: 1
+    description:
+      GPIO used to enable the turbo mode. This mode is used to increase the
+      sampling rate of the ADC at the expense of power consumption.
 
 patternProperties:
   "^channel@([0-8])$":
@@ -164,6 +176,18 @@ allOf:
         "^channel@([0-8])$":
           required:
             - adi,single-channel
+
+  - if:
+      properties:
+        compatible:
+          contains:
+            enum:
+              - adi,pulsar,ad7986
+              - adi,pulsar,ad7985
+              - adi,pulsar,ad7944
+    then:
+      required:
+        - turbo-gpios
 
 required:
   - compatible

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad7944.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad7944.dts
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD7944
+ * https://www.analog.com/en/products/ad7944.html
+ *
+ * hdl_project: <pulsar_adc_pmdz/zed>
+ * board_revision: <>
+ *
+ * Copyright (C) 2023 Analog Devices Inc.
+ */
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+
+#include "zynq-zed.dtsi"
+#include "zynq-zed-adv7511.dtsi"
+
+/ {
+	vref: ad7944-internal-reference-regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "AD7944 internal reference";
+		regulator-min-microvolt = <4096000>;
+		regulator-max-microvolt = <4096000>;
+		regulator-always-on;
+	};
+};
+
+&fpga_axi {
+	adc_trigger: pwm@44b00000 {
+		compatible = "adi,axi-pwmgen";
+		reg = <0x44b00000 0x1000>;
+		label = "adc_conversion_trigger";
+		#pwm-cells = <2>;
+		clocks = <&spi_clk>;
+	};
+
+	rx_dma: rx-dmac@44a30000 {
+		compatible = "adi,axi-dmac-1.00.a";
+		reg = <0x44a30000 0x1000>;
+		#dma-cells = <1>;
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&clkc 17>;
+
+		adi,channels {
+			#size-cells = <0>;
+			#address-cells = <1>;
+
+			dma-channel@0 {
+				reg = <0>;
+				adi,source-bus-width = <32>;
+				adi,source-bus-type = <1>;
+				adi,destination-bus-width = <64>;
+				adi,destination-bus-type = <0>;
+			};
+		};
+	};
+
+	spi_clk: clock-controller@44a70000 {
+		compatible = "adi,axi-clkgen-2.00.a";
+		reg = <0x44a70000 0x1000>;
+		#clock-cells = <0>;
+		clocks = <&clkc 15>, <&clkc 15>;
+		clock-names = "s_axi_aclk", "clkin1";
+		clock-output-names = "spi_clk";
+	};
+
+	axi_spi_engine_0: spi@44a00000 {
+		compatible = "adi,axi-spi-engine-1.00.a";
+		reg = <0x44a00000 0x1000>;
+		interrupt-parent = <&intc>;
+		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&clkc 15>, <&spi_clk>;
+		clock-names = "s_axi_aclk", "spi_clk";
+		num-cs = <1>;
+
+		#address-cells = <0x1>;
+		#size-cells = <0x0>;
+
+		ad7944: adc@0 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			compatible = "adi,pulsar,ad7944";
+			reg = <0>;
+			spi-max-frequency = <80000000>;
+			turbo-gpios = <&gpio0 87 GPIO_ACTIVE_HIGH>;
+			clocks = <&spi_clk>;
+			clock-names = "ref_clk";
+			dmas = <&rx_dma 0>;
+			dma-names = "rx";
+			pwms = <&adc_trigger 0 0>;
+			pwm-names = "cnv";
+			vref-supply = <&vref>;
+			channel@0 {
+				reg = <0>;
+				diff-channels = <0 1>;
+			};
+		};
+	};
+};

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad7985.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad7985.dts
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD7985
+ * https://www.analog.com/en/products/ad7985.html
+ *
+ * hdl_project: <pulsar_adc_pmdz/zed>
+ * board_revision: <>
+ *
+ * Copyright (C) 2023 Analog Devices Inc.
+ */
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+
+#include "zynq-zed.dtsi"
+#include "zynq-zed-adv7511.dtsi"
+
+/ {
+	vref: ad7985-internal-reference-regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "AD7985 internal reference";
+		regulator-min-microvolt = <4096000>;
+		regulator-max-microvolt = <4096000>;
+		regulator-always-on;
+	};
+};
+
+&fpga_axi {
+	adc_trigger: pwm@44b00000 {
+		compatible = "adi,axi-pwmgen";
+		reg = <0x44b00000 0x1000>;
+		label = "adc_conversion_trigger";
+		#pwm-cells = <2>;
+		clocks = <&spi_clk>;
+	};
+
+	rx_dma: rx-dmac@44a30000 {
+		compatible = "adi,axi-dmac-1.00.a";
+		reg = <0x44a30000 0x1000>;
+		#dma-cells = <1>;
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&clkc 17>;
+
+		adi,channels {
+			#size-cells = <0>;
+			#address-cells = <1>;
+
+			dma-channel@0 {
+				reg = <0>;
+				adi,source-bus-width = <32>;
+				adi,source-bus-type = <1>;
+				adi,destination-bus-width = <64>;
+				adi,destination-bus-type = <0>;
+			};
+		};
+	};
+
+	spi_clk: clock-controller@44a70000 {
+		compatible = "adi,axi-clkgen-2.00.a";
+		reg = <0x44a70000 0x1000>;
+		#clock-cells = <0>;
+		clocks = <&clkc 15>, <&clkc 15>;
+		clock-names = "s_axi_aclk", "clkin1";
+		clock-output-names = "spi_clk";
+	};
+
+	axi_spi_engine_0: spi@44a00000 {
+		compatible = "adi,axi-spi-engine-1.00.a";
+		reg = <0x44a00000 0x1000>;
+		interrupt-parent = <&intc>;
+		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&clkc 15>, <&spi_clk>;
+		clock-names = "s_axi_aclk", "spi_clk";
+		num-cs = <1>;
+
+		#address-cells = <0x1>;
+		#size-cells = <0x0>;
+
+		ad7985: adc@0 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			compatible = "adi,pulsar,ad7985";
+			reg = <0>;
+			spi-max-frequency = <80000000>;
+			turbo-gpios = <&gpio0 87 GPIO_ACTIVE_HIGH>;
+			clocks = <&spi_clk>;
+			clock-names = "ref_clk";
+			dmas = <&rx_dma 0>;
+			dma-names = "rx";
+			pwms = <&adc_trigger 0 0>;
+			pwm-names = "cnv";
+			vref-supply = <&vref>;
+			channel@0 {
+				reg = <0>;
+				diff-channels = <0 1>;
+			};
+		};
+	};
+};

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad7986.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad7986.dts
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD7986
+ * https://www.analog.com/en/products/ad7986.html
+ *
+ * hdl_project: <pulsar_adc_pmdz/zed>
+ * board_revision: <>
+ *
+ * Copyright (C) 2023 Analog Devices Inc.
+ */
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+
+#include "zynq-zed.dtsi"
+#include "zynq-zed-adv7511.dtsi"
+
+/ {
+	vref: ad7986-internal-reference-regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "AD7986 internal reference";
+		regulator-min-microvolt = <4096000>;
+		regulator-max-microvolt = <4096000>;
+		regulator-always-on;
+	};
+};
+
+&fpga_axi {
+	adc_trigger: pwm@44b00000 {
+		compatible = "adi,axi-pwmgen";
+		reg = <0x44b00000 0x1000>;
+		label = "adc_conversion_trigger";
+		#pwm-cells = <2>;
+		clocks = <&spi_clk>;
+	};
+
+	rx_dma: rx-dmac@44a30000 {
+		compatible = "adi,axi-dmac-1.00.a";
+		reg = <0x44a30000 0x1000>;
+		#dma-cells = <1>;
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&clkc 17>;
+
+		adi,channels {
+			#size-cells = <0>;
+			#address-cells = <1>;
+
+			dma-channel@0 {
+				reg = <0>;
+				adi,source-bus-width = <32>;
+				adi,source-bus-type = <1>;
+				adi,destination-bus-width = <64>;
+				adi,destination-bus-type = <0>;
+			};
+		};
+	};
+
+	spi_clk: clock-controller@44a70000 {
+		compatible = "adi,axi-clkgen-2.00.a";
+		reg = <0x44a70000 0x1000>;
+		#clock-cells = <0>;
+		clocks = <&clkc 15>, <&clkc 15>;
+		clock-names = "s_axi_aclk", "clkin1";
+		clock-output-names = "spi_clk";
+	};
+
+	axi_spi_engine_0: spi@44a00000 {
+		compatible = "adi,axi-spi-engine-1.00.a";
+		reg = <0x44a00000 0x1000>;
+		interrupt-parent = <&intc>;
+		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&clkc 15>, <&spi_clk>;
+		clock-names = "s_axi_aclk", "spi_clk";
+		num-cs = <1>;
+
+		#address-cells = <0x1>;
+		#size-cells = <0x0>;
+
+		ad7986: adc@0 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			compatible = "adi,pulsar,ad7986";
+			reg = <0>;
+			spi-max-frequency = <80000000>;
+			turbo-gpios = <&gpio0 87 GPIO_ACTIVE_HIGH>;
+			clocks = <&spi_clk>;
+			clock-names = "ref_clk";
+			dmas = <&rx_dma 0>;
+			dma-names = "rx";
+			pwms = <&adc_trigger 0 0>;
+			pwm-names = "cnv";
+			vref-supply = <&vref>;
+			channel@0 {
+				reg = <0>;
+				diff-channels = <0 1>;
+			};
+		};
+	};
+};

--- a/drivers/iio/adc/ad_pulsar.c
+++ b/drivers/iio/adc/ad_pulsar.c
@@ -140,6 +140,24 @@ static const struct ad_pulsar_chip_info ad7988_1_chip_info = {
 	.sclk_rate = 80000000
 };
 
+static const struct ad_pulsar_chip_info ad7986_chip_info = {
+	.name = "ad7986",
+	.input_type = DIFFERENTIAL,
+	.max_rate = 2000000,
+	.resolution = 18,
+	.num_channels = 1,
+	.sclk_rate = 80000000
+};
+
+static const struct ad_pulsar_chip_info ad7985_chip_info = {
+	.name = "ad7985",
+	.input_type = DIFFERENTIAL,
+	.max_rate = 2500000,
+	.resolution = 16,
+	.num_channels = 1,
+	.sclk_rate = 80000000
+};
+
 static const struct ad_pulsar_chip_info ad7984_chip_info = {
 	.name = "ad7984",
 	.input_type = DIFFERENTIAL,
@@ -191,6 +209,15 @@ static const struct ad_pulsar_chip_info ad7946_chip_info = {
 	.name = "ad7946",
 	.input_type = SINGLE_ENDED,
 	.max_rate = 500000,
+	.resolution = 14,
+	.num_channels = 1,
+	.sclk_rate = 40000000
+};
+
+static const struct ad_pulsar_chip_info ad7944_chip_info = {
+	.name = "ad7944",
+	.input_type = SINGLE_ENDED,
+	.max_rate = 25000000,
 	.resolution = 14,
 	.num_channels = 1,
 	.sclk_rate = 40000000
@@ -895,12 +922,15 @@ static int ad_pulsar_probe(struct spi_device *spi)
 static const struct of_device_id ad_pulsar_of_match[] = {
 	{ .compatible = "adi,pulsar,ad7988-5", .data = &ad7988_5_chip_info },
 	{ .compatible = "adi,pulsar,ad7988-1", .data = &ad7988_1_chip_info },
+	{ .compatible = "adi,pulsar,ad7986", .data = &ad7986_chip_info },
+	{ .compatible = "adi,pulsar,ad7985", .data = &ad7985_chip_info },
 	{ .compatible = "adi,pulsar,ad7984", .data = &ad7984_chip_info },
 	{ .compatible = "adi,pulsar,ad7983", .data = &ad7983_chip_info },
 	{ .compatible = "adi,pulsar,ad7982", .data = &ad7982_chip_info },
 	{ .compatible = "adi,pulsar,ad7980", .data = &ad7980_chip_info },
 	{ .compatible = "adi,pulsar,ad7949", .data = &ad7949_chip_info },
 	{ .compatible = "adi,pulsar,ad7946", .data = &ad7946_chip_info },
+	{ .compatible = "adi,pulsar,ad7944", .data = &ad7944_chip_info },
 	{ .compatible = "adi,pulsar,ad7942", .data = &ad7942_chip_info },
 	{ .compatible = "adi,pulsar,ad7699", .data = &ad7699_chip_info },
 	{ .compatible = "adi,pulsar,ad7693", .data = &ad7693_chip_info },
@@ -919,12 +949,15 @@ MODULE_DEVICE_TABLE(of, ad_pulsar_of_match);
 static const struct spi_device_id ad_pulsar_spi_id[] = {
 	{ "adi,pulsar,ad7988-5", (kernel_ulong_t)&ad7988_5_chip_info },
 	{ "adi,pulsar,ad7988-1", (kernel_ulong_t)&ad7988_1_chip_info },
+	{ "adi,pulsar,ad7986", (kernel_ulong_t)&ad7986_chip_info },
+	{ "adi,pulsar,ad7985", (kernel_ulong_t)&ad7985_chip_info },
 	{ "adi,pulsar,ad7984", (kernel_ulong_t)&ad7984_chip_info },
 	{ "adi,pulsar,ad7983", (kernel_ulong_t)&ad7983_chip_info },
 	{ "adi,pulsar,ad7982", (kernel_ulong_t)&ad7982_chip_info },
 	{ "adi,pulsar,ad7980", (kernel_ulong_t)&ad7980_chip_info },
 	{ "adi,pulsar,ad7949", (kernel_ulong_t)&ad7949_chip_info },
 	{ "adi,pulsar,ad7946", (kernel_ulong_t)&ad7946_chip_info },
+	{ "adi,pulsar,ad7944", (kernel_ulong_t)&ad7944_chip_info },
 	{ "adi,pulsar,ad7942", (kernel_ulong_t)&ad7942_chip_info },
 	{ "adi,pulsar,ad7699", (kernel_ulong_t)&ad7699_chip_info },
 	{ "adi,pulsar,ad7693", (kernel_ulong_t)&ad7693_chip_info },


### PR DESCRIPTION
This adds device tree bindings compatible strings, ad_pulsar driver support and ZedBoard device trees for the AD7944, AD7985, and AD7986 chips.

- https://www.analog.com/media/en/technical-documentation/data-sheets/AD7944.pdf
- https://www.analog.com/media/en/technical-documentation/data-sheets/AD7985.pdf
- https://www.analog.com/media/en/technical-documentation/data-sheets/AD7986.pdf

This has not been tested yet since we are waiting on HDL for these.