### PR TITLE
dts: arria10: ad9081: add axi-pl-fifo-enable

### DIFF
--- a/arch/arm/boot/dts/socfpga_arria10_socdk_ad9081.dts
+++ b/arch/arm/boot/dts/socfpga_arria10_socdk_ad9081.dts
@@ -206,6 +206,8 @@
 				jesd204-device;
 				#jesd204-cells = <2>;
 				jesd204-inputs = <&axi_ad9081_tx_jesd 0 DEFRAMER_LINK0_TX>;
+
+				adi,axi-pl-fifo-enable;
 			};
 		};
 	};


### PR DESCRIPTION
Add axi-pl-fifo-enable in arch/arm/boot/dts/socfpga_arria10_socdk_ad9081.dts to fix the issue related to DAC buffer.