### PR TITLE
Update rpi-adt7420-overlay

### DIFF
--- a/arch/arm/boot/dts/overlays/rpi-adt7420-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-adt7420-overlay.dts
@@ -12,10 +12,13 @@
 			#size-cells = <0>;
 			status = "okay";
 
-			adt7420@4b {
+			adt7420: adt7420@4b {
 				compatible = "adt7420";
 				reg = <0x4b>;
 			};
 		};
+	};
+	__overrides__ {
+		i2c_address = <&adt7420>,"reg:0";
 	};
 };

--- a/arch/arm/boot/dts/overlays/rpi-adt7420-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-adt7420-overlay.dts
@@ -12,9 +12,9 @@
 			#size-cells = <0>;
 			status = "okay";
 
-			adt7420: adt7420@4b {
+			adt7420: adt7420@48 {
 				compatible = "adt7420";
-				reg = <0x4b>;
+				reg = <0x48>;
 			};
 		};
 	};


### PR DESCRIPTION
## PR Description

Update rpi-adt7420-overlay to allow boot time reconfiguration of I2C address via dt_params.
According to documentation, the default I2C address is 0x48(which works fine). However the default I2C address defined in the overlay is 0x4B. This mismatch will cause the SD card to not run out-of-box. Should either re-build the overlay with address 0x48, either re-solder J1 & J2 to match what's described in the dtbo.

Make this PR directly to rpi-6.1.y branch since folder arch/arm/boot/dts/overlays does not even exists in 'main', being specific to RPI branches.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
