### PR TITLE
iio: frequency: adrf6780: rm clk provider include

### DIFF
--- a/drivers/iio/frequency/adrf6780.c
+++ b/drivers/iio/frequency/adrf6780.c
@@ -9,7 +9,6 @@
 #include <linux/bits.h>
 #include <linux/clk.h>
 #include <linux/clkdev.h>
-#include <linux/clk-provider.h>
 #include <linux/delay.h>
 #include <linux/device.h>
 #include <linux/iio/iio.h>


### PR DESCRIPTION
## PR Description

The driver has no clock provider implementation, therefore remove the include.

Link: https://lore.kernel.org/lkml/20240530092835.36892-1-antoniu.miclaus@analog.com/
Fixes: https://github.com/analogdevicesinc/linux/commit/63aaf6d06d87866dd6b58265711a979ed4968420 ("iio: frequency: adrf6780: add support for ADRF6780")

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
