### PR TITLE
pwm: drop picosecond support and cleanups

### DIFF
--- a/drivers/iio/adc/ad400x.c
+++ b/drivers/iio/adc/ad400x.c
@@ -192,16 +192,14 @@ static int ad400x_get_sampling_freq(struct ad400x_state *st)
 
 static int __ad400x_set_sampling_freq(struct ad400x_state *st, int freq)
 {
-	unsigned long long ref_clk_period_ns;
 	struct pwm_state cnv_state;
 
 	/* Sync up PWM state and prepare for pwm_apply_state(). */
 	pwm_init_state(st->cnv_trigger, &cnv_state);
 
-	ref_clk_period_ns = DIV_ROUND_CLOSEST_ULL(NSEC_PER_SEC,
-						  st->ref_clk_rate);
 	cnv_state.period = DIV_ROUND_CLOSEST_ULL(NSEC_PER_SEC, freq);
-	cnv_state.duty_cycle = ref_clk_period_ns;
+	cnv_state.duty_cycle = DIV_ROUND_UP(NSEC_PER_SEC, st->ref_clk_rate);
+
 	return pwm_apply_state(st->cnv_trigger, &cnv_state);
 }
 

--- a/drivers/iio/adc/ad400x.c
+++ b/drivers/iio/adc/ad400x.c
@@ -192,17 +192,16 @@ static int ad400x_get_sampling_freq(struct ad400x_state *st)
 
 static int __ad400x_set_sampling_freq(struct ad400x_state *st, int freq)
 {
-	unsigned long long ref_clk_period_ps;
+	unsigned long long ref_clk_period_ns;
 	struct pwm_state cnv_state;
 
 	/* Sync up PWM state and prepare for pwm_apply_state(). */
 	pwm_init_state(st->cnv_trigger, &cnv_state);
 
-	ref_clk_period_ps = DIV_ROUND_CLOSEST_ULL(1000000000000,
+	ref_clk_period_ns = DIV_ROUND_CLOSEST_ULL(NSEC_PER_SEC,
 						  st->ref_clk_rate);
-	cnv_state.period = DIV_ROUND_CLOSEST_ULL(1000000000000, freq);
-	cnv_state.duty_cycle = ref_clk_period_ps;
-	cnv_state.time_unit = PWM_UNIT_PSEC;
+	cnv_state.period = DIV_ROUND_CLOSEST_ULL(NSEC_PER_SEC, freq);
+	cnv_state.duty_cycle = ref_clk_period_ns;
 	return pwm_apply_state(st->cnv_trigger, &cnv_state);
 }
 

--- a/drivers/iio/adc/ad400x.c
+++ b/drivers/iio/adc/ad400x.c
@@ -193,11 +193,38 @@ static int ad400x_get_sampling_freq(struct ad400x_state *st)
 static int __ad400x_set_sampling_freq(struct ad400x_state *st, int freq)
 {
 	struct pwm_state cnv_state;
+	u32 rem;
 
 	/* Sync up PWM state and prepare for pwm_apply_state(). */
 	pwm_init_state(st->cnv_trigger, &cnv_state);
 
-	cnv_state.period = DIV_ROUND_CLOSEST_ULL(NSEC_PER_SEC, freq);
+	/*
+	 * The goal here is that the PWM is configured with a minimal period not
+	 * less than 1 / freq (with freq measured in Hz). It should not be less
+	 * because freq is usually st->chip->max_rate which is a hard limit.
+	 *
+	 * When a period P (measured in ns) is passed to pwm_apply_state(), the
+	 * actually implemented period is:
+	 *
+	 * 	round_down(P * R / NSEC_PER_SEC) / R
+	 *
+	 * (measured in s) with R = st->ref_clk_rate. So we have:
+	 *
+	 * 	  round_down(P * R / NSEC_PER_SEC) / R ≥ 1 / freq
+	 * 	⟺ round_down(P * R / NSEC_PER_SEC) ≥ R / freq
+	 *
+	 * With the LHS being integer this is equivalent to:
+	 *
+	 * 	  round_down(P * R / NSEC_PER_SEC) ≥ round_up(R / freq)
+	 * 	⟺ P * R / NSEC_PER_SEC ≥ round_up(R / freq)
+	 * 	⟺ P ≥ round_up(R / freq) * NSEC_PER_SEC / R
+	 */
+
+	cnv_state.period = div_u64_rem((u64)DIV_ROUND_UP(st->ref_clk_rate, freq) * NSEC_PER_SEC,
+				       st->ref_clk_rate, &rem);
+	if (rem)
+		cnv_state.period += 1;
+
 	cnv_state.duty_cycle = DIV_ROUND_UP(NSEC_PER_SEC, st->ref_clk_rate);
 
 	return pwm_apply_state(st->cnv_trigger, &cnv_state);

--- a/drivers/iio/adc/ad4134.c
+++ b/drivers/iio/adc/ad4134.c
@@ -95,9 +95,8 @@ static int _ad4134_set_odr(struct ad4134_state *st, unsigned int odr)
 	 * tODR_HIGH_TIME = 3 * tDIGCLK
 	 * See datasheet page 10, Table 3. Data Interface Timing with Gated DCLK.
 	 */
-	state.duty_cycle = DIV_ROUND_CLOSEST_ULL(PICO * 6, st->sys_clk_rate);
-	state.period = DIV_ROUND_CLOSEST_ULL(PICO, odr);
-	state.time_unit = PWM_UNIT_PSEC;
+	state.duty_cycle = DIV_ROUND_CLOSEST_ULL(6ULL * NSEC_PER_SEC, st->sys_clk_rate);
+	state.period = DIV_ROUND_CLOSEST(NSEC_PER_SEC, odr);
 
 	ret = pwm_apply_state(st->odr_pwm, &state);
 	if (ret)

--- a/drivers/iio/adc/ad4630.c
+++ b/drivers/iio/adc/ad4630.c
@@ -377,9 +377,11 @@ static int __ad4630_set_sampling_freq(const struct ad4630_state *st, unsigned in
 	struct pwm_state conv_state = {
 		.duty_cycle = 10000,
 		.time_unit = PWM_UNIT_PSEC,
+		.enabled = true,
 	}, fetch_state = {
 		.duty_cycle = 10000,
 		.time_unit = PWM_UNIT_PSEC,
+		.enabled = true,
 	};
 	int ret;
 

--- a/drivers/iio/adc/ad4630.c
+++ b/drivers/iio/adc/ad4630.c
@@ -375,17 +375,15 @@ static int ad4630_read_avail(struct iio_dev *indio_dev,
 static int __ad4630_set_sampling_freq(const struct ad4630_state *st, unsigned int freq)
 {
 	struct pwm_state conv_state = {
-		.duty_cycle = 10000,
-		.time_unit = PWM_UNIT_PSEC,
+		.duty_cycle = 10,
 		.enabled = true,
 	}, fetch_state = {
-		.duty_cycle = 10000,
-		.time_unit = PWM_UNIT_PSEC,
+		.duty_cycle = 10,
 		.enabled = true,
 	};
 	int ret;
 
-	conv_state.period =  DIV_ROUND_CLOSEST_ULL(PICO, freq);
+	conv_state.period = DIV_ROUND_CLOSEST(NSEC_PER_SEC, freq);
 	ret = pwm_apply_state(st->conv_trigger, &conv_state);
 	if (ret)
 		return ret;
@@ -411,7 +409,7 @@ static int __ad4630_set_sampling_freq(const struct ad4630_state *st, unsigned in
 	 * tsync + tquiet_con_delay being tsync the conversion signal period
 	 * and tquiet_con_delay 9.8ns. Hence set the PWM phase accordingly.
 	 */
-	fetch_state.phase = fetch_state.period + 9800;
+	fetch_state.phase = fetch_state.period + 10;
 
 	return pwm_apply_state(st->fetch_trigger, &fetch_state);
 }

--- a/drivers/iio/adc/ad4630.c
+++ b/drivers/iio/adc/ad4630.c
@@ -400,7 +400,15 @@ static int __ad4630_set_sampling_freq(const struct ad4630_state *st, unsigned in
 		if (ret)
 			return ret;
 
-		fetch_state.period *= 1 << avg;
+		/*
+		 * AD4630_REG_AVG is an 8 bit wide register with bits 5 and 6
+		 * RAZ and bit 7 self clearing. Still mask the value to be sure
+		 * not to trigger undefined behaviour (which happens with
+		 * avg >= 64).
+		 */
+		avg &= 0x1f;
+
+		fetch_state.period <<= avg;
 	}
 
 	/*

--- a/drivers/iio/adc/ad7944.c
+++ b/drivers/iio/adc/ad7944.c
@@ -426,7 +426,7 @@ static ssize_t ad7944_sampling_frequency_store(struct device *dev,
 {
 	struct iio_dev *indio_dev = dev_to_iio_dev(dev);
 	struct ad7944_adc *adc = iio_priv(indio_dev);
-	u64 period_ns;
+	struct pwm_state sample_state;
 	u32 val;
 	int ret;
 
@@ -440,9 +440,12 @@ static ssize_t ad7944_sampling_frequency_store(struct device *dev,
 	if (val == 0)
 		return -EINVAL;
 
-	period_ns = div_u64(NSEC_PER_SEC, val);
+	pwm_init_state(adc->pwm, &sample_state);
+	sample_state.period = div_u64(NSEC_PER_SEC, val);
+	sample_state.duty_cycle = AD7944_PWM_TRIGGER_DUTY_CYCLE_NS;
+	sample_state.enabled = true;
 
-	ret = pwm_config(adc->pwm, AD7944_PWM_TRIGGER_DUTY_CYCLE_NS, period_ns);
+	ret = pwm_apply_state(adc->pwm, &sample_state);
 	if (ret)
 		return ret;
 

--- a/drivers/iio/adc/ad7944.c
+++ b/drivers/iio/adc/ad7944.c
@@ -735,7 +735,6 @@ static int ad7944_probe(struct spi_device *spi)
 			.period = NSEC_PER_SEC / AD7944_DEFAULT_SAMPLE_FREQ_HZ,
 			.duty_cycle = AD7944_PWM_TRIGGER_DUTY_CYCLE_NS,
 			.enabled = true,
-			.time_unit = PWM_UNIT_NSEC,
 		};
 
 		adc->pwm = devm_pwm_get(dev, NULL);

--- a/drivers/iio/adc/ad_pulsar.c
+++ b/drivers/iio/adc/ad_pulsar.c
@@ -427,7 +427,7 @@ static int ad_pulsar_set_samp_freq(struct ad_pulsar_adc *adc, int freq)
 	struct pwm_state cnv_state;
 	int ret;
 
-	freq = clamp(freq, 0, adc->info->max_rate);
+	freq = clamp(freq, 1, adc->info->max_rate);
 	target = DIV_ROUND_CLOSEST_ULL(adc->ref_clk_rate, freq);
 	ref_clk_period_ps = DIV_ROUND_CLOSEST_ULL(1000000000000,
 						  adc->ref_clk_rate);

--- a/drivers/iio/adc/ad_pulsar.c
+++ b/drivers/iio/adc/ad_pulsar.c
@@ -431,11 +431,15 @@ static int ad_pulsar_set_samp_freq(struct ad_pulsar_adc *adc, int freq)
 	target = DIV_ROUND_CLOSEST_ULL(adc->ref_clk_rate, freq);
 	ref_clk_period_ps = DIV_ROUND_CLOSEST_ULL(1000000000000,
 						  adc->ref_clk_rate);
-	cnv_state.period = ref_clk_period_ps * target;
-	cnv_state.duty_cycle = ref_clk_period_ps;
-	cnv_state.phase = ref_clk_period_ps;
-	cnv_state.time_unit = PWM_UNIT_PSEC;
-	cnv_state.enabled = true;
+
+	cnv_state = (struct pwm_state){
+		.period = ref_clk_period_ps * target,
+		.duty_cycle = ref_clk_period_ps,
+		.phase = ref_clk_period_ps,
+		.time_unit = PWM_UNIT_PSEC,
+		.enabled = true,
+	};
+
 	ret = pwm_apply_state(adc->cnv, &cnv_state);
 	if (ret)
 		return ret;

--- a/drivers/iio/adc/ltc2358.c
+++ b/drivers/iio/adc/ltc2358.c
@@ -59,7 +59,6 @@ static int __ltc235x_set_sampling_freq(struct ltc235x_state *st,
 	pwm_get_state(st->cnv_pwm, &cnv_state);
 	cnv_state.duty_cycle = LTC235X_TCNVH_NS;
 	cnv_state.period = DIV_ROUND_CLOSEST_ULL(NANO, freq);
-	cnv_state.time_unit = PWM_UNIT_NSEC;
 
 	return pwm_apply_state(st->cnv_pwm, &cnv_state);
 }

--- a/drivers/iio/adc/ltc2387.c
+++ b/drivers/iio/adc/ltc2387.c
@@ -152,11 +152,14 @@ static int ltc2387_set_sampling_freq(struct ltc2387_dev *ltc, int freq)
 	target = DIV_ROUND_CLOSEST_ULL(ltc->ref_clk_rate, freq);
 	ref_clk_period_ps = DIV_ROUND_CLOSEST_ULL(1000000000000ULL,
 						  ltc->ref_clk_rate);
-	cnv_state.period = ref_clk_period_ps * target;
-	cnv_state.duty_cycle = ref_clk_period_ps;
-	cnv_state.phase = 0;
-	cnv_state.time_unit = PWM_UNIT_PSEC;
-	cnv_state.enabled = true;
+
+	cnv_state = (struct pwm_state) {
+		.period = ref_clk_period_ps * target,
+		.duty_cycle = ref_clk_period_ps,
+		.time_unit = PWM_UNIT_PSEC,
+		.enabled = true,
+	};
+
 	ret = pwm_apply_state(ltc->cnv, &cnv_state);
 	if (ret < 0)
 		return ret;
@@ -166,11 +169,15 @@ static int ltc2387_set_sampling_freq(struct ltc2387_dev *ltc, int freq)
 		clk_en_time = DIV_ROUND_UP_ULL(ltc->device_info->resolution, 4);
 	else
 		clk_en_time = DIV_ROUND_UP_ULL(ltc->device_info->resolution, 2);
-	clk_en_state.period = cnv_state.period;
-	clk_en_state.duty_cycle = ref_clk_period_ps * clk_en_time;
-	clk_en_state.phase = cnv_state.phase + LTC2387_T_FIRSTCLK;
-	clk_en_state.time_unit = PWM_UNIT_PSEC;
-	clk_en_state.enabled = true;
+
+	clk_en_state = (struct pwm_state) {
+		.period = cnv_state.period,
+		.duty_cycle = ref_clk_period_ps * clk_en_time,
+		.phase = cnv_state.phase + LTC2387_T_FIRSTCLK,
+		.time_unit = PWM_UNIT_PSEC,
+		.enabled = true,
+	};
+
 	ret = pwm_apply_state(ltc->clk_en, &clk_en_state);
 	if (ret < 0)
 		return ret;

--- a/drivers/iio/adc/ltc2387.c
+++ b/drivers/iio/adc/ltc2387.c
@@ -26,7 +26,15 @@
 
 #define LTC2387_VREF		4096
 #define LTC2387_T_CNVH		8
-#define LTC2387_T_FIRSTCLK	70
+
+/*
+ * Minimal value for t_{FIRSTCLK} according to
+ * https://www.analog.com/media/en/technical-documentation/data-sheets/238718fa.pdf
+ * is 65 ns. Add some slack because there is some rounding involved in the PWM
+ * driver. With the PWM driver rounding to the nearest possible value, targeting
+ * 70 ns works for input clk rates >= 100 MHz.
+ */
+#define LTC2387_T_FIRSTCLK_NS	70
 
 #define KHz 1000
 #define MHz (1000 * KHz)
@@ -173,7 +181,7 @@ static int ltc2387_set_sampling_freq(struct ltc2387_dev *ltc, int freq)
 	clk_en_state = (struct pwm_state) {
 		.period = cnv_state.period,
 		.duty_cycle = ref_clk_period_ps * clk_en_time,
-		.phase = cnv_state.phase + LTC2387_T_FIRSTCLK,
+		.phase = cnv_state.phase + LTC2387_T_FIRSTCLK_NS * PSEC_PER_NSEC,
 		.time_unit = PWM_UNIT_PSEC,
 		.enabled = true,
 	};

--- a/drivers/pwm/core.c
+++ b/drivers/pwm/core.c
@@ -568,8 +568,7 @@ int pwm_apply_state(struct pwm_device *pwm, const struct pwm_state *state)
 	    state->polarity == pwm->state.polarity &&
 	    state->enabled == pwm->state.enabled &&
 	    state->usage_power == pwm->state.usage_power &&
-	    state->phase == pwm->state.phase &&
-	    state->time_unit == pwm->state.time_unit)
+	    state->phase == pwm->state.phase)
 		return 0;
 
 	err = chip->ops->apply(chip, pwm, state);
@@ -645,7 +644,6 @@ int pwm_adjust_config(struct pwm_device *pwm)
 		state.duty_cycle = 0;
 		state.period = pargs.period;
 		state.polarity = pargs.polarity;
-		state.time_unit = pargs.time_unit;
 
 		return pwm_apply_state(pwm, &state);
 	}
@@ -1107,15 +1105,6 @@ struct pwm_device *devm_fwnode_pwm_get(struct device *dev,
 EXPORT_SYMBOL_GPL(devm_fwnode_pwm_get);
 
 #ifdef CONFIG_DEBUG_FS
-
-const char *pwm_time_unit_strings[] = {
-	[PWM_UNIT_SEC] = "s",
-	[PWM_UNIT_MSEC] = "ms",
-	[PWM_UNIT_USEC] = "us",
-	[PWM_UNIT_NSEC] = "ns",
-	[PWM_UNIT_PSEC] = "ps",
-};
-
 static void pwm_dbg_show(struct pwm_chip *chip, struct seq_file *s)
 {
 	unsigned int i;
@@ -1125,8 +1114,6 @@ static void pwm_dbg_show(struct pwm_chip *chip, struct seq_file *s)
 		struct pwm_state state;
 
 		pwm_get_state(pwm, &state);
-		if (!state.time_unit)
-			state.time_unit = PWM_UNIT_NSEC;
 
 		seq_printf(s, " pwm-%-3d (%-20.20s):", i, pwm->label);
 
@@ -1136,12 +1123,9 @@ static void pwm_dbg_show(struct pwm_chip *chip, struct seq_file *s)
 		if (state.enabled)
 			seq_puts(s, " enabled");
 
-		seq_printf(s, " period: %llu %s", state.period,
-			   pwm_time_unit_strings[state.time_unit]);
-		seq_printf(s, " duty: %llu %s", state.duty_cycle,
-			   pwm_time_unit_strings[state.time_unit]);
-		seq_printf(s, " phase: %llu %s", state.phase,
-			   pwm_time_unit_strings[state.time_unit]);
+		seq_printf(s, " period: %llu ns", state.period);
+		seq_printf(s, " duty: %llu ns", state.duty_cycle);
+		seq_printf(s, " phase: %llu ns", state.phase);
 		seq_printf(s, " polarity: %s",
 			   state.polarity ? "inverse" : "normal");
 

--- a/drivers/pwm/pwm-axi-pwmgen.c
+++ b/drivers/pwm/pwm-axi-pwmgen.c
@@ -138,27 +138,24 @@ static void axi_pwmgen_get_state(struct pwm_chip *chip, struct pwm_device *pwm,
 	cnt = axi_pwmgen_read(pwmgen, AXI_PWMGEN_CHX_PERIOD(pwmgen, ch));
 	cnt *= clk_period_ps;
 	if (cnt)
-		state->period = DIV_ROUND_CLOSEST_ULL(cnt,
-				axi_pwmgen_scales[pwm->state.time_unit]);
+		state->period = DIV_ROUND_CLOSEST_ULL(cnt, PSEC_PER_NSEC);
 	else
 		state->period = 0;
 	cnt = axi_pwmgen_read(pwmgen, AXI_PWMGEN_CHX_DUTY(pwmgen, ch));
 	cnt *= clk_period_ps;
 	if (cnt)
-		state->duty_cycle = DIV_ROUND_CLOSEST_ULL(cnt,
-				axi_pwmgen_scales[pwm->state.time_unit]);
+		state->duty_cycle = DIV_ROUND_CLOSEST_ULL(cnt, PSEC_PER_NSEC);
 	else
 		state->duty_cycle = 0;
 	cnt = axi_pwmgen_read(pwmgen, AXI_PWMGEN_CHX_PHASE(pwmgen, ch));
 	cnt *= clk_period_ps;
 	if (cnt)
-		state->phase = DIV_ROUND_CLOSEST_ULL(cnt,
-				axi_pwmgen_scales[pwm->state.time_unit]);
+		state->phase = DIV_ROUND_CLOSEST_ULL(cnt, PSEC_PER_NSEC);
 	else
 		state->phase = 0;
 
 	state->enabled = state->period > 0;
-	state->time_unit = pwm->state.time_unit;
+	state->time_unit = PWM_UNIT_NSEC;
 }
 
 static const struct pwm_ops axi_pwmgen_pwm_ops = {

--- a/drivers/pwm/pwm-axi-pwmgen.c
+++ b/drivers/pwm/pwm-axi-pwmgen.c
@@ -129,32 +129,21 @@ static void axi_pwmgen_get_state(struct pwm_chip *chip, struct pwm_device *pwm,
 {
 	struct axi_pwmgen *pwmgen = to_axi_pwmgen(chip);
 	unsigned long rate;
-	unsigned long long cnt, clk_period_ps;
+	unsigned long long cnt;
 	unsigned int ch = pwm->hwpwm;
 
 	rate = clk_get_rate(pwmgen->clk);
 	if (!rate)
 		return;
 
-	clk_period_ps = DIV_ROUND_CLOSEST_ULL(AXI_PWMGEN_PSEC_PER_SEC, rate);
 	cnt = axi_pwmgen_read(pwmgen, AXI_PWMGEN_CHX_PERIOD(pwmgen, ch));
-	cnt *= clk_period_ps;
-	if (cnt)
-		state->period = DIV_ROUND_CLOSEST_ULL(cnt, PSEC_PER_NSEC);
-	else
-		state->period = 0;
+	state->period = DIV_ROUND_CLOSEST_ULL(cnt * NSEC_PER_SEC, rate);
+
 	cnt = axi_pwmgen_read(pwmgen, AXI_PWMGEN_CHX_DUTY(pwmgen, ch));
-	cnt *= clk_period_ps;
-	if (cnt)
-		state->duty_cycle = DIV_ROUND_CLOSEST_ULL(cnt, PSEC_PER_NSEC);
-	else
-		state->duty_cycle = 0;
+	state->duty_cycle = DIV_ROUND_CLOSEST_ULL(cnt * NSEC_PER_SEC, rate);
+
 	cnt = axi_pwmgen_read(pwmgen, AXI_PWMGEN_CHX_PHASE(pwmgen, ch));
-	cnt *= clk_period_ps;
-	if (cnt)
-		state->phase = DIV_ROUND_CLOSEST_ULL(cnt, PSEC_PER_NSEC);
-	else
-		state->phase = 0;
+	state->phase = DIV_ROUND_CLOSEST_ULL(cnt * NSEC_PER_SEC, rate);
 
 	state->enabled = state->period > 0;
 	state->time_unit = PWM_UNIT_NSEC;

--- a/drivers/pwm/pwm-axi-pwmgen.c
+++ b/drivers/pwm/pwm-axi-pwmgen.c
@@ -94,7 +94,8 @@ static inline struct axi_pwmgen *to_axi_pwmgen(struct pwm_chip *chip)
 static int axi_pwmgen_apply(struct pwm_chip *chip, struct pwm_device *device,
 			     const struct pwm_state *state)
 {
-	unsigned long long rate, clk_period_ps, target, cnt;
+	unsigned long rate;
+	unsigned long long clk_period_ps, target, cnt;
 	unsigned int ch = device->hwpwm;
 	struct axi_pwmgen *pwm;
 
@@ -127,7 +128,8 @@ static void axi_pwmgen_get_state(struct pwm_chip *chip, struct pwm_device *pwm,
 				 struct pwm_state *state)
 {
 	struct axi_pwmgen *pwmgen = to_axi_pwmgen(chip);
-	unsigned long long rate, cnt, clk_period_ps;
+	unsigned long rate;
+	unsigned long long cnt, clk_period_ps;
 	unsigned int ch = pwm->hwpwm;
 
 	rate = clk_get_rate(pwmgen->clk);

--- a/drivers/pwm/pwm-axi-pwmgen.c
+++ b/drivers/pwm/pwm-axi-pwmgen.c
@@ -135,7 +135,6 @@ static int axi_pwmgen_apply(struct pwm_chip *chip, struct pwm_device *pwm,
 
 	/* Apply the new config */
 	axi_pwmgen_write(pwmgen, AXI_PWMGEN_REG_CONFIG, AXI_PWMGEN_LOAD_CONIG);
-	pwm->state.time_unit = state->time_unit;
 
 	return 0;
 }

--- a/drivers/pwm/pwm-axi-pwmgen.c
+++ b/drivers/pwm/pwm-axi-pwmgen.c
@@ -62,28 +62,28 @@ struct axi_pwmgen {
 	unsigned int		ch_period[AXI_PWMGEN_N_MAX_PWMS];
 };
 
-static inline unsigned int axi_pwmgen_read(struct axi_pwmgen *pwm,
+static inline unsigned int axi_pwmgen_read(struct axi_pwmgen *pwmgen,
 					   unsigned int reg)
 {
-	return readl(pwm->base + reg);
+	return readl(pwmgen->base + reg);
 }
 
-static inline void axi_pwmgen_write(struct axi_pwmgen *pwm,
+static inline void axi_pwmgen_write(struct axi_pwmgen *pwmgen,
 				    unsigned int reg,
 				    unsigned int value)
 {
-	writel(value, pwm->base + reg);
+	writel(value, pwmgen->base + reg);
 }
 
-static void axi_pwmgen_write_mask(struct axi_pwmgen *pwm,
+static void axi_pwmgen_write_mask(struct axi_pwmgen *pwmgen,
 				  unsigned int reg,
 				  unsigned int mask,
 				  unsigned int value)
 {
 	unsigned int temp;
 
-	temp = axi_pwmgen_read(pwm, reg);
-	axi_pwmgen_write(pwm, reg, (temp & ~mask) | value);
+	temp = axi_pwmgen_read(pwmgen, reg);
+	axi_pwmgen_write(pwmgen, reg, (temp & ~mask) | value);
 }
 
 static inline struct axi_pwmgen *to_axi_pwmgen(struct pwm_chip *chip)
@@ -91,35 +91,35 @@ static inline struct axi_pwmgen *to_axi_pwmgen(struct pwm_chip *chip)
 	return container_of(chip, struct axi_pwmgen, chip);
 }
 
-static int axi_pwmgen_apply(struct pwm_chip *chip, struct pwm_device *device,
+static int axi_pwmgen_apply(struct pwm_chip *chip, struct pwm_device *pwm,
 			     const struct pwm_state *state)
 {
 	unsigned long rate;
 	unsigned long long clk_period_ps, target, cnt;
-	unsigned int ch = device->hwpwm;
-	struct axi_pwmgen *pwm;
+	unsigned int ch = pwm->hwpwm;
+	struct axi_pwmgen *pwmgen;
 
-	pwm = to_axi_pwmgen(chip);
-	rate = clk_get_rate(pwm->clk);
+	pwmgen = to_axi_pwmgen(chip);
+	rate = clk_get_rate(pwmgen->clk);
 	clk_period_ps = DIV_ROUND_CLOSEST_ULL(AXI_PWMGEN_PSEC_PER_SEC, rate);
 
 	target = state->period * axi_pwmgen_scales[state->time_unit];
 	cnt = target ? DIV_ROUND_CLOSEST_ULL(target, clk_period_ps) : 0;
-	pwm->ch_period[ch] = cnt;
-	axi_pwmgen_write(pwm, AXI_PWMGEN_CHX_PERIOD(pwm, ch),
-			 state->enabled ? pwm->ch_period[ch] : 0);
+	pwmgen->ch_period[ch] = cnt;
+	axi_pwmgen_write(pwmgen, AXI_PWMGEN_CHX_PERIOD(pwmgen, ch),
+			 state->enabled ? pwmgen->ch_period[ch] : 0);
 
 	target = state->duty_cycle * axi_pwmgen_scales[state->time_unit];
 	cnt = target ? DIV_ROUND_CLOSEST_ULL(target, clk_period_ps) : 0;
-	axi_pwmgen_write(pwm, AXI_PWMGEN_CHX_DUTY(pwm, ch), cnt);
+	axi_pwmgen_write(pwmgen, AXI_PWMGEN_CHX_DUTY(pwmgen, ch), cnt);
 
 	target = state->phase * axi_pwmgen_scales[state->time_unit];
 	cnt = target ? DIV_ROUND_CLOSEST_ULL(target, clk_period_ps) : 0;
-	axi_pwmgen_write(pwm, AXI_PWMGEN_CHX_PHASE(pwm, ch), cnt);
+	axi_pwmgen_write(pwmgen, AXI_PWMGEN_CHX_PHASE(pwmgen, ch), cnt);
 
 	/* Apply the new config */
-	axi_pwmgen_write(pwm, AXI_PWMGEN_REG_CONFIG, AXI_PWMGEN_LOAD_CONIG);
-	device->state.time_unit = state->time_unit;
+	axi_pwmgen_write(pwmgen, AXI_PWMGEN_REG_CONFIG, AXI_PWMGEN_LOAD_CONIG);
+	pwm->state.time_unit = state->time_unit;
 
 	return 0;
 }
@@ -165,22 +165,22 @@ MODULE_DEVICE_TABLE(of, axi_pwmgen_ids);
 
 static int axi_pwmgen_setup(struct pwm_chip *chip)
 {
-	struct axi_pwmgen *pwm;
+	struct axi_pwmgen *pwmgen;
 	unsigned int reg;
 	int idx;
 
-	pwm = to_axi_pwmgen(chip);
-	axi_pwmgen_write(pwm, AXI_PWMGEN_REG_SCRATCHPAD, AXI_PWMGEN_TEST_DATA);
-	reg = axi_pwmgen_read(pwm, AXI_PWMGEN_REG_SCRATCHPAD);
+	pwmgen = to_axi_pwmgen(chip);
+	axi_pwmgen_write(pwmgen, AXI_PWMGEN_REG_SCRATCHPAD, AXI_PWMGEN_TEST_DATA);
+	reg = axi_pwmgen_read(pwmgen, AXI_PWMGEN_REG_SCRATCHPAD);
 	if (reg != AXI_PWMGEN_TEST_DATA) {
 		dev_err(chip->dev, "failed to access the device registers\n");
 		return -EIO;
 	}
 
-	reg = axi_pwmgen_read(pwm, AXI_PWMGEN_REG_CORE_VERSION);
-	pwm->hw_maj_ver = AXI_PWMGEN_VERSION_MAJOR(reg);
+	reg = axi_pwmgen_read(pwmgen, AXI_PWMGEN_REG_CORE_VERSION);
+	pwmgen->hw_maj_ver = AXI_PWMGEN_VERSION_MAJOR(reg);
 
-	if (pwm->hw_maj_ver != 1 && pwm->hw_maj_ver != 2) {
+	if (pwmgen->hw_maj_ver != 1 && pwmgen->hw_maj_ver != 2) {
 		dev_err(chip->dev, "Unsupported peripheral version %u.%u.%u\n",
 			AXI_PWMGEN_VERSION_MAJOR(reg),
 			AXI_PWMGEN_VERSION_MINOR(reg),
@@ -188,19 +188,19 @@ static int axi_pwmgen_setup(struct pwm_chip *chip)
 		return -ENODEV;
 	}
 
-	pwm->chip.npwm = axi_pwmgen_read(pwm, AXI_PWMGEN_REG_NPWM);
-	if (pwm->chip.npwm > AXI_PWMGEN_N_MAX_PWMS)
+	pwmgen->chip.npwm = axi_pwmgen_read(pwmgen, AXI_PWMGEN_REG_NPWM);
+	if (pwmgen->chip.npwm > AXI_PWMGEN_N_MAX_PWMS)
 		return -EINVAL;
 
 	/* Disable all the outputs */
-	for (idx = 0; idx < pwm->chip.npwm; idx++) {
-		axi_pwmgen_write(pwm, AXI_PWMGEN_CHX_PERIOD(pwm, idx), 0);
-		axi_pwmgen_write(pwm, AXI_PWMGEN_CHX_DUTY(pwm, idx), 0);
-		axi_pwmgen_write(pwm, AXI_PWMGEN_CHX_PHASE(pwm, idx), 0);
+	for (idx = 0; idx < pwmgen->chip.npwm; idx++) {
+		axi_pwmgen_write(pwmgen, AXI_PWMGEN_CHX_PERIOD(pwmgen, idx), 0);
+		axi_pwmgen_write(pwmgen, AXI_PWMGEN_CHX_DUTY(pwmgen, idx), 0);
+		axi_pwmgen_write(pwmgen, AXI_PWMGEN_CHX_PHASE(pwmgen, idx), 0);
 	}
 
 	/* Enable the core */
-	axi_pwmgen_write_mask(pwm, AXI_PWMGEN_REG_CONFIG, AXI_PWMGEN_RESET, 0);
+	axi_pwmgen_write_mask(pwmgen, AXI_PWMGEN_REG_CONFIG, AXI_PWMGEN_RESET, 0);
 
 	return 0;
 }
@@ -212,40 +212,40 @@ static void axi_pwmgen_clk_disable(void *data)
 
 static int axi_pwmgen_probe(struct platform_device *pdev)
 {
-	struct axi_pwmgen *pwm;
+	struct axi_pwmgen *pwmgen;
 	struct resource *mem;
 	int ret;
 
-	pwm = devm_kzalloc(&pdev->dev, sizeof(*pwm), GFP_KERNEL);
-	if (!pwm)
+	pwmgen = devm_kzalloc(&pdev->dev, sizeof(*pwmgen), GFP_KERNEL);
+	if (!pwmgen)
 		return -ENOMEM;
 
 	mem = platform_get_resource(pdev, IORESOURCE_MEM, 0);
-	pwm->base = devm_ioremap_resource(&pdev->dev, mem);
-	if (IS_ERR(pwm->base))
-		return PTR_ERR(pwm->base);
+	pwmgen->base = devm_ioremap_resource(&pdev->dev, mem);
+	if (IS_ERR(pwmgen->base))
+		return PTR_ERR(pwmgen->base);
 
-	pwm->clk = devm_clk_get(&pdev->dev, NULL);
-	if (IS_ERR(pwm->clk))
-		return PTR_ERR(pwm->clk);
+	pwmgen->clk = devm_clk_get(&pdev->dev, NULL);
+	if (IS_ERR(pwmgen->clk))
+		return PTR_ERR(pwmgen->clk);
 
-	ret = clk_prepare_enable(pwm->clk);
+	ret = clk_prepare_enable(pwmgen->clk);
 	if (ret)
 		return ret;
 	ret = devm_add_action_or_reset(&pdev->dev, axi_pwmgen_clk_disable,
-				       pwm->clk);
+				       pwmgen->clk);
 	if (ret)
 		return ret;
 
-	pwm->chip.dev = &pdev->dev;
-	pwm->chip.ops = &axi_pwmgen_pwm_ops;
-	pwm->chip.base = -1;
+	pwmgen->chip.dev = &pdev->dev;
+	pwmgen->chip.ops = &axi_pwmgen_pwm_ops;
+	pwmgen->chip.base = -1;
 
-	ret = axi_pwmgen_setup(&pwm->chip);
+	ret = axi_pwmgen_setup(&pwmgen->chip);
 	if (ret < 0)
 		return ret;
 
-	return devm_pwmchip_add(&pdev->dev, &pwm->chip);
+	return devm_pwmchip_add(&pdev->dev, &pwmgen->chip);
 }
 
 static struct platform_driver axi_pwmgen_driver = {

--- a/drivers/pwm/pwm-axi-pwmgen.c
+++ b/drivers/pwm/pwm-axi-pwmgen.c
@@ -57,9 +57,6 @@ struct axi_pwmgen {
 	struct clk		*clk;
 	void __iomem		*base;
 	u8			hw_maj_ver;
-
-	/* Used to store the period when the channel is disabled */
-	unsigned int		ch_period[AXI_PWMGEN_N_MAX_PWMS];
 };
 
 static inline unsigned int axi_pwmgen_read(struct axi_pwmgen *pwmgen,
@@ -105,9 +102,8 @@ static int axi_pwmgen_apply(struct pwm_chip *chip, struct pwm_device *pwm,
 
 	target = state->period * axi_pwmgen_scales[state->time_unit];
 	cnt = target ? DIV_ROUND_CLOSEST_ULL(target, clk_period_ps) : 0;
-	pwmgen->ch_period[ch] = cnt;
 	axi_pwmgen_write(pwmgen, AXI_PWMGEN_CHX_PERIOD(pwmgen, ch),
-			 state->enabled ? pwmgen->ch_period[ch] : 0);
+			 state->enabled ? cnt : 0);
 
 	target = state->duty_cycle * axi_pwmgen_scales[state->time_unit];
 	cnt = target ? DIV_ROUND_CLOSEST_ULL(target, clk_period_ps) : 0;

--- a/drivers/pwm/pwm-axi-pwmgen.c
+++ b/drivers/pwm/pwm-axi-pwmgen.c
@@ -116,15 +116,21 @@ static int axi_pwmgen_apply(struct pwm_chip *chip, struct pwm_device *pwm,
 
 	cnt = mul_u64_u64_div_u64_roundclosest(state->period * axi_pwmgen_scales[state->time_unit],
 					       rate, PSEC_PER_SEC);
+	if (cnt > U32_MAX)
+		cnt = U32_MAX;
 	axi_pwmgen_write(pwmgen, AXI_PWMGEN_CHX_PERIOD(pwmgen, ch),
 			 state->enabled ? cnt : 0);
 
 	cnt = mul_u64_u64_div_u64_roundclosest(state->duty_cycle * axi_pwmgen_scales[state->time_unit],
 					       rate, PSEC_PER_SEC);
+	if (cnt > U32_MAX)
+		cnt = U32_MAX;
 	axi_pwmgen_write(pwmgen, AXI_PWMGEN_CHX_DUTY(pwmgen, ch), cnt);
 
 	cnt = mul_u64_u64_div_u64_roundclosest(state->phase * axi_pwmgen_scales[state->time_unit],
 					       rate, PSEC_PER_SEC);
+	if (cnt > U32_MAX)
+		cnt = U32_MAX;
 	axi_pwmgen_write(pwmgen, AXI_PWMGEN_CHX_PHASE(pwmgen, ch), cnt);
 
 	/* Apply the new config */

--- a/drivers/pwm/pwm-axi-pwmgen.c
+++ b/drivers/pwm/pwm-axi-pwmgen.c
@@ -172,7 +172,7 @@ static void axi_pwmgen_get_state(struct pwm_chip *chip, struct pwm_device *pwm,
 	if (ret < 0)
 		return;
 
-	state->enabled = state;
+	state->enabled = capture.period > 0;
 	state->period = capture.period;
 	state->duty_cycle = capture.duty_cycle;
 	state->phase = capture.phase;

--- a/drivers/pwm/pwm-sti.c
+++ b/drivers/pwm/pwm-sti.c
@@ -371,10 +371,10 @@ static int sti_pwm_capture(struct pwm_chip *chip, struct pwm_device *pwm,
 		effective_ticks = clk_get_rate(pc->cpt_clk);
 
 		result->period = (high + low) * NSEC_PER_SEC;
-		result->period = div_u64(result->period, effective_ticks);
+		result->period /= effective_ticks;
 
 		result->duty_cycle = high * NSEC_PER_SEC;
-		result->duty_cycle = div_u64(result->duty_cycle, effective_ticks);
+		result->duty_cycle /= effective_ticks;
 
 		break;
 

--- a/drivers/pwm/sysfs.c
+++ b/drivers/pwm/sysfs.c
@@ -247,8 +247,7 @@ static ssize_t capture_show(struct device *child,
 	if (ret)
 		return ret;
 
-	return sysfs_emit(buf, "%llu %llu %llu\n", result.period,
-			  result.duty_cycle, result.phase);
+	return sysfs_emit(buf, "%u %u\n", result.period, result.duty_cycle);
 }
 
 static DEVICE_ATTR_RW(period);

--- a/drivers/pwm/sysfs.c
+++ b/drivers/pwm/sysfs.c
@@ -235,69 +235,6 @@ static ssize_t polarity_store(struct device *child,
 	return ret ? : size;
 }
 
-static ssize_t time_unit_show(struct device *child,
-			      struct device_attribute *attr,
-			      char *buf)
-{
-	const struct pwm_device *pwm = child_to_pwm_device(child);
-	const char *unit = "unknown";
-	struct pwm_state state;
-
-	pwm_get_state(pwm, &state);
-
-	switch (state.time_unit) {
-	case PWM_UNIT_SEC:
-		unit = "second";
-		break;
-	case PWM_UNIT_MSEC:
-		unit = "milisecond";
-		break;
-	case PWM_UNIT_USEC:
-		unit = "microsecond";
-		break;
-	case PWM_UNIT_NSEC:
-		unit = "nanosecond";
-		break;
-	case PWM_UNIT_PSEC:
-		unit = "picosecond";
-		break;
-	}
-
-	return sprintf(buf, "%s\n", unit);
-}
-
-static ssize_t time_unit_store(struct device *child,
-			       struct device_attribute *attr,
-			       const char *buf, size_t size)
-{
-	struct pwm_export *export = child_to_pwm_export(child);
-	struct pwm_device *pwm = export->pwm;
-	enum pwm_time_unit unit;
-	struct pwm_state state;
-	int ret;
-
-	if (sysfs_streq(buf, "second"))
-		unit = PWM_UNIT_SEC;
-	else if (sysfs_streq(buf, "milisecond"))
-		unit = PWM_UNIT_MSEC;
-	else if (sysfs_streq(buf, "microsecond"))
-		unit = PWM_UNIT_USEC;
-	else if (sysfs_streq(buf, "nanosecond"))
-		unit = PWM_UNIT_NSEC;
-	else if (sysfs_streq(buf, "picosecond"))
-		unit = PWM_UNIT_PSEC;
-	else
-		return -EINVAL;
-
-	mutex_lock(&export->lock);
-	pwm_get_state(pwm, &state);
-	state.time_unit = unit;
-	ret = pwm_apply_state(pwm, &state);
-	mutex_unlock(&export->lock);
-
-	return ret ? : size;
-}
-
 static ssize_t capture_show(struct device *child,
 			    struct device_attribute *attr,
 			    char *buf)
@@ -319,7 +256,6 @@ static DEVICE_ATTR_RW(duty_cycle);
 static DEVICE_ATTR_RW(phase);
 static DEVICE_ATTR_RW(enable);
 static DEVICE_ATTR_RW(polarity);
-static DEVICE_ATTR_RW(time_unit);
 static DEVICE_ATTR_RO(capture);
 
 static struct attribute *pwm_attrs[] = {
@@ -328,7 +264,6 @@ static struct attribute *pwm_attrs[] = {
 	&dev_attr_phase.attr,
 	&dev_attr_enable.attr,
 	&dev_attr_polarity.attr,
-	&dev_attr_time_unit.attr,
 	&dev_attr_capture.attr,
 	NULL
 };

--- a/include/linux/pwm.h
+++ b/include/linux/pwm.h
@@ -274,9 +274,8 @@ pwm_set_relative_duty_cycle(struct pwm_state *state, unsigned int duty_cycle,
  * @duty_cycle: duty cycle of the PWM signal (in nanoseconds)
  */
 struct pwm_capture {
-	u64 period;
-	u64 duty_cycle;
-	u64 phase;
+	unsigned int period;
+	unsigned int duty_cycle;
 };
 
 /**

--- a/include/linux/pwm.h
+++ b/include/linux/pwm.h
@@ -325,8 +325,8 @@ int pwm_adjust_config(struct pwm_device *pwm);
  *
  * Returns: 0 on success or a negative error code on failure.
  */
-static inline int pwm_config(struct pwm_device *pwm, u64 duty_ns,
-			     u64 period_ns)
+static inline int pwm_config(struct pwm_device *pwm, int duty_ns,
+			     int period_ns)
 {
 	struct pwm_state state;
 
@@ -436,8 +436,8 @@ static inline int pwm_adjust_config(struct pwm_device *pwm)
 	return -ENOTSUPP;
 }
 
-static inline int pwm_config(struct pwm_device *pwm, u64 duty_ns,
-			     u64 period_ns)
+static inline int pwm_config(struct pwm_device *pwm, int duty_ns,
+			     int period_ns)
 {
 	might_sleep();
 	return -EINVAL;

--- a/include/linux/pwm.h
+++ b/include/linux/pwm.h
@@ -148,21 +148,6 @@ static inline u64 pwm_get_duty_cycle(const struct pwm_device *pwm)
 	return state.duty_cycle;
 }
 
-static inline void pwm_set_phase(struct pwm_device *pwm, u64 phase)
-{
-	if (pwm)
-		pwm->state.phase = phase;
-}
-
-static inline u64 pwm_get_phase(const struct pwm_device *pwm)
-{
-	struct pwm_state state;
-
-	pwm_get_state(pwm, &state);
-
-	return state.phase;
-}
-
 static inline enum pwm_polarity pwm_get_polarity(const struct pwm_device *pwm)
 {
 	struct pwm_state state;

--- a/include/linux/pwm.h
+++ b/include/linux/pwm.h
@@ -26,7 +26,6 @@ enum pwm_polarity {
  * struct pwm_args - board-dependent PWM arguments
  * @period: reference period
  * @polarity: reference polarity
- * @phase: reference phase
  *
  * This structure describes board-dependent arguments attached to a PWM
  * device. These arguments are usually retrieved from the PWM lookup table or
@@ -38,7 +37,6 @@ enum pwm_polarity {
  */
 struct pwm_args {
 	u64 period;
-	u64 phase;
 	enum pwm_polarity polarity;
 };
 
@@ -547,7 +545,7 @@ static inline void pwm_apply_args(struct pwm_device *pwm)
 	state.enabled = false;
 	state.polarity = pwm->args.polarity;
 	state.period = pwm->args.period;
-	state.phase = pwm->args.phase;
+	state.phase = 0;
 	state.usage_power = false;
 
 	pwm_apply_state(pwm, &state);


### PR DESCRIPTION
## PR Description

With no known PWM having an input clock that runs faster than 1 GHz it has no effect to be able to specify PWM parameters with picosecond resolution apart from giving a wrong impression.

On the tour to create these commits I found a few questionable drivers where I'm unsure if the drivers work at all as intended.
See the commit logs of 8050703fe3050051fed4ed4b9f43e5ea08929ef3 and 27e6fb3c5c13726187d6bf60c65b10a6633ecd92 for some details.

Note the changes are only compile tested as I don't have all the affected hardware.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [x] I have updated the documentation outside this repo accordingly (if there is the case)
