### PR TITLE
dts: zynq-zc706-adv7511-ad9081: axi_data_offload devices and enable TX

### DIFF
--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad9081.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad9081.dts
@@ -7,7 +7,7 @@
  * hdl_project: <ad9081_fmca_ebz/zc706>
  * board_revision: <>
  *
- * Copyright (C) 2019-2020 Analog Devices Inc.
+ * Copyright (C) 2019-2023 Analog Devices Inc.
  */
 /dts-v1/;
 
@@ -97,7 +97,9 @@
 			clocks = <&trx0_ad9081 1>;
 			clock-names = "sampl_clk";
 			spibus-connected = <&trx0_ad9081>;
-			//adi,axi-pl-fifo-enable;
+			adi,axi-pl-fifo-enable;
+			adi,axi-data-offload-connected = <&axi_data_offload_tx>;
+
 
 			jesd204-device;
 			#jesd204-cells = <2>;
@@ -182,6 +184,16 @@
 		axi_sysid_0: axi-sysid-0@45000000 {
 			compatible = "adi,axi-sysid-1.00.a";
 			reg = <0x45000000 0x10000>;
+		};
+
+		axi_data_offload_tx: axi-data-offload-tx@7c440000 {
+			compatible = "adi,axi-data-offload-1.0.a";
+			reg = <0x7C440000 0x10000>;
+		};
+
+		axi_data_offload_rx: axi-data-offload-rx@7c450000 {
+			compatible = "adi,axi-data-offload-1.0.a";
+			reg = <0x7C450000 0x10000>;
 		};
 };
 


### PR DESCRIPTION
Add axi_data_offload platfrom devices and enable TX offload fifo by default.