### PR TITLE
rtc: max31335: fix interrupt status reg

### DIFF
--- a/drivers/rtc/rtc-max31335.c
+++ b/drivers/rtc/rtc-max31335.c
@@ -204,7 +204,7 @@ static bool max31335_volatile_reg(struct device *dev, unsigned int reg)
 		return true;
 
 	/* interrupt status register */
-	if (reg == MAX31335_INT_EN1_A1IE)
+	if (reg == MAX31335_STATUS1)
 		return true;
 
 	/* temperature registers */


### PR DESCRIPTION
Fix the register value comparison in the `max31335_volatile_reg` function for the interrupt status register.

MAX31335_STATUS1 macro definition corresponds to the actual interrupt status register.

Fixes: 706316f5e083 ("rtc: max31335: add driver support")
Link: https://lore.kernel.org/linux-rtc/20240219091616.24480-1-antoniu.miclaus@analog.com/