### PR TITLE
overlays: rpi-ltc2672-overlay.dts: Add LTC2672 example overlay

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -266,6 +266,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	rpi-lm75.dtbo \
 	rpi-ltc2497.dtbo \
 	rpi-ltc2664.dtbo \
+	rpi-ltc2672.dtbo \
 	rpi-ltc2688.dtbo \
 	rpi-ltc2991.dtbo \
 	rpi-ltc6952.dtbo \

--- a/arch/arm/boot/dts/overlays/rpi-ltc2672-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ltc2672-overlay.dts
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Overlay for the 5 channel LTC2672 DAC
+ *
+ * Copyright 2024 Analog Devices Inc.
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709";
+};
+
+&{/} {
+	vcc: fixedregulator@1 {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc-supply";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+	};
+
+	v_neg: fixedregulator@2 {
+		compatible = "regulator-fixed";
+		regulator-name = "v-neg-supply";
+		regulator-min-microvolt = <0>;
+		regulator-max-microvolt = <0>;
+	};
+};
+
+&spidev0 {
+	status = "disabled";
+};
+
+&spidev1 {
+	status = "disabled";
+};
+
+&spi0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	ltc2672: ltc2672@0 {
+		compatible = "adi,ltc2672";
+		reg = <0>;
+		spi-max-frequency = <5000000>;
+
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		vcc-supply = <&vcc>;
+		iovcc-supply = <&vcc>;
+		v-neg-supply = <&v_neg>;
+
+		channel@0 {
+			reg = <0>;
+			output-range-microamp = <0 300000000>;
+		};
+
+		channel@1 {
+			reg = <1>;
+			adi,toggle-mode;
+			output-range-microamp = <0 200000000>;
+		};
+
+		channel@2 {
+			reg = <2>;
+			output-range-microamp = <0 300000000>;
+		};
+
+		channel@3 {
+			reg = <3>;
+			output-range-microamp = <0 300000000>;
+		};
+
+		channel@4 {
+			reg = <4>;
+			output-range-microamp = <0 300000000>;
+		};
+	};
+};


### PR DESCRIPTION
The LTC2672 is a 5-channel, 12-/16-bit DAC offering high compliance current source outputs up to 300 mA per channel, with programmable current ranges. Channels can be combined for up to 1.5 A output. It operates between 2.1 V to VCC, supports optional negative supply, and includes a precision 1.25 V reference. The device features a low-voltage, high-speed SPI interface.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
