### PR TITLE
[nextstable] iio: adc: ad_sigma_delta: fix buffered mode irq

### DIFF
--- a/drivers/iio/adc/ad_sigma_delta.c
+++ b/drivers/iio/adc/ad_sigma_delta.c
@@ -450,7 +450,7 @@ static int ad_sd_buffer_postenable(struct iio_dev *indio_dev)
 	 * Differs from upstream because of the spi engine support and we want to enable
 	 * the irq only after setting AD_SD_MODE_CONTINUOUS (as in the upstream lib)
 	 */
-	if (iio_device_get_current_mode(indio_dev) == INDIO_BUFFER_HARDWARE) {
+	if (iio_device_get_current_mode(indio_dev) != INDIO_BUFFER_HARDWARE) {
 		sigma_delta->irq_dis = false;
 		enable_irq(sigma_delta->irq_line);
 	}


### PR DESCRIPTION
## PR Description
Buffered mode using ad_sigma_delta is not functional as the IRQ is not enabled in the postenable callback for devices that are not using spi_engine (INDIO_BUFFER_HARDWARE mode).
Comparing to the 2022_R2 version, it seems that the condition should have been negated.

Fix by checking inequality instead of equality to INDIO_BUFFER_HARDWARE.
Fixes: 27b588fc154f ("Merge tag 'xilinx-v2023.1' of https://github.com/Xilinx/linux-xlnx.git")
## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
