### PR TITLE
arm: dts: Use proper 100MHz clock handle for axi-jesd204-[rx|tx] devices

### DIFF
--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad6676-fmc.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad6676-fmc.dts
@@ -123,7 +123,7 @@
 
 		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
 
-		clocks = <&clkc 16>, <&axi_adxcvr 1>, <&axi_adxcvr 0>;
+		clocks = <&clkc 15>, <&axi_adxcvr 1>, <&axi_adxcvr 0>;
 		clock-names = "s_axi_aclk", "device_clk", "lane_clk";
 
 		#clock-cells = <0>;

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad9081-np12.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad9081-np12.dts
@@ -332,7 +332,7 @@
 
 			interrupts = <0 55 IRQ_TYPE_LEVEL_HIGH>;
 
-			clocks = <&clkc 16>, <&hmc7044 10>, <&axi_ad9081_adxcvr_rx 1>, <&axi_ad9081_adxcvr_rx 0>;
+			clocks = <&clkc 15>, <&hmc7044 10>, <&axi_ad9081_adxcvr_rx 1>, <&axi_ad9081_adxcvr_rx 0>;
 			clock-names = "s_axi_aclk", "device_clk", "link_clk", "lane_clk";
 
 			#clock-cells = <0>;
@@ -349,7 +349,7 @@
 
 			interrupts = <0 54 IRQ_TYPE_LEVEL_HIGH>;
 
-			clocks = <&clkc 16>, <&hmc7044 6>, <&axi_ad9081_adxcvr_tx 1>, <&axi_ad9081_adxcvr_tx 0>;
+			clocks = <&clkc 15>, <&hmc7044 6>, <&axi_ad9081_adxcvr_tx 1>, <&axi_ad9081_adxcvr_tx 0>;
 			clock-names = "s_axi_aclk", "device_clk", "link_clk", "lane_clk";
 
 			#clock-cells = <0>;

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad9081.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad9081.dts
@@ -112,7 +112,7 @@
 
 			interrupts = <0 55 IRQ_TYPE_LEVEL_HIGH>;
 
-			clocks = <&clkc 16>, <&hmc7044 10>, <&axi_ad9081_adxcvr_rx 0>;
+			clocks = <&clkc 15>, <&hmc7044 10>, <&axi_ad9081_adxcvr_rx 0>;
 			clock-names = "s_axi_aclk", "device_clk", "lane_clk";
 
 			#clock-cells = <0>;
@@ -129,7 +129,7 @@
 
 			interrupts = <0 54 IRQ_TYPE_LEVEL_HIGH>;
 
-			clocks = <&clkc 16>, <&hmc7044 6>, <&axi_ad9081_adxcvr_tx 0>;
+			clocks = <&clkc 15>, <&hmc7044 6>, <&axi_ad9081_adxcvr_tx 0>;
 			clock-names = "s_axi_aclk", "device_clk", "lane_clk";
 
 			#clock-cells = <0>;

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad9172-fmc-ebz.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad9172-fmc-ebz.dts
@@ -57,7 +57,7 @@
 
 		interrupts = <0 54 IRQ_TYPE_LEVEL_HIGH>;
 
-		clocks = <&clkc 16>, <&axi_ad9172_adxcvr 1>, <&axi_ad9172_adxcvr 0>;
+		clocks = <&clkc 15>, <&axi_ad9172_adxcvr 1>, <&axi_ad9172_adxcvr 0>;
 		clock-names = "s_axi_aclk", "device_clk", "lane_clk";
 
 		#clock-cells = <0>;

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad9625-fmcadc2.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad9625-fmcadc2.dts
@@ -97,7 +97,7 @@
 
 		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
 
-		clocks = <&clkc 16>, <&axi_adxcvr 1>, <&axi_adxcvr 0>;
+		clocks = <&clkc 15>, <&axi_adxcvr 1>, <&axi_adxcvr 0>;
 		clock-names = "s_axi_aclk", "device_clk", "lane_clk";
 
 		#clock-cells = <0>;

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9008-1.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9008-1.dts
@@ -71,7 +71,7 @@
 
 		interrupts = <0 54 IRQ_TYPE_LEVEL_HIGH>;
 
