### PR TITLE
Fix: JESD204 AMD/Versal GT reset handling 

### DIFF
--- a/arch/arm64/boot/dts/xilinx/versal-vck190-reva-ad9081.dts
+++ b/arch/arm64/boot/dts/xilinx/versal-vck190-reva-ad9081.dts
@@ -176,6 +176,10 @@
 			jesd204-device;
 			#jesd204-cells = <2>;
 			jesd204-inputs = <&hmc7044 0 FRAMER_LINK0_RX>;
+
+			reset-done-gpios = <&axi_gpio 32 0>;
+			pll-datapath-reset-gpios = <&axi_gpio 36 0>;
+			datapath-reset-gpios = <&axi_gpio 38 0>;
 		};
 
 		axi_ad9081_tx_jesd: axi-jesd204-tx@a4b90000 {
@@ -193,6 +197,10 @@
 			jesd204-device;
 			#jesd204-cells = <2>;
 			jesd204-inputs = <&hmc7044 0 DEFRAMER_LINK0_TX>;
+
+			reset-done-gpios = <&axi_gpio 33 0>;
+			pll-datapath-reset-gpios = <&axi_gpio 37 0>;
+			datapath-reset-gpios = <&axi_gpio 39 0>;
 		};
 
 		axi_sysid_0: axi-sysid-0@a5000000 {

--- a/drivers/iio/jesd204/axi_jesd204.h
+++ b/drivers/iio/jesd204/axi_jesd204.h
@@ -14,4 +14,62 @@
 #define JESD204_ENCODER_MASK		GENMASK(9, 8)
 #define JESD204_ENCODER_GET(x)		FIELD_GET(JESD204_ENCODER_MASK, x)
 
+/**
+ * axi_jesd_ext_reset - Perform an optional external GT reset using GPIO signals
+ * @dev: Pointer to the device structure
+ * @name: Name of the reset signal
+ * @reset: Pointer to the GPIO descriptor for the reset pin
+ * @done: Pointer to the GPIO descriptor for the done pin
+ *
+ * This function performs an external reset by controlling the reset and done
+ * GPIO pins. It sets the reset pin to high, waits for a short delay, and then
+ * sets the reset pin to low. It then waits for the done pin to indicate that
+ * the reset is complete. The function will retry up to 32 times, waiting for
+ * 1 millisecond between each attempt. If the reset is successful, it returns 0.
+ * If the reset times out, it returns -ETIMEDOUT.
+ *
+ * Return: 0 on success, -ETIMEDOUT on timeout, or an error code on failure
+ */
+static inline int axi_jesd_ext_reset(struct device *dev, const char *name,
+				     struct gpio_desc *reset, struct gpio_desc *done)
+{
+	int ret, count = 0;
+	unsigned int resetdone;
+
+	if (!(reset && done))
+		return 0;
+
+	gpiod_set_value(reset, 1);
+	fsleep(20);
+	gpiod_set_value(reset, 0);
+
+	while (count < 32) {
+		fsleep(1000);
+		ret = gpiod_get_value(done);
+		if (ret < 0) {
+			dev_err(dev, "Waiting for %s_reset_done failed (%d)\n", name, ret);
+			return ret;
+		}
+		resetdone = ret;
+		fsleep(1000);
+
+		ret = gpiod_get_value(done);
+		if (ret < 0) {
+			dev_err(dev, "Waiting for %s_reset_done failed (%d)\n", name, ret);
+			return ret;
+		}
+
+		resetdone &= ret;
+
+		if (resetdone) {
+			dev_dbg(dev, "Waiting for %s_reset_done: %d\n", name, count);
+			return 0;
+		}
+		count++;
+	}
+
+	dev_err(dev, "Waiting for %s_reset_done timedout (%d)\n", name, ret);
+
+	return -ETIMEDOUT;
+}
 #endif


### PR DESCRIPTION
## PR Description

When using the ADXVR IP, the driver handles the GT resets.
However, for AMD/Versal we currently use the Xilinx PHY IP directly.
In this case the RESETs are provided as GPIOs.
And we issue PLL and Datapath resets at the proper  jesd204-fsm states.
This patch depends on corresponding HDL changes.


## PR Type
- [X] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [X] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [X] I have conducted a self-review of my own code changes
- [X] I have tested the changes on the relevant hardware

