### PR TITLE
Ad4630 remove avg 0

### DIFF
--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad4630-24.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad4630-24.dts
@@ -90,7 +90,7 @@
 	};
 
 	axi_spi_engine: spi@44a00000 {
-		compatible = "adi,axi-spi-engine-1.00.a";
+		compatible = "adi-ex,axi-spi-engine-1.00.a";
 		reg = <0x44a00000 0x1FF>;
 		interrupt-parent = <&intc>;
 		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;

--- a/arch/arm/boot/dts/zynq-zed-adv7511-adaq4224-24.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-adaq4224-24.dts
@@ -115,7 +115,7 @@
 	};
 
 	axi_spi_engine: spi@44a00000 {
-		compatible = "adi,axi-spi-engine-1.00.a";
+		compatible = "adi-ex,axi-spi-engine-1.00.a";
 		reg = <0x44a00000 0x1FF>;
 		interrupt-parent = <&intc>;
 		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;

--- a/arch/arm/boot/dts/zynq-zed-adv7511-adaq4224-24.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-adaq4224-24.dts
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0
 /*
- * Analog Devices ADAQ4224
+ * Analog Devices ADAQ4224 without isolated power supply
  *
  * hdl_project: <ad4630_fmc/zed>
- * board_revision: <B>
+ * board_revision: <3>
  *
  * Copyright (C) 2023 Analog Devices Inc.
  */
@@ -18,8 +18,8 @@
 	vref: regulator-vref {
 		compatible = "regulator-fixed";
 		regulator-name = "fixed-supply";
-		regulator-min-microvolt = <5000000>;
-		regulator-max-microvolt = <5000000>;
+		regulator-min-microvolt = <4096000>;
+		regulator-max-microvolt = <4096000>;
 		regulator-always-on;
 	};
 
@@ -50,14 +50,13 @@
 };
 
 &fpga_axi {
-	i2c@44c00000 {
+	i2c@41620000 {
 		compatible = "xlnx,axi-iic-1.01.b", "xlnx,xps-iic-2.00.a";
-		reg = <0x44c00000 0x10000>;
+		reg = <0x41620000 0x10000>;
 		interrupt-parent = <&intc>;
-		interrupts = <0 54 IRQ_TYPE_LEVEL_HIGH>;
+		interrupts = <0 55 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 15>;
 		clock-names = "pclk";
-
 		#size-cells = <0>;
 		#address-cells = <1>;
 
@@ -65,8 +64,18 @@
 			compatible = "adi,max31827";
 			reg = <0x5f>;
 			vref-supply = <&vio>;
+			adi,comp-int;
+			adi,alarm-pol = <0>;
+			adi,fault-q = <1>;
+			adi,timeout-enable;
+		};
+
+		eeprom1: eeprom@50 {
+			compatible = "at24,24c02";
+			reg = <0x50>;
 		};
 	};
+
 	rx_dma: rx-dmac@44a30000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x44a30000 0x1000>;
@@ -103,7 +112,6 @@
 		label = "ad463x_cnv";
 		#pwm-cells = <2>;
 		clocks = <&cnv_ext_clk>;
-
 	};
 
 	axi_spi_engine: spi@44a00000 {
@@ -114,7 +122,6 @@
 		clocks = <&clkc 15>, <&spi_clk>;
 		clock-names = "s_axi_aclk", "spi_clk";
 		num-cs = <1>;
-
 		#address-cells = <0x1>;
 		#size-cells = <0x0>;
 
@@ -129,18 +136,14 @@
 			reset-gpios = <&gpio0 86 GPIO_ACTIVE_LOW>;
 			adi,pga-gpios = <&gpio0 87 GPIO_ACTIVE_HIGH>,
 					<&gpio0 88 GPIO_ACTIVE_HIGH>;
-			adi,lane-mode = <1>;
-			adi,clock-mode = <1>;
+			adi,lane-mode = <0>;
+			adi,clock-mode = <0>;
 			adi,out-data-mode = <0>;
-			adi,dual-data-rate;
 			adi,spi-trigger;
-
 			clocks = <&cnv_ext_clk>;
 			clock-names = "trigger_clock";
-
 			dmas = <&rx_dma 0>;
 			dma-names = "rx";
-
 			pwm-names = "spi_trigger", "cnv";
 			pwms = <&axi_pwm_gen 0 0>, <&axi_pwm_gen 1 0>;
 		};

--- a/arch/arm/boot/dts/zynq-zed-adv7511-adaq4224-24_cm0_sdi4_cz2.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-adaq4224-24_cm0_sdi4_cz2.dts
@@ -132,7 +132,7 @@
 	};
 
 	axi_spi_engine: spi@44a00000 {
-		compatible = "adi,axi-spi-engine-1.00.a";
+		compatible = "adi-ex,axi-spi-engine-1.00.a";
 		reg = <0x44a00000 0x1FF>;
 		interrupt-parent = <&intc>;
 		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;

--- a/drivers/iio/adc/ad4630.c
+++ b/drivers/iio/adc/ad4630.c
@@ -613,11 +613,11 @@ static int ad4630_set_avg_frame_len(struct iio_dev *dev,
 	if (ret)
 		return ret;
 
-	ret = regmap_write(st->regmap, AD4630_REG_AVG, avg_len);
+	ret = regmap_write(st->regmap, AD4630_REG_AVG, avg_len + 1);
 	if (ret)
 		goto out_error;
 
-	ret = ad4630_update_sample_fetch_trigger(st, avg_len);
+	ret = ad4630_update_sample_fetch_trigger(st, avg_len + 1);
 out_error:
 	iio_device_release_direct_mode(dev);
 
@@ -640,7 +640,7 @@ static int ad4630_get_avg_frame_len(struct iio_dev *dev,
 	if (ret)
 		return ret;
 
-	return avg_len;
+	return avg_len - 1;
 }
 
 static int ad4630_sampling_enable(const struct ad4630_state *st, bool enable)
@@ -752,7 +752,7 @@ out_error:
 }
 
 static const char *const ad4630_average_modes[] = {
-	"0", "2", "4", "8", "16", "32",	"64", "128", "256", "512", "1024",
+	"2", "4", "8", "16", "32", "64", "128", "256", "512", "1024",
 	"2048", "4096", "8192", "16384", "32768", "65536"
 };
 
@@ -1479,6 +1479,14 @@ static int ad4630_probe(struct spi_device *spi)
 		ad4630_fill_scale_tbl(st);
 		ad4630_set_pga_gain(indio_dev, 0);
 	}
+
+	/*
+	 * Due to a hardware bug in some chips when using average mode zero
+	 * (no averaging), set default averaging mode to 2 samples.
+	 */
+	ret = regmap_write(st->regmap, AD4630_REG_AVG, 0x01);
+	if (ret)
+		return ret;
 
 	ret = ad4630_pwm_get(st);
 	if (ret)


### PR DESCRIPTION
## PR Description

ADI engineers have reported a hardware bug when using average mode zero (no averaging) with AD4630 devices and requested to disallow using that average mode. 
This PR contains a commit to remove average mode zero from the list of available average modes and make average mode one (average over 2 samples) the default average mode on device startup.
This PR also includes a fix from @nunojsa which testers said to be needed as well.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have tested the changes on the relevant hardware (@ladace reported it has been tested and deemed good)
- [x] I have updated the documentation outside this repo accordingly (if there is the case) (no need to update docs)
