### PR TITLE
Add AD7091r-8 rpi overlay

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -218,6 +218,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	rpi-ad5686.dtbo \
 	rpi-ad5679r.dtbo \
 	rpi-ad5766.dtbo \
+	rpi-ad7091r8.dtbo \
 	rpi-ad7124.dtbo \
 	rpi-ad7124-8-all-diff.dtbo \
 	rpi-ad7173.dtbo \

--- a/arch/arm/boot/dts/overlays/rpi-ad7091r8-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ad7091r8-overlay.dts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-2.0
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/interrupt-controller/irq.h>
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	compatible = "brcm,bcm2835", "brcm,bcm2711";
+};
+
+&spi0 {
+	status = "okay";
+
+	cs-gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+
+	ad7091r8@0 {
+		compatible = "adi,ad7091r8";
+		reg = <0x0>;
+		spi-max-frequency = <1000000>;
+		adi,conversion-start-gpios = <&gpio 25 GPIO_ACTIVE_LOW>;
+		reset-gpios = <&gpio 27 GPIO_ACTIVE_LOW>;
+		interrupts = <22 IRQ_TYPE_EDGE_RISING>;
+		interrupt-parent = <&gpio>;
+	};
+};
+
+&spidev0 {
+	status = "disabled";
+};
+
+&spidev1 {
+	status = "disabled";
+};


### PR DESCRIPTION
Pull request with raspberry pi overlay for AD7091R-8.
This is the device tree overlay used during the tests with EVAL-AD7091R-xSDZ and Raspberry Pi 4.
Documentation here: https://wiki.analog.com/resources/tools-software/linux-drivers/iio-adc/ad7091r8
Requested on #2204.