### PR TITLE
Fix AD4630 sampling frequency display

### DIFF
--- a/drivers/iio/adc/ad4630.c
+++ b/drivers/iio/adc/ad4630.c
@@ -261,7 +261,7 @@ static void ad4630_get_sampling_freq(const struct ad4630_state *st, int *freq)
 	struct pwm_state conversion_state;
 
 	pwm_get_state(st->conv_trigger, &conversion_state);
-	*freq = DIV_ROUND_CLOSEST_ULL(PICO, conversion_state.period);
+	*freq = DIV_ROUND_CLOSEST_ULL(NANO, conversion_state.period);
 }
 
 static int ad4630_get_chan_gain(struct iio_dev *indio_dev, int ch, int *val)


### PR DESCRIPTION
## PR Description

BU reported the sampling frequency shown by AD4630-like devices was 1000 times higher than the actual one.
This was confirmed by @ladace and me and this patch fixes the issue.

The ad4630 driver calculated the inverse of the PWM period in pico seconds to report the sampling frequency provided by the device. However, that lead to a sampling frequency 1000 higher than the actual one since the PWM period is actually in the nano seconds. Use NANO instead of PICO to correctly calculate the sampling frequency in Hz.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
