### PR TITLE
RPi 4 DTS overlay changes to use AD242x nodes as sound card

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -209,6 +209,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	rpi-admv1014.dtbo \
 	rpi-admv8818.dtbo \
 	rpi-adrf6780.dtbo \
+	rpi-ad242x.dtbo \
 	rpi-ad4130.dtbo \
 	rpi-ad5592r.dtbo \
 	rpi-ad5593r.dtbo \

--- a/arch/arm/boot/dts/overlays/rpi-ad242x-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ad242x-overlay.dts
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-2.0
+#include <dt-bindings/clock/bcm2835.h>
+/*
+ * Device tree overlay - AD242X Transceivers
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm, bcm2711";
+};
+
+&sound {
+	compatible = "simple-audio-card";
+	simple-audio-card,name = "ad242x";
+	status="okay";
+
+	capture_link: simple-audio-card,dai-link@0 {
+	format = "i2s";
+
+		r_cpu_dai: cpu {
+			sound-dai = <&i2s>;
+			//TDM slot configuration for stereo
+			dai-tdm-slot-num = <2>;
+			dai-tdm-slot-width = <32>;
+		};
+		r_codec_dai: codec {
+			sound-dai = <&codec_in>;
+		};
+	};
+
+	playback_link: simple-audio-card,dai-link@1 {
+		format = "i2s";
+
+		p_cpu_dai: cpu {
+			sound-dai = <&i2s>;
+
+			//TDM slot configuration for stereo
+			dai-tdm-slot-num = <2>;
+			dai-tdm-slot-width = <32>;
+		};
+		p_codec_dai: codec {
+			sound-dai = <&codec_out>;
+		};
+	};
+};
+
+&{/} {
+	codec_out: spdif-transmitter {
+		#address-cells = <0>;
+		#size-cells = <0>;
+		#sound-dai-cells = <0>;
+		/*
+		 *"linux,spdif-dit" is used in generic I2S(transmitter) driver.
+		 *You can see details "linux,spdif-dit" by bellow command
+		 *modinfo snd_soc_spdif_tx
+		 */
+		compatible = "linux,spdif-dit";
+		status = "okay";
+	};
+
+	codec_in: spdif-receiver {
+		#address-cells = <0>;
+		#size-cells = <0>;
+		#sound-dai-cells = <0>;
+		/*
+		 *"linux,spdif-dir" is used in generic I2S(receiver) driver.
+		 *You can see details "linux,spdif-dir" by bellow command
+		 *modinfo snd_soc_spdif_rx
+		 */
+		compatible = "linux,spdif-dir";
+		status = "okay";
+	};
+};
+
+&i2s {
+	#sound-dai-cells = <0>;
+	status = "okay";
+};
+


### PR DESCRIPTION
Overlay changes to detect AD242x as Sound card 