### PR TITLE
arch/arm64/boot/dts/xilinx/stingray: Change DO modes

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-stingray.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-stingray.dts
@@ -371,7 +371,11 @@
 };
 
 &axi_data_offload_tx {
-	/delete-property/ adi,oneshot;
+	adi,oneshot;
+};
+
+&axi_data_offload_rx {
+	adi,bypass;
 };
 
 &iio_axi_tdd_0 {


### PR DESCRIPTION
## PR Description

To achieve synchronized TX signals, configure the TX DO in one-shot mode. 
For capturing a large buffer of data on the RX side, the DO has to be bypassed.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
