### PR TITLE
arm: dts: Update PulSAR HDL project references

### DIFF
--- a/arch/arm/boot/dts/zynq-coraz7s-ad7687-pmdz.dts
+++ b/arch/arm/boot/dts/zynq-coraz7s-ad7687-pmdz.dts
@@ -3,7 +3,8 @@
  * Analog Devices AD7687
  * https://www.analog.com/en/products/ad7687.html
  *
- * hdl_project: <pulsar_adc_pmdz/coraz7s>
+ * hdl_project: <pulsar_adc>
+ * Link: https://github.com/analogdevicesinc/hdl/tree/main/projects/pulsar_adc
  * board_revision: <A>
  *
  * Copyright (C) 2022 Analog Devices Inc.

--- a/arch/arm/boot/dts/zynq-coraz7s-ad7689-ardz.dts
+++ b/arch/arm/boot/dts/zynq-coraz7s-ad7689-ardz.dts
@@ -3,7 +3,8 @@
  * Analog Devices AD7689
  * https://www.analog.com/en/products/ad7689.html
  *
- * hdl_project: <pulsar_adc_pmdz/coraz7s>
+ * hdl_project: <pulsar_adc>
+ * Link: https://github.com/analogdevicesinc/hdl/tree/main/projects/pulsar_adc
  * board_revision: <A>
  *
  * Copyright (C) 2022 Analog Devices Inc.

--- a/arch/arm/boot/dts/zynq-coraz7s-ad7946.dts
+++ b/arch/arm/boot/dts/zynq-coraz7s-ad7946.dts
@@ -3,7 +3,8 @@
  * Analog Devices AD7946
  * https://www.analog.com/en/products/ad7946.html
  *
- * hdl_project: <pulsar_adc_pmdz/coraz7s>
+ * hdl_project: <pulsar_adc>
+ * Link: https://github.com/analogdevicesinc/hdl/tree/main/projects/pulsar_adc
  * board_revision: <A>
  *
  * Copyright (C) 2022 Analog Devices Inc.

--- a/arch/arm/boot/dts/zynq-coraz7s-ad7984.dts
+++ b/arch/arm/boot/dts/zynq-coraz7s-ad7984.dts
@@ -3,7 +3,8 @@
  * Analog Devices AD7984
  * https://www.analog.com/en/products/ad7984.html
  *
- * hdl_project: <pulsar_adc_pmdz/coraz7s>
+ * hdl_project: <pulsar_adc>
+ * Link: https://github.com/analogdevicesinc/hdl/tree/main/projects/pulsar_adc
  * board_revision: <A>
  *
  * Copyright (C) 2022 Analog Devices Inc.

--- a/arch/arm/boot/dts/zynq-coraz7s-adaq4003.dts
+++ b/arch/arm/boot/dts/zynq-coraz7s-adaq4003.dts
@@ -2,7 +2,8 @@
 /*
  * Analog Devices ADAQ4003
  *
- * hdl_project: <pulsar_adc_pmdz>
+ * hdl_project: <pulsar_adc>
+ * Link: https://github.com/analogdevicesinc/hdl/tree/main/projects/pulsar_adc
  * board_revision: <A>
  *
  * Copyright (C) 2023 Analog Devices Inc.

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad4020.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad4020.dts
@@ -4,7 +4,8 @@
  * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-adc/ad400x
  * https://wiki.analog.com/resources/eval/user-guides/ad400x
  *
- * hdl_project: <ad40xx_fmc/zed>
+ * hdl_project: <pulsar_adc>
+ * Link: https://github.com/analogdevicesinc/hdl/tree/main/projects/pulsar_adc
  * board_revision: <>
  *
  * Copyright (C) 2016-2019 Analog Devices Inc.

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad7944.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad7944.dts
@@ -3,7 +3,8 @@
  * Analog Devices EVAL-AD7944FMCZ
  * https://www.analog.com/en/products/ad7944.html
  *
- * hdl_project: <pulsar_adc_pmdz/zed>
+ * hdl_project: <pulsar_adc>
+ * Link: https://github.com/analogdevicesinc/hdl/tree/main/projects/pulsar_adc
  * board_revision: <>
  *
  * Copyright (C) 2024 Analog Devices Inc.

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad7985.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad7985.dts
@@ -3,7 +3,8 @@
  * Analog Devices EVAL-AD7985FMCZ
  * https://www.analog.com/en/products/ad7985.html
  *
- * hdl_project: <pulsar_adc_pmdz/zed>
+ * hdl_project: <pulsar_adc>
+ * Link: https://github.com/analogdevicesinc/hdl/tree/main/projects/pulsar_adc
  * board_revision: <>
  *
  * Copyright (C) 2024 Analog Devices Inc.

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad7986.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad7986.dts
@@ -3,7 +3,8 @@
  * Analog Devices EVAL-AD7986FMCZ
  * https://www.analog.com/en/products/ad7986.html
  *
- * hdl_project: <pulsar_adc_pmdz/zed>
+ * hdl_project: <pulsar_adc>
+ * Link: https://github.com/analogdevicesinc/hdl/tree/main/projects/pulsar_adc
  * board_revision: <>
  *
  * Copyright (C) 2024 Analog Devices Inc.


### PR DESCRIPTION
The HDL support for the AD4000 series and PulSAR series of ADCs was once provided by the **ad40xx_fmc** and **pulsar_adc_pmdz** HDL projects. Those are now integrated into a single HDL project called **pulsar_adc** [1]. Update device tree references to the new project name and point to the new project location.

[1]: https://github.com/analogdevicesinc/hdl/commit/b2dc91b30dae891b6319d88e083f26e726f43ba0

This is expected to help the team taking care of Kuiper releases get compatible HDLs for dts files.

## PR Description

- Please replace this comment with a summary of your changes, and add any context
necessary to understand them. List any dependencies required for this change.
- To check the checkboxes below, insert a 'x' between square brackets (without
any space), or simply check them after publishing the PR.
- If you changes include a breaking change, please specify dependent PRs in the
description and try to push all related PRs simultaneously.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
