### PR TITLE
jesd204: jesd204-core: Declare jesd204_device_count_get() with void

### DIFF
--- a/drivers/iio/Kconfig.adi
+++ b/drivers/iio/Kconfig.adi
@@ -193,3 +193,5 @@ config IIO_ALL_ADI_DRIVERS
 	imply MAX11410
 	imply AD5110
 	imply MAX31865
+	imply ADRV9025
+

--- a/drivers/jesd204/jesd204-core.c
+++ b/drivers/jesd204/jesd204-core.c
@@ -98,7 +98,7 @@ bool jesd204_link_get_paused(const struct jesd204_link *lnk)
 }
 EXPORT_SYMBOL_GPL(jesd204_link_get_paused);
 
-int jesd204_device_count_get()
+int jesd204_device_count_get(void)
 {
 	return jesd204_device_count;
 }


### PR DESCRIPTION
jesd204_device_count_get() was being declared with empty arguments. Declare it with 'void'.

Signed-off-by: Nuno Sa <nuno.sa@analog.com>
(cherry picked from commit ac4017e6bd71d476da4468b5ae54706f8300925b)

---

Otherwise it won'z build with clang