### PR TITLE
iio: adc: ltc2387: Fix for PWM driver rounding down duty cycle

### DIFF
--- a/drivers/iio/adc/ltc2387.c
+++ b/drivers/iio/adc/ltc2387.c
@@ -158,7 +158,7 @@ static int ltc2387_set_sampling_freq(struct ltc2387_dev *ltc, int freq)
 	int ret, clk_en_time;
 	u32 rem;
 
-	ref_clk_period_ns = DIV_ROUND_CLOSEST(NSEC_PER_SEC, ltc->ref_clk_rate);
+	ref_clk_period_ns = DIV_ROUND_UP(NSEC_PER_SEC, ltc->ref_clk_rate);
 
 	cnv_state = (struct pwm_state) {
 		.duty_cycle = ref_clk_period_ns,


### PR DESCRIPTION
The normal behaviour for PWM drivers in upstream is to round down the duty cycle value (FTR: also period and duty offset). The pwm-axipwmgen driver implements that behaviour since commit

	ea331335bc2b ("pwm: Replace axi-pwmgen driver by a backport of the mainline driver")

That means that if

	.duty_cycle = DIV_ROUND_CLOSEST(NSEC_PER_SEC, ltc->ref_clk_rate)

is requested and that division happens to round down, the duty cycle programmed will be zero and the PWM won't toggle at all.

So use up-rounding for the duty_cycle value.