### PR TITLE
Add code to probe AD7683, AD7684 and AD7694

### DIFF
--- a/Documentation/devicetree/bindings/iio/adc/adi,pulsar.yaml
+++ b/Documentation/devicetree/bindings/iio/adc/adi,pulsar.yaml
@@ -21,6 +21,7 @@ description: |
     https://www.analog.com/en/products/ad7946.html
     https://www.analog.com/en/products/ad7942.html
     https://www.analog.com/en/products/ad7699.html
+    https://www.analog.com/en/products/ad7694.html
     https://www.analog.com/en/products/ad7693.html
     https://www.analog.com/en/products/ad7691.html
     https://www.analog.com/en/products/ad7690.html
@@ -29,6 +30,8 @@ description: |
     https://www.analog.com/en/products/ad7687.html
     https://www.analog.com/en/products/ad7686.html
     https://www.analog.com/en/products/ad7685.html
+    https://www.analog.com/en/products/ad7684.html
+    https://www.analog.com/en/products/ad7683.html
     https://www.analog.com/en/products/ad7682.html
     https://www.analog.com/en/products/ad4022.html
     https://www.analog.com/en/products/ad4021.html
@@ -53,6 +56,7 @@ properties:
       - adi,pulsar,ad7946
       - adi,pulsar,ad7942
       - adi,pulsar,ad7699
+      - adi,pulsar,ad7694
       - adi,pulsar,ad7693
       - adi,pulsar,ad7691
       - adi,pulsar,ad7690
@@ -61,6 +65,8 @@ properties:
       - adi,pulsar,ad7687
       - adi,pulsar,ad7686
       - adi,pulsar,ad7685
+      - adi,pulsar,ad7684
+      - adi,pulsar,ad7683
       - adi,pulsar,ad7682
       - adi,pulsar,ad4022
       - adi,pulsar,ad4021

--- a/drivers/iio/adc/ad_pulsar.c
+++ b/drivers/iio/adc/ad_pulsar.c
@@ -211,6 +211,15 @@ static const struct ad_pulsar_chip_info ad7699_chip_info = {
 	.cfg_register = true
 };
 
+static const struct ad_pulsar_chip_info ad7694_chip_info = {
+	.name = "ad7694",
+	.input_type = DIFFERENTIAL,
+	.max_rate = 250000,
+	.resolution = 16,
+	.num_channels = 1,
+	.sclk_rate = 40000000
+};
+
 static const struct ad_pulsar_chip_info ad7693_chip_info = {
 	.name = "ad7693",
 	.input_type = DIFFERENTIAL,
@@ -280,6 +289,24 @@ static const struct ad_pulsar_chip_info ad7685_chip_info = {
 	.name = "ad7685",
 	.input_type = SINGLE_ENDED,
 	.max_rate = 250000,
+	.resolution = 16,
+	.num_channels = 1,
+	.sclk_rate = 40000000
+};
+
+static const struct ad_pulsar_chip_info ad7684_chip_info = {
+	.name = "ad7684",
+	.input_type = DIFFERENTIAL,
+	.max_rate = 100000,
+	.resolution = 16,
+	.num_channels = 1,
+	.sclk_rate = 40000000
+};
+
+static const struct ad_pulsar_chip_info ad7683_chip_info = {
+	.name = "ad7683",
+	.input_type = SINGLE_ENDED,
+	.max_rate = 100000,
 	.resolution = 16,
 	.num_channels = 1,
 	.sclk_rate = 40000000
@@ -898,6 +925,7 @@ static const struct of_device_id ad_pulsar_of_match[] = {
 	{ .compatible = "adi,pulsar,ad7946", .data = &ad7946_chip_info },
 	{ .compatible = "adi,pulsar,ad7942", .data = &ad7942_chip_info },
 	{ .compatible = "adi,pulsar,ad7699", .data = &ad7699_chip_info },
+	{ .compatible = "adi,pulsar,ad7694", .data = &ad7694_chip_info },
 	{ .compatible = "adi,pulsar,ad7693", .data = &ad7693_chip_info },
 	{ .compatible = "adi,pulsar,ad7691", .data = &ad7691_chip_info },
 	{ .compatible = "adi,pulsar,ad7690", .data = &ad7690_chip_info },
@@ -906,6 +934,8 @@ static const struct of_device_id ad_pulsar_of_match[] = {
 	{ .compatible = "adi,pulsar,ad7687", .data = &ad7687_chip_info },
 	{ .compatible = "adi,pulsar,ad7686", .data = &ad7686_chip_info },
 	{ .compatible = "adi,pulsar,ad7685", .data = &ad7685_chip_info },
+	{ .compatible = "adi,pulsar,ad7684", .data = &ad7684_chip_info },
+	{ .compatible = "adi,pulsar,ad7683", .data = &ad7683_chip_info },
 	{ .compatible = "adi,pulsar,ad7682", .data = &ad7682_chip_info },
 	{ },
 };
@@ -922,6 +952,7 @@ static const struct spi_device_id ad_pulsar_spi_id[] = {
 	{ "pulsar,ad7946", (kernel_ulong_t)&ad7946_chip_info },
 	{ "pulsar,ad7942", (kernel_ulong_t)&ad7942_chip_info },
 	{ "pulsar,ad7699", (kernel_ulong_t)&ad7699_chip_info },
+	{ "pulsar,ad7694", (kernel_ulong_t)&ad7694_chip_info },
 	{ "pulsar,ad7693", (kernel_ulong_t)&ad7693_chip_info },
 	{ "pulsar,ad7691", (kernel_ulong_t)&ad7691_chip_info },
 	{ "pulsar,ad7690", (kernel_ulong_t)&ad7690_chip_info },
@@ -930,6 +961,8 @@ static const struct spi_device_id ad_pulsar_spi_id[] = {
 	{ "pulsar,ad7687", (kernel_ulong_t)&ad7687_chip_info },
 	{ "pulsar,ad7686", (kernel_ulong_t)&ad7686_chip_info },
 	{ "pulsar,ad7685", (kernel_ulong_t)&ad7685_chip_info },
+	{ "pulsar,ad7684", (kernel_ulong_t)&ad7684_chip_info },
+	{ "pulsar,ad7683", (kernel_ulong_t)&ad7683_chip_info },
 	{ "pulsar,ad7682", (kernel_ulong_t)&ad7682_chip_info },
 	{ }
 


### PR DESCRIPTION
## Add code to probe  AD7683, AD7684, AD7694

I received email reporting people were asking about support for AD7683.
It clearly belongs to the PulSAR series of ADCs so adding to that driver.
Also adding AD7684 and AD7694 which were also not there.
This is one example of stuff that didn't go upstream.
Looking back at it now, I think this ad_pulsar driver can be improved (maybe split into a driver for single channel ADCs and another for multiple channel ADCs) and upstreamed with some work.
For now, I'm just sort of taking note this should also support AD7683, AD7684, and AD7694.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
