### PR TITLE
Staging/fix tdd dts

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9081-m8-l4-tdd.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9081-m8-l4-tdd.dts
@@ -24,10 +24,31 @@
 
 &fpga_axi {
 	axi_tdd_0: axi-tdd-0@9c460000 {
-		compatible = "adi,axi-tdd-1.00";
+		compatible = "adi,axi-tdd";
 		reg = <0x9c460000 0x10000>;
 		clocks = <&zynqmp_clk PL0_REF>, <&hmc7044 6>;
 		clock-names = "s_axi_aclk", "intf_clk";
+	};
+
+	iio_axi_tdd_0@0 {
+		compatible = "adi,iio-fake-platform-device";
+		adi,faked-dev = <&axi_tdd_0>;
+		adi,attribute-names =
+			"version", "core_id", "scratch", "magic",
+			"sync_soft", "sync_external", "sync_internal", "sync_reset",
+			"enable", "startup_delay_raw", "startup_delay_ms",
+			"burst_count", "frame_length_raw", "frame_length_ms",
+			"state", "internal_sync_period_raw", "internal_sync_period_ms",
+			"out_channel0_enable", "out_channel0_polarity",
+			"out_channel0_on_raw", "out_channel0_on_ms",
+			"out_channel0_off_raw", "out_channel0_off_ms",
+			"out_channel1_enable", "out_channel1_polarity",
+			"out_channel1_on_raw", "out_channel1_on_ms",
+			"out_channel1_off_raw", "out_channel1_off_ms",
+			"out_channel2_enable", "out_channel2_polarity",
+			"out_channel2_on_raw", "out_channel2_on_ms",
+			"out_channel2_off_raw", "out_channel2_off_ms";
+		label = "axi-core-tdd";
 	};
 };
 

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-tdd.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-tdd.dts
@@ -40,5 +40,25 @@
 			clock-names = "intf_clk", "s_axi_aclk";
 		};
 
+		iio_axi_tdd@0 {
+			compatible = "adi,iio-fake-platform-device";
+			adi,faked-dev = <&tdd>;
+			adi,attribute-names =
+				"version", "core_id", "scratch", "magic",
+				"sync_soft", "sync_external", "sync_internal", "sync_reset",
+				"enable", "startup_delay_raw", "startup_delay_ms",
+				"burst_count", "frame_length_raw", "frame_length_ms",
+				"state", "internal_sync_period_raw", "internal_sync_period_ms",
+				"out_channel0_enable", "out_channel0_polarity",
+				"out_channel0_on_raw", "out_channel0_on_ms",
+				"out_channel0_off_raw", "out_channel0_off_ms",
+				"out_channel1_enable", "out_channel1_polarity",
+				"out_channel1_on_raw", "out_channel1_on_ms",
+				"out_channel1_off_raw", "out_channel1_off_ms",
+				"out_channel2_enable", "out_channel2_polarity",
+				"out_channel2_on_raw", "out_channel2_on_ms",
+				"out_channel2_off_raw", "out_channel2_off_ms";
+			label = "axi-core-tdd";
+		};
 	};
 };


### PR DESCRIPTION
The ad9081_fmca_ebz_x_band (stingray)  project is using the new TDD core.
Update the corresponding dts to use the new TDD driver with libiio support.