### PR TITLE
arm64: dts: zynqmp-jupiter-sdr: properly use clk-gpio mux

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-jupiter-sdr.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-jupiter-sdr.dts
@@ -404,13 +404,6 @@
 		line-name = "usb-reset";
 	};
 
-	adrv9002_clksrc {
-		gpio-hog;
-		gpios = <79 GPIO_ACTIVE_HIGH>;
-		output-high;
-		line-name = "adrv9002-clksrc";
-	};
-
 	fan_ctl {
 		gpio-hog;
 		gpios = <145 GPIO_ACTIVE_HIGH>;
@@ -600,9 +593,36 @@
 
 #include "adi-adrv9002.dtsi"
 
+/ {
+	clocks {
+		adrv9002_clkin2: clock2 {
+			compatible = "fixed-clock";
+
+			clock-frequency = <30720000>;
+			clock-output-names = "adrv9002_refclk_mux0";
+			#clock-cells = <0>;
+		};
+	};
+
+	adrv9002_clk_mux: clk-mux {
+			#clock-cells = <0>;
+			compatible = "gpio-mux-clock";
+			/* 30.72MHz, 38.4MHz */
+			clocks = <&adrv9002_clkin2>, <&adrv9002_clkin>;
+			clock-output-names = "adrv9002_ext_refclk";
+			select-gpios = <&gpio 79 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&adrv9002_clkin {
+	clock-output-names = "adrv9002_refclk_mux1";
+};
+
 &adc0_adrv9002 {
 	reset-gpios = <&gpio 81 GPIO_ACTIVE_LOW>;
 	interrupts = <78 IRQ_TYPE_EDGE_RISING>;
+
+	clocks = <&adrv9002_clk_mux>;
 
 	adi,channels {
 		rx@0 {


### PR DESCRIPTION
In jupiter we have a gpio to toggle between a 38.4 and 30.72MHz reference clock. We had a gpio-hog to default to the 38.4MHz source and then we need to manually change the GPIO value when applying a profile for the other reference. This is far from ideal and more importantly, with commit c2edc6279f31 (" iio: adc: adrv9002: check and allow to change ref_clk"), we now try to change the refclk according with the rate we get from the profile (which makes sense). Therefore, with the current DT, we would fail to load the 30.72MHz reference clock based profile. Hence, let's make use of the clk-gpio driver and define our reference clock to be a clk-gpio mux with two parents for the rates we want. With this, we can change clock sources solely by loading the profile without any other manual step for the GPIO.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
