### PR TITLE
dts: overlays: rpi-adt7420: Add I2C address override

### DIFF
--- a/arch/arm/boot/dts/overlays/rpi-adt7420-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-adt7420-overlay.dts
@@ -12,10 +12,13 @@
 			#size-cells = <0>;
 			status = "okay";
 
-			adt7420@4b {
+			adt7420: adt7420@4b {
 				compatible = "adt7420";
 				reg = <0x4b>;
 			};
 		};
+	};
+	__overrides__ {
+		i2c_address = <&adt7420>,"reg:0";
 	};
 };


### PR DESCRIPTION
Current DTS only supports 0x4b I2C address.
This PR aims to allow boot time reconfiguration of the I2C address via dt_params