### PR TITLE
dts/xilinx/zynqmp-adrv9009-zu11eg-reva: ADM1177 switch to HWMON device

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-reva.dtsi
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-reva.dtsi
@@ -83,10 +83,10 @@
 	sda-gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
 
 	current_limiter@58 { /* U12 */
-		compatible = "adi,adm1177-iio";
+		compatible = "adi,adm1177";
 		reg = <0x58>;
-		adi,r-sense-mohm = <10>; /* 10 mOhm */
-		adi,shutdown-threshold-ma = <10000>; /* 10 A */
+		shunt-resistor-micro-ohms = <10>; /* 10 mOhm used by hwmon/adm1177 */
+		adi,shutdown-threshold-microamp  = <10000000>; /* 10 A */
 		adi,vrange-high-enable;
 	};
 


### PR DESCRIPTION
## PR Description

ADM1177 switch to HWMON device
Since the IIO version is no longer build into the kernel.

## PR Type
- [x] Bug fix (a change that fixes an issue)

## PR Checklist
- [X] I have conducted a self-review of my own code changes
- [X] I have tested the changes on the relevant hardware

