### PR TITLE
arch/arm/boot/dts/arria10: Add sysid in DTSes

### DIFF
--- a/arch/arm/boot/dts/adi-intel-dac-fmc-ebz.dtsi
+++ b/arch/arm/boot/dts/adi-intel-dac-fmc-ebz.dtsi
@@ -90,6 +90,11 @@
 				#clock-cells = <0>;
 				clock-output-names = "jesd204_tx_link_clock";
 			};
+
+			axi_sysid_0: axi-sysid-0@18000 {
+				compatible = "adi,axi-sysid-1.00.a";
+				reg = <0x00018000 0x8000>;
+			};
 		};
 	};
 };

--- a/arch/arm/boot/dts/socfpga_arria10_socdk_ad9081.dts
+++ b/arch/arm/boot/dts/socfpga_arria10_socdk_ad9081.dts
@@ -209,6 +209,11 @@
 
 				adi,axi-pl-fifo-enable;
 			};
+
+			axi_sysid_0: axi-sysid-0@18000 {
+				compatible = "adi,axi-sysid-1.00.a";
+				reg = <0x00018000 0x8000>;
+			};
 		};
 	};
 };

--- a/arch/arm/boot/dts/socfpga_arria10_socdk_ad9083_fmc_ebz.dts
+++ b/arch/arm/boot/dts/socfpga_arria10_socdk_ad9083_fmc_ebz.dts
@@ -142,6 +142,11 @@
 				#jesd204-cells = <2>;
 				jesd204-inputs = <&axi_ad9083_rx_jesd 0 0>;
 			};
+
+			axi_sysid_0: axi-sysid-0@18000 {
+				compatible = "adi,axi-sysid-1.00.a";
+				reg = <0x00018000 0x8000>;
+			};
 		};
 	};
 };

--- a/arch/arm/boot/dts/socfpga_arria10_socdk_adrv9002.dts
+++ b/arch/arm/boot/dts/socfpga_arria10_socdk_adrv9002.dts
@@ -205,6 +205,11 @@
 				clock-names = "s_axi_aclk", "intf_clk";
 				label = "axi-core-tdd-2";
 			};
+
+			axi_sysid_0: axi-sysid-0@18000 {
+				compatible = "adi,axi-sysid-1.00.a";
+				reg = <0x00018000 0x8000>;
+			};
 		};
 	};
 };

--- a/arch/arm/boot/dts/socfpga_arria10_socdk_adrv9002_rx2tx2.dts
+++ b/arch/arm/boot/dts/socfpga_arria10_socdk_adrv9002_rx2tx2.dts
@@ -125,6 +125,11 @@
 				adi,axi-dds-default-scale = <0x800>;
 				adi,axi-dds-default-frequency = <2000000>;
 			};
+
+			axi_sysid_0: axi-sysid-0@18000 {
+				compatible = "adi,axi-sysid-1.00.a";
+				reg = <0x00018000 0x8000>;
+			};
 		};
 	};
 };

--- a/arch/arm/boot/dts/socfpga_arria10_socdk_adrv9009.dts
+++ b/arch/arm/boot/dts/socfpga_arria10_socdk_adrv9009.dts
@@ -287,6 +287,11 @@
 				clocks = <&trx0_adrv9009 1>;
 				clock-names = "sampl_clk";
 			};
+
+			axi_sysid_0: axi-sysid-0@18000 {
+				compatible = "adi,axi-sysid-1.00.a";
+				reg = <0x00018000 0x8000>;
+			};
 		};
 	};
 };

--- a/arch/arm/boot/dts/socfpga_arria10_socdk_adrv9371.dts
+++ b/arch/arm/boot/dts/socfpga_arria10_socdk_adrv9371.dts
@@ -290,6 +290,10 @@
 				#clock-cells = <0>;
 				clock-output-names = "jesd204_rx_os_link_clock";
 			};
+			axi_sysid_0: axi-sysid-0@18000 {
+				compatible = "adi,axi-sysid-1.00.a";
+				reg = <0x00018000 0x8000>;
+			};
 		};
 	};
 };

--- a/arch/arm/boot/dts/socfpga_arria10_socdk_daq2.dts
+++ b/arch/arm/boot/dts/socfpga_arria10_socdk_daq2.dts
@@ -234,6 +234,11 @@
 				clocks = <&clk0_ad9523 4>;
 				clock-output-names = "jesd204_rx_link_clock";
 			};
+
+			axi_sysid_0: axi-sysid-0@18000 {
+				compatible = "adi,axi-sysid-1.00.a";
+				reg = <0x00018000 0x8000>;
+			};
 		};
 	};
 };

