### PR TITLE
Specify PulSAR HDL subproject directories

### DIFF
--- a/arch/arm/boot/dts/zynq-coraz7s-ad7687-pmdz.dts
+++ b/arch/arm/boot/dts/zynq-coraz7s-ad7687-pmdz.dts
@@ -3,7 +3,7 @@
  * Analog Devices AD7687
  * https://www.analog.com/en/products/ad7687.html
  *
- * hdl_project: <pulsar_adc>
+ * hdl_project: <pulsar_adc/coraz7s>
  * Link: https://github.com/analogdevicesinc/hdl/tree/main/projects/pulsar_adc
  * board_revision: <A>
  *

--- a/arch/arm/boot/dts/zynq-coraz7s-ad7689-ardz.dts
+++ b/arch/arm/boot/dts/zynq-coraz7s-ad7689-ardz.dts
@@ -3,7 +3,7 @@
  * Analog Devices AD7689
  * https://www.analog.com/en/products/ad7689.html
  *
- * hdl_project: <pulsar_adc>
+ * hdl_project: <pulsar_adc/coraz7s>
  * Link: https://github.com/analogdevicesinc/hdl/tree/main/projects/pulsar_adc
  * board_revision: <A>
  *

--- a/arch/arm/boot/dts/zynq-coraz7s-ad7946.dts
+++ b/arch/arm/boot/dts/zynq-coraz7s-ad7946.dts
@@ -3,7 +3,7 @@
  * Analog Devices AD7946
  * https://www.analog.com/en/products/ad7946.html
  *
- * hdl_project: <pulsar_adc>
+ * hdl_project: <pulsar_adc/coraz7s>
  * Link: https://github.com/analogdevicesinc/hdl/tree/main/projects/pulsar_adc
  * board_revision: <A>
  *

--- a/arch/arm/boot/dts/zynq-coraz7s-ad7984.dts
+++ b/arch/arm/boot/dts/zynq-coraz7s-ad7984.dts
@@ -3,7 +3,7 @@
  * Analog Devices AD7984
  * https://www.analog.com/en/products/ad7984.html
  *
- * hdl_project: <pulsar_adc>
+ * hdl_project: <pulsar_adc/coraz7s>
  * Link: https://github.com/analogdevicesinc/hdl/tree/main/projects/pulsar_adc
  * board_revision: <A>
  *

--- a/arch/arm/boot/dts/zynq-coraz7s-adaq4003.dts
+++ b/arch/arm/boot/dts/zynq-coraz7s-adaq4003.dts
@@ -2,7 +2,7 @@
 /*
  * Analog Devices ADAQ4003
  *
- * hdl_project: <pulsar_adc>
+ * hdl_project: <pulsar_adc/coraz7s>
  * Link: https://github.com/analogdevicesinc/hdl/tree/main/projects/pulsar_adc
  * board_revision: <A>
  *

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad4020.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad4020.dts
@@ -4,7 +4,7 @@
  * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-adc/ad400x
  * https://wiki.analog.com/resources/eval/user-guides/ad400x
  *
- * hdl_project: <pulsar_adc>
+ * hdl_project: <pulsar_adc/zed>
  * Link: https://github.com/analogdevicesinc/hdl/tree/main/projects/pulsar_adc
  * board_revision: <>
  *

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad7944.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad7944.dts
@@ -3,7 +3,7 @@
  * Analog Devices EVAL-AD7944FMCZ
  * https://www.analog.com/en/products/ad7944.html
  *
- * hdl_project: <pulsar_adc>
+ * hdl_project: <pulsar_adc/zed>
  * Link: https://github.com/analogdevicesinc/hdl/tree/main/projects/pulsar_adc
  * board_revision: <>
  *

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad7985.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad7985.dts
@@ -3,7 +3,7 @@
  * Analog Devices EVAL-AD7985FMCZ
  * https://www.analog.com/en/products/ad7985.html
  *
- * hdl_project: <pulsar_adc>
+ * hdl_project: <pulsar_adc/zed>
  * Link: https://github.com/analogdevicesinc/hdl/tree/main/projects/pulsar_adc
  * board_revision: <>
  *

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad7986.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad7986.dts
@@ -3,7 +3,7 @@
  * Analog Devices EVAL-AD7986FMCZ
  * https://www.analog.com/en/products/ad7986.html
  *
- * hdl_project: <pulsar_adc>
+ * hdl_project: <pulsar_adc/zed>
  * Link: https://github.com/analogdevicesinc/hdl/tree/main/projects/pulsar_adc
  * board_revision: <>
  *


### PR DESCRIPTION
In CI scripts, the DTS and HDL project pairs are identified by the hdl_project tags and those should point to the exact subproject directory of HDL build.
Update hdl_project tags to point to exact subproject directories.

Fixes: 24b683f0bffa ("arm: dts: Update PulSAR HDL project references")

## PR Description

- Please replace this comment with a summary of your changes, and add any context
necessary to understand them. List any dependencies required for this change.
- To check the checkboxes below, insert a 'x' between square brackets (without
any space), or simply check them after publishing the PR.
- If you changes include a breaking change, please specify dependent PRs in the
description and try to push all related PRs simultaneously.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
