### PR TITLE
Fix module compilation

### DIFF
--- a/drivers/char/axi-intr-monitor.c
+++ b/drivers/char/axi-intr-monitor.c
@@ -220,3 +220,5 @@ static struct platform_driver axi_intr_mon_driver = {
 	},
 };
 module_platform_driver(axi_intr_mon_driver);
+
+MODULE_LICENSE("GPL");

--- a/drivers/iio/adc/Kconfig
+++ b/drivers/iio/adc/Kconfig
@@ -481,7 +481,7 @@ config AD9208
 	  Provides direct access via sysfs.
 
 config AD9361
-	tristate "Analog Devices AD9361, AD9364 RF Agile Transceiver driver"
+	bool "Analog Devices AD9361, AD9364 RF Agile Transceiver driver"
 	depends on SPI
 	depends on COMMON_CLK
 	help

--- a/drivers/iio/adc/Makefile
+++ b/drivers/iio/adc/Makefile
@@ -64,11 +64,13 @@ ad9081_drv-y := ad9081.o \
 
 obj-$(CONFIG_AD9081) += ad9081_drv.o
 
-obj-$(CONFIG_AD9083) += ad9083.o \
+ad9083_drv-y := ad9083.o \
 	ad9083/adi_ad9083_device.o \
 	ad9083/adi_ad9083_hal.o \
 	ad9083/adi_ad9083_jesd.o \
 	ad9083/adi_ad9083_rx.o
+
+obj-$(CONFIG_AD9083) += ad9083_drv.o
 
 ad9361_drv-y := ad9361.o ad9361_conv.o
 ad9361_drv-$(CONFIG_AD9361_EXT_BAND_CONTROL) += ad9361_ext_band_ctrl.o

--- a/drivers/iio/adc/ltc2358.c
+++ b/drivers/iio/adc/ltc2358.c
@@ -406,7 +406,7 @@ static const struct spi_device_id ltc235x_id[] = {
 	{ "ltc2358-18", (kernel_ulong_t)&ltc235x_chip_info[ID_LTC2358_18] },
 	{ },
 };
