### PR TITLE
[2022_R2] iio: adc: adrv9002: fix tx port selection

### DIFF
--- a/drivers/iio/adc/navassa/adrv9002.h
+++ b/drivers/iio/adc/navassa/adrv9002.h
@@ -191,6 +191,7 @@ struct adrv9002_tx_chan {
 	struct adi_adrv9001_DpdInitCfg *dpd_init;
 	struct adi_adrv9001_DpdCfg *dpd;
 	struct adi_adrv9001_TxAttenuationPinControlCfg *pin_cfg;
+	u8 port_sel;
 	u8 dac_boost_en;
 	u8 elb_en;
 	u8 ext_path_calib;


### PR DESCRIPTION
When running (on demand or automatically) the initial calibrations the TX port selection would not be respected as we were blindly asserting the TX muxes. Note this would be also an issue in case someone selected TX_B and then reinitialize (or loaded a new profile). This changes makes sure the port selection is respected when re-enabling the ports.

While at it, leave the port 50ohm terminated in case it's not enabled in the profile.

Fixes: ffd7faecf904 ("iio: adc: adrv9002: add initial_calibrations attribute")