### PR TITLE
iio: frequency: ltc6952: keep unused channels disabled

### DIFF
--- a/drivers/iio/frequency/ltc6952.c
+++ b/drivers/iio/frequency/ltc6952.c
@@ -84,7 +84,7 @@
 #define LTC6952_PD8(x)		FIELD_PREP(LTC6952_PD8_MSK, x)
 
 #define LTC6952_PD_MSK(ch)	GENMASK(((ch) & 0x03) * 2 + 1, ((ch) & 0x03) * 2)
-#define LTC6952_PD(ch, x)	((x) << ((ch) & 0x03))
+#define LTC6952_PD(ch, x)	((x) << ((ch) & 0x03) * 2)
 
 /* LTC6952_REG6 */
 #define LTC6952_RAO_MSK		BIT(7)
@@ -615,6 +615,23 @@ static int ltc6952_setup(struct iio_dev *indio_dev)
 	/* Resets all registers to default values */
 	ret = ltc6952_write_mask(indio_dev, LTC6952_REG(0x02),
 				 LTC6952_POR_MSK, LTC6952_POR(1));
+	if (ret < 0)
+		goto err_unlock;
+
+	ret = ltc6952_write_mask(indio_dev, LTC6952_REG(0x02),
+				 LTC6952_POR_MSK, LTC6952_POR(0));
+	if (ret < 0)
+		goto err_unlock;
+
+	ret = ltc6952_write(indio_dev, LTC6952_REG(0x03), 0xFF);
+	if (ret < 0)
+		goto err_unlock;
+
+	ret = ltc6952_write(indio_dev, LTC6952_REG(0x04), 0xFF);
+	if (ret < 0)
+		goto err_unlock;
+
+	ret = ltc6952_write(indio_dev, LTC6952_REG(0x05), 0x3F);
 	if (ret < 0)
 		goto err_unlock;
 


### PR DESCRIPTION

## PR Description

 * On POR all channels are fully enabled. This patch keeps those disabled which are not represented by a node in the device-tree.

 * We also clear the POR reset bit, which might not be necessary but looks cleaner.

 * We also fix LTC6952_PD(x) mask which wasn't doing anything until now.

## PR Type
- [X] Bug fix (a change that fixes an issue)
- [X] New feature (a change that adds new functionality)


## PR Checklist
- [X] I have conducted a self-review of my own code changes
- [X] I have tested the changes on the relevant hardware

