### PR TITLE
azure-pipeline-rpi.yml: increase timeout for build jobs

### DIFF
--- a/azure-pipelines-rpi.yml
+++ b/azure-pipelines-rpi.yml
@@ -31,6 +31,7 @@ stages:
       displayName: 'Checkpatch Script'
 
   - job: BuildDockerized
+    timeoutInMinutes: 75
     strategy:
       matrix:
         bcm2709_arm_adi:


### PR DESCRIPTION
The default timeout for azure jobs is 60 minutes but currently the build for rpi braches is failing because of that, and for now this value will be increased to 75 minutes.