### PR TITLE
M2k-dac spike bug and trigger support

### DIFF
--- a/drivers/iio/frequency/m2k-dac.c
+++ b/drivers/iio/frequency/m2k-dac.c
@@ -49,6 +49,8 @@
 #define M2K_DAC_TRIGGER_EXT_SOURCE		GENMASK(17, 16)
 #define M2K_DAC_REG_RAW_PATTERN_CHAN_A_MASK	GENMASK(15, 0)
 #define M2K_DAC_REG_RAW_PATTERN_CHAN_B_MASK	GENMASK(31, 16)
+#define M2K_DAC_TRIGGER_START_ENABLE		BIT(14)
+#define M2K_DAC_TRIGGER_STOP_ENABLE		BIT(15)
 #define M2K_DAC_RAW_PATTERN_MASK(chan_num)	(!(chan_num) ? M2K_DAC_REG_RAW_PATTERN_CHAN_A_MASK :\
 							     M2K_DAC_REG_RAW_PATTERN_CHAN_B_MASK)
 #define M2K_DAC_RAW_PATTERN(x, chan_num)	(!(chan_num) ? FIELD_PREP(M2K_DAC_REG_RAW_PATTERN_CHAN_A_MASK, x) :\
@@ -549,6 +551,72 @@ static const struct iio_enum m2k_dac_raw_enable_enum = {
 	.get = m2k_dac_get_raw_enable,
 };
 
+static int m2k_dac_get_start_trigger(struct iio_dev *indio_dev,
+				     const struct iio_chan_spec *chan)
+{
+	struct m2k_dac_ch *ch = iio_priv(indio_dev);
+	struct m2k_dac *m2k_dac = ch->dac;
+	unsigned int val;
+
+	val = ioread32(m2k_dac->regs + M2K_DAC_REG_INSTRUMENT_TRIGGER);
+	return FIELD_GET(M2K_DAC_TRIGGER_START_ENABLE, val);
+}
+
+static int m2k_dac_set_start_trigger(struct iio_dev *indio_dev,
+				     const struct iio_chan_spec *chan,
+				     unsigned int val)
+{
+	m2k_dac_reg_update(indio_dev, M2K_DAC_REG_INSTRUMENT_TRIGGER,
+			   FIELD_PREP(M2K_DAC_TRIGGER_START_ENABLE, val),
+			   M2K_DAC_TRIGGER_START_ENABLE);
+	return 0;
+}
+
+static const char * const m2k_dac_start_trigger_items[] = {
+	"disabled",
+	"enabled",
+};
+
+static const struct iio_enum m2k_dac_start_trigger_enum = {
+	.items = m2k_dac_start_trigger_items,
+	.num_items = ARRAY_SIZE(m2k_dac_start_trigger_items),
+	.set = m2k_dac_set_start_trigger,
+	.get = m2k_dac_get_start_trigger,
+};
+
+static int m2k_dac_get_stop_trigger(struct iio_dev *indio_dev,
+				    const struct iio_chan_spec *chan)
+{
+	struct m2k_dac_ch *ch = iio_priv(indio_dev);
+	struct m2k_dac *m2k_dac = ch->dac;
+	unsigned int val;
+
+	val = ioread32(m2k_dac->regs + M2K_DAC_REG_INSTRUMENT_TRIGGER);
+	return FIELD_GET(M2K_DAC_TRIGGER_STOP_ENABLE, val);
+}
+
+static int m2k_dac_set_stop_trigger(struct iio_dev *indio_dev,
+				    const struct iio_chan_spec *chan,
+				    unsigned int val)
+{
+	m2k_dac_reg_update(indio_dev, M2K_DAC_REG_INSTRUMENT_TRIGGER,
+			   FIELD_PREP(M2K_DAC_TRIGGER_STOP_ENABLE, val),
+			   M2K_DAC_TRIGGER_STOP_ENABLE);
+	return 0;
+}
+
+static const char * const m2k_dac_stop_trigger_items[] = {
+	"disabled",
+	"enabled",
+};
+
+static const struct iio_enum m2k_dac_stop_trigger_enum = {
+	.items = m2k_dac_stop_trigger_items,
+	.num_items = ARRAY_SIZE(m2k_dac_stop_trigger_items),
+	.set = m2k_dac_set_stop_trigger,
+	.get = m2k_dac_get_stop_trigger,
+};
+
 static const struct iio_chan_spec_ext_info m2k_dac_ext_info[] = {
 	IIO_ENUM_AVAILABLE("sampling_frequency", IIO_SHARED_BY_ALL,
 			   &m2k_dac_samp_freq_available_enum),
@@ -560,6 +628,10 @@ static const struct iio_chan_spec_ext_info m2k_dac_ext_info[] = {
 			   &m2k_dac_trig_condition_enum),
 	IIO_ENUM_AVAILABLE("raw_enable", IIO_SEPARATE, &m2k_dac_raw_enable_enum),
 	IIO_ENUM("raw_enable", IIO_SEPARATE, &m2k_dac_raw_enable_enum),
+	IIO_ENUM_AVAILABLE("start_trigger", IIO_SEPARATE, &m2k_dac_start_trigger_enum),
+	IIO_ENUM("start_trigger", IIO_SEPARATE, &m2k_dac_start_trigger_enum),
+	IIO_ENUM_AVAILABLE("stop_trigger", IIO_SEPARATE, &m2k_dac_stop_trigger_enum),
+	IIO_ENUM("stop_trigger", IIO_SEPARATE, &m2k_dac_stop_trigger_enum),
 	{ },
 };
 


### PR DESCRIPTION
Fix spike bug issues from m2k dac when pushing a series of cyclical buffers by using a new HDL attribute that forces raw values on output.

Add support for triggered start and stop of the dac DMA.