### PR TITLE
iio: adc: adm1177: Fix compilation with CONFIG_ADM1177=m

### DIFF
--- a/drivers/iio/adc/adm1177.c
+++ b/drivers/iio/adc/adm1177.c
@@ -219,7 +219,7 @@ static const struct of_device_id adm1177_dt_ids[] = {
 	{ .compatible = "adi,adm1177-iio" },
 	{},
 };
-MODULE_DEVICE_TABLE(of, nau7802_dt_ids);
+MODULE_DEVICE_TABLE(of, adm1177_dt_ids);
 
 static struct i2c_driver adm1177_driver = {
 	.driver = {


### PR DESCRIPTION
This fixes:

	In file included from include/linux/device/driver.h:21,
			 from include/linux/device.h:32,
			 from drivers/iio/adc/adm1177.c:9:
	drivers/iio/adc/adm1177.c:222:25: error: ‘nau7802_dt_ids’ undeclared here (not in a function)
	  222 | MODULE_DEVICE_TABLE(of, nau7802_dt_ids);
	      |                         ^~~~~~~~~~~~~~
	include/linux/module.h:243:15: note: in definition of macro ‘MODULE_DEVICE_TABLE’
	  243 | extern typeof(name) __mod_##type##__##name##_device_table               \
	      |               ^~~~
	include/linux/module.h:243:21: error: ‘__mod_of__nau7802_dt_ids_device_table’ aliased to undefined symbol ‘nau7802_dt_ids’
	  243 | extern typeof(name) __mod_##type##__##name##_device_table               \
	      |                     ^~~~~~
	drivers/iio/adc/adm1177.c:222:1: note: in expansion of macro ‘MODULE_DEVICE_TABLE’
	  222 | MODULE_DEVICE_TABLE(of, nau7802_dt_ids);
	      | ^~~~~~~~~~~~~~~~~~~

Should I try to guess which driver was used as a template for the adm1177 one?

Fixes: dc2f40afb221 ("iio: Add ADM1177 Hot Swap Controller and Digital Power Monitor driver")

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [-] New feature (a change that adds new functionality)
- [-] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [-] I have tested the changes on the relevant hardware
- [-] I have updated the documentation outside this repo accordingly (if there is the case)
