### PR TITLE
dts/socfpga_arria10_socdk_adrv9025.dts: Change sysref mode to continuous

### DIFF
--- a/arch/arm/boot/dts/socfpga_arria10_socdk_adrv9025.dts
+++ b/arch/arm/boot/dts/socfpga_arria10_socdk_adrv9025.dts
@@ -112,9 +112,8 @@
 
 					/* SYSREF config */
 					adi,sysref-src = <SYSREF_SRC_INTERNAL>;
-					adi,sysref-pattern-mode = <SYSREF_PATTERN_NSHOT>;
+					adi,sysref-pattern-mode = <SYSREF_PATTERN_CONTINUOUS>;
 					adi,sysref-k-div = <512>;
-					adi,sysref-nshot-mode = <SYSREF_NSHOT_8_PULSES>;
 					adi,jesd204-desired-sysref-frequency-hz = <3840000>;
 
 					adi,rpole2 = <RPOLE2_900_OHM>;


### PR DESCRIPTION
## PR Description

When booting the system with sysref in N-Shot mode there are always about 9 to 12 errors on the lanes while Continuous sysref gives 0 errors. Those errors don't seem to affect functionality. Both modes work fine in hardware, but continuous gives a cleaner jesd_status.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
