### PR TITLE
arch: arm: boot: dts: ad9434/zed: Fix clock frequency

### DIFF
--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad9434-fmc-500ebz.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad9434-fmc-500ebz.dts
@@ -52,3 +52,12 @@
 #define fmc_spi spi0
 
 #include "adi-ad9434-fmc-500ebz.dtsi"
+
+/*
+ * It is limited because of Zed board; check AC DC switching characteristics:
+ * 464MHz is the limit.
+ * 2.156ns is the adc_clk period in HDL
+ */
+&ad9517_ref_clk {
+	clock-frequency = <463820000>; // 463.82MHz
+};


### PR DESCRIPTION
## PR Description

Set the frequency to 463.82MHz because on Zedboard, there is a limitation for BUFG input clock frequency to 464MHz, which is below the maximum sampling rate of the ADC (500MSPS).

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
