### PR TITLE
iio: adc: adrv9009: Enable radio RX/TX/ORX pin control feature

### DIFF
--- a/drivers/iio/adc/adrv9009.h
+++ b/drivers/iio/adc/adrv9009.h
@@ -242,6 +242,8 @@ struct adrv9009_rf_phy {
 	u32 			framer_b_m;
 	u32 			framer_b_f;
 	u32 			orx_channel_enabled;
+	u32			pin_options_mask;
+	u32			orx_en_gpio_pinsel;
 };
 
 int adrv9009_register_axi_converter(struct adrv9009_rf_phy *phy);


### PR DESCRIPTION
This patch enables RX/TX/ORX pin control. It introduces a new device file called 'radio_pinctrl_en'. Writing '1' enables pin control based on the configuration provided by following devicetree attributes:
 * adi,radio-ctl-pin-mode-options-mask and
 * adi,radio-ctl-pin-mode-orx-en-pinsel Writing '0' respectively disables pin control.

adi,radio-ctl-pin-mode-options-mask: Mask to configure radio tx, rx, orx pin control options
 * (TAL_TXRX_PIN_MODE)      0x01: selects Tx and Rx signaling via pins
 * (TAL_ORX_PIN_MODE)       0x02: selects ORx signaling via pins
 * (TAL_ORX_USES_RX_PINS)   0x04: selects if Rx pins are used to indicate
                                  ORx mode activation/deactivation
 * (TAL_ORX_SEL)            0x10: selects ORx2 (1), when not used defaults
                                  to ORx1 (0)
 * (TAL_ORX_SINGLE_CHANNEL) 0x20: selects SPI to choose ORx channel and
                                  single pin to enable ORx mode
 * (TAL_ORX_ENAB_SEL_PIN)   0x40: selects the pin from the GPIO pin pair
                                  for ORx enable

adi,radio-ctl-pin-mode-orx-en-pinsel: enumerated type which selects one of three possible GPIO pin pair combinations:
* (TAL_ORX1ORX2_PAIR_01_SEL)   0x00: GPIO pin pair (0,1) assigned to
                                     ORx1 and ORx2 respectively
* (TAL_ORX1ORX2_PAIR_45_SEL)   0x01: GPIO pin pair (4,5) assigned to
                                     ORx1 and ORx2 respectively
* (TAL_ORX1ORX2_PAIR_89_SEL)   0x02: GPIO pin pair (8,9) assigned to
                                     ORx1 and ORx2 respectively
* (TAL_ORX1ORX2_PAIR_NONE_SEL) 0x03: no GPIO pins selected