### PR TITLE
iio: adc: adaq4224: Fix AD4030 of_match

### DIFF
--- a/drivers/iio/adc/ad4630.c
+++ b/drivers/iio/adc/ad4630.c
@@ -1329,9 +1329,9 @@ static const struct spi_device_id ad4630_id_table[] = {
 MODULE_DEVICE_TABLE(spi, ad4630_id_table);
 
 static const struct of_device_id ad4630_of_match[] = {
-	{ .compatible = "adi,ad4630-24", .data = &ad4630_chip_info[ID_AD4030_24] },
+	{ .compatible = "adi,ad4030-24", .data = &ad4630_chip_info[ID_AD4030_24] },
 	{ .compatible = "adi,ad4630-16", .data = &ad4630_chip_info[ID_AD4630_16] },
-	{ .compatible = "adi,ad4030-24", .data = &ad4630_chip_info[ID_AD4630_24] },
+	{ .compatible = "adi,ad4630-24", .data = &ad4630_chip_info[ID_AD4630_24] },
 	{ .compatible = "adi,ad463x", .data = &ad463x_chip_info},
 	{}
 };


### PR DESCRIPTION
Unswap IDs for ad4030 and ad4630 in open firmware / devicetree match table.

Fixes: <04ff9ea893f9> (drivers: iio: adc: add support for ad4630)



(cherry picked from commit 46a898df00e812073816657c0fb679593f9e1b02)