### PR TITLE
ad5791 offload

### DIFF
--- a/Documentation/devicetree/bindings/iio/dac/adi,ad5791.yaml
+++ b/Documentation/devicetree/bindings/iio/dac/adi,ad5791.yaml
@@ -91,7 +91,7 @@ examples:
             vrefn-supply = <&dac_vrefn>;
             reset-gpios = <&gpio_bd 16 GPIO_ACTIVE_LOW>;
             clear-gpios = <&gpio_bd 17 GPIO_ACTIVE_LOW>;
-            ldac-gpios = <&gpio_bd 18 GPIO_ACTIVE_HIGH>;
+            ldac-gpios = <&gpio_bd 18 GPIO_ACTIVE_LOW>;
         };
     };
 ...

--- a/Documentation/devicetree/bindings/iio/dac/adi,ad5791.yaml
+++ b/Documentation/devicetree/bindings/iio/dac/adi,ad5791.yaml
@@ -26,6 +26,22 @@ properties:
   vdd-supply: true
   vss-supply: true
 
+  vcc-supply:
+    description:
+      Supply that powers the chip.
+
+  iovcc-supply:
+    description:
+      Supply for the digital interface.
+
+  vrefp-supply:
+    description:
+      Positive referance input voltage range. From 5v to (vdd - 2.5)
+
+  vrefn-supply:
+    description:
+      Negative referance input voltage range. From (vss + 2.5) to 0.
+
   adi,rbuf-gain2-en:
     description: Specify to allow an external amplifier to be connected in a
       gain of two configuration.
@@ -47,6 +63,10 @@ required:
   - reg
   - vdd-supply
   - vss-supply
+  - vcc-supply
+  - iovcc-supply
+  - vrefp-supply
+  - vrefn-supply
 
 allOf:
   - $ref: /schemas/spi/spi-peripheral-props.yaml#
@@ -65,6 +85,10 @@ examples:
             reg = <0>;
             vss-supply = <&dac_vss>;
             vdd-supply = <&dac_vdd>;
+            vcc-supply = <&dac_vcc>;
+            iovcc-supply = <&dac_iovcc>;
+            vrefp-supply = <&dac_vrefp>;
+            vrefn-supply = <&dac_vrefn>;
             reset-gpios = <&gpio_bd 16 GPIO_ACTIVE_LOW>;
             clear-gpios = <&gpio_bd 17 GPIO_ACTIVE_LOW>;
             ldac-gpios = <&gpio_bd 18 GPIO_ACTIVE_HIGH>;

--- a/Documentation/devicetree/bindings/iio/dac/adi,ad5791.yaml
+++ b/Documentation/devicetree/bindings/iio/dac/adi,ad5791.yaml
@@ -31,6 +31,17 @@ properties:
       gain of two configuration.
     type: boolean
 
+  reset-gpios:
+    maxItems: 1
+
+  clear-gpios:
+    maxItems: 1
+
+  ldac-gpios:
+    description:
+      LDAC pin to be used as a hardware trigger to update the DAC channels.
+    maxItems: 1
+
 required:
   - compatible
   - reg
@@ -44,6 +55,7 @@ unevaluatedProperties: false
 
 examples:
   - |
+    #include <dt-bindings/gpio/gpio.h>
     spi {
         #address-cells = <1>;
         #size-cells = <0>;
@@ -53,6 +65,9 @@ examples:
             reg = <0>;
             vss-supply = <&dac_vss>;
             vdd-supply = <&dac_vdd>;
+            reset-gpios = <&gpio_bd 16 GPIO_ACTIVE_LOW>;
+            clear-gpios = <&gpio_bd 17 GPIO_ACTIVE_LOW>;
+            ldac-gpios = <&gpio_bd 18 GPIO_ACTIVE_HIGH>;
         };
     };
 ...

