### PR TITLE
Add dts files and fixes for AD4030-24, AD4032-24, AD4630-16, ADAQ4216 and ADAQ4220

### DIFF
--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad4030-24.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad4030-24.dts
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD4630-24
+ *
+ * hdl_project: <ad4630_fmc/zed>
+ * board_revision: <B>
+ *
+ * Copyright (C) 2023 Analog Devices Inc.
+ */
+/dts-v1/;
+
+#include "zynq-zed.dtsi"
+#include "zynq-zed-adv7511.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/pwm/pwm.h>
+
+/ {
+	vref: regulator-vref {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-supply";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		regulator-always-on;
+	};
+
+	vdd_1_8: regulator-vdd-1-8 {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-supply";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+		regulator-always-on;
+	};
+
+	vio: regulator-vio {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-supply";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+		regulator-always-on;
+	};
+
+	clocks {
+		cnv_ext_clk: ext-clk {
+			#clock-cells = <0x0>;
+			compatible = "fixed-clock";
+			clock-frequency = <100000000>;
+			clock-output-names = "cnv_ext_clk";
+		};
+	};
+};
+
+&fpga_axi {
+	rx_dma: rx-dmac@44a30000 {
+		compatible = "adi,axi-dmac-1.00.a";
+		reg = <0x44a30000 0x1000>;
+		#dma-cells = <1>;
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&clkc 15>;
+
+		adi,channels {
+			#size-cells = <0>;
+			#address-cells = <1>;
+
+			dma-channel@0 {
+				reg = <0>;
+				adi,source-bus-width = <64>;
+				adi,source-bus-type = <1>;
+				adi,destination-bus-width = <64>;
+				adi,destination-bus-type = <0>;
+			};
+		};
+	};
+
+	spi_clk: axi-clkgen@0x44a70000 {
+		compatible = "adi,axi-clkgen-2.00.a";
+		reg = <0x44a70000 0x10000>;
+		#clock-cells = <0>;
+		clocks = <&clkc 15>, <&clkc 15>;
+		clock-names = "s_axi_aclk", "clkin1";
+		clock-output-names = "spi_clk";
+	};
+
+	axi_pwm_gen: axi-pwm-gen@ {
+		compatible = "adi,axi-pwmgen";
+		reg = <0x44b00000 0x1000>;
+		label = "ad463x_cnv";
+		#pwm-cells = <2>;
+		clocks = <&cnv_ext_clk>;
+
+	};
+
+	axi_spi_engine: spi@44a00000 {
+		compatible = "adi-ex,axi-spi-engine-1.00.a";
+		reg = <0x44a00000 0x1FF>;
+		interrupt-parent = <&intc>;
+		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&clkc 15>, <&spi_clk>;
+		clock-names = "s_axi_aclk", "spi_clk";
+		num-cs = <1>;
+
+		#address-cells = <0x1>;
+		#size-cells = <0x0>;
+
+		ad4030: ad4030@0 {
+			compatible = "adi,ad4030-24";
+			reg = <0>;
+			vdd-supply = <&vref>;
+			vdd_1_8-supply = <&vdd_1_8>;
+			vio-supply = <&vio>;
+			vref-supply = <&vref>;
+			spi-max-frequency = <80000000>;
+			reset-gpios = <&gpio0 86 GPIO_ACTIVE_LOW>;
+
+			adi,lane-mode = <0>;
+			adi,clock-mode = <0>;
+			adi,out-data-mode = <0>;
+
+			adi,spi-trigger;
+			clocks = <&cnv_ext_clk>;
+			clock-names = "trigger_clock";
+			dmas = <&rx_dma 0>;
+			dma-names = "rx";
+			pwm-names = "spi_trigger", "cnv";
+			pwms = <&axi_pwm_gen 0 0>, <&axi_pwm_gen 1 0>;
+		};
+	};
+};

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad4032-24.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad4032-24.dts
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD4630-24
+ *
+ * hdl_project: <ad4630_fmc/zed>
+ * board_revision: <B>
+ *
+ * Copyright (C) 2023 Analog Devices Inc.
+ */
+/dts-v1/;
+
+#include "zynq-zed.dtsi"
+#include "zynq-zed-adv7511.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/pwm/pwm.h>
+
+/ {
+	vref: regulator-vref {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-supply";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		regulator-always-on;
+	};
+
+	vdd_1_8: regulator-vdd-1-8 {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-supply";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+		regulator-always-on;
+	};
+
+	vio: regulator-vio {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-supply";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+		regulator-always-on;
+	};
+
+	clocks {
+		cnv_ext_clk: ext-clk {
+			#clock-cells = <0x0>;
+			compatible = "fixed-clock";
+			clock-frequency = <100000000>;
+			clock-output-names = "cnv_ext_clk";
+		};
+	};
+};
+
+&fpga_axi {
+	rx_dma: rx-dmac@44a30000 {
+		compatible = "adi,axi-dmac-1.00.a";
+		reg = <0x44a30000 0x1000>;
+		#dma-cells = <1>;
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&clkc 15>;
+
+		adi,channels {
+			#size-cells = <0>;
+			#address-cells = <1>;
+
+			dma-channel@0 {
+				reg = <0>;
+				adi,source-bus-width = <64>;
+				adi,source-bus-type = <1>;
+				adi,destination-bus-width = <64>;
+				adi,destination-bus-type = <0>;
+			};
+		};
+	};
+
+	spi_clk: axi-clkgen@0x44a70000 {
+		compatible = "adi,axi-clkgen-2.00.a";
+		reg = <0x44a70000 0x10000>;
+		#clock-cells = <0>;
+		clocks = <&clkc 15>, <&clkc 15>;
+		clock-names = "s_axi_aclk", "clkin1";
+		clock-output-names = "spi_clk";
+	};
+
+	axi_pwm_gen: axi-pwm-gen@ {
+		compatible = "adi,axi-pwmgen";
+		reg = <0x44b00000 0x1000>;
+		label = "ad463x_cnv";
+		#pwm-cells = <2>;
+		clocks = <&cnv_ext_clk>;
+
+	};
+
+	axi_spi_engine: spi@44a00000 {
+		compatible = "adi-ex,axi-spi-engine-1.00.a";
+		reg = <0x44a00000 0x1FF>;
+		interrupt-parent = <&intc>;
+		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&clkc 15>, <&spi_clk>;
+		clock-names = "s_axi_aclk", "spi_clk";
+		num-cs = <1>;
+
+		#address-cells = <0x1>;
+		#size-cells = <0x0>;
+
+		ad4032: ad4032@0 {
+			compatible = "adi,ad4032-24";
+			reg = <0>;
+			vdd-supply = <&vref>;
+			vdd_1_8-supply = <&vdd_1_8>;
+			vio-supply = <&vio>;
+			vref-supply = <&vref>;
+			spi-max-frequency = <80000000>;
+			reset-gpios = <&gpio0 86 GPIO_ACTIVE_LOW>;
+
+			adi,lane-mode = <0>;
+			adi,clock-mode = <0>;
+			adi,out-data-mode = <0>;
+
+			adi,spi-trigger;
+			clocks = <&cnv_ext_clk>;
+			clock-names = "trigger_clock";
+			dmas = <&rx_dma 0>;
+			dma-names = "rx";
+			pwm-names = "spi_trigger", "cnv";
+			pwms = <&axi_pwm_gen 0 0>, <&axi_pwm_gen 1 0>;
+		};
+	};
+};

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad4630-16.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad4630-16.dts
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD4630-24
+ *
+ * hdl_project: <ad4630_fmc/zed>
+ * board_revision: <B>
+ *
+ * Copyright (C) 2022 Analog Devices Inc.
+ */
+/dts-v1/;
+
+#include "zynq-zed.dtsi"
+#include "zynq-zed-adv7511.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/pwm/pwm.h>
+
+/ {
+	vref: regulator-vref {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-supply";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		regulator-always-on;
+	};
+
+	vdd_1_8: regulator-vdd-1-8 {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-supply";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+		regulator-always-on;
+	};
+
+	vio: regulator-vio {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-supply";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+		regulator-always-on;
+	};
+
+	clocks {
+		cnv_ext_clk: ext-clk {
+			#clock-cells = <0x0>;
+			compatible = "fixed-clock";
+			clock-frequency = <100000000>;
+			clock-output-names = "cnv_ext_clk";
+		};
+	};
+};
+
+&fpga_axi {
+	rx_dma: rx-dmac@44a30000 {
+		compatible = "adi,axi-dmac-1.00.a";
+		reg = <0x44a30000 0x1000>;
+		#dma-cells = <1>;
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&clkc 15>;
+
+		adi,channels {
+			#size-cells = <0>;
+			#address-cells = <1>;
+
+			dma-channel@0 {
+				reg = <0>;
+				adi,source-bus-width = <64>;
+				adi,source-bus-type = <1>;
+				adi,destination-bus-width = <64>;
+				adi,destination-bus-type = <0>;
+			};
+		};
+	};
+
+	spi_clk: axi-clkgen@0x44a70000 {
+		compatible = "adi,axi-clkgen-2.00.a";
+		reg = <0x44a70000 0x10000>;
+		#clock-cells = <0>;
+		clocks = <&clkc 15>, <&clkc 15>;
+		clock-names = "s_axi_aclk", "clkin1";
+		clock-output-names = "spi_clk";
+	};
+
+	axi_pwm_gen: axi-pwm-gen@ {
+		compatible = "adi,axi-pwmgen";
+		reg = <0x44b00000 0x1000>;
+		label = "ad463x_cnv";
+		#pwm-cells = <2>;
+		clocks = <&cnv_ext_clk>;
+
+	};
+
+	axi_spi_engine: spi@44a00000 {
+		compatible = "adi-ex,axi-spi-engine-1.00.a";
+		reg = <0x44a00000 0x1FF>;
+		interrupt-parent = <&intc>;
+		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&clkc 15>, <&spi_clk>;
+		clock-names = "s_axi_aclk", "spi_clk";
+		num-cs = <1>;
+
+		#address-cells = <0x1>;
+		#size-cells = <0x0>;
+
+		ad4630: ad4630-16@0 {
+			compatible = "adi,ad4630-16";
+			reg = <0>;
+			vdd-supply = <&vref>;
+			vdd_1_8-supply = <&vdd_1_8>;
+			vio-supply = <&vio>;
+			vref-supply = <&vref>;
+			spi-max-frequency = <80000000>;
+			reset-gpios = <&gpio0 86 GPIO_ACTIVE_LOW>;
+			adi,lane-mode = <0>;
+			adi,clock-mode = <0>;
+			adi,out-data-mode = <0>;
+			adi,spi-trigger;
+			clocks = <&cnv_ext_clk>;
+			clock-names = "trigger_clock";
+			dmas = <&rx_dma 0>;
+			dma-names = "rx";
+			pwm-names = "spi_trigger", "cnv";
+			pwms = <&axi_pwm_gen 0 0>, <&axi_pwm_gen 1 0>;
+		};
+	};
+};

