### PR TITLE
iio:adc:ad7768: Fix the ad7768 scale factor

### DIFF
--- a/drivers/iio/adc/ad7768.c
+++ b/drivers/iio/adc/ad7768.c
@@ -464,7 +464,7 @@ static int ad7768_read_raw(struct iio_dev *indio_dev,
 		if (ret < 0)
 			return ret;
 
-		*val = 2 * (ret / 1000);
+		*val = 2 * (ret / 1000000);
 		*val2 = chan->scan_type.realbits;
 		return IIO_VAL_FRACTIONAL_LOG2;
 	case IIO_CHAN_INFO_SAMP_FREQ:


### PR DESCRIPTION
The scale factor had to be corrected from 488uV to 488nV, according to the following formula: (2*4.096)/(2^24) = 488.28125nV.