### PR TITLE
hwmon: max31827: Add PEC support

### DIFF
--- a/Documentation/hwmon/max31827.rst
+++ b/Documentation/hwmon/max31827.rst
@@ -131,7 +131,13 @@ The Fault Queue bits select how many consecutive temperature faults must occur
 before overtemperature or undertemperature faults are indicated in the
 corresponding status bits.
 
-Notes
------
+PEC (packet error checking) can be enabled from the "pec" device attribute.
+If PEC is enabled, a PEC byte is appended to the end of each message transfer.
+This is a CRC-8 byte that is calculated on all of the message bytes (including
+the address/read/write byte). The last device to transmit a data byte also
+transmits the PEC byte. The master transmits the PEC byte after a write
+transaction, and the MAX31827 transmits the PEC byte after a read transaction.
 
-PEC is not implemented.
+The read PEC error is handled inside the i2c_smbus_read_word_swapped() function.
+To check if the write had any PEC error a read is performed on the configuration
+register, to check the PEC Error bit.


### PR DESCRIPTION
PEC is basically a CRC-8 byte.

Removed regmap and used my functions to read, write and update bits. In these functions i2c_smbus_ helper functions are used. These check if there were any PEC errors during read. In the write function, if PEC is enabled, I check for PEC Error bit, to see if there were any errors.

This is my last day at the company and unfortunately I did not manage to get this patch accepted on upstream. I was asked not to replace regmap, but with regmap I could not send and receive the PEC byte. The discussion is still in progress at:
https://lore.kernel.org/linux-hwmon/PH0PR03MB677186C968350C7ABD0B3DA58996A@PH0PR03MB6771.namprd03.prod.outlook.com/