### PR TITLE
Append status ad_sigma_delta backport

### DIFF
--- a/drivers/iio/adc/ad7124.c
+++ b/drivers/iio/adc/ad7124.c
@@ -914,8 +914,8 @@ static int ad7124_probe(struct spi_device *spi)
 
 	st->chip_info = info;
 
-	ad_sd_init(&st->sd, indio_dev, spi, &ad7124_sigma_delta_info);
 	st->sd.num_slots = AD7124_SEQUENCER_SLOTS;
+	ad_sd_init(&st->sd, indio_dev, spi, &ad7124_sigma_delta_info);
 
 	indio_dev->name = st->chip_info->name;
 	indio_dev->modes = INDIO_DIRECT_MODE;

--- a/drivers/iio/adc/ad7124.c
+++ b/drivers/iio/adc/ad7124.c
@@ -45,6 +45,8 @@
 #define AD7124_STATUS_POR_FLAG_MSK	BIT(4)
 
 /* AD7124_ADC_CONTROL */
+#define AD7124_ADC_STATUS_EN_MSK	BIT(10)
+#define AD7124_ADC_STATUS_EN(x)		FIELD_PREP(AD7124_ADC_STATUS_EN_MSK, x)
 #define AD7124_ADC_CTRL_REF_EN_MSK	BIT(8)
 #define AD7124_ADC_CTRL_REF_EN(x)	FIELD_PREP(AD7124_ADC_CTRL_REF_EN_MSK, x)
 #define AD7124_ADC_CTRL_PWR_MSK	GENMASK(7, 6)
@@ -519,12 +521,32 @@ static int ad7124_set_channel(struct ad_sigma_delta *sd, unsigned int slot,
 	return ret;
 }
 
+static int ad7124_append_status(struct ad_sigma_delta *sd, bool append)
+{
+	struct ad7124_state *st = container_of(sd, struct ad7124_state, sd);
+	unsigned int adc_control = st->adc_control;
+	int ret;
+
+	adc_control &= ~AD7124_ADC_STATUS_EN_MSK;
+	adc_control |= AD7124_ADC_STATUS_EN(append);
+
+	ret = ad_sd_write_reg(&st->sd, AD7124_ADC_CONTROL, 2, adc_control);
+	if (ret < 0)
+		return ret;
+
+	st->adc_control = adc_control;
+
+	return 0;
+}
+
 static const struct ad_sigma_delta_info ad7124_sigma_delta_info = {
 	.set_channel = ad7124_set_channel,
+	.append_status = ad7124_append_status,
 	.set_mode = ad7124_set_mode,
 	.has_registers = true,
 	.addr_shift = 0,
 	.read_mask = BIT(6),
+	.status_ch_mask = GENMASK(3, 0),
 	.data_reg = AD7124_DATA,
 	.irq_flags = IRQF_TRIGGER_FALLING
 };

--- a/drivers/iio/adc/ad7173.c
+++ b/drivers/iio/adc/ad7173.c
@@ -747,9 +747,8 @@ static int ad7173_probe(struct spi_device *spi)
 	id = spi_get_device_id(spi);
 	st->info = &ad7173_device_info[id->driver_data];
 
-	ad_sd_init(&st->sd, indio_dev, spi, &ad7173_sigma_delta_info);
-
 	st->sd.num_slots = st->info->num_configs;
+	ad_sd_init(&st->sd, indio_dev, spi, &ad7173_sigma_delta_info);
 
 	spi_set_drvdata(spi, indio_dev);
 


### PR DESCRIPTION
## PR Description

Backport append status support that is present on the ad_sigma_delta main/upstream version.
Added support for append status to the 2 ADC drivers that feature a channel sequencer.

This PR fixes a bug that is observed when using buffered mode with multiple channels enabled
and the channels are desynced due to losing samples.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
