### PR TITLE
iio: frequency: ad9783: fix calibration array values

### DIFF
--- a/drivers/iio/frequency/ad9783.c
+++ b/drivers/iio/frequency/ad9783.c
@@ -227,8 +227,7 @@ static int ad9783_timing_adjust(struct ad9783_phy *phy)
 			ret = ad9783_seek(phy);
 			if (ret < 0)
 				return ret;
-
-		} while (ret > 0 && hld < AD9783_MAX_HLD);
+		} while ((ret == table[smp][SEEK]) && hld < (AD9783_MAX_HLD - 1));
 
 		table[smp][HLD] = hld;
 		hld = 0;
@@ -250,7 +249,7 @@ static int ad9783_timing_adjust(struct ad9783_phy *phy)
 			if (ret < 0)
 				return ret;
 
-		} while (ret > 0 && set < AD9783_MAX_SET);
+		} while ((ret == table[smp][SEEK]) && set < (AD9783_MAX_SET - 1));
 
 		table[smp][SET] = set;
 	}


### PR DESCRIPTION
## PR Description
Run loop in accordance with the method described in section "building the array" of the datasheet[1] rev C. page 26. The loop shall be continued until the seek bit toggles, not until the seek bit goes low.

For the case where a value for SET or HLD is not found that would make the SEEK bit toggle, the value should be set to 15. The loop did not break out until HLD == 16, causing overflowing value to be written to the HLD field[0..3] of register 0x4.

[1] https://www.analog.com/media/en/technical-documentation/data-sheets/AD9780_9781_9783.pdf

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
