### PR TITLE
spi: spi-axi-spi-engine: fix divide by 0 exception

### DIFF
--- a/drivers/spi/spi-axi-spi-engine.c
+++ b/drivers/spi/spi-axi-spi-engine.c
@@ -180,7 +180,10 @@ static void spi_engine_update_xfer_len(struct spi_engine *spi_engine,
 				       struct spi_transfer *xfer)
 {
 	unsigned int word_length = spi_engine->word_length;
-	unsigned int word_len_bytes = word_length / 8;
+	unsigned int word_len_bytes = 1;
+
+	if (word_length > 8)
+		word_len_bytes = word_length / 8;
 
 	if ((xfer->len * 8) < word_length)
 		xfer->len = 1;


### PR DESCRIPTION
If the transfer word_length is lower than 8, word_len_bytes would be 0. That together with xfer->len * 8 > word_length would lead to a divide by 0 exception. Fix it by setting word_len_bytes to 1 in case word_length is lower or equal to 8.

Fixes: 30707b090c25 ("spi-axi-engine: Calculate buffer dimension for xfer")

---

Note this is a bit of a bandaid fix (as result of abusing the spi framework and going around it) and it's again not being done in main as I'm expecting the driver to be synced with upstream. But this showed me that after the driver is properly synced we will need to update the offload engine users we have (which are not that many) so that they properly populate the offload transfer `.len` field .