### PR TITLE
dt-bindings: iio: admv1014: make all regs required

### DIFF
--- a/Documentation/devicetree/bindings/iio/frequency/adi,admv1014.yaml
+++ b/Documentation/devicetree/bindings/iio/frequency/adi,admv1014.yaml
@@ -103,6 +103,14 @@ required:
   - clocks
   - clock-names
   - vcm-supply
+  - vcc-if-bb-supply
+  - vcc-vga-supply
+  - vcc-vva-supply
+  - vcc-lna-3p3-supply
+  - vcc-lna-1p5-supply
+  - vcc-bg-supply
+  - vcc-quad-supply
+  - vcc-mixer-supply
 
 additionalProperties: false
 


### PR DESCRIPTION
Make the regulators required in the dt bindings.

Despite the fact that the datasheet is not explicit enough, all the specifications of the part are built around these pins being supplied.


Acked-by: Krzysztof Kozlowski <krzysztof.kozlowski@linaro.org>
Link: https://lore.kernel.org/r/20230731144404.389255-1-antoniu.miclaus@analog.com