### PR TITLE
dts: overlays: adis16475: Add parameters for sync mode configuration

### DIFF
--- a/arch/arm/boot/dts/overlays/adis16475-overlay.dts
+++ b/arch/arm/boot/dts/overlays/adis16475-overlay.dts
@@ -38,7 +38,20 @@
 			};
 		};
 	};
+
 	fragment@4 {
+		target-path = "/";
+		__overlay__ {
+			clocks {
+				adis16475_ref_clk: clock@0 {
+					     #clock-cells = <0>;
+					     compatible = "fixed-clock";
+				};
+			};
+		};
+	};
+
+	fragment@5 {
 		target = <&spi0>;
 		__overlay__ {
 			/* needed to avoid dtc warning */
@@ -71,5 +84,8 @@
 		drdy_gpio25 = <&adis16475_pins>,"brcm,pins:0=25",
 				<&adis16475>,"interrupts:0=25";
 		device = <&adis16475>,"compatible";
+		sync_mode = <&adis16475>,"adi,sync-mode:0";
+		ext_sync_freq = <&adis16475_ref_clk>, "clock-frequency:0",
+				<&adis16475>,"clocks:0=",<&adis16475_ref_clk>;
 	};
 };


### PR DESCRIPTION
Add parameters for sync mode configuration: sync_mode to select the desired sync mode and ext_sync_freq to select the external sync frequency (needed for direct mode and scaled sync mode).

## PR Description

- Please replace this comment with a summary of your changes, and add any context
necessary to understand them. List any dependencies required for this change.
- To check the checkboxes below, insert a 'x' between square brackets (without
any space), or simply check them after publishing the PR.
- If you changes include a breaking change, please specify dependent PRs in the
description and try to push all related PRs simultaneously.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
