### PR TITLE
arm64: dts: Update xmicrowave HDL project tag

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-revb-adrv2crr-fmc-revb-jesd204-fsm-xmicrowave.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-revb-adrv2crr-fmc-revb-jesd204-fsm-xmicrowave.dts
@@ -7,11 +7,14 @@
  * https://wiki.analog.com/resources/tools-software/linux-software/adrv9009_advanced_plugin
  * https://wiki.analog.com/resources/eval/user-guides/adrv9009-zu11eg/adrv2crr-fmc_carrier_board
  *
- * hdl_project: <adrv9009zu11eg/adrv2crr_xmicrowave>
+ * hdl_project: <adrv9009zu11eg/adrv2crr_fmcxmwbr1>
  * board_revision: <B>
  *
  * Copyright (C) 2021 Analog Devices Inc.
  */
+
+ // HDL Synthesis Parameters:
+ // ADI_PRODUCTION=1
 
 #include "zynqmp-adrv9009-zu11eg-revb-adrv2crr-fmc-revb-jesd204-fsm.dts"
 


### PR DESCRIPTION
The HDL support for adrv9009zu11eg/adrv2crr_xmicrowave has merged with another project, adrv9009zu11eg/adrv2crr_fmcxmwbr1 [1]. Update device tree references to point to the correct HDL project and update HDL synthesis parameters for adrv2crr_xmicrowave.

[1]: https://github.com/analogdevicesinc/hdl/commit/4b8f3f0

## PR Description

- Please replace this comment with a summary of your changes, and add any context
necessary to understand them. List any dependencies required for this change.
- To check the checkboxes below, insert a 'x' between square brackets (without
any space), or simply check them after publishing the PR.
- If you changes include a breaking change, please specify dependent PRs in the
description and try to push all related PRs simultaneously.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
