### PR TITLE
regulator: core: fix unbalanced of node refcount in regulator_dev_loo…

### DIFF
--- a/drivers/regulator/core.c
+++ b/drivers/regulator/core.c
@@ -1880,6 +1880,7 @@ static struct regulator_dev *regulator_dev_lookup(struct device *dev,
 		node = of_get_regulator(dev, supply);
 		if (node) {
 			r = of_find_regulator_by_node(node);
+			of_node_put(node);
 			if (r)
 				return r;
 


### PR DESCRIPTION
…kup()

I got the the following report:

  OF: ERROR: memory leak, expected refcount 1 instead of 2,
  of_node_get()/of_node_put() unbalanced - destroy cset entry:
  attach overlay node /i2c/pmic@62/regulators/exten

In of_get_regulator(), the node is returned from of_parse_phandle() with refcount incremented, after using it, of_node_put() need be called.

Fixes: 69511a452e6d ("regulator: map consumer regulator based on device tree")

Link: https://lore.kernel.org/r/20221115091508.900752-1-yangyingliang@huawei.com

---

Same as #2264. Note that the fix is already present in linux 6.1 so no need to backport there