### PR TITLE
ad9361: fix FORCE_VCO_TUNE_ENABLE typo

### DIFF
--- a/drivers/iio/adc/ad9361.c
+++ b/drivers/iio/adc/ad9361.c
@@ -4645,9 +4645,9 @@ static int ad9361_fastlock_prepare(struct ad9361_rf_phy *phy, bool tx,
 
 		/* Workaround: Exiting Fastlock Mode */
 		ad9361_spi_writef(phy->spi, REG_RX_FORCE_ALC + offs, FORCE_ALC_ENABLE, 1);
-		ad9361_spi_writef(phy->spi, REG_RX_FORCE_VCO_TUNE_1 + offs, FORCE_VCO_TUNE, 1);
+		ad9361_spi_writef(phy->spi, REG_RX_FORCE_VCO_TUNE_1 + offs, FORCE_VCO_TUNE_ENABLE, 1);
 		ad9361_spi_writef(phy->spi, REG_RX_FORCE_ALC + offs, FORCE_ALC_ENABLE, 0);
-		ad9361_spi_writef(phy->spi, REG_RX_FORCE_VCO_TUNE_1 + offs, FORCE_VCO_TUNE, 0);
+		ad9361_spi_writef(phy->spi, REG_RX_FORCE_VCO_TUNE_1 + offs, FORCE_VCO_TUNE_ENABLE, 0);
 
 		ad9361_trx_vco_cal_control(phy, tx, true);
 		ad9361_spi_writef(phy->spi, REG_ENSM_CONFIG_2, ready_mask, 0);


### PR DESCRIPTION


## PR Description

The author used FORCE_VCO_TUNE instead of FORCE_VCO_TUNE_ENABLE.

FORCE_VCO_TUNE is the 8th (MSB) of the VCO capacitor tune word. FORCE_VCO_TUNE_ENABLE is the bit that forces or not the usage of the VCO capacitor tune word.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