--- a/arch/arm/boot/dts/zynq-zed-adv7511-adaq4216.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-adaq4216.dts
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices ADAQ4216 without isolated power supply
+ *
+ * hdl_project: <ad4630_fmc/zed>
+ * board_revision: <3>
+ *
+ * Copyright (C) 2024 Analog Devices Inc.
+ */
+/dts-v1/;
+
+#include "zynq-zed.dtsi"
+#include "zynq-zed-adv7511.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/pwm/pwm.h>
+
+/ {
+	vref: regulator-vref {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-supply";
+		regulator-min-microvolt = <4096000>;
+		regulator-max-microvolt = <4096000>;
+		regulator-always-on;
+	};
+
+	vdd_1_8: regulator-vdd-1-8 {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-supply";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+		regulator-always-on;
+	};
+
+	vio: regulator-vio {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-supply";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+		regulator-always-on;
+	};
+
+	clocks {
+		cnv_ext_clk: ext-clk {
+			#clock-cells = <0x0>;
+			compatible = "fixed-clock";
+			clock-frequency = <100000000>;
+			clock-output-names = "cnv_ext_clk";
+		};
+	};
+};
+
+&fpga_axi {
+	i2c@41620000 {
+		compatible = "xlnx,axi-iic-1.01.b", "xlnx,xps-iic-2.00.a";
+		reg = <0x41620000 0x10000>;
+		interrupt-parent = <&intc>;
+		interrupts = <0 55 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&clkc 15>;
+		clock-names = "pclk";
+		#size-cells = <0>;
+		#address-cells = <1>;
+
+		eeprom1: eeprom@50 {
+			compatible = "at24,24c02";
+			reg = <0x50>;
+		};
+	};
+
+	rx_dma: rx-dmac@44a30000 {
+		compatible = "adi,axi-dmac-1.00.a";
+		reg = <0x44a30000 0x1000>;
+		#dma-cells = <1>;
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&clkc 15>;
+
+		adi,channels {
+			#size-cells = <0>;
+			#address-cells = <1>;
+
+			dma-channel@0 {
+				reg = <0>;
+				adi,source-bus-width = <64>;
+				adi,source-bus-type = <1>;
+				adi,destination-bus-width = <64>;
+				adi,destination-bus-type = <0>;
+			};
+		};
+	};
+
+	spi_clk: axi-clkgen@0x44a70000 {
+		compatible = "adi,axi-clkgen-2.00.a";
+		reg = <0x44a70000 0x10000>;
+		#clock-cells = <0>;
+		clocks = <&clkc 15>, <&clkc 15>;
+		clock-names = "s_axi_aclk", "clkin1";
+		clock-output-names = "spi_clk";
+	};
+
+	axi_pwm_gen: axi-pwm-gen@ {
+		compatible = "adi,axi-pwmgen";
+		reg = <0x44b00000 0x1000>;
+		label = "ad463x_cnv";
+		#pwm-cells = <2>;
+		clocks = <&cnv_ext_clk>;
+	};
+
+	axi_spi_engine: spi@44a00000 {
+		compatible = "adi-ex,axi-spi-engine-1.00.a";
+		reg = <0x44a00000 0x1FF>;
+		interrupt-parent = <&intc>;
+		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&clkc 15>, <&spi_clk>;
+		clock-names = "s_axi_aclk", "spi_clk";
+		num-cs = <1>;
+		#address-cells = <0x1>;
+		#size-cells = <0x0>;
+
+		adaq4216: adaq4216@0 {
+			compatible = "adi,adaq4216";
+			reg = <0>;
+			vdd-supply = <&vref>;
+			vdd_1_8-supply = <&vdd_1_8>;
+			vio-supply = <&vio>;
+			vref-supply = <&vref>;
+			spi-max-frequency = <80000000>;
+			reset-gpios = <&gpio0 86 GPIO_ACTIVE_LOW>;
+			adi,pga-gpios = <&gpio0 87 GPIO_ACTIVE_HIGH>,
+					<&gpio0 88 GPIO_ACTIVE_HIGH>;
+			adi,lane-mode = <1>;
+			adi,clock-mode = <0>;
+			adi,out-data-mode = <0>;
+			adi,spi-trigger;
+			clocks = <&cnv_ext_clk>;
+			clock-names = "trigger_clock";
+			dmas = <&rx_dma 0>;
+			dma-names = "rx";
+			pwm-names = "spi_trigger", "cnv";
+			pwms = <&axi_pwm_gen 0 0>, <&axi_pwm_gen 1 0>;
+		};
+	};
+};

