### PR TITLE
spi: axi-spi-engine: fix use after free after timeout

### DIFF
--- a/drivers/spi/spi-axi-spi-engine.c
+++ b/drivers/spi/spi-axi-spi-engine.c
@@ -531,6 +531,12 @@ static void spi_engine_complete_message(struct spi_master *master, int status)
 	msg->status = status;
 	msg->actual_length = msg->frame_length;
 	spi_engine->msg = NULL;
+	spi_engine->tx_xfer = NULL;
+	spi_engine->tx_buf = NULL;
+	spi_engine->tx_length = 0;
+	spi_engine->rx_xfer = NULL;
+	spi_engine->rx_buf = NULL;
+	spi_engine->rx_length = 0;
 	spi_finalize_current_message(master);
 }
 


### PR DESCRIPTION
This fixes a use after free that can happen if the watchdog timer times out on an SPI message then another message is attempted.

The following struct spi_engine members point to memory managed by the spi framework

	struct spi_message *msg;
	struct spi_transfer *tx_xfer;
	const uint8_t *tx_buf;
	struct spi_transfer *rx_xfer;
	uint8_t *rx_buf;

During normal operation, tx_xfer and rx_xfer set to NULL by spi_engine_xfer_next() when the last xfer of a message is completed. However, this code path is not taken when the watchdog timer times out and therefore tx_xfer and rx_xfer are not set to NULL and still point to memory that gets freed by spi_finalize_current_message().

When the next message is attempted, spi_engine_transfer_one() will call spi_engine_xfer_next() with the old pointers and will attempt to dereference them. This can cause a crash.

To fix this, always set tx_xfer and rx_xfer to NULL before calling spi_finalize_current_message().

Fixes: fde5597b0ddd ("spi: axi-spi-engine: Add watchdog timer")

Fixes: #2287