### PR TITLE
dts: zynqmp-jupiter-sdr: remove fan_en gpio

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-jupiter-sdr.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-jupiter-sdr.dts
@@ -411,13 +411,6 @@
 		line-name = "adrv9002-clksrc";
 	};
 
-	fan_en {
-		gpio-hog;
-		gpios = <144 GPIO_ACTIVE_HIGH>;
-		output-high;
-		line-name = "fan-en";
-	};
-
 	fan_ctl {
 		gpio-hog;
 		gpios = <145 GPIO_ACTIVE_HIGH>;


### PR DESCRIPTION
## PR Description

The fan_en has been set high from the hdl and
the gpio is no longer used for that. 

https://github.com/analogdevicesinc/hdl/blob/main/projects/jupiter_sdr/system_top.v#L202

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have tested the changes on the relevant hardware
- [x] I have updated the documentation outside this repo accordingly (if there is the case)
