### PR TITLE
iio: adc: ad_sigma_delta: Remove mutex locking

### DIFF
--- a/drivers/iio/adc/ad_sigma_delta.c
+++ b/drivers/iio/adc/ad_sigma_delta.c
@@ -307,7 +307,6 @@ int ad_sigma_delta_single_conversion(struct iio_dev *indio_dev,
 	if (ret)
 		return ret;
 
-	mutex_lock(&indio_dev->mlock);
 	ad_sigma_delta_prepare_channel(sigma_delta, 0, chan);
 	ad_sigma_delta_set_channel(sigma_delta, 0, chan->address);
 


### PR DESCRIPTION
Do not lock the mutex multiple times within the same thread. iio_device_claim_direct_mode() already locks the mutex.

Fixes: bfa02fe ("iio: Add initial ad7173 support")