### PR TITLE
prepare_artifacts.sh: Add current branch to logs

### DIFF
--- a/ci/travis/prepare_artifacts.sh
+++ b/ci/travis/prepare_artifacts.sh
@@ -60,7 +60,7 @@ artifacts_swdownloads() {
 	echo "checksum_modules=${md5_modules}" >> rpi_archives_properties.txt
 	echo "checksum_boot_files=${md5_boot}" >> rpi_archives_properties.txt
 	echo "git_sha=${GIT_SHA}" >> rpi_archives_properties.txt
-        echo "git_sha_date=${GIT_SHA_DATE}" >> rpi_archives_properties.txt
+	echo "git_sha_date=${GIT_SHA_DATE}" >> rpi_archives_properties.txt
 
 	scp -2 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o HostKeyAlgorithms=+ssh-dss \
                 -i ${KEY_FILE} -r rpi_archives_properties.txt ${DEST_SERVER}/${BUILD_SOURCEBRANCHNAME}

--- a/ci/travis/prepare_artifacts.sh
+++ b/ci/travis/prepare_artifacts.sh
@@ -10,6 +10,7 @@ artifacts_structure() {
 	cd ${SOURCE_DIRECTORY}
 	mkdir ${timestamp}
 
+	echo "git_branch=${BUILD_SOURCEBRANCHNAME}" >> ${timestamp}/rpi_git_properties.txt
 	echo "git_sha=${GIT_SHA}" >> ${timestamp}/rpi_git_properties.txt
 	echo "git_sha_date=${GIT_SHA_DATE}" >> ${timestamp}/rpi_git_properties.txt
 
@@ -53,7 +54,7 @@ artifacts_swdownloads() {
 	scp -2 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o HostKeyAlgorithms=+ssh-dss \
 	    -i ${KEY_FILE} -r rpi_latest_boot.tar.gz ${DEST_SERVER}/${BUILD_SOURCEBRANCHNAME}
 
-	echo "boot_date=${timestamp}" >> rpi_archives_properties.txt
+	echo "git_branch=${BUILD_SOURCEBRANCHNAME}" >> rpi_archives_properties.txt
 	echo "https://swdownloads.analog.com/cse/linux_rpi/${BUILD_SOURCEBRANCHNAME}/rpi_modules.tar.gz" >> rpi_archives_properties.txt
 	echo "https://swdownloads.analog.com/cse/linux_rpi/${BUILD_SOURCEBRANCHNAME}/rpi_latest_boot.tar.gz" >> rpi_archives_properties.txt
 	echo "checksum_modules=${md5_modules}" >> rpi_archives_properties.txt


### PR DESCRIPTION
The CIs will fail because we cannot build rpi on master, due to the following errors:
```
ERROR: modpost: module uio uses symbol dma_buf_attach from namespace DMA_BUF, but does not import it.
ERROR: modpost: module uio uses symbol dma_buf_map_attachment from namespace DMA_BUF, but does not import it.
ERROR: modpost: module uio uses symbol dma_buf_unmap_attachment from namespace DMA_BUF, but does not import it.
ERROR: modpost: module uio uses symbol dma_buf_get from namespace DMA_BUF, but does not import it.
ERROR: modpost: module uio uses symbol dma_buf_put from namespace DMA_BUF, but does not import it.
ERROR: modpost: module uio uses symbol dma_buf_detach from namespace DMA_BUF, but does not import it.
make[1]: *** [scripts/Makefile.modpost:126: Module.symvers] Error 1
make: *** [Makefile:1940: modpost] Error 2
```
This happens because rpi shouldn't be built on the master branch. This commit will be automatically cherry-picked onto the `rpi-6.1.y` branch, where the builds actually pass.