### PR TITLE
vcu118_ad9081_204c_txmode_24_rxmode_26_lr_24_75Gbps.dts: Bug fix

### DIFF
--- a/arch/microblaze/boot/dts/vcu118_ad9081_204c_txmode_24_rxmode_26_lr_24_75Gbps.dts
+++ b/arch/microblaze/boot/dts/vcu118_ad9081_204c_txmode_24_rxmode_26_lr_24_75Gbps.dts
@@ -123,12 +123,12 @@
 				adi,nco-frequency-shift-hz =  /bits/ 64 <0>;
 			};
 			ad9081_tx_fddc_chan2: channel@2 {
-				reg = <0>;
+				reg = <2>;
 				adi,gain = <2048>; /* 2048 * 10^(gain_dB/20) */
 				adi,nco-frequency-shift-hz =  /bits/ 64 <0>;
 			};
 			ad9081_tx_fddc_chan3: channel@3 {
-				reg = <1>;
+				reg = <3>;
 				adi,gain = <2048>; /* 2048 * 10^(gain_dB/20) */
 				adi,nco-frequency-shift-hz =  /bits/ 64 <0>;
 			};
@@ -142,7 +142,7 @@
 				#size-cells = <0>;
 				reg = <0>;
 				adi,logical-lane-mapping = /bits/ 8 <0 2 7 6 1 5 4 3>;
-				adi,link-mode = <23>;			/* JESD Quick Configuration Mode */
+				adi,link-mode = <24>;			/* JESD Quick Configuration Mode */
 				adi,subclass = <1>;			/* JESD SUBCLASS 0,1,2 */
 				adi,version = <2>;			/* JESD VERSION 0=204A,1=204B,2=204C */
 				adi,dual-link = <0>;			/* JESD Dual Link Mode */
@@ -232,7 +232,7 @@
 					<&ad9081_rx_fddc_chan4 FDDC_I>, <&ad9081_rx_fddc_chan4 FDDC_Q>,
 					<&ad9081_rx_fddc_chan5 FDDC_I>, <&ad9081_rx_fddc_chan5 FDDC_Q>;
 				adi,logical-lane-mapping = /bits/ 8 <2 0 7 6 5 4 3 1>;
-				adi,link-mode = <25>;			/* JESD Quick Configuration Mode */
+				adi,link-mode = <26>;			/* JESD Quick Configuration Mode */
 				adi,subclass = <1>;			/* JESD SUBCLASS 0,1,2 */
 				adi,version = <2>;			/* JESD VERSION 0=204A,1=204B,2=204C */
 				adi,dual-link = <0>;			/* JESD Dual Link Mode */

--- a/arch/microblaze/boot/dts/vcu118_ad9081_204c_txmode_24_rxmode_26_lr_24_75Gbps.dts
+++ b/arch/microblaze/boot/dts/vcu118_ad9081_204c_txmode_24_rxmode_26_lr_24_75Gbps.dts
@@ -82,52 +82,56 @@
 		#size-cells = <0>;
 		#address-cells = <1>;
 		adi,dac-frequency-hz = /bits/ 64 <8000000000>;
+		/* CDUCs*/
 		adi,main-data-paths {
 			#address-cells = <1>;
 			#size-cells = <0>;
+			/* Mtx */
 			adi,interpolation = <4>;
 			ad9081_dac0: dac@0 {
 				reg = <0>;
-				adi,crossbar-select = <&ad9081_tx_fddc_chan0>;
+				adi,crossbar-select = <&ad9081_tx_fduc_chan0>;
 				adi,nco-frequency-shift-hz = /bits/ 64 <1000000000>; /* 100 MHz */
 			};
 			ad9081_dac1: dac@1 {
 				reg = <1>;
-				adi,crossbar-select = <&ad9081_tx_fddc_chan1>;
+				adi,crossbar-select = <&ad9081_tx_fduc_chan1>;
 				adi,nco-frequency-shift-hz = /bits/ 64 <1100000000>; /* 1100 MHz */
 			};
 			ad9081_dac2: dac@2 {
 				reg = <2>;
-				adi,crossbar-select = <&ad9081_tx_fddc_chan2>;
+				adi,crossbar-select = <&ad9081_tx_fduc_chan2>;
 				adi,nco-frequency-shift-hz = /bits/ 64 <1000000000>; /* 100 MHz */
 			};
 			ad9081_dac3: dac@3 {
 				reg = <3>;
-				adi,crossbar-select = <&ad9081_tx_fddc_chan3>;
+				adi,crossbar-select = <&ad9081_tx_fduc_chan3>;
 				adi,nco-frequency-shift-hz = /bits/ 64 <1100000000>; /* 1100 MHz */
 			};
 		};
 
