### PR TITLE
ABI: testing: fix admv8818 attr description

### DIFF
--- a/Documentation/ABI/testing/sysfs-bus-iio-filter-admv8818
+++ b/Documentation/ABI/testing/sysfs-bus-iio-filter-admv8818
@@ -3,7 +3,7 @@ KernelVersion:
 Contact:	linux-iio@vger.kernel.org
 Description:
 		Reading this returns the valid values that can be written to the
-		on_altvoltage0_mode attribute:
+		filter_mode attribute:
 
 		- auto -> Adjust bandpass filter to track changes in input clock rate.
 		- manual -> disable/unregister the clock rate notifier / input clock tracking.


### PR DESCRIPTION
## PR Description

Fix description of the filter_mode_available attribute by pointing to the correct name of the attribute that can be written with valid values.

Link: https://lore.kernel.org/lkml/20240702081851.4663-1-antoniu.miclaus@analog.com/
Fixes: bf92d87 ("iio:filter:admv8818: Add sysfs ABI documentation")

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
