### PR TITLE
arch: arm: boot: dts: Add label attribute for ADAQ4224

### DIFF
--- a/arch/arm/boot/dts/zynq-zed-adv7511-adaq4224-24.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-adaq4224-24.dts
@@ -62,6 +62,7 @@
 
 		max31827: max31827@5f {
 			compatible = "adi,max31827";
+			label = "adaq4224-temp";
 			reg = <0x5f>;
 			vref-supply = <&vio>;
 			adi,comp-int;
@@ -127,6 +128,7 @@
 
 		adaq4224: adaq4224@0 {
 			compatible = "adi,adaq4224";
+			label = "adaq4224";
 			reg = <0>;
 			vdd-supply = <&vref>;
 			vdd_1_8-supply = <&vdd_1_8>;


### PR DESCRIPTION
## PR Description

To have the name of temperature sensor as adaq4224-temp and not max31827
added the label attribute in dts.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
