### PR TITLE
Improve precision for ad400x iio driver

### DIFF
--- a/drivers/iio/adc/ad400x.c
+++ b/drivers/iio/adc/ad400x.c
@@ -198,7 +198,6 @@ static int __ad400x_set_sampling_freq(struct ad400x_state *st, int freq)
 	/* Sync up PWM state and prepare for pwm_apply_state(). */
 	pwm_init_state(st->cnv_trigger, &cnv_state);
 
-	freq = clamp(freq, 0, st->chip->max_rate);
 	target = DIV_ROUND_CLOSEST_ULL(st->ref_clk_rate, freq);
 	ref_clk_period_ps = DIV_ROUND_CLOSEST_ULL(1000000000000,
 						  st->ref_clk_rate);

--- a/drivers/iio/adc/ad400x.c
+++ b/drivers/iio/adc/ad400x.c
@@ -192,16 +192,15 @@ static int ad400x_get_sampling_freq(struct ad400x_state *st)
 
 static int __ad400x_set_sampling_freq(struct ad400x_state *st, int freq)
 {
-	unsigned long long target, ref_clk_period_ps;
+	unsigned long long ref_clk_period_ps;
 	struct pwm_state cnv_state;
 
 	/* Sync up PWM state and prepare for pwm_apply_state(). */
 	pwm_init_state(st->cnv_trigger, &cnv_state);
 
-	target = DIV_ROUND_CLOSEST_ULL(st->ref_clk_rate, freq);
 	ref_clk_period_ps = DIV_ROUND_CLOSEST_ULL(1000000000000,
 						  st->ref_clk_rate);
-	cnv_state.period = ref_clk_period_ps * target;
+	cnv_state.period = DIV_ROUND_CLOSEST_ULL(1000000000000, freq);
 	cnv_state.duty_cycle = ref_clk_period_ps;
 	cnv_state.time_unit = PWM_UNIT_PSEC;
 	return pwm_apply_state(st->cnv_trigger, &cnv_state);


### PR DESCRIPTION
## PR Description

While looking at the ad400x driver to try to find out why/if sub-nanosecond precision for the pwm subsystem is necessary, I noticed these improvements.

## PR Type
- [?] Bug fix (a change that fixes an issue)
- [-] New feature (a change that adds new functionality)
- [-] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [-] I have tested the changes on the relevant hardware
- [-] I have updated the documentation outside this repo accordingly (if there is the case)
