### PR TITLE
rtc: Kconfig: add missing dependency for lpc24xx

### DIFF
--- a/drivers/rtc/Kconfig
+++ b/drivers/rtc/Kconfig
@@ -1718,6 +1718,7 @@ config RTC_DRV_LPC24XX
 	tristate "NXP RTC for LPC178x/18xx/408x/43xx"
 	depends on ARCH_LPC18XX || COMPILE_TEST
 	depends on OF && HAS_IOMEM
+	depends on COMMON_CLK
 	help
 	  This enables support for the NXP RTC found which can be found on
 	  NXP LPC178x/18xx/408x/43xx devices.


### PR DESCRIPTION
The driver depends on COMMON_CLK. Add the dependency in Kconfig.

Link: https://lore.kernel.org/all/20231114114532.37840-1-antoniu.miclaus@analog.com/