### PR TITLE
iio: adc: ad_pulsar: drop 5.10 compatibility

### DIFF
--- a/drivers/iio/adc/ad_pulsar.c
+++ b/drivers/iio/adc/ad_pulsar.c
@@ -29,11 +29,6 @@
 #include <linux/iio/iio.h>
 #include <linux/iio/sysfs.h>
 
-/* 5.10 compatibility */
-#include <linux/slab.h>
-#define IIO_DMA_MINALIGN		ARCH_KMALLOC_MINALIGN
-/* end 5.10 compatibility */
-
 #define AD_PULSAR_REG_CONFIG		0x00
 
 #define AD7682_NUM_TEMP_CHANNELS	1


### PR DESCRIPTION
This removes the #define IIO_DMA_MINALIGN from the ad_pulsar driver. This was previously needed to support 5.10 kernels, but is no longer needed since we are now based on the 6.1 kernel.