--- a/arch/arm/boot/dts/zynq-zed-adv7511-adaq4220.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-adaq4220.dts
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices ADAQ4220 without isolated power supply
+ *
+ * hdl_project: <ad4630_fmc/zed>
+ * board_revision: <3>
+ *
+ * Copyright (C) 2024 Analog Devices Inc.
+ */
+/dts-v1/;
+
+#include "zynq-zed.dtsi"
+#include "zynq-zed-adv7511.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/pwm/pwm.h>
+
+/ {
+	vref: regulator-vref {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-supply";
+		regulator-min-microvolt = <4096000>;
+		regulator-max-microvolt = <4096000>;
+		regulator-always-on;
+	};
+
+	vdd_1_8: regulator-vdd-1-8 {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-supply";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+		regulator-always-on;
+	};
+
+	vio: regulator-vio {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-supply";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+		regulator-always-on;
+	};
+
+	clocks {
+		cnv_ext_clk: ext-clk {
+			#clock-cells = <0x0>;
+			compatible = "fixed-clock";
+			clock-frequency = <100000000>;
+			clock-output-names = "cnv_ext_clk";
+		};
+	};
+};
+
+&fpga_axi {
+	i2c@41620000 {
+		compatible = "xlnx,axi-iic-1.01.b", "xlnx,xps-iic-2.00.a";
+		reg = <0x41620000 0x10000>;
+		interrupt-parent = <&intc>;
+		interrupts = <0 55 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&clkc 15>;
+		clock-names = "pclk";
+		#size-cells = <0>;
+		#address-cells = <1>;
+
+		max31827: max31827@5f {
+			compatible = "adi,max31827";
+			label = "adaq4220-temp";
+			reg = <0x5f>;
+			vref-supply = <&vio>;
+			adi,comp-int;
+			adi,alarm-pol = <0>;
+			adi,fault-q = <1>;
+			adi,timeout-enable;
+		};
+
+		eeprom1: eeprom@50 {
+			compatible = "at24,24c02";
+			reg = <0x50>;
+		};
+	};
+
+	rx_dma: rx-dmac@44a30000 {
+		compatible = "adi,axi-dmac-1.00.a";
+		reg = <0x44a30000 0x1000>;
+		#dma-cells = <1>;
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&clkc 15>;
+
+		adi,channels {
+			#size-cells = <0>;
+			#address-cells = <1>;
+
+			dma-channel@0 {
+				reg = <0>;
+				adi,source-bus-width = <64>;
+				adi,source-bus-type = <1>;
+				adi,destination-bus-width = <64>;
+				adi,destination-bus-type = <0>;
+			};
+		};
+	};
+
+	spi_clk: axi-clkgen@0x44a70000 {
+		compatible = "adi,axi-clkgen-2.00.a";
+		reg = <0x44a70000 0x10000>;
+		#clock-cells = <0>;
+		clocks = <&clkc 15>, <&clkc 15>;
+		clock-names = "s_axi_aclk", "clkin1";
+		clock-output-names = "spi_clk";
+	};
+
+	axi_pwm_gen: axi-pwm-gen@ {
+		compatible = "adi,axi-pwmgen";
+		reg = <0x44b00000 0x1000>;
+		label = "ad463x_cnv";
+		#pwm-cells = <2>;
+		clocks = <&cnv_ext_clk>;
+	};
+
+	axi_spi_engine: spi@44a00000 {
+		compatible = "adi-ex,axi-spi-engine-1.00.a";
+		reg = <0x44a00000 0x1FF>;
+		interrupt-parent = <&intc>;
+		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&clkc 15>, <&spi_clk>;
+		clock-names = "s_axi_aclk", "spi_clk";
+		num-cs = <1>;
+		#address-cells = <0x1>;
+		#size-cells = <0x0>;
+
+		adaq4220: adaq4220@0 {
+			compatible = "adi,adaq4220";
+			label = "adaq4220";
+			reg = <0>;
+			vdd-supply = <&vref>;
+			vdd_1_8-supply = <&vdd_1_8>;
+			vio-supply = <&vio>;
+			vref-supply = <&vref>;
+			spi-max-frequency = <80000000>;
+			reset-gpios = <&gpio0 86 GPIO_ACTIVE_LOW>;
+			adi,pga-gpios = <&gpio0 87 GPIO_ACTIVE_HIGH>,
+					<&gpio0 88 GPIO_ACTIVE_HIGH>;
+			adi,lane-mode = <1>;
+			adi,clock-mode = <0>;
+			adi,out-data-mode = <0>;
+			adi,spi-trigger;
+			clocks = <&cnv_ext_clk>;
+			clock-names = "trigger_clock";
+			dmas = <&rx_dma 0>;
+			dma-names = "rx";
+			pwm-names = "spi_trigger", "cnv";
+			pwms = <&axi_pwm_gen 0 0>, <&axi_pwm_gen 1 0>;
+		};
+	};
+};

