### PR TITLE
dts: arm: adi-cn0506-*: Update to the corresponding macb_config

### DIFF
--- a/arch/arm/boot/dts/adi-cn0506-mii.dtsi
+++ b/arch/arm/boot/dts/adi-cn0506-mii.dtsi
@@ -7,7 +7,7 @@
 	 * PHY after matching MAC link caps with PHY link caps,
 	 * even though, the design won't be able to actually support it
 	 */
-	compatible = "cdns,macb";
+	compatible = "xlnx,zynq-gem";
 
 	ethernet_gem0_phy1: ethernet-phy@1 {
 		reg = <1>;
@@ -23,7 +23,7 @@
 	 * PHY after matching MAC link caps with PHY link caps,
 	 * even though, the design won't be able to actually support it
 	 */
-	compatible = "cdns,macb";
+	compatible = "xlnx,zynq-gem";
 
 	ethernet_gem1_phy2: ethernet-phy@2 {
 		reg = <2>;

--- a/arch/arm/boot/dts/adi-cn0506-rgmii.dtsi
+++ b/arch/arm/boot/dts/adi-cn0506-rgmii.dtsi
@@ -2,6 +2,7 @@
 	status = "okay";
 	phy-mode = "rgmii-id";
 	phy-handle = <&ethernet_gem0_phy1>;
+	compatible = "xlnx,zynq-gem";
 
 	ethernet_gem0_phy1: ethernet-phy@1 {
 		reg = <1>;
@@ -18,6 +19,7 @@
 	status = "okay";
 	phy-mode = "rgmii-id";
 	phy-handle = <&ethernet_gem1_phy2>;
+	compatible = "xlnx,zynq-gem";
 
 	ethernet_gem1_phy2: ethernet-phy@2 {
 		reg = <2>;

--- a/arch/arm/boot/dts/adi-cn0506-rmii.dtsi
+++ b/arch/arm/boot/dts/adi-cn0506-rmii.dtsi
@@ -9,7 +9,7 @@
 	 * PHY after matching MAC link caps with PHY link caps,
 	 * even though, the design won't be able to actually support it
 	 */
-	compatible = "cdns,macb";
+	compatible = "xlnx,zynq-gem";
 
 	clocks = <&clkc 30>, <&fmc_mii_clk1>, <&clkc 13>;
 	clock-names = "pclk", "hclk", "tx_clk";
@@ -31,7 +31,7 @@
 	 * PHY after matching MAC link caps with PHY link caps,
 	 * even though, the design won't be able to actually support it
 	 */
-	compatible = "cdns,macb";
+	compatible = "xlnx,zynq-gem";
 
 	clocks = <&clkc 31>, <&fmc_mii_clk2>, <&clkc 14>;
 	clock-names = "pclk", "hclk", "tx_clk";


### PR DESCRIPTION
The previous [PR for the 2022_R2 branch](https://github.com/analogdevicesinc/linux/pull/2361) contains only the changes for arm64, this one being related to the code changes for the arch=arm.