### PR TITLE
tty: serial: amba-pl011: fix versal uart support

### DIFF
--- a/drivers/tty/serial/amba-pl011.c
+++ b/drivers/tty/serial/amba-pl011.c
@@ -2358,8 +2358,6 @@ static const struct uart_ops xlnx_sbsa_uart_pops = {
 	.shutdown	= sbsa_uart_shutdown,
 	.set_termios	= xlnx_sbsa_uart_set_termios,
 	.type		= pl011_type,
-	.release_port	= pl011_release_port,
-	.request_port	= pl011_request_port,
 	.config_port	= pl011_config_port,
 	.verify_port	= pl011_verify_port,
 #ifdef CONFIG_CONSOLE_POLL


### PR DESCRIPTION
pl011_release_port() and pl011_request_port() were removed in the xilinx 5.15 LTS branch. I suspect the versal changes were somehow squashed together with commit
aee7ef0305b1 ("serial: amba-pl011: do not request memory region twice") so that we never noticed it as we merged directly with the stable tree.