### PR TITLE
Fix scale attribute for PulSAR bipolar channels

### DIFF
--- a/arch/arm/boot/dts/zynq-coraz7s-ad7687-pmdz.dts
+++ b/arch/arm/boot/dts/zynq-coraz7s-ad7687-pmdz.dts
@@ -61,6 +61,7 @@
 			vref-supply = <&vref>;
 			channel@0 {
 				reg = <0>;
+				bipolar;
 				diff-channels = <0 1>;
 			};
 		};

--- a/arch/arm/boot/dts/zynq-coraz7s-ad7984.dts
+++ b/arch/arm/boot/dts/zynq-coraz7s-ad7984.dts
@@ -61,6 +61,7 @@
 			vref-supply = <&vref>;
 			channel@0 {
 				reg = <0>;
+				bipolar;
 				diff-channels = <0 1>;
 			};
 		};

--- a/drivers/iio/adc/ad_pulsar.c
+++ b/drivers/iio/adc/ad_pulsar.c
@@ -508,7 +508,7 @@ static int ad_pulsar_read_raw(struct iio_dev *indio_dev,
 		if (ret)
 			return ret;
 
-		if (chan->differential)
+		if (chan->scan_type.sign == 's')
 			*val = sign_extend32(*val, adc->info->resolution - 1);
 
 		return IIO_VAL_INT;
@@ -523,7 +523,14 @@ static int ad_pulsar_read_raw(struct iio_dev *indio_dev,
 			if (ret < 0)
 				return ret;
 			*val = ret / 1000;
-			*val2 = adc->info->resolution;
+			/* When the channel is bipolar, one of the precision
+			 * bits accounts for the sign and we end up with one
+			 * less bit to express voltage magnitude.
+			 */
+			if (chan->scan_type.sign == 's')
+				*val2 = adc->info->resolution - 1;
+			else
+				*val2 = adc->info->resolution;
 
 			return IIO_VAL_FRACTIONAL_LOG2;
 		case IIO_TEMP:


### PR DESCRIPTION
## PR Description

Some Pulsar ADCs are not presumed to have a fixed voltage to their negative input (IN-).
When the channel is bipolar and the output code is two's complement, one of the precision bits accounts for the sign and we end up with one less bit to express voltage magnitude. The channel scale attribute has to take that into account to provide a proper conversion factor to mV.
Update ad_pulsar driver to provide proper scale for unipolar and bipolar channels. Update dts to set the bipolar property for ADC channels when IN- is not specified to any restricted voltage level.

`grep -nriI arch/arm/boot/dts/ -e "pulsar,ad"` shows we currently have 4 dts for "pulsar,ad" compatibles.

AD7687 has true differential analog input range and IN- is assumed to float from 0V to VREF. That is better modeled as a differential bipolar IIO channel.

AD7689 datasheet states the configuration register defaults to 0x3FFF which leads to unipolar conversion, INx referenced to GND, so dodn't update device tree channels for AD7689.

AD7946 datasheet specifies the ADC inputs are pseudo-differential with IN- at GND level and IN+ swinging from GND to REF. IIO channel pseudo-differential unipolar.

AD7984 specifies the ADC has true differential analog input range with no restriction to IN- so support that as a bipolar IIO channel.




## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have tested the changes on the relevant hardware (AD7687)
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
