### PR TITLE
overlays: rpi-ltc2664-overlay.dts: Update LTC2664 example overlay

### DIFF
--- a/arch/arm/boot/dts/overlays/rpi-ltc2664-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ltc2664-overlay.dts
@@ -21,6 +21,20 @@
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
 	};
+
+	v_pos: fixedregulator@2 {
+		compatible = "regulator-fixed";
+		regulator-name = "v-pos-supply";
+		regulator-min-microvolt = <10000000>;
+		regulator-max-microvolt = <10000000>;
+	};
+
+	v_neg: fixedregulator@3 {
+		compatible = "regulator-fixed";
+		regulator-name = "v-neg-supply";
+		regulator-min-microvolt = <10000000>;
+		regulator-max-microvolt = <10000000>;
+	};
 };
 
 &spidev0 {
@@ -36,7 +50,7 @@
 	#size-cells = <0>;
 	status = "okay";
 
-	ltc2688: ltc2688@0 {
+	ltc2664: ltc2664@0 {
 		compatible = "adi,ltc2664";
 		reg = <0>;
 		spi-max-frequency = <5000000>;
@@ -46,34 +60,34 @@
 
 		vcc-supply = <&vcc>;
 		iovcc-supply = <&vcc>;
-
-		adi,manual-span-operation-config = <7>;
+		v-pos-supply = <&v_pos>;
+		v-neg-supply = <&v_neg>;
 
 		channel@0 {
 			reg = <0>;
-			adi,output-range-microvolt = <(-10000000) 10000000>;
+			output-range-microvolt = <(-10000000) 10000000>;
 		};
 
 		channel@1 {
 			reg = <1>;
-			adi,output-range-microvolt = <(-10000000) 10000000>;
 			adi,toggle-mode;
+			output-range-microvolt = <(-10000000) 10000000>;
 		};
 
 		channel@2 {
 			reg = <2>;
-			adi,output-range-microvolt = <(-10000000) 10000000>;
+			output-range-microvolt = <(-10000000) 10000000>;
 		};
 
 		channel@3 {
 			reg = <3>;
-			adi,output-range-microvolt = <(-10000000) 10000000>;
+			output-range-microvolt = <(-10000000) 10000000>;
 		};
 	};
 };
 
 / {
 	__overrides__ {
-		cs_pin = <&ltc2688>,"reg:0";
+		cs_pin = <&ltc2664>,"reg:0";
 	};
 };


### PR DESCRIPTION
Update overlay to align with mainline kernel changes. Adding configurations for the v-pos and v-neg supply regulators. Modify output-range-microvolt based on generalized property name.

## PR Description

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
