### PR TITLE
adin1110: Reduce the MDIO_TRDONE poll interval

### DIFF
--- a/drivers/net/ethernet/adi/adin1110.c
+++ b/drivers/net/ethernet/adi/adin1110.c
@@ -464,8 +464,9 @@ static int adin1110_mdio_read(struct mii_bus *bus, int phy_id, int reg)
 	 * bitfield of ADIN1110_MDIOACC register will contain
 	 * the requested register value.
 	 */
-	ret = readx_poll_timeout(adin1110_read_mdio_acc, priv, val,
-				 (val & ADIN1110_MDIO_TRDONE), 10000, 30000);
+	ret = readx_poll_timeout_atomic(adin1110_read_mdio_acc, priv, val,
+					(val & ADIN1110_MDIO_TRDONE),
+					100, 30000);
 	if (ret < 0)
 		return ret;
 
@@ -495,8 +496,9 @@ static int adin1110_mdio_write(struct mii_bus *bus, int phy_id,
 	if (ret < 0)
 		return ret;
 
-	return readx_poll_timeout(adin1110_read_mdio_acc, priv, val,
-				  (val & ADIN1110_MDIO_TRDONE), 10000, 30000);
+	return readx_poll_timeout_atomic(adin1110_read_mdio_acc, priv, val,
+					 (val & ADIN1110_MDIO_TRDONE),
+					 100, 30000);
 }
 
 /* ADIN1110 MAC-PHY contains an ADIN1100 PHY.


### PR DESCRIPTION
In order to do a clause 22 access to the PHY registers of the ADIN1110,
we have to write the MDIO frame to the ADIN1110_MDIOACC register, and
then poll the MDIO_TRDONE bit (for a 1) in the same register. The
device will set this bit to 1 once the internal MDIO transaction is
done. In practice, this bit takes ~50 - 60 us to be set.

The first attempt to poll the bit is right after the ADIN1110_MDIOACC
register is written, so it will always be read as 0. The next check will
only be done after 10 ms, which will result in the MDIO transactions
taking a long time to complete. Reduce this polling interval to 100 us.
Since this interval is short enough, switch the poll function to
readx_poll_timeout_atomic() instead.