### PR TITLE
dts: zynqmp-zcu102-rev10-adrv9025: change hdl_project to advr9026

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9025.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9025.dts
@@ -4,7 +4,7 @@
  * https://wiki.analog.com/resources/eval/user-guides/adrv9025
  * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9025
  *
- * hdl_project: <adrv9025/zcu102>
+ * hdl_project: <adrv9026/zcu102>
  * board_revision: <>
  *
  * Copyright (C) 2020-2023 Analog Devices Inc.


### PR DESCRIPTION
In order to create boot partition folder for the madura project, the hdl_project needs to be set in the description of the dts, but in hdl repository the project is named advr9026.

No functional changes.