-		clocks = <&clkc 16>, <&axi_rx_clkgen>, <&axi_adrv9009_adxcvr_rx 0>;
+		clocks = <&clkc 15>, <&axi_rx_clkgen>, <&axi_adrv9009_adxcvr_rx 0>;
 		clock-names = "s_axi_aclk", "device_clk", "lane_clk";
 
 		#clock-cells = <0>;

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9008-2.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9008-2.dts
@@ -104,7 +104,7 @@
 
 		interrupts = <0 53 IRQ_TYPE_LEVEL_HIGH>;
 
-		clocks = <&clkc 16>, <&axi_tx_clkgen>, <&axi_adrv9009_adxcvr_tx 0>;
+		clocks = <&clkc 15>, <&axi_tx_clkgen>, <&axi_adrv9009_adxcvr_tx 0>;
 		clock-names = "s_axi_aclk", "device_clk", "lane_clk";
 
 		#clock-cells = <0>;
@@ -124,7 +124,7 @@
 
 		interrupts = <0 52 IRQ_TYPE_LEVEL_HIGH>;
 
-		clocks = <&clkc 16>, <&axi_rx_os_clkgen>, <&axi_adrv9009_adxcvr_rx_os 0>;
+		clocks = <&clkc 15>, <&axi_rx_os_clkgen>, <&axi_adrv9009_adxcvr_rx_os 0>;
 		clock-names = "s_axi_aclk", "device_clk", "lane_clk";
 
 		#clock-cells = <0>;

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9009-tx-l1-rx-l1-orx-l1.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9009-tx-l1-rx-l1-orx-l1.dts
@@ -127,7 +127,7 @@
 		};
 
 		axi_adrv9009_rx_jesd: axi-jesd204-rx@44aa0000 {
-			clocks = <&clkc 16>, <&axi_rx_clkgen>, <&rx_fixed_device_clk>, <&axi_adrv9009_adxcvr_rx 0>;
+			clocks = <&clkc 15>, <&axi_rx_clkgen>, <&rx_fixed_device_clk>, <&axi_adrv9009_adxcvr_rx 0>;
 			clock-names = "s_axi_aclk", "link_clk", "device_clk", "lane_clk";
 
 			adi,octets-per-frame = <8>;

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9009-tx-l2-rx-l1-orx-l1.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9009-tx-l2-rx-l1-orx-l1.dts
@@ -115,7 +115,7 @@
 		};
 
 		axi_adrv9009_rx_jesd: axi-jesd204-rx@44aa0000 {
-			clocks = <&clkc 16>, <&axi_rx_clkgen>, <&rx_fixed_device_clk>, <&axi_adrv9009_adxcvr_rx 0>;
+			clocks = <&clkc 15>, <&axi_rx_clkgen>, <&rx_fixed_device_clk>, <&axi_adrv9009_adxcvr_rx 0>;
 			clock-names = "s_axi_aclk", "link_clk", "device_clk", "lane_clk";
 
 			adi,octets-per-frame = <8>;

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9009.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9009.dts
@@ -137,7 +137,7 @@
 
 		interrupts = <0 54 IRQ_TYPE_LEVEL_HIGH>;
 
-		clocks = <&clkc 16>, <&axi_rx_clkgen>, <&axi_adrv9009_adxcvr_rx 0>;
+		clocks = <&clkc 15>, <&axi_rx_clkgen>, <&axi_adrv9009_adxcvr_rx 0>;
 		clock-names = "s_axi_aclk", "device_clk", "lane_clk";
 
 		#clock-cells = <0>;
@@ -153,7 +153,7 @@
 
 		interrupts = <0 53 IRQ_TYPE_LEVEL_HIGH>;
 
-		clocks = <&clkc 16>, <&axi_tx_clkgen>, <&axi_adrv9009_adxcvr_tx 0>;
+		clocks = <&clkc 15>, <&axi_tx_clkgen>, <&axi_adrv9009_adxcvr_tx 0>;
 		clock-names = "s_axi_aclk", "device_clk", "lane_clk";
 
 		#clock-cells = <0>;
@@ -173,7 +173,7 @@
 
 		interrupts = <0 52 IRQ_TYPE_LEVEL_HIGH>;
 
-		clocks = <&clkc 16>, <&axi_rx_os_clkgen>, <&axi_adrv9009_adxcvr_rx_os 0>;
+		clocks = <&clkc 15>, <&axi_rx_os_clkgen>, <&axi_adrv9009_adxcvr_rx_os 0>;
 		clock-names = "s_axi_aclk", "device_clk", "lane_clk";
 
 		#clock-cells = <0>;

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9371.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9371.dts
@@ -136,7 +136,7 @@
 
 		interrupts = <0 54 IRQ_TYPE_LEVEL_HIGH>;
 
-		clocks = <&clkc 16>, <&axi_rx_clkgen>, <&axi_ad9371_adxcvr_rx 0>;
+		clocks = <&clkc 15>, <&axi_rx_clkgen>, <&axi_ad9371_adxcvr_rx 0>;
 		clock-names = "s_axi_aclk", "device_clk", "lane_clk";
 
 		#clock-cells = <0>;
@@ -152,7 +152,7 @@
 
 		interrupts = <0 53 IRQ_TYPE_LEVEL_HIGH>;
 
-		clocks = <&clkc 16>, <&axi_tx_clkgen>, <&axi_ad9371_adxcvr_tx 0>;
+		clocks = <&clkc 15>, <&axi_tx_clkgen>, <&axi_ad9371_adxcvr_tx 0>;
 		clock-names = "s_axi_aclk", "device_clk", "lane_clk";
 
 		#clock-cells = <0>;
@@ -172,7 +172,7 @@
 
 		interrupts = <0 52 IRQ_TYPE_LEVEL_HIGH>;
 
-		clocks = <&clkc 16>, <&axi_rx_os_clkgen>, <&axi_ad9371_adxcvr_rx_os 0>;
+		clocks = <&clkc 15>, <&axi_rx_os_clkgen>, <&axi_ad9371_adxcvr_rx_os 0>;
 		clock-names = "s_axi_aclk", "device_clk", "lane_clk";
 
 		#clock-cells = <0>;

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcadc4.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcadc4.dts
@@ -49,7 +49,7 @@
 
 		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
 
-		clocks = <&clkc 16>, <&axi_adxcvr 1>, <&axi_adxcvr 0>;
+		clocks = <&clkc 15>, <&axi_adxcvr 1>, <&axi_adxcvr 0>;
 		clock-names = "s_axi_aclk", "device_clk", "lane_clk";
 
 		#clock-cells = <0>;

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcdaq2.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcdaq2.dts
@@ -96,7 +96,7 @@
 
 		interrupts = <0 54 IRQ_TYPE_LEVEL_HIGH>;
 
-		clocks = <&clkc 16>, <&axi_ad9144_adxcvr 1>, <&axi_ad9144_adxcvr 0>;
+		clocks = <&clkc 15>, <&axi_ad9144_adxcvr 1>, <&axi_ad9144_adxcvr 0>;
 		clock-names = "s_axi_aclk", "device_clk", "lane_clk";
 
 		#clock-cells = <0>;
@@ -127,7 +127,7 @@
 
 		interrupts = <0 55 IRQ_TYPE_LEVEL_HIGH>;
 
-		clocks = <&clkc 16>, <&axi_ad9680_adxcvr 1>, <&axi_ad9680_adxcvr 0>;
+		clocks = <&clkc 15>, <&axi_ad9680_adxcvr 1>, <&axi_ad9680_adxcvr 0>;
 		clock-names = "s_axi_aclk", "device_clk", "lane_clk";
 
 		adi,octets-per-frame = <1>;

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcdaq3.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcdaq3.dts
@@ -96,7 +96,7 @@
 
 		interrupts = <0 54 IRQ_TYPE_LEVEL_HIGH>;
 
-		clocks = <&clkc 16>, <&axi_ad9152_adxcvr 1>, <&axi_ad9152_adxcvr 0>;
+		clocks = <&clkc 15>, <&axi_ad9152_adxcvr 1>, <&axi_ad9152_adxcvr 0>;
 		clock-names = "s_axi_aclk", "device_clk", "lane_clk";
 		#clock-cells = <0>;
 		clock-output-names = "jesd_dac_lane_clk";
@@ -127,7 +127,7 @@
 
 		interrupts = <0 55 IRQ_TYPE_LEVEL_HIGH>;
 
-		clocks = <&clkc 16>, <&axi_ad9680_adxcvr 1>, <&axi_ad9680_adxcvr 0>;
+		clocks = <&clkc 15>, <&axi_ad9680_adxcvr 1>, <&axi_ad9680_adxcvr 0>;
 		clock-names = "s_axi_aclk", "device_clk", "lane_clk";
 		#clock-cells = <0>;
 

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcjesdadc1.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcjesdadc1.dts
@@ -69,7 +69,7 @@
 
 		interrupts = <0 55 IRQ_TYPE_LEVEL_HIGH>;
 
-		clocks = <&clkc 16>, <&axi_adxcvr 1>, <&axi_adxcvr 0>;
+		clocks = <&clkc 15>, <&axi_adxcvr 1>, <&axi_adxcvr 0>;
 		clock-names = "s_axi_aclk", "device_clk", "lane_clk";
 
 		#clock-cells = <0>;

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmclidar1.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmclidar1.dts
@@ -105,7 +105,7 @@
 
 		interrupts = <0 55 IRQ_TYPE_LEVEL_HIGH>;
 
-		clocks = <&clkc 16>, <&ad9528 3>, <&axi_ad9094_adxcvr 0>;
+		clocks = <&clkc 15>, <&ad9528 3>, <&axi_ad9094_adxcvr 0>;
 		clock-names = "s_axi_aclk", "device_clk", "lane_clk";
 
 		adi,octets-per-frame = <1>;

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcomms11-RevA.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcomms11-RevA.dts
@@ -80,7 +80,7 @@
 
 		interrupts = <0 54 IRQ_TYPE_LEVEL_HIGH>;
 
-		clocks = <&clkc 16>, <&tx_adxcvr 1>, <&tx_adxcvr 0>;
+		clocks = <&clkc 15>, <&tx_adxcvr 1>, <&tx_adxcvr 0>;
 		clock-names = "s_axi_aclk", "device_clk", "lane_clk";
 
 		adi,octets-per-frame = <1>;
@@ -107,7 +107,7 @@
 
 		interrupts = <0 55 IRQ_TYPE_LEVEL_HIGH>;
 
-		clocks = <&clkc 16>, <&rx_adxcvr 1>, <&rx_adxcvr 0>;
+		clocks = <&clkc 15>, <&rx_adxcvr 1>, <&rx_adxcvr 0>;
 		clock-names = "s_axi_aclk", "device_clk", "lane_clk";
 
 		adi,octets-per-frame = <1>;

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcomms11.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcomms11.dts
@@ -95,7 +95,7 @@
 
 		interrupts = <0 54 IRQ_TYPE_LEVEL_HIGH>;
 
-		clocks = <&clkc 16>, <&tx_adxcvr 1>, <&tx_adxcvr 0>;
+		clocks = <&clkc 15>, <&tx_adxcvr 1>, <&tx_adxcvr 0>;
 		clock-names = "s_axi_aclk", "device_clk", "lane_clk";
 
 		#clock-cells = <0>;
@@ -120,7 +120,7 @@
 
 		interrupts = <0 55 IRQ_TYPE_LEVEL_HIGH>;
 
-		clocks = <&clkc 16>, <&rx_adxcvr 1>, <&rx_adxcvr 0>;
+		clocks = <&clkc 15>, <&rx_adxcvr 1>, <&rx_adxcvr 0>;
 		clock-names = "s_axi_aclk", "device_clk", "lane_clk";
 
 		adi,octets-per-frame = <1>;


### PR DESCRIPTION
This fixes incorrectly displayed link/device clock frequencies.