### PR TITLE
dts: arria10: ad9081: add axi-pl-fifo-enable

### DIFF
--- a/arch/arm/boot/dts/socfpga_arria10_socdk_ad9081.dts
+++ b/arch/arm/boot/dts/socfpga_arria10_socdk_ad9081.dts
@@ -206,6 +206,8 @@
 				jesd204-device;
 				#jesd204-cells = <2>;
 				jesd204-inputs = <&axi_ad9081_tx_jesd 0 DEFRAMER_LINK0_TX>;
+
+				adi,axi-pl-fifo-enable;
 			};
 		};
 	};


### PR DESCRIPTION
## PR Description

Add axi-pl-fifo-enable in
arch/arm/boot/dts/socfpga_arria10_socdk_ad9081.dts to fix the issue related to DAC buffer.

Signed-off-by: Stefan Raus <Stefan.Raus@analog.com>
(cherry picked from commit b333e020922e363eaab763795b6bee87678d9194)

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
