### PR TITLE
iio: frequency: adf4371: fix muxout enable (2022_r2)

### DIFF
--- a/drivers/iio/frequency/adf4371.c
+++ b/drivers/iio/frequency/adf4371.c
@@ -726,7 +726,7 @@ static ssize_t adf4371_write(struct iio_dev *indio_dev,
 			break;
 
 		ret = regmap_update_bits(st->regmap, ADF4371_REG(0x20),
-					 ADF4371_AUX_FREQ_SEL_MSK,
+					 ADF4371_MUXOUT_EN_MSK,
 					 ADF4371_MUXOUT_EN(muxout_en));
 		if (ret < 0)
 			break;


### PR DESCRIPTION
## PR Description

Currently the muxout_en attribute does not set the correct bit in the 0x20 register of adf4371.

This makes the muxout feature not being available for usage.

Use the appropriate mask for the MUXOUT_EN bit which is BIT(3) according to the datasheet.

Fixes: df88660ee30f ("iio: frequency: adf4371: Support for RFAUX8 VCO output mux")

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
