### PR TITLE
arch: arm: boot: dts: Align dts lane-mode with default build of HDL

### DIFF
--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad4630-24.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad4630-24.dts
@@ -110,7 +110,7 @@
 			vref-supply = <&vref>;
 			spi-max-frequency = <80000000>;
 			reset-gpios = <&gpio0 86 GPIO_ACTIVE_LOW>;
-			adi,lane-mode = <0>;
+			adi,lane-mode = <1>;
 			adi,clock-mode = <0>;
 			adi,out-data-mode = <0>;
 			adi,spi-trigger;

--- a/arch/arm/boot/dts/zynq-zed-adv7511-adaq4224-24.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-adaq4224-24.dts
@@ -136,7 +136,7 @@
 			reset-gpios = <&gpio0 86 GPIO_ACTIVE_LOW>;
 			adi,pga-gpios = <&gpio0 87 GPIO_ACTIVE_HIGH>,
 					<&gpio0 88 GPIO_ACTIVE_HIGH>;
-			adi,lane-mode = <0>;
+			adi,lane-mode = <1>;
 			adi,clock-mode = <0>;
 			adi,out-data-mode = <0>;
 			adi,spi-trigger;


### PR DESCRIPTION
## PR Description

Default build of HDL uses NUM_SDI=4 this means 2 lanes per channel, accordingly the adi,lane-mode should be 1

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
