### PR TITLE
[adrv9002] Add Multi-chip sync support

### DIFF
--- a/drivers/iio/adc/navassa/adrv9002.c
+++ b/drivers/iio/adc/navassa/adrv9002.c
@@ -43,6 +43,8 @@
 #include "adi_adrv9001_fh_types.h"
 #include "adi_adrv9001_gpio.h"
 #include "adi_adrv9001_gpio_types.h"
+#include "adi_adrv9001_mcs.h"
+#include "adi_adrv9001_mcs_types.h"
 #include "adi_adrv9001_orx.h"
 #include "adi_adrv9001_powermanagement.h"
 #include "adi_adrv9001_powermanagement_types.h"
@@ -3302,7 +3304,7 @@ static int adrv9002_radio_init(const struct adrv9002_rf_phy *phy)
 		return ret;
 
 	for (chan = 0; chan < ARRAY_SIZE(phy->channels); chan++) {
-		const struct adrv9002_chan *c = phy->channels[chan];
+		struct adrv9002_chan *c = phy->channels[chan];
 		struct adi_adrv9001_ChannelEnablementDelays en_delays;
 
 		if (!c->enabled)
@@ -3342,6 +3344,14 @@ static int adrv9002_radio_init(const struct adrv9002_rf_phy *phy)
 			if (ret)
 				return ret;
 		}
+
+		if (!phy->curr_profile->sysConfig.mcsMode)
+			continue;
+
+		ret = api_call(phy, adi_adrv9001_Mcs_ChannelMcsDelay_Set, c->port,
+			       c->number, &c->mcs_delay);
+		if (ret)
+			return ret;
 	}
 
 	return api_call(phy, adi_adrv9001_arm_System_Program, channel_mask);

--- a/drivers/iio/adc/navassa/adrv9002.h
+++ b/drivers/iio/adc/navassa/adrv9002.h
@@ -22,6 +22,7 @@
 #include "adi_adrv9001_cals_types.h"
 #include "adi_adrv9001_dpd_types.h"
 #include "adi_adrv9001_fh_types.h"
+#include "adi_adrv9001_mcs_types.h"
 #include "adi_adrv9001_radio_types.h"
 #include "adi_adrv9001_rx_gaincontrol_types.h"
 #include "adi_adrv9001_rxSettings_types.h"
@@ -163,6 +164,7 @@ struct adrv9002_chan {
 	 * @adrv9002_chan_ns_to_en_delay() before passing them to the API.
 	 */
 	struct adi_adrv9001_ChannelEnablementDelays en_delays_ns;
+	struct adi_adrv9001_McsDelay mcs_delay;
 	unsigned long rate;
 	adi_adrv9001_InitCalibrations_e lo_cals;
 	adi_adrv9001_ChannelState_e cached_state;

--- a/drivers/iio/adc/navassa/adrv9002.h
+++ b/drivers/iio/adc/navassa/adrv9002.h
@@ -284,6 +284,7 @@ struct adrv9002_rf_phy {
 	 * derived from RX1/RX2 which means that TX cannot be enabled if RX is not...
 	 */
 	u8				tx_only;
+	bool				mcs_run;
 #ifdef CONFIG_DEBUG_FS
 	struct adi_adrv9001_SsiCalibrationCfg ssi_delays;
 #endif


### PR DESCRIPTION
Add support for multi-chip sync. This was requested by the HW team to be present in the release branch and that is the only reason this is being included because there are still two major failure with the feature:

1) We can only run MCS once. That's why the driver is not allowing multiple runs;
2) We need to force the carrier `loGenOptimization` value since the device returns an invalid value when calling `adi_adrv9001_Radio_Carrier_Inspect()`.