-MODULE_DEVICE_TABLE(spi, ltc2358_id);
+MODULE_DEVICE_TABLE(spi, ltc235x_id);
 
 static const struct of_device_id ltc235x_of_match[] = {
 	{ .compatible = "adi,ltc2353-16",

--- a/drivers/iio/adc/madura/adrv9025.c
+++ b/drivers/iio/adc/madura/adrv9025.c
@@ -2508,7 +2508,7 @@ static const struct of_device_id adrv9025_of_match[] = {
 	{ .compatible = "adi,adrv9029" },
 	{},
 };
-MODULE_DEVICE_TABLE(of, ad9081_of_match);
+MODULE_DEVICE_TABLE(of, adrv9025_of_match);
 
 static struct spi_driver adrv9025_driver = {
 	.driver = {

--- a/drivers/iio/beamformer/adar300x.c
+++ b/drivers/iio/beamformer/adar300x.c
@@ -301,6 +301,7 @@ enum adar300x_beamstate_mode_ctrl {
 };
 
 struct adar300x_chip_info {
+	const struct attribute_group	*attr_group;
 	unsigned int			chip_id;
 	unsigned int			num_channels;
 	const struct iio_chan_spec	*channels;
@@ -1541,7 +1542,7 @@ static int ad300x_reset(struct gpio_desc *gpio_reset)
 	return 0;
 }
 
-static int adar300x_probe(struct spi_device *spi, const struct attribute_group *attr_group)
+static int adar3000_probe(struct spi_device *spi)
 {
 	struct device_node		*child, *np = spi->dev.of_node;
 	int				ret, cnt = 0, num_dev;
@@ -1557,6 +1558,10 @@ static int adar300x_probe(struct spi_device *spi, const struct attribute_group *
 		dev_err(&spi->dev, "Number of devices is incorrect (%d)\n", num_dev);
 		return -ENODEV;
 	}
+
+	info = of_device_get_match_data(&spi->dev);
+	if (!info)
+		return -ENODEV;
 
 	regmap = devm_regmap_init_spi(spi, &adar300x_regmap_config);
 	if (IS_ERR(regmap)) {
@@ -1585,10 +1590,6 @@ static int adar300x_probe(struct spi_device *spi, const struct attribute_group *
 		if (!indio_dev)
 			return -ENOMEM;
 
-		info = of_device_get_match_data(&spi->dev);
-		if (!info)
-			return -ENODEV;
-
 		st = iio_priv(indio_dev);
 		st->spi = spi;
 		st->chip_info = info;
@@ -1603,7 +1604,7 @@ static int adar300x_probe(struct spi_device *spi, const struct attribute_group *
 		indio_dev->name = child->name;
 		indio_dev->channels = st->chip_info->channels;
 		indio_dev->num_channels = st->chip_info->num_channels;
-		adar300x_info.attrs = attr_group;
+		adar300x_info.attrs = st->chip_info->attr_group;
 		indio_dev->info = &adar300x_info;
 		indio_dev->modes = INDIO_DIRECT_MODE;
 		indio_dev->available_scan_masks = adar300x_available_scan_masks;
@@ -2057,61 +2058,6 @@ DECLARE_ADAR3000_CHANNELS(adar3000_channels);
 DECLARE_ADAR3000_CHANNELS(adar3001_channels);
 DECLARE_ADAR3000_CHANNELS(adar3002_channels);
 
-static const struct adar300x_chip_info adar3000_chip_info_tbl[] = {
-	[ID_ADAR3000] = {
-		.chip_id = ID_ADAR3000,
-		.channels = adar3000_channels,
-		.num_channels = ARRAY_SIZE(adar3000_channels),
-		.unpacked_beamst_len = 8,
-		.packed_beamst_len = 6,
-		.product_id = ADAR3000_PRODUCT_ID,
-	},
-	[ID_ADAR3001] = {
-		.chip_id = ID_ADAR3001,
-		.channels = adar3001_channels,
-		.num_channels = ARRAY_SIZE(adar3002_channels),
-		.unpacked_beamst_len = 8,
-		.packed_beamst_len = 6,
-		.product_id = ADAR3000_PRODUCT_ID,
-	},
-	[ID_ADAR3002] = {
-		.chip_id = ID_ADAR3002,
-		.channels = adar3002_channels,
-		.num_channels = ARRAY_SIZE(adar3002_channels),
-		.unpacked_beamst_len = 8,
-		.packed_beamst_len = 6,
-		.product_id = ADAR3000_PRODUCT_ID,
-	},
-};
-
-static int adar3000_probe(struct spi_device *spi)
-{
-	return adar300x_probe(spi, &adar3000_attribute_group);
-}
-
-static const struct of_device_id adar3000_of_match[] = {
-	{ .compatible = "adi,adar3000",
-		.data = &adar3000_chip_info_tbl[ID_ADAR3000], },
-	{ .compatible = "adi,adar3001",
-		.data = &adar3000_chip_info_tbl[ID_ADAR3001], },
-	{ .compatible = "adi,adar3002",
-		.data = &adar3000_chip_info_tbl[ID_ADAR3002], },
-	{ }
-};
-
-MODULE_DEVICE_TABLE(of, adar3000_of_match);
-
-static struct spi_driver adar3000_driver = {
-	.driver = {
-		.name	= "adar3000",
-		.of_match_table = adar3000_of_match,
-	},
-	.probe = adar3000_probe,
-};
-
-/* ADAR3003 */
-module_spi_driver(adar3000_driver);
-
 enum adar3003_iio_dev_attr {
 	ADAR3003_EL0VH,
 	ADAR3003_EL1VH,
@@ -2232,6 +2178,7 @@ static IIO_DEVICE_ATTR(el2vh_fifo_wr, 0644,
 static IIO_DEVICE_ATTR(el3vh_fifo_wr, 0644,
 		       adar300x_fifo_ptr_show, NULL, ADAR300x_FIFO_WR3);
 
+/* adar3003 */
 static struct attribute *adar3003_attributes[] = {
 	&iio_dev_attr_el0vh_update.dev_attr.attr,
 	&iio_dev_attr_el1vh_update.dev_attr.attr,
@@ -2369,8 +2316,36 @@ static const struct iio_chan_spec name[] = {			\
 
 DECLARE_ADAR3003_CHANNELS(adar3003_channels);
 
-static const struct adar300x_chip_info adar3003_chip_info_tbl[] = {
+static const struct adar300x_chip_info adar3000_chip_info_tbl[] = {
+	[ID_ADAR3000] = {
+		.attr_group = &adar3000_attribute_group,
+		.chip_id = ID_ADAR3000,
+		.channels = adar3000_channels,
+		.num_channels = ARRAY_SIZE(adar3000_channels),
+		.unpacked_beamst_len = 8,
+		.packed_beamst_len = 6,
+		.product_id = ADAR3000_PRODUCT_ID,
+	},
+	[ID_ADAR3001] = {
+		.attr_group = &adar3000_attribute_group,
+		.chip_id = ID_ADAR3001,
+		.channels = adar3001_channels,
+		.num_channels = ARRAY_SIZE(adar3002_channels),
+		.unpacked_beamst_len = 8,
+		.packed_beamst_len = 6,
+		.product_id = ADAR3000_PRODUCT_ID,
+	},
+	[ID_ADAR3002] = {
+		.attr_group = &adar3000_attribute_group,
+		.chip_id = ID_ADAR3002,
+		.channels = adar3002_channels,
+		.num_channels = ARRAY_SIZE(adar3002_channels),
+		.unpacked_beamst_len = 8,
+		.packed_beamst_len = 6,
+		.product_id = ADAR3000_PRODUCT_ID,
+	},
 	[ID_ADAR3003] = {
+		.attr_group = &adar3003_attribute_group,
 		.chip_id = ID_ADAR3003,
 		.channels = adar3003_channels,
 		.num_channels = ARRAY_SIZE(adar3003_channels),
@@ -2380,28 +2355,28 @@ static const struct adar300x_chip_info adar3003_chip_info_tbl[] = {
 	},
 };
 
-static const struct of_device_id adar3003_of_match[] = {
+static const struct of_device_id adar3000_of_match[] = {
+	{ .compatible = "adi,adar3000",
+		.data = &adar3000_chip_info_tbl[ID_ADAR3000], },
+	{ .compatible = "adi,adar3001",
+		.data = &adar3000_chip_info_tbl[ID_ADAR3001], },
+	{ .compatible = "adi,adar3002",
+		.data = &adar3000_chip_info_tbl[ID_ADAR3002], },
 	{ .compatible = "adi,adar3003",
-		.data = &adar3003_chip_info_tbl[ID_ADAR3003], },
+		.data = &adar3000_chip_info_tbl[ID_ADAR3003], },
 	{ }
 };
 
 MODULE_DEVICE_TABLE(of, adar3000_of_match);
 
-static int adar3003_probe(struct spi_device *spi)
-{
-	return adar300x_probe(spi, &adar3003_attribute_group);
-}
-
-static struct spi_driver adar3003_driver = {
+static struct spi_driver adar3000_driver = {
 	.driver = {
-		.name	= "adar3003",
-		.of_match_table = adar3003_of_match,
+		.name	= "adar3000",
+		.of_match_table = adar3000_of_match,
 	},
-	.probe = adar3003_probe,
+	.probe = adar3000_probe,
 };
-
-module_spi_driver(adar3003_driver);
+module_spi_driver(adar3000_driver);
 
 MODULE_AUTHOR("Cristian Pop <cristian.pop@analog.com>");
 MODULE_DESCRIPTION("Analog Devices ADAR300x Beamformer");

--- a/drivers/iio/dac/ad5686.c
+++ b/drivers/iio/dac/ad5686.c
@@ -518,7 +518,7 @@ static irqreturn_t ad5686_trigger_handler(int irq, void *p)
 	for_each_set_bit(i, indio_dev->active_scan_mask, indio_dev->masklength) {
 		val = (sample[1] << 8) + sample[0];
 
-		chan = iio_find_channel_from_si(indio_dev, i);
+		chan = &indio_dev->channels[i];
 		ret = st->write(st, AD5686_CMD_WRITE_INPUT_N_UPDATE_N,
 				chan->address, val << chan->scan_type.shift);
 	}

--- a/drivers/iio/frequency/Makefile
+++ b/drivers/iio/frequency/Makefile
@@ -31,10 +31,10 @@ obj-$(CONFIG_CF_AXI_DDS_AD9783) += ad9783.o
 obj-$(CONFIG_HMC7044) += hmc7044.o
 obj-$(CONFIG_LTC6952) += ltc6952.o
 
-ad916x_drv-y := ad916x/ad916x_api.o  ad916x/ad916x_irq_api.o  ad916x/ad916x_jesd_api.o  ad916x/ad916x_jesd_test_api.o  ad916x/ad916x_nco_api.o  ad916x/ad916x_reg.o  ad916x/api_errors.o  ad916x/utils.o
-obj-$(CONFIG_CF_AXI_DDS_AD9162) += ad9162.o ad916x_drv.o
+ad916x_drv-y := ad9162.o ad916x/ad916x_api.o  ad916x/ad916x_irq_api.o  ad916x/ad916x_jesd_api.o  ad916x/ad916x_jesd_test_api.o  ad916x/ad916x_nco_api.o  ad916x/ad916x_reg.o  ad916x/api_errors.o  ad916x/utils.o
+obj-$(CONFIG_CF_AXI_DDS_AD9162) += ad916x_drv.o
 
-ad917x_drv-y := ad917x/ad917x_api.o  ad917x/ad917x_jesd_api.o  ad917x/ad917x_nco_api.o  ad917x/ad917x_reg.o
-obj-$(CONFIG_CF_AXI_DDS_AD9172) += ad9172.o ad917x_drv.o
+ad917x_drv-y := ad9172.o ad917x/ad917x_api.o  ad917x/ad917x_jesd_api.o  ad917x/ad917x_nco_api.o  ad917x/ad917x_reg.o
+obj-$(CONFIG_CF_AXI_DDS_AD9172) += ad917x_drv.o
 obj-$(CONFIG_M2K_DAC) += m2k-dac.o
 

--- a/drivers/iio/frequency/m2k-dac.c
+++ b/drivers/iio/frequency/m2k-dac.c
@@ -846,7 +846,7 @@ static const struct of_device_id m2k_dac_of_match[] = {
 	},
 	{ },
 };
-MODULE_DEVICE_TABLE(of, m2k_dac_match);
+MODULE_DEVICE_TABLE(of, m2k_dac_of_match);
 
 static struct platform_driver m2k_dac_driver = {
 	.driver = {

--- a/drivers/iio/jesd204/Makefile
+++ b/drivers/iio/jesd204/Makefile
@@ -1,4 +1,5 @@
-obj-$(CONFIG_AXI_ADXCVR) += axi_adxcvr.o axi_adxcvr_eyescan.o
+axi_adxcvr_drv-y := axi_adxcvr.o axi_adxcvr_eyescan.o
+obj-$(CONFIG_AXI_ADXCVR) += axi_adxcvr_drv.o
 obj-$(CONFIG_AXI_JESD204B) += axi_jesd204b_v51.o axi_jesd204b_gt.o
 obj-$(CONFIG_AXI_JESD204_RX) += axi_jesd204_rx.o
 obj-$(CONFIG_AXI_JESD204_TX) += axi_jesd204_tx.o

--- a/drivers/iio/jesd204/axi_jesd204_rx.c
+++ b/drivers/iio/jesd204/axi_jesd204_rx.c
@@ -1329,7 +1329,7 @@ static const struct of_device_id axi_jesd204_rx_of_match[] = {
 	{ .compatible = "adi,axi-jesd204-rx-1.3" },
 	{ /* end of list */ },
 };
-MODULE_DEVICE_TABLE(of, adxcvr_of_match);
+MODULE_DEVICE_TABLE(of, axi_jesd204_rx_of_match);
 
 static struct platform_driver axi_jesd204_rx_driver = {
 	.probe = axi_jesd204_rx_probe,

--- a/drivers/iio/jesd204/axi_jesd204_tx.c
+++ b/drivers/iio/jesd204/axi_jesd204_tx.c
@@ -1056,7 +1056,7 @@ static const struct of_device_id axi_jesd204_tx_of_match[] = {
 	{ .compatible = "adi,axi-jesd204-tx-1.3" },
 	{ /* end of list */ },
 };
-MODULE_DEVICE_TABLE(of, adxcvr_of_match);
+MODULE_DEVICE_TABLE(of, axi_jesd204_tx_of_match);
 
 static struct platform_driver axi_jesd204_tx_driver = {
 	.probe = axi_jesd204_tx_probe,

--- a/drivers/iio/multiplexer/Kconfig
+++ b/drivers/iio/multiplexer/Kconfig
@@ -16,7 +16,7 @@ config IIO_MUX
 	  module will be called iio-mux.
 
 config IIO_GEN_MUX
-	tristate "IIO generic multiplexer driver"
+	bool "IIO generic multiplexer driver"
 	select MULTIPLEXER
 	depends on OF
 	help

--- a/drivers/jesd204/jesd204-core.c
+++ b/drivers/jesd204/jesd204-core.c
@@ -627,6 +627,7 @@ void jesd204_printk(const char *level, const struct jesd204_dev *jdev,
 
 	va_end(args);
 }
+EXPORT_SYMBOL_GPL(jesd204_printk);
 
 static int jesd204_dev_alloc_links(struct jesd204_dev_top *jdev_top)
 {

--- a/include/linux/jesd204/jesd204.h
+++ b/include/linux/jesd204/jesd204.h
@@ -7,6 +7,7 @@
 #ifndef _JESD204_H_
 #define _JESD204_H_
 
+#include <linux/kconfig.h>
 #include <linux/kern_levels.h>
 #include <dt-bindings/jesd204/device-states.h>
 
@@ -249,7 +250,7 @@ struct jesd204_dev_data {
 	struct jesd204_state_op			state_ops[__JESD204_MAX_OPS];
 };
 
-#ifdef CONFIG_JESD204
+#if IS_ENABLED(CONFIG_JESD204)
 
 struct jesd204_dev *devm_jesd204_dev_register(struct device *dev,
 					      const struct jesd204_dev_data *i);
@@ -400,7 +401,7 @@ static inline void jesd204_copy_link_params(struct jesd204_link *dst,
 
 #endif /* #ifdef CONFIG_JESD204 */
 
-#if defined(CONFIG_PRINTK) && defined(CONFIG_JESD204)
+#if defined(CONFIG_PRINTK) && IS_ENABLED(CONFIG_JESD204)
 
 __printf(3, 4)
 void jesd204_printk(const char *level, const struct jesd204_dev *jdev,


### PR DESCRIPTION
## PR Description

This is a first (and hopefully the only one) round of fixes to make sure we can compile our drivers as modules. Two exceptions though:

1. ad9361 makes use of non exported OF function and to change the driver to not using that function is non trivial. Since we lived this far without needing the driver as a module, let's go the easy path and just don't allow that driver to be compiled as a module.
2. Same story for the iio-gen-mux driver which uses a non exported function from CCF.

And also exporting the functions is also far from ideal as the two drivers are likely to never be upstreamed which means that we could not really upstream the patches exporting those functions.

This was just compile tested with:
```
make zynq_xcomm_adv7511_defconfig
make yes2modconfig
```

I need to see for zynqmp and other configs if more fixes are needed... Also to note that the above will fail compiling as xilinx/AMD also have things to be fixed that I'm not including in this pull (I'll likely send the patches directly to xilinx) .

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
