### PR TITLE
clk: ad9545: fix driver probe when R-divider is zero

### DIFF
--- a/drivers/clk/adi/clk-ad9545.c
+++ b/drivers/clk/adi/clk-ad9545.c
@@ -1802,8 +1802,11 @@ static int ad9545_set_r_div(struct ad9545_state *st, u32 div, int addr)
 	u32 val;
 	int ret;
 
-	if (div > AD9545_R_DIV_MAX || div == 0)
+	if (div > AD9545_R_DIV_MAX || div == 0) {
+		dev_err(st->dev, "Invalid R-divider value (addr: %d): %u",
+			addr, div);
 		return -EINVAL;
+	}
 
 	/* r-div ratios are mapped from 0 onward */
 	div -= 1;

--- a/drivers/clk/adi/clk-ad9545.c
+++ b/drivers/clk/adi/clk-ad9545.c
@@ -1882,16 +1882,14 @@ static int ad9545_input_refs_setup(struct ad9545_state *st)
 			return ret;
 	}
 
-	/* configure refs r dividers */
-	for (i = 0; i < ARRAY_SIZE(st->ref_in_clks); i++) {
-		ret = ad9545_set_r_div(st, st->ref_in_clks[i].r_div_ratio, i);
-		if (ret < 0)
-			return ret;
-	}
-
 	for (i = 0; i < ARRAY_SIZE(st->ref_in_clks); i++) {
 		if (!st->ref_in_clks[i].ref_used)
 			continue;
+
+		/* configure refs r dividers */
+		ret = ad9545_set_r_div(st, st->ref_in_clks[i].r_div_ratio, i);
+		if (ret < 0)
+			return ret;
 
 		/* write nominal period in attoseconds */
 		period_es = 1000000000000000000ULL;


### PR DESCRIPTION
Commit https://github.com/analogdevicesinc/linux/commit/e8b39147657c79b8bb65099bc20075d507370061 ("clk: ad9545: properly check R-divider") is valid, in
the sense that a divider value of zero should return -EINVAL.

However, the omission in the above commit, is that if a Ref is not used,
it will cause a probe fail, if one of the refs is not defined in the DT.
This breaks the AD9545 on the ADRV9009 Talise SOM.

The fix looks like a simple move into the next loop for the R-divider
config.

Fixes: https://github.com/analogdevicesinc/linux/commit/e8b39147657c79b8bb65099bc20075d507370061 ("clk: ad9545: properly check R-divider")
Cc: Jie Zhang <jie.zhang@analog.com>
Cc: Nuno Sa <nuno.sa@analog.com>
Cc: Michael Hennerich <michael.hennerich@analog.com>
Cc: Dragos Bogdan <dragos.bogdan@analog.com>
Signed-off-by: Alexandru Ardelean <alex@shruggie.ro>