### PR TITLE
iio: adc: ad9081: Disable ADC data inversion option for AD9082

### DIFF
--- a/drivers/iio/adc/ad9081.c
+++ b/drivers/iio/adc/ad9081.c
@@ -2264,10 +2264,12 @@ static int ad9081_setup_rx(struct spi_device *spi)
 	}
 
 	for_each_cddc(i, phy->rx_cddc_select) {
-		ret = adi_ad9081_adc_data_inversion_dc_coupling_set(&phy->ad9081,
-			BIT(i), phy->adc_invert_en[i]);
-		if (ret != 0)
-			return ret;
+		if ((conv->id == CHIPID_AD9081 || conv->id == CHIPID_AD9988) && phy->adc_invert_en[i]) {
+			ret = adi_ad9081_adc_data_inversion_dc_coupling_set(&phy->ad9081,
+				BIT(i), phy->adc_invert_en[i]);
+			if (ret != 0)
+				return ret;
+		}
 		ret = adi_ad9081_adc_ddc_coarse_gain_set(
 			&phy->ad9081, BIT(i), phy->rx_cddc_gain_6db_en[i]);
 		if (ret != 0)


### PR DESCRIPTION
## PR Description

Temporarily disable ADC data inversion option for AD9082, since this option my have negative side effects.
Needs further investigation.

## PR Type
- [X] Bug fix (a change that fixes an issue)

## PR Checklist
- [X] I have conducted a self-review of my own code changes
- [X] I have tested the changes on the relevant hardware
- [X] I have updated the documentation outside this repo accordingly (if there is the case)
