### PR TITLE
Staging rpi/bring fix

### DIFF
--- a/ci/travis/prepare_artifacts.sh
+++ b/ci/travis/prepare_artifacts.sh
@@ -60,7 +60,7 @@ artifacts_swdownloads() {
 	echo "checksum_modules=${md5_modules}" >> rpi_archives_properties.txt
 	echo "checksum_boot_files=${md5_boot}" >> rpi_archives_properties.txt
 	echo "git_sha=${GIT_SHA}" >> rpi_archives_properties.txt
-        echo "git_sha_date=${GIT_SHA_DATE}" >> rpi_archives_properties.txt
+	echo "git_sha_date=${GIT_SHA_DATE}" >> rpi_archives_properties.txt
 
 	scp -2 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o HostKeyAlgorithms=+ssh-dss \
                 -i ${KEY_FILE} -r rpi_archives_properties.txt ${DEST_SERVER}/${BUILD_SOURCEBRANCHNAME}

--- a/ci/travis/prepare_artifacts.sh
+++ b/ci/travis/prepare_artifacts.sh
@@ -10,6 +10,7 @@ artifacts_structure() {
 	cd ${SOURCE_DIRECTORY}
 	mkdir ${timestamp}
 
+	echo "git_branch=${BUILD_SOURCEBRANCHNAME}" >> ${timestamp}/rpi_git_properties.txt
 	echo "git_sha=${GIT_SHA}" >> ${timestamp}/rpi_git_properties.txt
 	echo "git_sha_date=${GIT_SHA_DATE}" >> ${timestamp}/rpi_git_properties.txt
 
@@ -53,7 +54,7 @@ artifacts_swdownloads() {
 	scp -2 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o HostKeyAlgorithms=+ssh-dss \
 	    -i ${KEY_FILE} -r rpi_latest_boot.tar.gz ${DEST_SERVER}/${BUILD_SOURCEBRANCHNAME}
 
-	echo "boot_date=${timestamp}" >> rpi_archives_properties.txt
+	echo "git_branch=${BUILD_SOURCEBRANCHNAME}" >> rpi_archives_properties.txt
 	echo "https://swdownloads.analog.com/cse/linux_rpi/${BUILD_SOURCEBRANCHNAME}/rpi_modules.tar.gz" >> rpi_archives_properties.txt
 	echo "https://swdownloads.analog.com/cse/linux_rpi/${BUILD_SOURCEBRANCHNAME}/rpi_latest_boot.tar.gz" >> rpi_archives_properties.txt
 	echo "checksum_modules=${md5_modules}" >> rpi_archives_properties.txt


### PR DESCRIPTION
This PR brings the changes that were automatically cherry-picked onto the `rpi-6.1.y` branch on the `rpi-5.15.y` branch as well. 
The changes that are introduced by this PR are:
- Removal of a redundant line (`"boot_date=${timestamp}`) inside the `rpi_archives_properties.txt` file.
- Adding the source branch to both the `rpi_archives_properties.txt` and `rpi_git_properties.txt` files.
- Fixing a bad indent from the `prepare_artifacts.sh` script