### PR TITLE
dts: zynqmp-jupiter-sdr: Add QSPI dual MT25QL512 64MB with 4 partitions

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-jupiter-sdr.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-jupiter-sdr.dts
@@ -215,6 +215,38 @@
 	};
 };
 
+&qspi {
+	status = "okay";
+	is-dual = <1>;
+	num-cs = <2>;
+	flash@0 {
+		compatible = "n25q512a", "jedec,spi-nor"; /* 32MB */
+		#address-cells = <1>;
+		#size-cells = <1>;
+		reg = <0>, <1>;
+		parallel-memories = /bits/ 64 <0x4000000 0x4000000>; /* 64MB */
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>; /* FIXME also DUAL configuration possible */
+		spi-max-frequency = <108000000>; /* Based on DC1 spec */
+		partition@0 { /* for testing purpose */
+			label = "qspi-fsbl-uboot";
+			reg = <0x0 0x100000>;
+		};
+		partition@100000 { /* for testing purpose */
+			label = "qspi-linux";
+			reg = <0x100000 0x500000>;
+		};
+		partition@600000 { /* for testing purpose */
+			label = "qspi-device-tree";
+			reg = <0x600000 0x20000>;
+		};
+		partition@620000 { /* for testing purpose */
+			label = "qspi-rootfs";
+			reg = <0x620000 0x5E0000>;
+		};
+	};
+};
+
 &uart1 {
 	status = "okay";
 	pinctrl-names = "default";


### PR DESCRIPTION
This adds following 4 partitions:

[ ] spi-nor spi1.0: SPI-NOR-UniqueID 10400030fc0b0012110018000c17a3a87f 
[ ] spi-nor spi1.0: n25q512a (131072 Kbytes)
[ ] 4 fixed-partitions partitions found on MTD device spi1.0 
[ ] Creating 4 MTD partitions on "spi1.0":
[ ] 0x000000000000-0x000000100000 : "qspi-fsbl-uboot" 
[ ] 0x000000100000-0x000000600000 : "qspi-linux"
[ ] 0x000000600000-0x000000620000 : "qspi-device-tree" 
[ ] 0x000000620000-0x000000c00000 : "qspi-rootfs"