### PR TITLE
Revert "net: macb: In shared MDIO usecase make MDIO producer ethernet…

### DIFF
--- a/drivers/net/ethernet/cadence/macb_main.c
+++ b/drivers/net/ethernet/cadence/macb_main.c
@@ -867,8 +867,7 @@ static int macb_mii_probe(struct net_device *dev)
 
 static int macb_mdiobus_register(struct macb *bp)
 {
-	struct device_node *child, *np = bp->pdev->dev.of_node, *mdio_np, *dev_np;
-	struct platform_device *mdio_pdev = NULL;
+	struct device_node *child, *np = bp->pdev->dev.of_node;
 
 	/* If we have a child named mdio, probe it instead of looking for PHYs
 	 * directly under the MAC node
@@ -899,29 +898,6 @@ static int macb_mdiobus_register(struct macb *bp)
 			return of_mdiobus_register(bp->mii_bus, np);
 		}
 
-	/* For shared MDIO usecases find out MDIO producer platform
-	 * device node by traversing through phy-handle DT property.
-	 */
-	np = of_parse_phandle(np, "phy-handle", 0);
-	mdio_np = of_get_parent(np);
-	of_node_put(np);
-	dev_np = of_get_parent(mdio_np);
-	of_node_put(mdio_np);
-	/* Handle error where bus_find_device returns a match for NULL */
-	if (dev_np)
-		mdio_pdev = of_find_device_by_node(dev_np);
-
-	of_node_put(dev_np);
-
-	/* Check MDIO producer device driver data to see if it's probed */
-	if (mdio_pdev && !dev_get_drvdata(&mdio_pdev->dev)) {
-		platform_device_put(mdio_pdev);
-		netdev_info(bp->dev, "Defer probe as mdio producer %s is not probed\n",
-			    dev_name(&mdio_pdev->dev));
-		return -EPROBE_DEFER;
-	}
-
-	platform_device_put(mdio_pdev);
 	return mdiobus_register(bp->mii_bus);
 }
 


### PR DESCRIPTION
## PR Description

… node to probe first"

This reverts commit 91ac3cc9e3bd40da2a63be0ba53af83a4b42afdb.

It breaks eth1 on the adrv9009 SOM. Moreover, this patch was sent upstream [1] and rejected. Hence, just rever it.

[1]: https://lore.kernel.org/all/1656618906-29881-1-git-send-email-radhey.shyam.pandey@amd.com/
Signed-off-by: Nuno Sa <nuno.sa@analog.com>

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
