### PR TITLE
[CI]:  fix dual licence job

### DIFF
--- a/ci/travis/run-build.sh
+++ b/ci/travis/run-build.sh
@@ -182,7 +182,7 @@ build_check_new_file_license() {
 		if git diff "$COMMIT_RANGE" "$file" | grep "+MODULE_LICENSE" | grep -q "Dual" ; then
 			bad_licence_error "$file"
 			ret=1
-		elif git diff "$COMMIT_RANGE" "$file" | grep "SPDX-License-Identifier:" | grep -qi "OR" ; then
+		elif git diff "$COMMIT_RANGE" "$file" | grep "SPDX-License-Identifier:" | grep -qi " OR " ; then
 			# The below might catch bad licenses in header files and also helps to make sure dual licenses are
 			# not in driver (eg: sometimes people have MODULE_LICENSE != SPDX-License-Identifier - which is also
 			# wrong and maybe someting to improve in this job)

--- a/ci/travis/run-build.sh
+++ b/ci/travis/run-build.sh
@@ -307,7 +307,8 @@ build_checkpatch() {
 	# could do '$GIT_FETCH_DEPTH="disable"' before calling __update_git_ref() but that
 	# would slow things a lot. Instead, let's do a treeless fetch which get's the whole
 	# history while being much faster than a typical fetch.
-	git fetch --filter=tree:0 --no-tags ${ORIGIN} +refs/heads/${ref_branch}:${ref_branch}
+	[ "${LOCAL_BUILD}" == "y" ] || \
+                git fetch --filter=tree:0 --no-tags ${ORIGIN} +refs/heads/${ref_branch}:${ref_branch}
 
 	scripts/checkpatch.pl --git "${ref_branch}.." \
 		--strict \
@@ -454,6 +455,9 @@ __update_git_ref() {
 	local ref="$1"
 	local local_ref="$2"
 	local depth
+
+        [ "${LOCAL_BUILD}" == "y" ] && return 0
+
 	[ "$GIT_FETCH_DEPTH" = "disabled" ] || {
 		depth="--depth=${GIT_FETCH_DEPTH:-50}"
 	}


### PR DESCRIPTION
The first patch it's just an improvement (potential fix) for running CI locally. The second change is the real fix on the dual license job. Should fix false positives as triggered in #2393.