--- a/drivers/iio/adc/ad4630.c
+++ b/drivers/iio/adc/ad4630.c
@@ -893,6 +893,48 @@ static const struct ad4630_out_mode ad4630_24_modes[] = {
 	}
 };
 
+static const struct ad4630_out_mode adaq4216_modes[] = {
+	[AD4630_16_DIFF] = {
+		.channels = {
+			AD4630_CHAN(0, BIT(IIO_CHAN_INFO_SCALE), 64, 16, 0, NULL),
+		},
+		.data_width = 16,
+	},
+	[AD4630_16_DIFF_8_COM] = {
+		.channels = {
+			AD4630_CHAN(0, BIT(IIO_CHAN_INFO_SCALE), 64, 16, 8, NULL),
+		},
+		.data_width = 24,
+	},
+	[AD4630_30_AVERAGED_DIFF] = {
+		.channels = {
+			AD4630_CHAN(0, BIT(IIO_CHAN_INFO_SCALE), 64, 30, 2, ad4630_ext_info),
+		},
+		.data_width = 32,
+	}
+};
+
+static const struct ad4630_out_mode adaq4220_modes[] = {
+	[AD4630_16_DIFF] = {
+		.channels = {
+			AD4630_CHAN(0, BIT(IIO_CHAN_INFO_SCALE), 64, 20, 0, NULL),
+		},
+		.data_width = 20,
+	},
+	[AD4630_16_DIFF_8_COM] = {
+		.channels = {
+			AD4630_CHAN(0, BIT(IIO_CHAN_INFO_SCALE), 64, 16, 8, NULL),
+		},
+		.data_width = 24,
+	},
+	[AD4630_30_AVERAGED_DIFF] = {
+		.channels = {
+			AD4630_CHAN(0, BIT(IIO_CHAN_INFO_SCALE), 64, 30, 2, ad4630_ext_info),
+		},
+		.data_width = 32,
+	}
+};
+
 static const struct ad4630_out_mode adaq4224_modes[] = {
 	[AD4630_24_DIFF] = {
 		.channels = {
@@ -1000,7 +1042,7 @@ static const struct ad4630_chip_info ad4630_chip_info[] = {
 	},
 	[ID_ADAQ4216] = {
 		.available_masks = ad4030_channel_masks,
-		.modes = adaq4224_modes,
+		.modes = adaq4216_modes,
 		.out_modes_mask = GENMASK(3, 0),
 		.name = "adaq4216",
 		.grade = 0x1E,
@@ -1012,7 +1054,7 @@ static const struct ad4630_chip_info ad4630_chip_info[] = {
 	},
 	[ID_ADAQ4220] = {
 		.available_masks = ad4030_channel_masks,
-		.modes = adaq4224_modes,
+		.modes = adaq4220_modes,
 		.out_modes_mask = GENMASK(3, 0),
 		.name = "adaq4220",
 		.grade = 0x1D,

--- a/drivers/iio/adc/ad4630.c
+++ b/drivers/iio/adc/ad4630.c
@@ -94,6 +94,7 @@
 /* sequence starting with "1 0 1" to enable reg access */
 #define AD4630_REG_ACCESS		0x2000
 /* Sampling timing */
+#define AD4630_TQUIET_CNV_DELAY_PS	9800
 #define AD4630_MAX_RATE_1_LANE		1750000
 #define AD4630_MAX_RATE			2000000
 
@@ -406,7 +407,7 @@ static int __ad4630_set_sampling_freq(const struct ad4630_state *st, unsigned in
 	 * tsync + tquiet_con_delay being tsync the conversion signal period
 	 * and tquiet_con_delay 9.8ns. Hence set the PWM phase accordingly.
 	 */
-	fetch_state.phase = fetch_state.period + 10;
+	fetch_state.phase = AD4630_TQUIET_CNV_DELAY_PS;
 
 	return pwm_apply_state(st->fetch_trigger, &fetch_state);
 }
@@ -599,7 +600,7 @@ static int ad4630_update_sample_fetch_trigger(const struct ad4630_state *st, u32
 	pwm_get_state(st->conv_trigger, &conv_state);
 	pwm_get_state(st->fetch_trigger, &fetch_state);
 	fetch_state.period = conv_state.period * 1 << avg;
-	fetch_state.phase = fetch_state.period + 9800;
+	fetch_state.phase = AD4630_TQUIET_CNV_DELAY_PS;
 
 	return pwm_apply_state(st->fetch_trigger, &fetch_state);
 }

--- a/drivers/iio/adc/ad4630.c
+++ b/drivers/iio/adc/ad4630.c
@@ -1322,11 +1322,7 @@ static int ad4630_config(struct ad4630_state *st)
 	if (ret)
 		return ret;
 
-	if (lane_mode == AD4630_ONE_LANE_PER_CH && data_rate &&
-	    st->chip->modes[st->out_data].data_width == 32)
-		st->max_rate = AD4630_MAX_RATE_1_LANE;
-	else
-		st->max_rate = AD4630_MAX_RATE;
+	st->max_rate = AD4630_MAX_RATE;
 
 	ad4630_prepare_spi_sampling_msg(st, clock_mode, lane_mode, data_rate);
 

--- a/drivers/iio/adc/ad4630.c
+++ b/drivers/iio/adc/ad4630.c
@@ -1479,7 +1479,8 @@ static int ad4630_probe(struct spi_device *spi)
 
 	ret = ad4630_config(st);
 	if (ret)
-		return ret;
+		return dev_err_probe(&spi->dev, ret,
+				     "Config failed: %d\n", ret);
 
 	if (st->pga_gpios) {
 		ad4630_fill_scale_tbl(st);
@@ -1496,7 +1497,8 @@ static int ad4630_probe(struct spi_device *spi)
 
 	ret = ad4630_pwm_get(st);
 	if (ret)
-		return ret;
+		return dev_err_probe(&spi->dev, ret,
+				     "Failed to get PWM: %d\n", ret);
 
 	indio_dev->name = st->chip->name;
 	indio_dev->info = &ad4630_info;


### PR DESCRIPTION
## PR Description

This PR contains the changes made during the latest tests done with ADAQ4216, ADAQ4220 and similar devices.
Summary of changes:
- Add dts files for using AD4030-24, AD4032-24, AD4630-16, ADAQ4216, and ADAQ4220 on ZedBoard.
- Fix sample read bug by adjusting the fetch trigger PWM phase.
- Add output mode to properly support ADAQ4216 and ADAQ4220
- Set max sampling frequency set to 2MSPS.
- Add a couple of probe error messages to help diagnose when device probe fails.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] The changes in this PR were testes by @ladace.
- [ ] I have updated the documentation outside this repo accordingly (if there is the case) (no need to update any doc).
