### PR TITLE
iio: frequency: m2k-dac: fix backport of trigger status

### DIFF
--- a/drivers/iio/frequency/m2k-dac.c
+++ b/drivers/iio/frequency/m2k-dac.c
@@ -641,7 +641,7 @@ static const struct iio_chan_spec_ext_info m2k_dac_ext_info[] = {
 			   	  &m2k_dac_trig_condition_enum),
 	IIO_ENUM_AVAILABLE_SHARED("raw_enable", IIO_SEPARATE, &m2k_dac_raw_enable_enum),
 	IIO_ENUM("raw_enable", IIO_SEPARATE, &m2k_dac_raw_enable_enum),
-	IIO_ENUM_AVAILABLE("trigger_status", IIO_SEPARATE, &m2k_dac_trigger_status_enum),
+	IIO_ENUM_AVAILABLE_SHARED("trigger_status", IIO_SEPARATE, &m2k_dac_trigger_status_enum),
 	IIO_ENUM("trigger_status", IIO_SEPARATE, &m2k_dac_trigger_status_enum),
 	{ },
 };


### PR DESCRIPTION
## PR Description

The IIO_ENUM_AVAILABLE() macro only has three arguments upstream (and in the main branch). As 2022_R2 is still based on 5.15, we still need the IIO_ENUM_AVAILABLE_SHARED() out of tree macro.

Fixes: c74f9d760c2e ("iio: frequency: m2k-dac: Improve trigger attributes")

Also Fixes #2607 

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