--- a/arch/arm/boot/dts/socfpga_arria10_socdk_fmclidar1.dts
+++ b/arch/arm/boot/dts/socfpga_arria10_socdk_fmclidar1.dts
@@ -173,6 +173,11 @@
 				interrupts = <0 32 4>;
 				clocks = <&ad9528 3>;
 			};
+
+			axi_sysid_0: axi-sysid-0@18000 {
+				compatible = "adi,axi-sysid-1.00.a";
+				reg = <0x00018000 0x8000>;
+			};
 		};
 	};
 };

--- a/arch/arm/boot/dts/socfpga_arria10_socdk_fmcomms8.dts
+++ b/arch/arm/boot/dts/socfpga_arria10_socdk_fmcomms8.dts
@@ -268,35 +268,34 @@
 			};
 
 
-		axi_adrv9009_core_rx: axi-adrv9009-rx-hpc@50000 {
-			compatible = "adi,axi-adrv9009-rx-1.0";
-			reg = <0x00050000 0x2000>;
-			dmas = <&rx_dma 0>;
-			dma-names = "rx";
-			spibus-connected = <&trx2_adrv9009>;
-		};
+			axi_adrv9009_core_rx: axi-adrv9009-rx-hpc@50000 {
+				compatible = "adi,axi-adrv9009-rx-1.0";
+				reg = <0x00050000 0x2000>;
+				dmas = <&rx_dma 0>;
+				dma-names = "rx";
+				spibus-connected = <&trx2_adrv9009>;
+			};
 
-		axi_adrv9009_core_rx_obs: axi-adrv9009-rx-obs-hpc@58000 {
-			compatible = "adi,axi-adrv9009-obs-1.0";
-			reg = <0x00058000 0x1000>;
-			dmas = <&rx_obs_dma 0>;
-			dma-names = "rx";
-			clocks = <&trx2_adrv9009 1>;
-			clock-names = "sampl_clk";
-		};
+			axi_adrv9009_core_rx_obs: axi-adrv9009-rx-obs-hpc@58000 {
+				compatible = "adi,axi-adrv9009-obs-1.0";
+				reg = <0x00058000 0x1000>;
+				dmas = <&rx_obs_dma 0>;
+				dma-names = "rx";
+				clocks = <&trx2_adrv9009 1>;
+				clock-names = "sampl_clk";
+			};
 
-		axi_adrv9009_core_tx: axi-adrv9009-tx-hpc@54000 {
-			compatible = "adi,axi-adrv9009-x2-tx-1.0";
-			reg = <0x00054000 0x2000>;
-			dmas = <&tx_dma 0>;
-			dma-names = "tx";
-			clocks = <&trx2_adrv9009 2>;
-			clock-names = "sampl_clk";
-			spibus-connected = <&trx2_adrv9009>;
-			adi,axi-pl-fifo-enable;
-			plddrbypass-gpios = <&sys_gpio_out 0 0>;
-		};
-
+			axi_adrv9009_core_tx: axi-adrv9009-tx-hpc@54000 {
+				compatible = "adi,axi-adrv9009-x2-tx-1.0";
+				reg = <0x00054000 0x2000>;
+				dmas = <&tx_dma 0>;
+				dma-names = "tx";
+				clocks = <&trx2_adrv9009 2>;
+				clock-names = "sampl_clk";
+				spibus-connected = <&trx2_adrv9009>;
+				adi,axi-pl-fifo-enable;
+				plddrbypass-gpios = <&sys_gpio_out 0 0>;
+			};
 		};
 	};
 };

--- a/arch/arm/boot/dts/socfpga_arria10_socdk_fmcomms8.dts
+++ b/arch/arm/boot/dts/socfpga_arria10_socdk_fmcomms8.dts
@@ -296,6 +296,11 @@
 				adi,axi-pl-fifo-enable;
 				plddrbypass-gpios = <&sys_gpio_out 0 0>;
 			};
+
+			axi_sysid_0: axi-sysid-0@18000 {
+				compatible = "adi,axi-sysid-1.00.a";
+				reg = <0x00018000 0x8000>;
+			};
 		};
 	};
 };


### PR DESCRIPTION
## PR Description

Add sys_id node in Arria10 devicetrees since it is already present in HDL projects.
Most of the touched DTSes got tested, and now the sysid looks as expected in dmesg (until now grep command was not finding anything):

`dmesg | grep sysid`
```
  axi_sysid ff218000.axi-sysid-000018000: AXI System ID core version (1.01.a) found
  axi_sysid ff218000.axi-sysid-000018000: [ad9081_fmca_ebz] on [a10soc]git branch <next_stable> git <606551b4785c676a3e78dab247641e569cba78f2> clean [2024-04-29 16:32:45] UTC
```



## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
