### PR TITLE
iio: frequency: adf4371: fix possible leak

### DIFF
--- a/drivers/iio/frequency/adf4371.c
+++ b/drivers/iio/frequency/adf4371.c
@@ -13,6 +13,7 @@
 #include <linux/gcd.h>
 #include <linux/kernel.h>
 #include <linux/module.h>
+#include <linux/property.h>
 #include <linux/regmap.h>
 #include <linux/sysfs.h>
 #include <linux/spi/spi.h>
@@ -1077,7 +1078,6 @@ static int adf4371_parse_dt(struct adf4371_state *st)
 {
 	unsigned char num_channels;
 	unsigned int channel, tmp;
-	struct fwnode_handle *child;
 	int ret, i;
 
 	if(device_property_read_bool(&st->spi->dev, "adi,spi-3wire-enable"))
@@ -1147,7 +1147,7 @@ static int adf4371_parse_dt(struct adf4371_state *st)
 	if (num_channels > st->chip_info->num_channels)
 		return -EINVAL;
 
-	device_for_each_child_node(&st->spi->dev, child) {
+	device_for_each_child_node_scoped(&st->spi->dev, child) {
 		ret = fwnode_property_read_u32(child, "reg", &channel);
 		if (ret)
 			return ret;


### PR DESCRIPTION
## PR Description

When returning early from a device_for_each_child_node() loop, we need to call fwnode_handle_put() on the child node so it does not leak. For that make use of device_for_each_child_node_scoped() which will automatically drop the node reference as soon as go out of the loop scope.

Fixes: c8e6b341abf7 ("iio: frequency: adf4371: Introduce channel child nodes")

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