--- a/arch/arm/boot/dts/intel/socfpga/socfpga_arria10_socdk_ad9081.dts
+++ b/arch/arm/boot/dts/intel/socfpga/socfpga_arria10_socdk_ad9081.dts
@@ -54,7 +54,6 @@
 			sys_gpio_out: gpio@20 {
 				compatible = "altr,pio-1.0";
 				reg = <0x00000020 0x00000010>;
-				altr,gpio-bank-width = <32>;
 				resetvalue = <0>;
 				#gpio-cells = <2>;
 				gpio-controller;

--- a/arch/arm/boot/dts/intel/socfpga/socfpga_arria10_socdk_ad9083_fmc_ebz.dts
+++ b/arch/arm/boot/dts/intel/socfpga/socfpga_arria10_socdk_ad9083_fmc_ebz.dts
@@ -60,7 +60,6 @@
 			sys_gpio_out: gpio@20 {
 				compatible = "altr,pio-1.0";
 				reg = <0x00000020 0x00000010>;
-				altr,gpio-bank-width = <32>;
 				resetvalue = <0>;
 				#gpio-cells = <2>;
 				gpio-controller;

--- a/arch/arm/boot/dts/intel/socfpga/socfpga_arria10_socdk_adrv9002.dts
+++ b/arch/arm/boot/dts/intel/socfpga/socfpga_arria10_socdk_adrv9002.dts
@@ -53,7 +53,6 @@
 				reg = <0x00060000 0x00000010>;
 				interrupt-parent = <&intc>;
 				interrupts = <0 33 4>;
-				altr,gpio-bank-width = <19>;
 				altr,interrupt-type = <4>;
 				altr,interrupt_type = <4>;
 				level_trigger = <1>;

--- a/arch/arm/boot/dts/intel/socfpga/socfpga_arria10_socdk_adrv9002_rx2tx2.dts
+++ b/arch/arm/boot/dts/intel/socfpga/socfpga_arria10_socdk_adrv9002_rx2tx2.dts
@@ -53,7 +53,6 @@
 				reg = <0x00060000 0x00000010>;
 				interrupt-parent = <&intc>;
 				interrupts = <0 33 4>;
-				altr,gpio-bank-width = <19>;
 				altr,interrupt-type = <4>;
 				altr,interrupt_type = <4>;
 				level_trigger = <1>;

--- a/arch/arm/boot/dts/intel/socfpga/socfpga_arria10_socdk_adrv9009.dts
+++ b/arch/arm/boot/dts/intel/socfpga/socfpga_arria10_socdk_adrv9009.dts
@@ -52,7 +52,6 @@
 			sys_gpio_out: gpio@20 {
 				compatible = "altr,pio-1.0";
 				reg = <0x00000020 0x00000010>;
-				altr,gpio-bank-width = <32>;
 				resetvalue = <0>;
 				#gpio-cells = <2>;
 				gpio-controller;

--- a/arch/arm/boot/dts/intel/socfpga/socfpga_arria10_socdk_adrv9025.dts
+++ b/arch/arm/boot/dts/intel/socfpga/socfpga_arria10_socdk_adrv9025.dts
@@ -58,7 +58,6 @@
 			sys_gpio_out: gpio@20 {
 				compatible = "altr,pio-1.0";
 				reg = <0x00000020 0x00000010>;
-				altr,gpio-bank-width = <32>;
 				resetvalue = <0>;
 				#gpio-cells = <2>;
 				gpio-controller;

--- a/arch/arm/boot/dts/intel/socfpga/socfpga_arria10_socdk_adrv9371.dts
+++ b/arch/arm/boot/dts/intel/socfpga/socfpga_arria10_socdk_adrv9371.dts
@@ -51,7 +51,6 @@
 			sys_gpio_out: gpio@20 {
 				compatible = "altr,pio-1.0";
 				reg = <0x00000020 0x00000010>;
-				altr,gpio-bank-width = <32>;
 				resetvalue = <0>;
 				#gpio-cells = <2>;
 				gpio-controller;

--- a/arch/arm/boot/dts/intel/socfpga/socfpga_arria10_socdk_fmcomms8.dts
+++ b/arch/arm/boot/dts/intel/socfpga/socfpga_arria10_socdk_fmcomms8.dts
@@ -53,7 +53,6 @@
 			sys_gpio_out: gpio@20 {
 				compatible = "altr,pio-1.0";
 				reg = <0x00000020 0x00000010>;
-				altr,gpio-bank-width = <32>;
 				resetvalue = <0>;
 				#gpio-cells = <2>;
 				gpio-controller;

--- a/arch/arm/boot/dts/intel/socfpga/socfpga_cyclone5_de10_nano_ad57xx.dts
+++ b/arch/arm/boot/dts/intel/socfpga/socfpga_cyclone5_de10_nano_ad57xx.dts
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD5791
+ * https://www.analog.com/en/products/ad5791.html
+ * https://analogdevicesinc.github.io/hdl/projects/ad57xx_ardz/index.html
+ * https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/EVAL-AD5791ARDZ.html
+ * https://wiki.analog.com/resources/tools-software/linux-build/generic/socfpga
+ *
+ * hdl_project: <ad57xx_ardz/de10nano>
+ * board_revision: <B>
+ *
+ * Copyright (C) 2024 Analog Devices Inc.
+ */
+/dts-v1/;
+#include "socfpga_cyclone5_de10_nano_hps.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	dac_vdd: regulator-vdd {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-supply";
+		regulator-min-microvolt = <4096000>;
+		regulator-max-microvolt = <4096000>;
+		regulator-always-on;
+	};
+
+	dac_vss: regulator-vss {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-supply";
+		regulator-min-microvolt = <4096000>;
+		regulator-max-microvolt = <4096000>;
+		regulator-always-on;
+	};
+
+};
+
+&fpga_axi {
+
+	dac_trigger: pwm@0x00050000 {
+		compatible = "adi,axi-pwmgen-2.00.a";
+		reg = <0x00050000 0x1000>;
+		#pwm-cells = <3>;
+		clocks = <&spi_clk 0>;
+	};
+
+	tx_dma: tx-dma@0x00030000 {
+		compatible = "adi,axi-dmac-1.00.a";
+		reg = <0x00030000 0x00000800>;
+		#dma-cells = <1>;
+		interrupt-parent = <&intc>;
+		interrupts = <0 44 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&spi_clk 0>;
+	};
+
+	spi_clk: clock-controller@0x00060000 {
+		compatible = "altr,c5-fpll";
+		reg = <0x00060000 0x00000100>;
+		#clock-cells = <0x1>;
+
+		#address-cells = <1>;
+		#size-cells = <0>;
+		clocks = <&sys_clk>;
+		assigned-clocks = <&spi_clk 0>;
+		assigned-clock-rates = <185000000>;
+		clock-output-names = "outclk0";
+		adi,fractional-carry-bit = <32>;
+
+		spi_c0: channel@0 {
+			reg = <0>;
+			adi,extended-name = "SPI_CLOCK";
+		};
+	};
+
+	spi@0x00040000 {
+		compatible = "adi-ex,axi-spi-engine-1.00.a";
+		reg = <0x00040000 0x00010000>;
+		interrupt-parent = <&intc>;
+		interrupts = <0 45 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&sys_clk>, <&spi_clk 0>;
+		clock-names = "s_axi_aclk", "spi_clk";
+		#address-cells = <0x1>;
+		#size-cells = <0x0>;
+
+		ad57xx_1: dac@0 {
+			compatible = "adi,ad5791";
+			spi-cpha;
+			reg = <0>;
+			spi-max-frequency = <35000000>;
+			vss-supply = <&dac_vss>;
+			vdd-supply = <&dac_vdd>;
+			reset-gpios = <&gpio_bd 16 GPIO_ACTIVE_LOW>;
+			clear-gpios = <&gpio_bd 17 GPIO_ACTIVE_LOW>;
+			ldac-gpios = <&gpio_bd 18 GPIO_ACTIVE_LOW>;
+
+			clocks = <&spi_clk 0>;
+			clock-names = "ref_clk";
+
+			dmas = <&tx_dma 0>;
+			dma-names = "tx";
+			pwms = <&dac_trigger 0 1000 0>;
+			pwm-names = "cnv";
+
+		};
+	};
+};

--- a/arch/arm/boot/dts/intel/socfpga/socfpga_cyclone5_de10_nano_hps.dtsi
+++ b/arch/arm/boot/dts/intel/socfpga/socfpga_cyclone5_de10_nano_hps.dtsi
@@ -36,6 +36,14 @@
 };
 
 &fpga_axi {
+	gpio_bd: gpio_bd@0x10080 {
+		compatible = "altr,pio-18.1", "altr,pio-1.0";
+		reg = <0x00010080 0x00000010>;
+		resetvalue = <0>;
+		#gpio-cells = <2>;
+		gpio-controller;
+	};
+
 	gpio_in: gpio_in@10100 {
 		compatible = "altr,pio-18.1", "altr,pio-1.0";
 		reg = <0x00010100 0x00000010>;

--- a/arch/arm/boot/dts/intel/socfpga/socfpga_cyclone5_de10_nano_hps.dtsi
+++ b/arch/arm/boot/dts/intel/socfpga/socfpga_cyclone5_de10_nano_hps.dtsi
@@ -39,7 +39,6 @@
 	gpio_in: gpio_in@10100 {
 		compatible = "altr,pio-18.1", "altr,pio-1.0";
 		reg = <0x00010100 0x00000010>;
-		altr,gpio-bank-width = <32>;
 		altr,interrupt-type = <4>;
 		altr,interrupt_type = <4>;
 		level_trigger = <1>;
@@ -105,7 +104,6 @@
 	gpio_out: gpio_out@109000 {
 		compatible = "altr,pio-1.0";
 		reg = <0x00109000 0x00000010>;
-		altr,gpio-bank-width = <32>;
 		resetvalue = <0>;
 		#gpio-cells = <2>;
 		gpio-controller;

--- a/arch/arm/boot/dts/intel/socfpga/socfpga_cyclone5_sockit_arradio.dts
+++ b/arch/arm/boot/dts/intel/socfpga/socfpga_cyclone5_sockit_arradio.dts
@@ -172,7 +172,6 @@
 				gpio: gpio@9000 {
 					compatible = "altr,pio-1.0";
 					reg = <0x00009000 0x00000010>;
-					altr,gpio-bank-width = <5>;
 					resetvalue = <0>;
 					#gpio-cells = <2>;
 					gpio-controller;

--- a/arch/arm/boot/dts/intel/socfpga/socfpga_cyclone5_sockit_dc2677a.dts
+++ b/arch/arm/boot/dts/intel/socfpga/socfpga_cyclone5_sockit_dc2677a.dts
@@ -145,7 +145,6 @@
 				gpio: gpio@9000 {
 					compatible = "altr,pio-1.0";
 					reg = <0x00020000 0x00010000>;
-					altr,gpio-bank-width = <5>;
 					resetvalue = <0>;
 					#gpio-cells = <2>;
 					gpio-controller;

--- a/drivers/iio/dac/ad5791.c
+++ b/drivers/iio/dac/ad5791.c
@@ -411,24 +411,12 @@ static int ad5791_probe(struct spi_device *spi)
 	if (ret)
 		return dev_err_probe(&spi->dev, ret, "fail to write ctrl register\n");
 
-	spi_set_drvdata(spi, indio_dev);
 	indio_dev->info = &ad5791_info;
 	indio_dev->modes = INDIO_DIRECT_MODE;
 	indio_dev->channels = &st->chip_info->channel;
 	indio_dev->num_channels = 1;
 	indio_dev->name = st->chip_info->name;
-	ret = iio_device_register(indio_dev);
-	if (ret)
-		return dev_err_probe(&spi->dev, ret, "unable to register iio device\n");
-
-	return 0;
-}
-
-static void ad5791_remove(struct spi_device *spi)
-{
-	struct iio_dev *indio_dev = spi_get_drvdata(spi);
-
-	iio_device_unregister(indio_dev);
+	return devm_iio_device_register(&spi->dev, indio_dev);
 }
 
 static const struct of_device_id ad5791_of_match[] = {
@@ -457,7 +445,6 @@ static struct spi_driver ad5791_driver = {
 		   .of_match_table = ad5791_of_match,
 		   },
 	.probe = ad5791_probe,
-	.remove = ad5791_remove,
 	.id_table = ad5791_id,
 };
 module_spi_driver(ad5791_driver);

--- a/drivers/spi/spi-axi-spi-engine-ex.c
+++ b/drivers/spi/spi-axi-spi-engine-ex.c
@@ -374,7 +374,17 @@ int spi_engine_ex_offload_load_msg(struct spi_device *spi,
 
 	/* TODO: validate that we don't exceed the offload SDO FIFO size */
 	list_for_each_entry(xfer, &msg->transfers, transfer_list) {
-		if (!xfer->tx_buf)
+		/*
+		 * To allow offload to stream a "tx" type of xfer we need the write flag
+		 * set but no messages on the SDO memory of the offload engine. but the
+		 * current code relies on the tx_buf pointer for both of these operations,
+		 * so there is no way to separate the two. So we use a pointer value of
+		 * -1 as flag to indicate this is a tx stream type of xfer not fot the fifo.
+		 * the work-in-progress offload will handle this with proper flags in
+		 * the core spi structures, So while that is merged upstream use this
+		 * workaround for DAC offload.
+		 */
+		if (!xfer->tx_buf || xfer->tx_buf == (void *)-1)
 			continue;
 
 		if (xfer->bits_per_word <= 8) {


### PR DESCRIPTION
## spi offload support for ad57xx dac

This adds offload support for the ad57xx dac to be able to send samples up to 1MSPS.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