+		/* FDUCs */
 		adi,channelizer-paths {
 			#address-cells = <1>;
 			#size-cells = <0>;
+			/* Ntx */
 			adi,interpolation = <1>;
-			ad9081_tx_fddc_chan0: channel@0 {
+			ad9081_tx_fduc_chan0: channel@0 {
 				reg = <0>;
 				adi,gain = <2048>; /* 2048 * 10^(gain_dB/20) */
 				adi,nco-frequency-shift-hz =  /bits/ 64 <0>;
 			};
-			ad9081_tx_fddc_chan1: channel@1 {
+			ad9081_tx_fduc_chan1: channel@1 {
 				reg = <1>;
 				adi,gain = <2048>; /* 2048 * 10^(gain_dB/20) */
 				adi,nco-frequency-shift-hz =  /bits/ 64 <0>;
 			};
-			ad9081_tx_fddc_chan2: channel@2 {
+			ad9081_tx_fduc_chan2: channel@2 {
 				reg = <2>;
 				adi,gain = <2048>; /* 2048 * 10^(gain_dB/20) */
 				adi,nco-frequency-shift-hz =  /bits/ 64 <0>;
 			};
-			ad9081_tx_fddc_chan3: channel@3 {
+			ad9081_tx_fduc_chan3: channel@3 {
 				reg = <3>;
 				adi,gain = <2048>; /* 2048 * 10^(gain_dB/20) */
 				adi,nco-frequency-shift-hz =  /bits/ 64 <0>;


### PR DESCRIPTION
## PR Description

This PR updates the JESD204C Tx and Rx modes, as well as the reg value for the Tx channelizer nodes 2, 3. The label for all 4 of them is also updated.

### The first commit

**The first issue**, is that the Rx and Tx JESD204C modes in the device tree were wrongly set (to 23 & 25, and not 24 & 26 as the name states). Even though the parameters (L, M, etc.) are correctly set, it would use the values given by the mode, causing it to use half of the lanes.

JESD204C Rx mode 26.00 defined now in dts _(and in italic, values for mode 25.00 which was previously set)_:
L = 8 _(4)_, M = 8 _(4)_, F = 3, S = 2, K = 256, E = 3, N = 12, NP = 12, HD = 0
Total DCM (Coarse x Fine) = 2x1 (extracted from dts)

JESD204C Tx mode 24 defined now in dts _(and in italic, values for mode 23 which was previously set)_:
L = 8 _(4)_, M = 8 _(4)_, F = 3, S = 2, K = 256, E = 3, N = 12, NP = 12, HD = 0
Interpolation mode (Coarse x Fine) = 4x1 (extracted from dts)

**The second issue** is the value of the reg in the Tx channelizer nodes 2 and 3. The values were set to 0, 1 respectively, which caused strange behaviour noticed in IIO Oscilloscope.
The Tx channels 2, 3 can not be enabled (the checkboxes are inactive) and the labels show these connections:

![image](https://github.com/analogdevicesinc/linux/assets/54354100/eb52b9ba-0d43-42e4-af8f-3e2d1b31ff18)
![image](https://github.com/analogdevicesinc/linux/assets/54354100/608a7634-decd-4fe0-b3cc-c68d0cc77371)
![image](https://github.com/analogdevicesinc/linux/assets/54354100/d1a4b0e7-0328-4a04-b80e-e1881d5ddb2d)

With the same settings in IIO and loopback between the channels, now it looks like this:

![image](https://github.com/analogdevicesinc/linux/assets/54354100/f3a5fad1-b051-473a-8082-d7684a9fe413)
![image](https://github.com/analogdevicesinc/linux/assets/54354100/2da4955e-b1a3-404b-a3c0-3d950293eb65)

### The second commit

The names of the Tx channelizer nodes were changed from FDDC to FDUC, because on the Tx side there are Fine Digital UP Converters (FDUC), and not Down (FDDC). This doesn't affect the IIO Osc. labels, but it's not correct.

If needed, these can be squashed.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
