### PR TITLE
dts: overlay: adl5580: Fully Differential, 10 GHz ADC Driver 10 dB Gain

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -234,6 +234,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	rpi-ad9834.dtbo \
 	rpi-adar1000.dtbo \
 	rpi-adgs1408.dtbo \
+	rpi-adl5580.dtbo \
 	rpi-adxl313-spi.dtbo \
 	rpi-adxl313-i2c.dtbo \
 	rpi-adxl345.dtbo \

--- a/arch/arm/boot/dts/overlays/rpi-adl5580-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-adl5580-overlay.dts
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Overlay for the ADL5580 IIO Amplifier Driver
+ *
+ * Copyright 2024 Analog Devices Inc.
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/iio/adi,adl5580.h>
+
+/ {
+	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709";
+};
+
+&{/} {
+	vcc: fixedregulator@1 {
+		compatible = "regulator-fixed";
+		regulator-name = "avcc-supply";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+	};
+	vee: fixedregulator@2 {
+		compatible = "regulator-fixed";
+		regulator-name = "avee-supply";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+	};
+};
+
+&spidev0 {
+	status = "disabled";
+};
+
+&spidev1 {
+	status = "disabled";
+};
+
+&spi0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	adl5580: adl5580@0 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "adi,adl5580";
+		reg = <0>;
+		spi-max-frequency = <1000000>;
+		enable-gpios = <&gpio 22 GPIO_ACTIVE_HIGH>;
+		avcc-supply = <&vcc>;
+		avee-supply = <&vee>;
+
+		adi,prg-otrm = <ADL5580_OUT_CM_0P5V>;
+		adi,ms-otrm = <ADL5580_OUT_TERM_MODE3>;
+		adi,prg-itrm = <ADL5580_IN_CM_1P75V>;
+		adi,ms-itrm = <ADL5580_IN_TERM_MODE0>;
+		adi,prg-cpeak = <4>;
+	};
+};
+
+/ {
+	__overrides__ {
+		cs_pin = <&adl5580>,"reg:0";
+	};
+};


### PR DESCRIPTION
The ADL5580 is a high performance, single-ended or differential amplifier with 10 dB of voltage gain, optimized for applications spanning from dc to 10.0 GHz. The amplifier offers a low referred to input (RTI) noise spectral density (NSD) and is optimized for distortion performance over a wide frequency range, making the device an ideal driver for high speed 12-bit to 16-bit analog-to-digital converters (ADCs).

The SPI of the ADL5580 allows the user to configure the device for specific functions or operations via a 3-wire SPI port. It includes enable blocks, the bias current level, transfer function peaking, change input and output termination block operation modes, and change input and output V CM termination for certain operation modes.