### PR TITLE
VPK180: AD9082 minor fixes and a default devicetree

### DIFF
--- a/arch/arm64/boot/dts/xilinx/versal-vpk180-reva-ad9082-m1-l8.dts
+++ b/arch/arm64/boot/dts/xilinx/versal-vpk180-reva-ad9082-m1-l8.dts
@@ -4,7 +4,7 @@
  * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-mxfe/ad9081
  * https://wiki.analog.com/resources/eval/user-guides/ad9081_fmca_ebz/ad9081_fmca_ebz_hdl
  *
- * hdl_project: <ad9081_fmca_ebz/vpk180>
+ * hdl_project: <ad9082_fmca_ebz/vpk180>
  * board_revision: <>
  *
  * Copyright (C) 2019-2023 Analog Devices Inc.
@@ -25,7 +25,7 @@
 #define AD9081_TX_LINK_CLK	180000000
 
 / {
-	model = "Analog Devices AD9081-FMC-EBZ-VPK180 Rev.A";
+	model = "Analog Devices AD9082-FMC-EBZ-VPK180 Rev.A";
 
 	chosen {
 		bootargs = "console=ttyAMA0 earlycon=pl011,mmio32,0xFF000000,115200n8 clk_ignore_unused root=/dev/mmcblk0p2 rw rootfstype=ext4 rootwait";

--- a/arch/arm64/boot/dts/xilinx/versal-vpk180-reva-ad9082.dts
+++ b/arch/arm64/boot/dts/xilinx/versal-vpk180-reva-ad9082.dts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD9081-FMC-EBZ
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-mxfe/ad9081
+ * https://wiki.analog.com/resources/eval/user-guides/ad9081_fmca_ebz/ad9081_fmca_ebz_hdl
+ *
+ * hdl_project: <ad9082_fmca_ebz/vpk180>
+ * board_revision: <>
+ *
+ * Copyright (C) 2019-2023 Analog Devices Inc.
+ */
+
+ #include "versal-vpk180-reva-ad9081.dts"
+
+&trx0_ad9081 {
+	compatible = "adi,ad9082";
+};


### PR DESCRIPTION
## PR Description

Adds a devicetree for the default VPK180 + AD9082 configuration.
Also changes some AD9081 references from the previous devicetrees.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
