### PR TITLE
next_stable: (iio: adc: ad7124: fix DT configuration parsing)

### DIFF
--- a/drivers/iio/adc/ad7124.c
+++ b/drivers/iio/adc/ad7124.c
@@ -841,8 +841,6 @@ static int ad7124_of_parse_channel_config(struct iio_dev *indio_dev,
 	st->channels = channels;
 
 	for_each_available_child_of_node(np, child) {
-		cfg = &st->channels[channel].cfg;
-
 		ret = of_property_read_u32(child, "reg", &channel);
 		if (ret)
 			goto err;
@@ -863,6 +861,7 @@ static int ad7124_of_parse_channel_config(struct iio_dev *indio_dev,
 		st->channels[channel].ain = AD7124_CHANNEL_AINP(ain[0]) |
 						  AD7124_CHANNEL_AINM(ain[1]);
 
+		cfg = &st->channels[channel].cfg;
 		cfg->bipolar = of_property_read_bool(child, "bipolar");
 
 		ret = of_property_read_u32(child, "adi,reference-select", &tmp);


### PR DESCRIPTION
## PR Description

The DT parsing for ad7124 assigns configurations for a certain channel to the next one.
This PR fixes this issue.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
