### PR TITLE
hwmon: max31827: include regulator header

### DIFF
--- a/drivers/hwmon/max31827.c
+++ b/drivers/hwmon/max31827.c
@@ -12,6 +12,7 @@
 #include <linux/i2c.h>
 #include <linux/mutex.h>
 #include <linux/regmap.h>
+#include <linux/regulator/consumer.h>
 
 #define MAX31827_T_REG	0x0
 #define MAX31827_CONFIGURATION_REG	0x2


### PR DESCRIPTION
Include `linux/regulator/consumer.h` since the driver is using `devm_regulator_get_enable` function.

Link: https://lore.kernel.org/all/20231031091324.23991-1-antoniu.miclaus@analog.com/