### PR TITLE
spi: spi-axi-spi-engine: setup the timer before IRQ enable

### DIFF
--- a/drivers/spi/spi-axi-spi-engine.c
+++ b/drivers/spi/spi-axi-spi-engine.c
@@ -628,6 +628,8 @@ static int spi_engine_transfer_one_message(struct spi_master *master,
 		return -ENOMEM;
 	spi_engine_compile_message(spi_engine, msg, false, p);
 
+	mod_timer(&spi_engine->watchdog_timer, jiffies + 5 * HZ);
+
 	spin_lock_irqsave(&spi_engine->lock, flags);
 	spi_engine->sync_id = (spi_engine->sync_id + 1) & 0xff;
 	spi_engine_program_add_cmd(p, false,
@@ -655,8 +657,6 @@ static int spi_engine_transfer_one_message(struct spi_master *master,
 		spi_engine->base + SPI_ENGINE_REG_INT_ENABLE);
 	spi_engine->int_enable = int_enable;
 	spin_unlock_irqrestore(&spi_engine->lock, flags);
-
-	mod_timer(&spi_engine->watchdog_timer, jiffies + 5*HZ);
 
 	return 0;
 }


### PR DESCRIPTION
The watchdog timer was being activated after enabling the interrupts and that could actually lead for the message to be transferred before we get to call mod_timer() which would lead to a spurious soft interrupt. In extreme cases (like playing with overlays to load + unload devices) this could lead to a panic splat as the timer callback would be called with the spi engine device gone already.

Fixes: fde5597b0ddd ("spi: axi-spi-engine: Add watchdog timer")

---

Note this is also an issue in the main branch but not an issue in the upstream version of the spi-engine @dlech worked on. As I'm expecting the upstream version to be synced in the ADI tree + offload support, I'm not doing this fix in main.