### PR TITLE
Staging/fix dts iio tdd

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9081-m8-l4-tdd.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9081-m8-l4-tdd.dts
@@ -30,7 +30,7 @@
 		clock-names = "s_axi_aclk", "intf_clk";
 	};
 
-	iio_axi_tdd_0@0 {
+	iio_axi_tdd_0: iio-axi-tdd-0@0 {
 		compatible = "adi,iio-fake-platform-device";
 		adi,faked-dev = <&axi_tdd_0>;
 		adi,attribute-names =
@@ -44,10 +44,7 @@
 			"out_channel0_off_raw", "out_channel0_off_ms",
 			"out_channel1_enable", "out_channel1_polarity",
 			"out_channel1_on_raw", "out_channel1_on_ms",
-			"out_channel1_off_raw", "out_channel1_off_ms",
-			"out_channel2_enable", "out_channel2_polarity",
-			"out_channel2_on_raw", "out_channel2_on_ms",
-			"out_channel2_off_raw", "out_channel2_off_ms";
+			"out_channel1_off_raw", "out_channel1_off_ms";
 		label = "axi-core-tdd";
 	};
 };

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-stingray.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-stingray.dts
@@ -373,3 +373,30 @@
 &axi_data_offload_tx {
 	/delete-property/ adi,oneshot;
 };
+
+&iio_axi_tdd_0 {
+	adi,attribute-names =
+		"version", "core_id", "scratch", "magic",
+		"sync_soft", "sync_external", "sync_internal", "sync_reset",
+		"enable", "startup_delay_raw", "startup_delay_ms",
+		"burst_count", "frame_length_raw", "frame_length_ms",
+		"state", "internal_sync_period_raw", "internal_sync_period_ms",
+		"out_channel0_enable", "out_channel0_polarity",
+		"out_channel0_on_raw", "out_channel0_on_ms",
+		"out_channel0_off_raw", "out_channel0_off_ms",
+		"out_channel1_enable", "out_channel1_polarity",
+		"out_channel1_on_raw", "out_channel1_on_ms",
+		"out_channel1_off_raw", "out_channel1_off_ms",
+		"out_channel2_enable", "out_channel2_polarity",
+		"out_channel2_on_raw", "out_channel2_on_ms",
+		"out_channel2_off_raw", "out_channel2_off_ms",
+		"out_channel3_enable", "out_channel3_polarity",
+		"out_channel3_on_raw", "out_channel3_on_ms",
+		"out_channel3_off_raw", "out_channel3_off_ms",
+		"out_channel4_enable", "out_channel4_polarity",
+		"out_channel4_on_raw", "out_channel4_on_ms",
+		"out_channel4_off_raw", "out_channel4_off_ms",
+		"out_channel5_enable", "out_channel5_polarity",
+		"out_channel5_on_raw", "out_channel5_on_ms",
+		"out_channel5_off_raw", "out_channel5_off_ms";
+};


### PR DESCRIPTION
## PR Description

- The zcu102/ad9081 device tree should export only channel 0 and channel 1 for TDD iio device (for each axi data offload)
- The Stingray device tree should export 6 tdd channels. The zcu102/ad9081 iio TDD node is overwritten to reflect all 6 channels. 
- The new TDD driver causes the ad9081 plugin in iio oscilloscope to crash. There is an open PR at https://github.com/analogdevicesinc/iio-oscilloscope/pull/491

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [x] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
