### PR TITLE
[main] ad7173 fixes

### DIFF
--- a/arch/arm/boot/dts/adi-zynq-cn0363.dtsi
+++ b/arch/arm/boot/dts/adi-zynq-cn0363.dtsi
@@ -61,30 +61,30 @@
 		ad7175: adc@0 {
 			compatible = "adi,ad7175-2";
 			reg = <0>;
-			spi-cpha;
-			spi-cpol;
 			spi-max-frequency = <10000000>;
 			interrupt-parent = <&gpio0>;
 			interrupts = <88 4>;
+			interrupt-names = "rdy";
 			#io-channel-cells = <1>;
 
-			adi,channels {
-				#address-cells = <2>;
-				#size-cells = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
 
-				channel@0,1 {
-					reg = <0 1>;
-					adi,bipolar;
-				};
+			channel@0 {
+				reg = <0>;
+				diff-channels = <0 1>;
+				bipolar;
+			};
 
-				channel@2,3 {
-					reg = <2 3>;
-					adi,bipolar;
-				};
+			channel@1 {
+				reg = <1>;
+				diff-channels = <2 3>;
+				bipolar;
+			};
 
-				channel@0,4 {
-					reg = <0 4>;
-				};
+			channel@2 {
+				reg = <2>;
+				diff-channels = <0 4>;
 			};
 		};
 

--- a/drivers/iio/adc/ad7173.c
+++ b/drivers/iio/adc/ad7173.c
@@ -1188,7 +1188,7 @@ static int ad7173_fw_parse_channel_config(struct iio_dev *indio_dev)
 	struct device *dev = indio_dev->dev.parent;
 	struct iio_chan_spec *chan_arr, *chan;
 	unsigned int ain[AD7173_NO_AINS_PER_CHANNEL], chan_index = 0;
-	int ref_sel, ret, is_current_chan, num_channels;
+	int ref_sel, ret, num_channels;
 
 	num_channels = device_get_child_node_count(dev);
 
@@ -1234,6 +1234,8 @@ static int ad7173_fw_parse_channel_config(struct iio_dev *indio_dev)
 	}
 
 	device_for_each_child_node_scoped(dev, child) {
+		bool is_current_chan = false;
+
 		chan = &chan_arr[chan_index];
 		*chan = ad7173_channel_template;
 		chan_st_priv = &chans_st_arr[chan_index];


### PR DESCRIPTION
## PR Description

This PR fixes issues in regards to the ad7173 driver and it's usage for cn0363.
- update dt ad7175 instance to match with the current driver parsing
- backport a fix from upstream

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
