### PR TITLE
AD4630 remove hacky compatible

### DIFF
--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad4630-24.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad4630-24.dts
@@ -101,8 +101,8 @@
 		#address-cells = <0x1>;
 		#size-cells = <0x0>;
 
-		ad463x: ad463x@0 {
-			compatible = "adi,ad463x";
+		ad4630_24: ad4630-24@0 {
+			compatible = "adi,ad4630-24";
 			reg = <0>;
 			vdd-supply = <&vref>;
 			vdd_1_8-supply = <&vdd_1_8>;

--- a/drivers/iio/adc/ad4630.c
+++ b/drivers/iio/adc/ad4630.c
@@ -1566,7 +1566,7 @@ static int ad4630_probe(struct spi_device *spi)
 	return 0;
 }
 
-static int __maybe_unused ad4630_runtime_suspend(struct device *dev)
+static int ad4630_runtime_suspend(struct device *dev)
 {
 	u32 val = FIELD_PREP(AD4630_POWER_MODE_MSK, AD4630_LOW_POWER_MODE);
 	struct ad4630_state *st = dev_get_drvdata(dev);
@@ -1574,7 +1574,7 @@ static int __maybe_unused ad4630_runtime_suspend(struct device *dev)
 	return regmap_write(st->regmap, AD4630_REG_DEVICE_CONFIG, val);
 }
 
-static int __maybe_unused ad4630_runtime_resume(struct device *dev)
+static int ad4630_runtime_resume(struct device *dev)
 {
 	struct ad4630_state *st = dev_get_drvdata(dev);
 	int ret;
@@ -1627,7 +1627,7 @@ static struct spi_driver ad4630_driver = {
 	.driver = {
 		.name = "ad4630",
 		.of_match_table = ad4630_of_match,
-		.pm = &ad4630_pm_ops,
+		.pm = pm_ptr(&ad4630_pm_ops),
 	},
 	.probe = ad4630_probe,
 	.id_table = ad4630_id_table,

--- a/drivers/iio/adc/ad4630.c
+++ b/drivers/iio/adc/ad4630.c
@@ -1472,13 +1472,10 @@ static int ad4630_probe(struct spi_device *spi)
 	st->spi = spi;
 	spi_set_drvdata(spi, indio_dev);
 
-	st->chip = device_get_match_data(dev);
-	if (!st->chip) {
-		st->chip = (void *)spi_get_device_id(spi)->driver_data;
-		if (!st->chip)
-			return dev_err_probe(dev, -ENODEV,
-					     "Could not find chip info data\n");
-	}
+	st->chip = spi_get_device_match_data(spi);
+	if (!st->chip)
+		return dev_err_probe(dev, -ENODEV,
+				     "Could not find chip info data\n");
 
 	st->regmap = devm_regmap_init(&spi->dev, &ad4630_regmap_bus, st,
 				      &ad4630_regmap_config);

--- a/drivers/iio/adc/ad4630.c
+++ b/drivers/iio/adc/ad4630.c
@@ -1470,7 +1470,7 @@ static int ad4630_probe(struct spi_device *spi)
 
 	st = iio_priv(indio_dev);
 	st->spi = spi;
-	spi_set_drvdata(spi, indio_dev);
+	spi_set_drvdata(spi, st);
 
 	st->chip = spi_get_device_match_data(spi);
 	if (!st->chip)
@@ -1569,16 +1569,14 @@ static int ad4630_probe(struct spi_device *spi)
 static int __maybe_unused ad4630_runtime_suspend(struct device *dev)
 {
 	u32 val = FIELD_PREP(AD4630_POWER_MODE_MSK, AD4630_LOW_POWER_MODE);
-	struct iio_dev *indio_dev = dev_get_drvdata(dev);
-	struct ad4630_state *st = iio_priv(indio_dev);
+	struct ad4630_state *st = dev_get_drvdata(dev);
 
 	return regmap_write(st->regmap, AD4630_REG_DEVICE_CONFIG, val);
 }
 
 static int __maybe_unused ad4630_runtime_resume(struct device *dev)
 {
-	struct iio_dev *indio_dev = dev_get_drvdata(dev);
-	struct ad4630_state *st = iio_priv(indio_dev);
+	struct ad4630_state *st = dev_get_drvdata(dev);
 	int ret;
 
 	ret = regmap_write(st->regmap, AD4630_REG_DEVICE_CONFIG,


### PR DESCRIPTION
## PR Description

The main goal of the pull is to remove the ad463x compatible as it's not needed anymore. Some other small improvements were done while at it.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [x] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
