### PR TITLE
don't allow dual licensed files

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -76,10 +76,10 @@ jobs:
       ./ci/travis/run-build.sh
     displayName: 'Bindings Check Script'
 
-- job: check_is_new_adi_driver_dual_licensed
+- job: check_new_file_license
   condition: eq(variables['Build.Reason'], 'PullRequest')
   variables:
-    BUILD_TYPE: check_is_new_adi_driver_dual_licensed
+    BUILD_TYPE: check_new_file_license
     TARGET_BRANCH: $[ variables['System.PullRequest.TargetBranch'] ]
   steps:
   - checkout: self

--- a/ci/travis/run-build.sh
+++ b/ci/travis/run-build.sh
@@ -155,6 +155,8 @@ build_check_is_new_adi_driver_dual_licensed() {
 		exit 1
 	fi
 
+	__update_git_ref "${ref_branch}" "${ref_branch}"
+
 	COMMIT_RANGE="${ref_branch}.."
 
 	echo_green "Running checkpatch for commit range '$COMMIT_RANGE'"


### PR DESCRIPTION
Having dual licensed files upstream is not as simple as one things. Hence (and since we almost never need it), let's flip the job in CI and not allow it.
