### PR TITLE
Add CODEOWNERS and PULL_REQUEST_TEMPLATE

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,17 @@
+# This document lists the code owners for all Linux repo sources, and it is
+# used automatically whenever Pull Requests are created, in next way:
+#  - People listed as CODEOWNERS are automatically added as reviewers to all
+#    PRs open to branches containing this file.
+#  - In addition to Code Owners, other reviewers can be added.
+#  - There can be different code owners for different branches.
+#  - PRs will require the approval of at least one code owner.
+#
+# For more details, you can refer [GitHub CodeOwners Documentation](ttps://github.blog/2017-07-06-introducing-code-owners/)
+#
+# The format of CODEOWNERS is: <pattern> + <mail address of one/more owners>
+#
+# In case of multiple matches, the last pattern matched will take precedence.
+
+##### Global code owners (for folders with no later match) #####
+
+*    nuno.sa@analog.com michael.hennerich@analog.com dragos.bogdan@analog.com bogdan.togorean@analog.com ciprian.hegbeli@analog.com darius.berghe@analog.com antoniu.miclaus@analog.com ramona.gradinariu@analog.com george.mois@analog.com ciprian.regus@analog.com marcelo.schmitt@analog.com

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## PR Description
+
+- Please replace this comment with a summary of your changes, and add any context
+necessary to understand them. List any dependencies required for this change.
+- To check the checkboxes below, insert a 'x' between square brackets (without
+any space), or simply check them after publishing the PR.
+- If you changes include a breaking change, please specify dependent PRs in the
+description and try to push all related PRs simultaneously.
+
+## PR Type
+- [ ] Bug fix (a change that fixes an issue)
+- [ ] New feature (a change that adds new functionality)
+- [ ] Breaking change (a change that affects other repos or cause CIs to fail)
+
+## PR Checklist
+- [ ] I have conducted a self-review of my own code changes
+- [ ] I have tested the changes on the relevant hardware
+- [ ] I have updated the documentation outside this repo accordingly (if there is the case)


### PR DESCRIPTION
Persons specified in **CODEOWNERS** will be automatically added as reviewers, whenever new PRs are opened. 
In addition to Code Owners, other reviewers can be added. CODEOWNERS file can be different from one branch to another.
All new PRs will require the approval of at least one code owner.

**PULL_REQUEST_TEMPLATE.md** will populate all new PR description field. Beside PR description, it contains a list of checkboxes, ensuring all team members follow the same guidelines and enforce best practices. PR Template applies for PRs against all protected branches.

Both files were added in .github