### PR TITLE
iio: adc: ad9081: Fix JESD204 2D eye scan for dual-link operation

### DIFF
--- a/drivers/iio/adc/ad9081.c
+++ b/drivers/iio/adc/ad9081.c
@@ -3778,10 +3778,13 @@ static ssize_t ad9081_debugfs_write(struct file *file,
 		else
 			ret = 0;
 
-		if (ad9081_link_is_dual(phy->jrx_link_tx) &&
-			phy->jrx_link_tx[1].logiclane_mapping[val] >=
-			phy->jrx_link_tx[1].jesd_param.jesd_l)
-			ret = -EINVAL;
+		if (ret && ad9081_link_is_dual(phy->jrx_link_tx)) {
+			if (phy->jrx_link_tx[1].logiclane_mapping[val] >=
+				phy->jrx_link_tx[1].jesd_param.jesd_l)
+				ret = -EINVAL;
+			else
+				ret = 0;
+		}
 
 		if (ret)
 			return ret;


### PR DESCRIPTION
Fixes: d65b7088e1d7 ("iio: adc: ad9081: Support of HR and QR 2D Eye Scan")