### PR TITLE
Use simpler syntax for dt overlays

### DIFF
--- a/arch/arm/boot/dts/overlays/rpi-ad7124-8-all-diff-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ad7124-8-all-diff-overlay.dts
@@ -2,6 +2,8 @@
 /dts-v1/;
 /plugin/;
 
+#include <dt-bindings/interrupt-controller/irq.h>
+
 / {
 	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709";
 
@@ -42,7 +44,7 @@
 				compatible = "adi,ad7124-8";
 				reg = <0>; //CS0 default
 				spi-max-frequency = <5000000>;
-				interrupts = <19 2>; // interrupt, Default to PMD-RPI-INTZ P1
+				interrupts = <19 IRQ_TYPE_EDGE_FALLING>; // interrupt, Default to PMD-RPI-INTZ P1
 				interrupt-parent = <&gpio>;
 				refin1-supply = <&vref>;
 				clocks = <&ad7124_mclk>;

--- a/arch/arm/boot/dts/overlays/rpi-ad7124-8-all-diff-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ad7124-8-all-diff-overlay.dts
@@ -7,111 +7,96 @@
 / {
 	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709";
 
-	fragment@0 {
-		target-path = "/";
-		__overlay__ {
-			vref: fixedregulator@0 {
-				compatible = "regulator-fixed";
-				regulator-name = "fixed-supply";
-				regulator-min-microvolt = <2500000>;
-				regulator-max-microvolt = <2500000>;
-				regulator-boot-on;
-			};
-		};
-	};
-
-	fragment@1 {
-		target-path = "/";
-		__overlay__ {
-			clocks {
-				ad7124_mclk: clock@0 {
-					#clock-cells = <0>;
-					compatible = "fixed-clock";
-					clock-frequency = <614400>;
-				};
-			};
-		};
-	};
-
-	fragment@2 {
-		target = <&spi0>;
-		__overlay__ {
-			#address-cells = <1>;
-			#size-cells = <0>;
-			status = "okay";
-
-			ad7124: ad7124@0 {
-				compatible = "adi,ad7124-8";
-				reg = <0>; //CS0 default
-				spi-max-frequency = <5000000>;
-				interrupts = <19 IRQ_TYPE_EDGE_FALLING>; // interrupt, Default to PMD-RPI-INTZ P1
-				interrupt-parent = <&gpio>;
-				refin1-supply = <&vref>;
-				clocks = <&ad7124_mclk>;
-				clock-names = "mclk";
-
-				#address-cells = <1>;
-				#size-cells = <0>;
-
-				channel@0 {
-					reg = <0>;
-					diff-channels = <0 1>;
-				};
-
-				channel@1 {
-					reg = <1>;
-					diff-channels = <2 3>;
-				};
-
-				channel@2 {
-					reg = <2>;
-					diff-channels = <4 5>;
-				};
-
-				channel@3 {
-					reg = <3>;
-					diff-channels = <6 7>;
-				};
-
-				channel@4 {
-					reg = <4>;
-					diff-channels = <8 9>;
-				};
-
-				channel@5 {
-					reg = <5>;
-					diff-channels = <10 11>;
-				};
-
-				channel@6 {
-					reg = <6>;
-					diff-channels = <12 13>;
-				};
-
-				channel@7 {
-					reg = <7>;
-					diff-channels = <14 15>;
-				};
-			};
-		};
-	};
-
-	fragment@3 {
-		target = <&spidev0>;
-		__overlay__ {
-			status = "disabled";
-		};
-	};
-
-	fragment@4 {
-		target = <&spidev1>;
-		__overlay__ {
-			status = "disabled";
-		};
-	};
-
 	__overrides__ {
-			cs_pin	= <&ad7124>,"reg:0";
-			irq_gpio = <&ad7124>,"interrupts:0";
+		cs_pin = <&ad7124>, "reg:0";
+		irq_gpio = <&ad7124>, "interrupts:0";
 	};
+};
+
+&{/} {
+	vref: fixedregulator@0 {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-supply";
+		regulator-min-microvolt = <2500000>;
+		regulator-max-microvolt = <2500000>;
+		regulator-boot-on;
+	};
+};
+
+&{/} {
+	clocks {
+		ad7124_mclk: clock@0 {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <614400>;
+		};
+	};
+};
+
+&spi0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	ad7124: ad7124@0 {
+		compatible = "adi,ad7124-8";
+		reg = <0>; //CS0 default
+		spi-max-frequency = <5000000>;
+		interrupts = <19 IRQ_TYPE_EDGE_FALLING>; // interrupt, Default to PMD-RPI-INTZ P1
+		interrupt-parent = <&gpio>;
+		refin1-supply = <&vref>;
+		clocks = <&ad7124_mclk>;
+		clock-names = "mclk";
+
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		channel@0 {
+			reg = <0>;
+			diff-channels = <0 1>;
+		};
+
+		channel@1 {
+			reg = <1>;
+			diff-channels = <2 3>;
+		};
+
+		channel@2 {
+			reg = <2>;
+			diff-channels = <4 5>;
+		};
+
+		channel@3 {
+			reg = <3>;
+			diff-channels = <6 7>;
+		};
+
+		channel@4 {
+			reg = <4>;
+			diff-channels = <8 9>;
+		};
+
+		channel@5 {
+			reg = <5>;
+			diff-channels = <10 11>;
+		};
+
+		channel@6 {
+			reg = <6>;
+			diff-channels = <12 13>;
+		};
+
+		channel@7 {
+			reg = <7>;
+			diff-channels = <14 15>;
+		};
+	};
+};
+
+&spidev0 {
+	status = "disabled";
+};
+
+&spidev1 {
+	status = "disabled";
 };


### PR DESCRIPTION
Simplify the syntax for the `rpi-ad7124-8-all-diff` overlay. While the resulting dtbo has a different binary representation, it's semantically equivalent. The source file just has less boilerplate. This also includes a simple commit that uses a symbolic name instead of a hardcoded number.

This is compilable with dtc v1.4.6 (since commit https://github.com/dgibson/dtc/commit/c1e55a5513e9bca41dc78a0f20245cc928596a3a from 2017).

If this PR is liked in general, I can follow up with a similar conversion of the other device trees.