### PR TITLE
arm: dts: make use of AXI DMA bus type macros

### DIFF
--- a/arch/arm/boot/dts/adi-common-dac-fmc-ebz.dtsi
+++ b/arch/arm/boot/dts/adi-common-dac-fmc-ebz.dtsi
@@ -1,3 +1,5 @@
+#include <dt-bindings/dma/axi-dmac.h>
+
 &dac_dma {
 	compatible = "adi,axi-dmac-1.00.a";
 
@@ -10,9 +12,9 @@
 		dma-channel@0 {
 			reg = <0>;
 			adi,source-bus-width = <64>;
-			adi,source-bus-type = <0>;
+			adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			adi,destination-bus-width = <256>;
-			adi,destination-bus-type = <2>;
+			adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 		};
 	};
 };

--- a/arch/arm/boot/dts/adi-zynq-cn0363.dtsi
+++ b/arch/arm/boot/dts/adi-zynq-cn0363.dtsi
@@ -1,3 +1,4 @@
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 
 / {
@@ -27,9 +28,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <32>;
-				adi,source-bus-type = <2>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/socfpga_arria10_socdk_adrv9002.dts
+++ b/arch/arm/boot/dts/socfpga_arria10_socdk_adrv9002.dts
@@ -9,6 +9,7 @@
  */
 /dts-v1/;
 #include "socfpga_arria10_socdk.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/gpio/gpio.h>
 
 &mmc {
@@ -77,9 +78,9 @@
 					dma-channel@0 {
 						reg = <0>;
 						adi,source-bus-width = <64>;
-						adi,source-bus-type = <2>;
+						adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 						adi,destination-bus-width = <64>;
-						adi,destination-bus-type = <0>;
+						adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 					};
 				};
 			};
@@ -99,9 +100,9 @@
 					dma-channel@0 {
 						reg = <0>;
 						adi,source-bus-width = <64>;
-						adi,source-bus-type = <2>;
+						adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 						adi,destination-bus-width = <64>;
-						adi,destination-bus-type = <0>;
+						adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 					};
 				};
 			};
@@ -121,9 +122,9 @@
 					dma-channel@0 {
 						reg = <0>;
 						adi,source-bus-width = <64>;
-						adi,source-bus-type = <0>;
+						adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 						adi,destination-bus-width = <64>;
-						adi,destination-bus-type = <2>;
+						adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 					};
 				};
 			};
@@ -143,9 +144,9 @@
 					dma-channel@0 {
 						reg = <0>;
 						adi,source-bus-width = <64>;
-						adi,source-bus-type = <0>;
+						adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 						adi,destination-bus-width = <64>;
-						adi,destination-bus-type = <2>;
+						adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 					};
 				};
 			};

--- a/arch/arm/boot/dts/socfpga_arria10_socdk_adrv9002_rx2tx2.dts
+++ b/arch/arm/boot/dts/socfpga_arria10_socdk_adrv9002_rx2tx2.dts
@@ -9,6 +9,7 @@
  */
 /dts-v1/;
 #include "socfpga_arria10_socdk.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/gpio/gpio.h>
 
 &mmc {
@@ -77,9 +78,9 @@
 					dma-channel@0 {
 						reg = <0>;
 						adi,source-bus-width = <64>;
-						adi,source-bus-type = <2>;
+						adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 						adi,destination-bus-width = <64>;
-						adi,destination-bus-type = <0>;
+						adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 					};
 				};
 			};
@@ -99,9 +100,9 @@
 					dma-channel@0 {
 						reg = <0>;
 						adi,source-bus-width = <64>;
-						adi,source-bus-type = <0>;
+						adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 						adi,destination-bus-width = <64>;
-						adi,destination-bus-type = <2>;
+						adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 					};
 				};
 			};

--- a/arch/arm/boot/dts/socfpga_arria10_socdk_adrv9009.dts
+++ b/arch/arm/boot/dts/socfpga_arria10_socdk_adrv9009.dts
@@ -12,6 +12,7 @@
  */
 /dts-v1/;
 #include "socfpga_arria10_socdk.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/iio/frequency/ad9528.h>
 
 &mmc {
@@ -129,9 +130,9 @@
 					dma-channel@0 {
 						reg = <0>;
 						adi,source-bus-width = <128>;
-						adi,source-bus-type = <0>;
+						adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 						adi,destination-bus-width = <128>;
-						adi,destination-bus-type = <1>;
+						adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_STREAM>;
 					};
 				};
 			};
@@ -191,9 +192,9 @@
 					dma-channel@0 {
 						reg = <0>;
 						adi,source-bus-width = <64>;
-						adi,source-bus-type = <2>;
+						adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 						adi,destination-bus-width = <128>;
-						adi,destination-bus-type = <0>;
+						adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 					};
 				};
 			};
@@ -253,9 +254,9 @@
 					dma-channel@0 {
 						reg = <0>;
 						adi,source-bus-width = <128>;
-						adi,source-bus-type = <2>;
+						adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 						adi,destination-bus-width = <128>;
-						adi,destination-bus-type = <0>;
+						adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 					};
 				};
 			};

--- a/arch/arm/boot/dts/socfpga_arria10_socdk_adrv9371.dts
+++ b/arch/arm/boot/dts/socfpga_arria10_socdk_adrv9371.dts
@@ -10,6 +10,7 @@
  */
 /dts-v1/;
 #include "socfpga_arria10_socdk.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/iio/frequency/ad9528.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 
@@ -186,9 +187,9 @@
 					dma-channel@0 {
 						reg = <0>;
 						adi,source-bus-width = <128>;
-						adi,source-bus-type = <0>;
+						adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 						adi,destination-bus-width = <128>;
-						adi,destination-bus-type = <1>;
+						adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_STREAM>;
 					};
 				};
 			};
@@ -207,9 +208,9 @@
 					dma-channel@0 {
 						reg = <0>;
 						adi,source-bus-width = <64>;
-						adi,source-bus-type = <2>;
+						adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 						adi,destination-bus-width = <128>;
-						adi,destination-bus-type = <0>;
+						adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 					};
 				};
 			};
@@ -228,9 +229,9 @@
 					dma-channel@0 {
 						reg = <0>;
 						adi,source-bus-width = <64>;
-						adi,source-bus-type = <2>;
+						adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 						adi,destination-bus-width = <128>;
-						adi,destination-bus-type = <0>;
+						adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 					};
 				};
 			};

--- a/arch/arm/boot/dts/socfpga_arria10_socdk_daq2.dts
+++ b/arch/arm/boot/dts/socfpga_arria10_socdk_daq2.dts
@@ -10,6 +10,7 @@
  */
 /dts-v1/;
 #include "socfpga_arria10_socdk.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 
 &mmc {
@@ -84,9 +85,9 @@
 					dma-channel@0 {
 						reg = <0>;
 						adi,source-bus-width = <128>;
-						adi,source-bus-type = <1>;
+						adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_STREAM>;
 						adi,destination-bus-width = <128>;
-						adi,destination-bus-type = <0>;
+						adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 					};
 				};
 			};
@@ -105,9 +106,9 @@
 					dma-channel@0 {
 						reg = <0>;
 						adi,source-bus-width = <128>;
-						adi,source-bus-type = <0>;
+						adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 						adi,destination-bus-width = <128>;
-						adi,destination-bus-type = <1>;
+						adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_STREAM>;
 					adi,cyclic;
 					};
 				};

--- a/arch/arm/boot/dts/socfpga_arria10_socdk_fmclidar1.dts
+++ b/arch/arm/boot/dts/socfpga_arria10_socdk_fmclidar1.dts
@@ -10,6 +10,7 @@
  */
 /dts-v1/;
 #include "socfpga_arria10_socdk.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/iio/frequency/ad9528.h>
 
 &mmc {
@@ -151,9 +152,9 @@
 					dma-channel@0 {
 						reg = <0>;
 						adi,source-bus-width = <256>;
-						adi,source-bus-type = <2>;
+						adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 						adi,destination-bus-width = <64>;
-						adi,destination-bus-type = <0>;
+						adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 					};
 				};
 			};

--- a/arch/arm/boot/dts/socfpga_arria10_socdk_fmcomms8.dts
+++ b/arch/arm/boot/dts/socfpga_arria10_socdk_fmcomms8.dts
@@ -12,6 +12,7 @@
  */
 /dts-v1/;
 #include "socfpga_arria10_socdk.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/iio/frequency/hmc7044.h>
 #include <dt-bindings/iio/adc/adi,adrv9009.h>
 
@@ -216,9 +217,9 @@
 					dma-channel@0 {
 						reg = <0>;
 						adi,source-bus-width = <256>;
-						adi,source-bus-type = <2>;
+						adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 						adi,destination-bus-width = <128>;
-						adi,destination-bus-type = <0>;
+						adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 					};
 				};
 			};
@@ -238,9 +239,9 @@
 					dma-channel@0 {
 						reg = <0>;
 						adi,source-bus-width = <128>;
-						adi,source-bus-type = <2>;
+						adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 						adi,destination-bus-width = <128>;
-						adi,destination-bus-type = <0>;
+						adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 					};
 				};
 			};
@@ -260,9 +261,9 @@
 					dma-channel@0 {
 						reg = <0>;
 						adi,source-bus-width = <128>;
-						adi,source-bus-type = <0>;
+						adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 						adi,destination-bus-width = <256>;
-						adi,destination-bus-type = <1>;
+						adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_STREAM>;
 					};
 				};
 			};

--- a/arch/arm/boot/dts/socfpga_cyclone5_de10_nano.dtsi
+++ b/arch/arm/boot/dts/socfpga_cyclone5_de10_nano.dtsi
@@ -6,6 +6,7 @@
  */
 
 #include "socfpga_cyclone5_de10_nano_hps.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 #include <dt-bindings/gpio/gpio.h>
 
@@ -126,9 +127,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <0>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <1>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_STREAM>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/socfpga_cyclone5_de10_nano_cn0501.dts
+++ b/arch/arm/boot/dts/socfpga_cyclone5_de10_nano_cn0501.dts
@@ -10,6 +10,7 @@
  */
 /dts-v1/;
 #include "socfpga_cyclone5_de10_nano.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 #include <dt-bindings/gpio/gpio.h>
 
@@ -60,9 +61,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <256>;
-				adi,source-bus-type = <2>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/socfpga_cyclone5_de10_nano_cn0540.dts
+++ b/arch/arm/boot/dts/socfpga_cyclone5_de10_nano_cn0540.dts
@@ -12,6 +12,7 @@
  */
 /dts-v1/;
 #include "socfpga_cyclone5_de10_nano.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 #include <dt-bindings/gpio/gpio.h>
 
@@ -106,9 +107,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <32>;
-				adi,source-bus-type = <1>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_STREAM>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/socfpga_cyclone5_de10_nano_cn0579_i2c.dts
+++ b/arch/arm/boot/dts/socfpga_cyclone5_de10_nano_cn0579_i2c.dts
@@ -9,6 +9,7 @@
  * Copyright (C) 2023 Analog Devices Inc.
  */
 #include "socfpga_cyclone5_de10_nano.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 #include <dt-bindings/gpio/gpio.h>
 
@@ -85,9 +86,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <128>;
-				adi,source-bus-type = <2>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/socfpga_cyclone5_sockit_arradio.dts
+++ b/arch/arm/boot/dts/socfpga_cyclone5_sockit_arradio.dts
@@ -8,6 +8,7 @@
  *
  * Copyright 2020 Analog Devices Inc.
  */
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 
 #include "socfpga_cyclone5.dtsi"
@@ -166,9 +167,9 @@
 						dma-channel@0 {
 							reg = <0>;
 							adi,source-bus-width = <64>;
-							adi,source-bus-type = <0>;
+							adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 							adi,destination-bus-width = <64>;
-							adi,destination-bus-type = <1>;
+							adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_STREAM>;
 						};
 					};
 				};
@@ -188,9 +189,9 @@
 						dma-channel@0 {
 							reg = <0>;
 							adi,source-bus-width = <64>;
-							adi,source-bus-type = <2>;
+							adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 							adi,destination-bus-width = <128>;
-							adi,destination-bus-type = <0>;
+							adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 						};
 					};
 				};

--- a/arch/arm/boot/dts/socfpga_cyclone5_sockit_dc2677a.dts
+++ b/arch/arm/boot/dts/socfpga_cyclone5_sockit_dc2677a.dts
@@ -7,6 +7,7 @@
  *
  * Copyright 2023 Analog Devices Inc.
  */
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/pwm/pwm.h>
@@ -141,9 +142,9 @@
 						dma-channel@0 {
 							reg = <0>;
 							adi,source-bus-width = <256>;
-							adi,source-bus-type = <2>;
+							adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 							adi,destination-bus-width = <64>;
-							adi,destination-bus-type = <0>;
+							adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 						};
 					};
 				};

--- a/arch/arm/boot/dts/zynq-adrv9002-rx2tx2.dtsi
+++ b/arch/arm/boot/dts/zynq-adrv9002-rx2tx2.dtsi
@@ -1,3 +1,4 @@
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 #include <dt-bindings/gpio/gpio.h>
 
@@ -17,9 +18,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <2>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};
@@ -39,9 +40,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <0>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <2>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-adrv9002.dtsi
+++ b/arch/arm/boot/dts/zynq-adrv9002.dtsi
@@ -1,3 +1,4 @@
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 #include <dt-bindings/gpio/gpio.h>
 
@@ -17,9 +18,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <2>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};
@@ -39,9 +40,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <2>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};
@@ -61,9 +62,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <0>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <2>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 			};
 		};
 	};
@@ -83,9 +84,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <0>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <2>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-adrv9361-z7035-fmc.dts
+++ b/arch/arm/boot/dts/zynq-adrv9361-z7035-fmc.dts
@@ -12,6 +12,7 @@
 /dts-v1/;
 #include "zynq-adrv9361-z7035.dtsi"
 
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/input/input.h>
 
 / {
@@ -184,9 +185,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <64>;
-					adi,source-bus-type = <0>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 					adi,destination-bus-width = <64>;
-					adi,destination-bus-type = <1>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_STREAM>;
 				};
 			};
 		};

--- a/arch/arm/boot/dts/zynq-adrv9361-z7035.dtsi
+++ b/arch/arm/boot/dts/zynq-adrv9361-z7035.dtsi
@@ -7,6 +7,7 @@
  */
 #include "zynq.dtsi"
 
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 
 / {
@@ -151,9 +152,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <64>;
-					adi,source-bus-type = <2>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 					adi,destination-bus-width = <64>;
-					adi,destination-bus-type = <0>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				};
 			};
 		};
@@ -172,9 +173,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <64>;
-					adi,source-bus-type = <0>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 					adi,destination-bus-width = <64>;
-					adi,destination-bus-type = <2>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				};
 			};
 		};

--- a/arch/arm/boot/dts/zynq-adrv9364-z7020.dtsi
+++ b/arch/arm/boot/dts/zynq-adrv9364-z7020.dtsi
@@ -7,6 +7,7 @@
  */
 #include "zynq.dtsi"
 
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 
 / {
@@ -143,9 +144,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <64>;
-					adi,source-bus-type = <2>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 					adi,destination-bus-width = <64>;
-					adi,destination-bus-type = <0>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				};
 			};
 		};
@@ -164,9 +165,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <64>;
-					adi,source-bus-type = <0>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 					adi,destination-bus-width = <64>;
-					adi,destination-bus-type = <2>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				};
 			};
 		};

--- a/arch/arm/boot/dts/zynq-coraz7s-ad7687-pmdz.dts
+++ b/arch/arm/boot/dts/zynq-coraz7s-ad7687-pmdz.dts
@@ -11,6 +11,7 @@
  */
 /dts-v1/;
 #include "zynq-coraz7s.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 #include <dt-bindings/gpio/gpio.h>
 
@@ -82,9 +83,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <32>;
-				adi,source-bus-type = <1>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_STREAM>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-coraz7s-ad7689-ardz.dts
+++ b/arch/arm/boot/dts/zynq-coraz7s-ad7689-ardz.dts
@@ -11,6 +11,7 @@
  */
 /dts-v1/;
 #include "zynq-coraz7s.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 #include <dt-bindings/gpio/gpio.h>
 
@@ -105,9 +106,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <32>;
-				adi,source-bus-type = <1>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_STREAM>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-coraz7s-ad7946.dts
+++ b/arch/arm/boot/dts/zynq-coraz7s-ad7946.dts
@@ -11,6 +11,7 @@
  */
 /dts-v1/;
 #include "zynq-coraz7s.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 #include <dt-bindings/gpio/gpio.h>
 
@@ -81,9 +82,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <32>;
-				adi,source-bus-type = <1>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_STREAM>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-coraz7s-ad7984.dts
+++ b/arch/arm/boot/dts/zynq-coraz7s-ad7984.dts
@@ -11,6 +11,7 @@
  */
 /dts-v1/;
 #include "zynq-coraz7s.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 #include <dt-bindings/gpio/gpio.h>
 
@@ -82,9 +83,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <32>;
-				adi,source-bus-type = <1>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_STREAM>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-coraz7s-adaq4003.dts
+++ b/arch/arm/boot/dts/zynq-coraz7s-adaq4003.dts
@@ -10,6 +10,7 @@
  */
 /dts-v1/;
 #include "zynq-coraz7s.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 #include <dt-bindings/gpio/gpio.h>
 
@@ -84,9 +85,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <32>;
-				adi,source-bus-type = <1>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_STREAM>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-coraz7s-cn0501.dts
+++ b/arch/arm/boot/dts/zynq-coraz7s-cn0501.dts
@@ -10,6 +10,7 @@
  */
 /dts-v1/;
 #include "zynq-coraz7s.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 
 / {
@@ -46,9 +47,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <256>;
-				adi,source-bus-type = <2>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-coraz7s-cn0540.dts
+++ b/arch/arm/boot/dts/zynq-coraz7s-cn0540.dts
@@ -12,6 +12,7 @@
  */
 /dts-v1/;
 #include "zynq-coraz7s.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 #include <dt-bindings/gpio/gpio.h>
 
@@ -123,9 +124,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <32>;
-				adi,source-bus-type = <1>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_STREAM>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-coraz7s-cn0579_i2c.dts
+++ b/arch/arm/boot/dts/zynq-coraz7s-cn0579_i2c.dts
@@ -10,6 +10,7 @@
  */
 /dts-v1/;
 #include "zynq-coraz7s.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 #include <dt-bindings/gpio/gpio.h>
 
@@ -76,9 +77,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <128>;
-				adi,source-bus-type = <2>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-e310.dts
+++ b/arch/arm/boot/dts/zynq-e310.dts
@@ -10,6 +10,7 @@
  */
 /dts-v1/;
 #include "zynq.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/interrupt-controller/irq.h>
@@ -147,9 +148,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <64>;
-					adi,source-bus-type = <2>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 					adi,destination-bus-width = <64>;
-					adi,destination-bus-type = <0>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				};
 			};
 		};
@@ -168,9 +169,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <64>;
-					adi,source-bus-type = <0>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 					adi,destination-bus-width = <64>;
-					adi,destination-bus-type = <2>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				};
 			};
 		};

--- a/arch/arm/boot/dts/zynq-m2k-reva.dts
+++ b/arch/arm/boot/dts/zynq-m2k-reva.dts
@@ -15,6 +15,7 @@
 
 #include "zynq-m2k.dtsi"
 
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/interrupt-controller/irq.h>
@@ -228,9 +229,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <32>;
-					adi,source-bus-type = <2>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 					adi,destination-bus-width = <64>;
-					adi,destination-bus-type = <0>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				};
 			};
 		};
@@ -262,9 +263,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <64>;
-					adi,source-bus-type = <0>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 					adi,destination-bus-width = <16>;
-					adi,destination-bus-type = <2>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				};
 			};
 		};
@@ -283,9 +284,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <64>;
-					adi,source-bus-type = <0>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 					adi,destination-bus-width = <16>;
-					adi,destination-bus-type = <2>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				};
 			};
 		};
@@ -334,9 +335,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <16>;
-					adi,source-bus-type = <2>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 					adi,destination-bus-width = <64>;
-					adi,destination-bus-type = <0>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				};
 			};
 		};
@@ -356,9 +357,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <64>;
-					adi,source-bus-type = <0>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 					adi,destination-bus-width = <16>;
-					adi,destination-bus-type = <2>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				};
 			};
 		};

--- a/arch/arm/boot/dts/zynq-pluto-sdr.dtsi
+++ b/arch/arm/boot/dts/zynq-pluto-sdr.dtsi
@@ -7,6 +7,7 @@
  */
 #include "zynq.dtsi"
 
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 
 / {
@@ -124,9 +125,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <32>;
-					adi,source-bus-type = <2>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 					adi,destination-bus-width = <64>;
-					adi,destination-bus-type = <0>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				};
 			};
 		};
@@ -145,9 +146,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <64>;
-					adi,source-bus-type = <0>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 					adi,destination-bus-width = <32>;
-					adi,destination-bus-type = <2>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				};
 			};
 		};

--- a/arch/arm/boot/dts/zynq-zc702-adv7511-ad9361-fmcomms2-3.dts
+++ b/arch/arm/boot/dts/zynq-zc702-adv7511-ad9361-fmcomms2-3.dts
@@ -13,6 +13,7 @@
 
 #include "zynq-zc702.dtsi"
 #include "zynq-zc702-adv7511.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 
 &spi0 {
 	status = "okay";
@@ -40,9 +41,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <2>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};
@@ -61,9 +62,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <0>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <2>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-zc702-adv7511-ad9361-fmcomms5.dts
+++ b/arch/arm/boot/dts/zynq-zc702-adv7511-ad9361-fmcomms5.dts
@@ -12,6 +12,7 @@
 
 #include "zynq-zc702.dtsi"
 #include "zynq-zc702-adv7511.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 
 &spi0 {
 	status = "okay";
@@ -34,9 +35,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <128>;
-				adi,source-bus-type = <2>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};
@@ -55,9 +56,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <0>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				adi,destination-bus-width = <128>;
-				adi,destination-bus-type = <2>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-zc702-adv7511-ad9364-fmcomms4.dts
+++ b/arch/arm/boot/dts/zynq-zc702-adv7511-ad9364-fmcomms4.dts
@@ -12,6 +12,7 @@
 
 #include "zynq-zc702.dtsi"
 #include "zynq-zc702-adv7511.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 
 &fpga_axi {
 	rx_dma: dma@7c400000 {
@@ -28,9 +29,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <2>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};
@@ -49,9 +50,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <0>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <2>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-zc702-adv7511-fmcomms1.dts
+++ b/arch/arm/boot/dts/zynq-zc702-adv7511-fmcomms1.dts
@@ -2,6 +2,7 @@
 
 #include "zynq-zc702.dtsi"
 #include "zynq-zc702-adv7511.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 
 &fpga_axi {
 	rx_dma: dma@7c400000 {
@@ -18,9 +19,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <2>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};
@@ -39,9 +40,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <0>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <2>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-zc702-adv7511.dtsi
+++ b/arch/arm/boot/dts/zynq-zc702-adv7511.dtsi
@@ -1,3 +1,5 @@
+#include <dt-bindings/dma/axi-dmac.h>
+
 / {
 	fpga_axi: fpga-axi@0 {
 		compatible = "simple-bus";
@@ -92,9 +94,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <64>;
-					adi,source-bus-type = <0>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 					adi,destination-bus-width = <64>;
-					adi,destination-bus-type = <1>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_STREAM>;
 				};
 			};
 		};

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad6676-fmc.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad6676-fmc.dts
@@ -13,6 +13,7 @@
 
 #include "zynq-zc706.dtsi"
 #include "zynq-zc706-adv7511.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/jesd204/adxcvr.h>
 
 / {
@@ -102,9 +103,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <2>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad9265-fmc-125ebz.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad9265-fmc-125ebz.dts
@@ -13,6 +13,7 @@
 
 #include "zynq-zc706.dtsi"
 #include "zynq-zc706-adv7511.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 
 &fpga_axi {
 	rx_dma: rx-dmac@44a30000 {
@@ -29,9 +30,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <16>;
-				adi,source-bus-type = <2>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad9361-fmcomms2-3.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad9361-fmcomms2-3.dts
@@ -13,6 +13,7 @@
 
 #include "zynq-zc706.dtsi"
 #include "zynq-zc706-adv7511.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 
 &i2c_mux {
 	fmc_i2c: i2c@6 {
@@ -37,9 +38,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <2>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};
@@ -58,9 +59,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <0>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <2>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad9361-fmcomms5.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad9361-fmcomms5.dts
@@ -12,6 +12,7 @@
 
 #include "zynq-zc706.dtsi"
 #include "zynq-zc706-adv7511.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 
 &i2c_mux {
 	fmc_i2c: i2c@5 { /* HPC */
@@ -36,9 +37,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <128>;
-				adi,source-bus-type = <2>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};
@@ -57,9 +58,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <0>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				adi,destination-bus-width = <128>;
-				adi,destination-bus-type = <2>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad9364-fmcomms4.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad9364-fmcomms4.dts
@@ -12,6 +12,7 @@
 
 #include "zynq-zc706.dtsi"
 #include "zynq-zc706-adv7511.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 
 &i2c_mux {
 	fmc_i2c: i2c@6 {
@@ -36,9 +37,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <2>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};
@@ -57,9 +58,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <0>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <2>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad9434-fmc-500ebz.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad9434-fmc-500ebz.dts
@@ -13,6 +13,7 @@
 
 #include "zynq-zc706.dtsi"
 #include "zynq-zc706-adv7511.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 
 &fpga_axi {
 	rx_dma: rx-dmac@44a30000 {
@@ -29,9 +30,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <2>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad9625-fmcadc2.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad9625-fmcadc2.dts
@@ -12,6 +12,7 @@
 
 #include "zynq-zc706.dtsi"
 #include "zynq-zc706-adv7511.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/jesd204/adxcvr.h>
 
 / {
@@ -76,9 +77,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <1>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_STREAM>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-ad9739a-fmc.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-ad9739a-fmc.dts
@@ -13,6 +13,7 @@
 
 #include "zynq-zc706.dtsi"
 #include "zynq-zc706-adv7511.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 
 &i2c_mux {
 	fmc_i2c: i2c@6 {
@@ -57,9 +58,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <256>;
-				adi,source-bus-type = <0>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				adi,destination-bus-width = <256>;
-				adi,destination-bus-type = <2>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9008-1.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9008-1.dts
@@ -14,6 +14,7 @@
 
 #include "zynq-zc706.dtsi"
 #include "zynq-zc706-adv7511.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/jesd204/adxcvr.h>
 
 &i2c_mux {
@@ -50,9 +51,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <2>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9008-2.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9008-2.dts
@@ -14,6 +14,7 @@
 
 #include "zynq-zc706.dtsi"
 #include "zynq-zc706-adv7511.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/jesd204/adxcvr.h>
 
 &i2c_mux {
@@ -50,9 +51,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <128>;
-				adi,source-bus-type = <2>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};
@@ -71,9 +72,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <128>;
-				adi,source-bus-type = <0>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				adi,destination-bus-width = <128>;
-				adi,destination-bus-type = <2>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9009.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9009.dts
@@ -14,6 +14,7 @@
 
 #include "zynq-zc706.dtsi"
 #include "zynq-zc706-adv7511.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/jesd204/adxcvr.h>
 
@@ -50,9 +51,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <2>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};
@@ -71,9 +72,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <128>;
-				adi,source-bus-type = <2>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};
@@ -92,9 +93,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <128>;
-				adi,source-bus-type = <0>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				adi,destination-bus-width = <128>;
-				adi,destination-bus-type = <2>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9371.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-adrv9371.dts
@@ -13,6 +13,7 @@
 
 #include "zynq-zc706.dtsi"
 #include "zynq-zc706-adv7511.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/jesd204/adxcvr.h>
 
@@ -49,9 +50,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <2>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};
@@ -70,9 +71,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <2>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};
@@ -91,9 +92,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <0>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				adi,destination-bus-width = <128>;
-				adi,destination-bus-type = <1>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_STREAM>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcadc4.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcadc4.dts
@@ -2,6 +2,7 @@
 
 #include "zynq-zc706.dtsi"
 #include "zynq-zc706-adv7511.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/jesd204/adxcvr.h>
 
 &fpga_axi {
@@ -19,9 +20,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <1>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_STREAM>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcdaq1.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcdaq1.dts
@@ -2,6 +2,7 @@
 
 #include "zynq-zc706.dtsi"
 #include "zynq-zc706-adv7511.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 
 &fpga_axi {
 	rx_dma: dma@44a60000 {
@@ -18,9 +19,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <2>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcdaq2.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcdaq2.dts
@@ -12,6 +12,7 @@
 
 #include "zynq-zc706.dtsi"
 #include "zynq-zc706-adv7511.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/jesd204/adxcvr.h>
 
 &i2c_mux {
@@ -48,9 +49,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <2>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};
@@ -69,9 +70,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <128>;
-				adi,source-bus-type = <0>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				adi,destination-bus-width = <128>;
-				adi,destination-bus-type = <1>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_STREAM>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcdaq3.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcdaq3.dts
@@ -12,6 +12,7 @@
 
 #include "zynq-zc706.dtsi"
 #include "zynq-zc706-adv7511.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/jesd204/adxcvr.h>
 
 &i2c_mux {
@@ -47,9 +48,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <2>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};
@@ -68,9 +69,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <128>;
-				adi,source-bus-type = <0>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				adi,destination-bus-width = <128>;
-				adi,destination-bus-type = <1>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_STREAM>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcjesdadc1.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcjesdadc1.dts
@@ -12,6 +12,7 @@
 
 #include "zynq-zc706.dtsi"
 #include "zynq-zc706-adv7511.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/jesd204/adxcvr.h>
 
 &i2c_mux {
@@ -47,9 +48,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <128>;
-				adi,source-bus-type = <2>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				adi,destination-bus-width = <128>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmclidar1.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmclidar1.dts
@@ -12,6 +12,7 @@
 
 #include "zynq-zc706.dtsi"
 #include "zynq-zc706-adv7511.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/jesd204/adxcvr.h>
 
 &i2c_mux {
@@ -83,9 +84,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <256>;
-				adi,source-bus-type = <2>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcomms1.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcomms1.dts
@@ -2,6 +2,7 @@
 
 #include "zynq-zc706.dtsi"
 #include "zynq-zc706-adv7511.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 
 &i2c_mux {
 	fmc_i2c: i2c@6 {
@@ -26,9 +27,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <2>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};
@@ -47,9 +48,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <0>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <2>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcomms11-RevA.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcomms11-RevA.dts
@@ -2,6 +2,7 @@
 
 #include "zynq-zc706.dtsi"
 #include "zynq-zc706-adv7511.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/jesd204/adxcvr.h>
 
 &i2c_mux {
@@ -37,9 +38,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <2>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 
@@ -59,9 +60,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <128>;
-				adi,source-bus-type = <0>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				adi,destination-bus-width = <128>;
-				adi,destination-bus-type = <2>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcomms11.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcomms11.dts
@@ -13,6 +13,7 @@
 
 #include "zynq-zc706.dtsi"
 #include "zynq-zc706-adv7511.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/jesd204/adxcvr.h>
 
 &i2c_mux {
@@ -48,9 +49,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <2>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};
@@ -69,9 +70,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <128>;
-				adi,source-bus-type = <0>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				adi,destination-bus-width = <128>;
-				adi,destination-bus-type = <2>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-zc706-adv7511-fmcomms6.dts
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511-fmcomms6.dts
@@ -2,6 +2,7 @@
 
 #include "zynq-zc706.dtsi"
 #include "zynq-zc706-adv7511.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 
 &i2c_mux {
 	fmc_i2c: i2c@6 { /* LPC */
@@ -26,9 +27,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <2>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-zc706-adv7511.dtsi
+++ b/arch/arm/boot/dts/zynq-zc706-adv7511.dtsi
@@ -1,3 +1,4 @@
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 
 / {
@@ -120,9 +121,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <64>;
-					adi,source-bus-type = <0>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 					adi,destination-bus-width = <64>;
-					adi,destination-bus-type = <1>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_STREAM>;
 				};
 			};
 		};

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad4003.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad4003.dts
@@ -13,6 +13,7 @@
 
 #include "zynq-zed.dtsi"
 #include "zynq-zed-adv7511.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 
 / {
 	adc_vref: regulator-vref {
@@ -56,9 +57,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <32>;
-				adi,source-bus-type = <1>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_STREAM>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad4020.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad4020.dts
@@ -14,6 +14,7 @@
 
 #include "zynq-zed.dtsi"
 #include "zynq-zed-adv7511.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 
 / {
 	adc_vref: regulator-vref {
@@ -57,9 +58,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <32>;
-				adi,source-bus-type = <1>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_STREAM>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad4030-24.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad4030-24.dts
@@ -13,6 +13,7 @@
 #include "zynq-zed-adv7511.dtsi"
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/pwm/pwm.h>
+#include <dt-bindings/dma/axi-dmac.h>
 
 / {
 	vref: regulator-vref {
@@ -64,9 +65,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <1>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_STREAM>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad4032-24.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad4032-24.dts
@@ -13,6 +13,7 @@
 #include "zynq-zed-adv7511.dtsi"
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/pwm/pwm.h>
+#include <dt-bindings/dma/axi-dmac.h>
 
 / {
 	vref: regulator-vref {
@@ -64,9 +65,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <1>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_STREAM>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad4134.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad4134.dts
@@ -14,6 +14,7 @@
 
 #include "zynq-zed.dtsi"
 #include "zynq-zed-adv7511.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 
 / {
 	avdd5: regulator-avdd5 {
@@ -71,9 +72,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <128>;
-				adi,source-bus-type = <1>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_STREAM>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad4630-16.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad4630-16.dts
@@ -11,6 +11,7 @@
 
 #include "zynq-zed.dtsi"
 #include "zynq-zed-adv7511.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/pwm/pwm.h>
 
@@ -64,9 +65,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <1>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_STREAM>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad4630-24.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad4630-24.dts
@@ -11,6 +11,7 @@
 
 #include "zynq-zed.dtsi"
 #include "zynq-zed-adv7511.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/pwm/pwm.h>
 
@@ -64,9 +65,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <1>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_STREAM>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad7768-1-evb.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad7768-1-evb.dts
@@ -12,6 +12,7 @@
 
 #include "zynq-zed.dtsi"
 #include "zynq-zed-adv7511.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 #include <dt-bindings/gpio/gpio.h>
 
@@ -49,9 +50,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <32>;
-				adi,source-bus-type = <1>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_STREAM>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad7768-4-axi-adc.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad7768-4-axi-adc.dts
@@ -12,6 +12,7 @@
 
 #include "zynq-zed.dtsi"
 #include "zynq-zed-adv7511.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/gpio/gpio.h>
 
 / {
@@ -47,9 +48,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <256>;
-				adi,source-bus-type = <2>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad7768-axi-adc.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad7768-axi-adc.dts
@@ -12,6 +12,7 @@
 
 #include "zynq-zed.dtsi"
 #include "zynq-zed-adv7511.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/gpio/gpio.h>
 
 / {
@@ -47,9 +48,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <256>;
-				adi,source-bus-type = <2>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad7768.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad7768.dts
@@ -12,7 +12,7 @@
 
 #include "zynq-zed.dtsi"
 #include "zynq-zed-adv7511.dtsi"
-
+#include <dt-bindings/dma/axi-dmac.h>
 
 / {
 	vref: regulator-vref {
@@ -47,9 +47,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <32>;
-				adi,source-bus-type = <2>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				adi,destination-bus-width = <32>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad9265-fmc-125ebz.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad9265-fmc-125ebz.dts
@@ -13,6 +13,7 @@
 
 #include "zynq-zed.dtsi"
 #include "zynq-zed-adv7511.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 
 &fpga_axi {
 	rx_dma: rx-dmac@44a30000 {
@@ -29,9 +30,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <16>;
-				adi,source-bus-type = <2>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad9361-fmcomms2-3.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad9361-fmcomms2-3.dts
@@ -13,6 +13,7 @@
 
 #include "zynq-zed.dtsi"
 #include "zynq-zed-adv7511.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 
 &fpga_axi {
 	fmc_i2c: i2c@41620000 {
@@ -41,9 +42,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <2>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};
@@ -62,9 +63,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <0>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <2>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad9364-fmcomms4.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad9364-fmcomms4.dts
@@ -13,6 +13,7 @@
 
 #include "zynq-zed.dtsi"
 #include "zynq-zed-adv7511.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 
 &fpga_axi {
 	fmc_i2c: i2c@41620000 {
@@ -41,9 +42,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <2>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};
@@ -62,9 +63,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <0>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <2>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad9434-fmc-500ebz.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad9434-fmc-500ebz.dts
@@ -13,6 +13,7 @@
 
 #include "zynq-zed.dtsi"
 #include "zynq-zed-adv7511.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 
 &fpga_axi {
 	rx_dma: rx-dmac@44a30000 {
@@ -29,9 +30,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <2>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad9467-fmc-250ebz.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad9467-fmc-250ebz.dts
@@ -14,6 +14,7 @@
 
 #include "zynq-zed.dtsi"
 #include "zynq-zed-adv7511.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 
 &fpga_axi {
 	rx_dma: rx-dmac@44a30000 {
@@ -30,9 +31,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <16>;
-				adi,source-bus-type = <2>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-zed-adv7511-adaq4003.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-adaq4003.dts
@@ -13,6 +13,7 @@
 
 #include "zynq-zed.dtsi"
 #include "zynq-zed-adv7511.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 
 / {
 	adc_vref: regulator-vref {
@@ -56,9 +57,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <32>;
-				adi,source-bus-type = <1>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_STREAM>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-zed-adv7511-adaq4216.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-adaq4216.dts
@@ -11,6 +11,7 @@
 
 #include "zynq-zed.dtsi"
 #include "zynq-zed-adv7511.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/pwm/pwm.h>
 
@@ -80,9 +81,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <1>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_STREAM>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-zed-adv7511-adaq4220.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-adaq4220.dts
@@ -11,6 +11,7 @@
 
 #include "zynq-zed.dtsi"
 #include "zynq-zed-adv7511.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/pwm/pwm.h>
 
@@ -91,9 +92,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <1>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_STREAM>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-zed-adv7511-adaq4224-24.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-adaq4224-24.dts
@@ -11,6 +11,7 @@
 
 #include "zynq-zed.dtsi"
 #include "zynq-zed-adv7511.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/pwm/pwm.h>
 
@@ -91,9 +92,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <1>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_STREAM>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-zed-adv7511-adaq4224-24_cm0_sdi4_cz2.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-adaq4224-24_cm0_sdi4_cz2.dts
@@ -11,6 +11,7 @@
 
 #include "zynq-zed.dtsi"
 #include "zynq-zed-adv7511.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/pwm/pwm.h>
 
@@ -78,9 +79,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <1>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_STREAM>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-zed-adv7511-adaq8092.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-adaq8092.dts
@@ -12,6 +12,7 @@
 
 #include "zynq-zed.dtsi"
 #include "zynq-zed-adv7511.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/gpio/gpio.h>
 
 / {
@@ -58,9 +59,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <32>;
-				adi,source-bus-type = <2>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-zed-adv7511-cn0577.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-cn0577.dts
@@ -11,6 +11,7 @@
 
 #include "zynq-zed.dtsi"
 #include "zynq-zed-adv7511.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/pwm/pwm.h>
 
@@ -62,9 +63,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <16>;
-				adi,source-bus-type = <2>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-zed-adv7511-fmcmotcon2.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-fmcmotcon2.dts
@@ -2,6 +2,7 @@
 
 #include "zynq-zed.dtsi"
 #include "zynq-zed-adv7511.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 
 &aliases {
 	ethernet1 = &gem1;
@@ -77,9 +78,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <32>;
-				adi,source-bus-type = <2>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};
@@ -104,9 +105,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <2>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};
@@ -136,9 +137,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <32>;
-				adi,source-bus-type = <2>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};
@@ -163,9 +164,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <2>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-zed-adv7511-fmcomms1.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-fmcomms1.dts
@@ -2,6 +2,7 @@
 
 #include "zynq-zed.dtsi"
 #include "zynq-zed-adv7511.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 
 &fpga_axi {
 	fmc_i2c: i2c@41620000 {
@@ -30,9 +31,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <2>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};
@@ -51,9 +52,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <0>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <2>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ltc2387.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ltc2387.dts
@@ -11,6 +11,7 @@
 
 #include "zynq-zed.dtsi"
 #include "zynq-zed-adv7511.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/pwm/pwm.h>
 
@@ -40,9 +41,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <16>;
-				adi,source-bus-type = <2>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/zynq-zed-adv7511.dtsi
+++ b/arch/arm/boot/dts/zynq-zed-adv7511.dtsi
@@ -1,3 +1,5 @@
+#include <dt-bindings/dma/axi-dmac.h>
+
 / {
 	fpga_axi: fpga-axi@0 {
 		compatible = "simple-bus";
@@ -90,9 +92,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <64>;
-					adi,source-bus-type = <0>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 					adi,destination-bus-width = <64>;
-					adi,destination-bus-type = <1>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_STREAM>;
 				};
 			};
 		};

--- a/arch/arm/boot/dts/zynq-zed-imageon.dts
+++ b/arch/arm/boot/dts/zynq-zed-imageon.dts
@@ -11,6 +11,7 @@
 /dts-v1/;
 
 #include "zynq-zed.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 
 / {
 	fpga_axi: fpga-axi@0 {
@@ -134,9 +135,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <64>;
-					adi,source-bus-type = <0>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 					adi,destination-bus-width = <64>;
-					adi,destination-bus-type = <1>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_STREAM>;
 				};
 			};
 		};
@@ -206,9 +207,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <64>;
-					adi,source-bus-type = <2>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 					adi,destination-bus-width = <64>;
-					adi,destination-bus-type = <0>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				};
 			};
 		};

--- a/arch/arm64/boot/dts/xilinx/versal-vck190-reva-ad9081.dts
+++ b/arch/arm64/boot/dts/xilinx/versal-vck190-reva-ad9081.dts
@@ -11,6 +11,7 @@
  */
 
 #include "versal-vck190-revA.dts"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 #include <dt-bindings/iio/adc/adi,ad9081.h>
 #include <dt-bindings/jesd204/adxcvr.h>
@@ -109,8 +110,8 @@
 
 				dma-channel@0 {
 					reg = <0>;
-					adi,source-bus-type = <2>;
-					adi,destination-bus-type = <0>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				};
 			};
 		};
@@ -129,8 +130,8 @@
 
 				dma-channel@0 {
 					reg = <0>;
-					adi,source-bus-type = <0>;
-					adi,destination-bus-type = <2>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				};
 			};
 		};

--- a/arch/arm64/boot/dts/xilinx/versal-vck190-reva-ad9209.dts
+++ b/arch/arm64/boot/dts/xilinx/versal-vck190-reva-ad9209.dts
@@ -11,6 +11,7 @@
  */
 
 #include "versal-vck190-revA.dts"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 #include <dt-bindings/iio/adc/adi,ad9081.h>
 #include <dt-bindings/jesd204/adxcvr.h>
@@ -91,8 +92,8 @@
 
 				dma-channel@0 {
 					reg = <0>;
-					adi,source-bus-type = <2>;
-					adi,destination-bus-type = <0>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				};
 			};
 		};

--- a/arch/arm64/boot/dts/xilinx/versal-vpk180-reva-ad9081.dts
+++ b/arch/arm64/boot/dts/xilinx/versal-vpk180-reva-ad9081.dts
@@ -11,6 +11,7 @@
  */
 
 #include "versal-vpk180-revA.dts"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 #include <dt-bindings/iio/adc/adi,ad9081.h>
 #include <dt-bindings/jesd204/adxcvr.h>
@@ -109,8 +110,8 @@
 
 				dma-channel@0 {
 					reg = <0>;
-					adi,source-bus-type = <2>;
-					adi,destination-bus-type = <0>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				};
 			};
 		};
@@ -129,8 +130,8 @@
 
 				dma-channel@0 {
 					reg = <0>;
-					adi,source-bus-type = <0>;
-					adi,destination-bus-type = <2>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				};
 			};
 		};

--- a/arch/arm64/boot/dts/xilinx/versal-vpk180-reva-ad9082-m1-l8.dts
+++ b/arch/arm64/boot/dts/xilinx/versal-vpk180-reva-ad9082-m1-l8.dts
@@ -11,6 +11,7 @@
  */
 
 #include "versal-vpk180-revA.dts"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 #include <dt-bindings/iio/adc/adi,ad9081.h>
 #include <dt-bindings/jesd204/adxcvr.h>
@@ -109,8 +110,8 @@
 
 				dma-channel@0 {
 					reg = <0>;
-					adi,source-bus-type = <2>;
-					adi,destination-bus-type = <0>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				};
 			};
 		};
@@ -129,8 +130,8 @@
 
 				dma-channel@0 {
 					reg = <0>;
-					adi,source-bus-type = <0>;
-					adi,destination-bus-type = <2>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				};
 			};
 		};

--- a/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-reva-adrv2crr-fmc-reva.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-reva-adrv2crr-fmc-reva.dts
@@ -47,6 +47,7 @@
 
 #include "zynqmp-adrv9009-zu11eg-reva.dtsi"
 #include <dt-bindings/clock/ad9545.h>
+#include <dt-bindings/dma/axi-dmac.h>
 
 / {
 	ref_clk0: ref_clk_0 {
@@ -571,9 +572,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <0>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				adi,destination-bus-width = <32>;
-				adi,destination-bus-type = <1>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_STREAM>;
 			};
 		};
 	};
@@ -593,9 +594,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <32>;
-				adi,source-bus-type = <1>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_STREAM>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};

--- a/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-reva.dtsi
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-reva.dtsi
@@ -10,6 +10,7 @@
 
 #include "zynqmp.dtsi"
 #include "zynqmp-clk-ccf.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/pinctrl/pinctrl-zynqmp.h>
@@ -1337,9 +1338,9 @@
 				rx_dma_channel: dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <128>;
-					adi,source-bus-type = <2>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 					adi,destination-bus-width = <128>;
-					adi,destination-bus-type = <0>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				};
 			};
 		};
@@ -1359,9 +1360,9 @@
 				rx_obs_dma_channel: dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <128>;
-					adi,source-bus-type = <2>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 					adi,destination-bus-width = <128>;
-					adi,destination-bus-type = <0>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				};
 			};
 		};
@@ -1381,9 +1382,9 @@
 				tx_dma_channel: dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <128>;
-					adi,source-bus-type = <0>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 					adi,destination-bus-width = <256>;
-					adi,destination-bus-type = <1>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_STREAM>;
 				};
 			};
 		};

--- a/arch/arm64/boot/dts/xilinx/zynqmp-jupiter-sdr.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-jupiter-sdr.dts
@@ -12,6 +12,7 @@
 
 #include "zynqmp.dtsi"
 #include "zynqmp-clk-ccf.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/gpio/gpio.h>
@@ -458,9 +459,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <64>;
-					adi,source-bus-type = <2>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 					adi,destination-bus-width = <64>;
-					adi,destination-bus-type = <0>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				};
 			};
 		};
@@ -479,9 +480,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <64>;
-					adi,source-bus-type = <2>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 					adi,destination-bus-width = <64>;
-					adi,destination-bus-type = <0>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				};
 			};
 		};
@@ -500,9 +501,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <64>;
-					adi,source-bus-type = <0>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 					adi,destination-bus-width = <64>;
-					adi,destination-bus-type = <2>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				};
 			};
 		};
@@ -521,9 +522,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <64>;
-					adi,source-bus-type = <0>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 					adi,destination-bus-width = <64>;
-					adi,destination-bus-type = <2>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				};
 			};
 		};

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9144-fmc-ebz.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9144-fmc-ebz.dts
@@ -15,6 +15,7 @@
  */
 
 #include "zynqmp-zcu102-rev1.0.dts"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 #include <dt-bindings/jesd204/adxcvr.h>
 
@@ -56,9 +57,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <128>;
-					adi,source-bus-type = <0>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 					adi,destination-bus-width = <256>;
-					adi,destination-bus-type = <1>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_STREAM>;
 					adi,cyclic;
 				};
 			};

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9154-fmc-ebz.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9154-fmc-ebz.dts
@@ -15,6 +15,7 @@
  */
 
 #include "zynqmp-zcu102-rev1.0.dts"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 #include <dt-bindings/jesd204/adxcvr.h>
 
@@ -56,9 +57,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <128>;
-					adi,source-bus-type = <0>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 					adi,destination-bus-width = <256>;
-					adi,destination-bus-type = <1>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_STREAM>;
 					adi,cyclic;
 				};
 			};

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9208.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9208.dts
@@ -11,6 +11,7 @@
  */
 
 #include "zynqmp-zcu102-rev1.0.dts"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 #include <dt-bindings/iio/adc/adi,ad9208.h>
 #include <dt-bindings/jesd204/adxcvr.h>
@@ -60,9 +61,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <128>;
-					adi,source-bus-type = <1>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_STREAM>;
 					adi,destination-bus-width = <128>;
-					adi,destination-bus-type = <0>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				};
 			};
 		};

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9361-fmcomms2-3.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9361-fmcomms2-3.dts
@@ -11,6 +11,7 @@
  */
 
 #include "zynqmp-zcu102-rev1.0.dts"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 
 &i2c1 {
@@ -57,9 +58,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <64>;
-					adi,source-bus-type = <2>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 					adi,destination-bus-width = <64>;
-					adi,destination-bus-type = <0>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				};
 			};
 		};
@@ -79,9 +80,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <64>;
-					adi,source-bus-type = <0>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 					adi,destination-bus-width = <64>;
-					adi,destination-bus-type = <2>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				};
 			};
 		};

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9361-fmcomms5.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9361-fmcomms5.dts
@@ -10,6 +10,7 @@
  */
 
 #include "zynqmp-zcu102-rev1.0.dts"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 
 &i2c1 {
@@ -53,9 +54,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <128>;
-					adi,source-bus-type = <2>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 					adi,destination-bus-width = <64>;
-					adi,destination-bus-type = <0>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				};
 			};
 		};
@@ -75,9 +76,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <64>;
-					adi,source-bus-type = <0>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 					adi,destination-bus-width = <128>;
-					adi,destination-bus-type = <2>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				};
 			};
 		};

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9364-fmcomms4.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9364-fmcomms4.dts
@@ -10,6 +10,7 @@
  */
 
 #include "zynqmp-zcu102-rev1.0.dts"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 
 &i2c1 {
@@ -56,9 +57,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <64>;
-					adi,source-bus-type = <2>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 					adi,destination-bus-width = <64>;
-					adi,destination-bus-type = <0>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				};
 			};
 		};
@@ -78,9 +79,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <64>;
-					adi,source-bus-type = <0>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 					adi,destination-bus-width = <64>;
-					adi,destination-bus-type = <2>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				};
 			};
 		};

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9694.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9694.dts
@@ -11,6 +11,7 @@
  */
 
 #include "zynqmp-zcu102-rev1.0.dts"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 #include <dt-bindings/iio/adc/adi,ad9208.h>
 #include <dt-bindings/jesd204/adxcvr.h>
@@ -75,9 +76,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <128>;
-					adi,source-bus-type = <2>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 					adi,destination-bus-width = <128>;
-					adi,destination-bus-type = <0>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				};
 			};
 		};

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9695.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9695.dts
@@ -11,6 +11,7 @@
  */
 
 #include "zynqmp-zcu102-rev1.0.dts"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 #include <dt-bindings/iio/adc/adi,ad9208.h>
 #include <dt-bindings/jesd204/adxcvr.h>
@@ -75,9 +76,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <128>;
-					adi,source-bus-type = <1>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_STREAM>;
 					adi,destination-bus-width = <128>;
-					adi,destination-bus-type = <0>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				};
 			};
 		};

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9783.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9783.dts
@@ -8,6 +8,7 @@
 /dts-v1/;
 
 #include "zynqmp-zcu102-rev1.0.dts"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 
 / {
@@ -58,9 +59,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <128>;
-					adi,source-bus-type = <0>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 					adi,destination-bus-width = <128>;
-					adi,destination-bus-type = <1>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_STREAM>;
 				};
 			};
 		};

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9002-rx2tx2.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9002-rx2tx2.dts
@@ -8,6 +8,7 @@
  * Copyright (C) 2020 Analog Devices Inc.
  */
 #include "zynqmp-zcu102-rev1.0.dts"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 #include <dt-bindings/gpio/gpio.h>
 
@@ -49,9 +50,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <64>;
-					adi,source-bus-type = <2>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 					adi,destination-bus-width = <64>;
-					adi,destination-bus-type = <0>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				};
 			};
 		};
@@ -70,9 +71,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <64>;
-					adi,source-bus-type = <0>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 					adi,destination-bus-width = <64>;
-					adi,destination-bus-type = <2>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				};
 			};
 		};

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9002.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9002.dts
@@ -8,6 +8,7 @@
  * Copyright (C) 2020 Analog Devices Inc.
  */
 #include "zynqmp-zcu102-rev1.0.dts"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 #include <dt-bindings/gpio/gpio.h>
 
@@ -48,9 +49,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <64>;
-					adi,source-bus-type = <2>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 					adi,destination-bus-width = <64>;
-					adi,destination-bus-type = <0>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				};
 			};
 		};
@@ -69,9 +70,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <64>;
-					adi,source-bus-type = <2>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 					adi,destination-bus-width = <64>;
-					adi,destination-bus-type = <0>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				};
 			};
 		};
@@ -90,9 +91,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <64>;
-					adi,source-bus-type = <0>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 					adi,destination-bus-width = <64>;
-					adi,destination-bus-type = <2>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				};
 			};
 		};
@@ -111,9 +112,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <64>;
-					adi,source-bus-type = <0>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 					adi,destination-bus-width = <64>;
-					adi,destination-bus-type = <2>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				};
 			};
 		};

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9008-1.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9008-1.dts
@@ -11,6 +11,7 @@
  * Copyright (C) 2019 Analog Devices Inc.
  */
 #include "zynqmp-zcu102-rev1.0.dts"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 #include <dt-bindings/jesd204/adxcvr.h>
 
@@ -57,9 +58,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <64>;
-					adi,source-bus-type = <2>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 					adi,destination-bus-width = <64>;
-					adi,destination-bus-type = <0>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				};
 			};
 		};

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9008-2.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9008-2.dts
@@ -11,6 +11,7 @@
  * Copyright (C) 2019 Analog Devices Inc.
  */
 #include "zynqmp-zcu102-rev1.0.dts"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 #include <dt-bindings/jesd204/adxcvr.h>
 
@@ -57,9 +58,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <128>;
-					adi,source-bus-type = <2>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 					adi,destination-bus-width = <64>;
-					adi,destination-bus-type = <0>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				};
 			};
 		};
@@ -79,9 +80,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <128>;
-					adi,source-bus-type = <0>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 					adi,destination-bus-width = <128>;
-					adi,destination-bus-type = <2>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				};
 			};
 		};

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9009-fmcomms8.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9009-fmcomms8.dts
@@ -11,6 +11,7 @@
  * Copyright (C) 2020 Analog Devices Inc.
  */
 #include "zynqmp-zcu102-rev1.0.dts"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 #include <dt-bindings/iio/frequency/hmc7044.h>
 #include <dt-bindings/jesd204/adxcvr.h>
@@ -216,9 +217,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <128>;
-					adi,source-bus-type = <2>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 					adi,destination-bus-width = <128>;
-					adi,destination-bus-type = <0>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				};
 			};
 		};
@@ -238,9 +239,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <128>;
-					adi,source-bus-type = <2>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 					adi,destination-bus-width = <128>;
-					adi,destination-bus-type = <0>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				};
 			};
 		};
@@ -260,9 +261,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <128>;
-					adi,source-bus-type = <0>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 					adi,destination-bus-width = <256>;
-					adi,destination-bus-type = <1>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_STREAM>;
 				};
 			};
 		};

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9009.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9009.dts
@@ -11,6 +11,7 @@
  * Copyright (C) 2019 Analog Devices Inc.
  */
 #include "zynqmp-zcu102-rev1.0.dts"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 #include <dt-bindings/jesd204/adxcvr.h>
 
@@ -75,9 +76,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <64>;
-					adi,source-bus-type = <2>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 					adi,destination-bus-width = <64>;
-					adi,destination-bus-type = <0>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				};
 			};
 		};
@@ -97,9 +98,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <128>;
-					adi,source-bus-type = <2>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 					adi,destination-bus-width = <64>;
-					adi,destination-bus-type = <0>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				};
 			};
 		};
@@ -119,9 +120,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <128>;
-					adi,source-bus-type = <0>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 					adi,destination-bus-width = <128>;
-					adi,destination-bus-type = <2>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				};
 			};
 		};

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9371.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9371.dts
@@ -9,6 +9,7 @@
  * Copyright 2016-2020 Analog Devices Inc.
  */
 #include "zynqmp-zcu102-rev1.0.dts"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 #include <dt-bindings/jesd204/adxcvr.h>
 
@@ -56,9 +57,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <64>;
-					adi,source-bus-type = <2>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 					adi,destination-bus-width = <64>;
-					adi,destination-bus-type = <0>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				};
 			};
 		};
@@ -78,9 +79,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <64>;
-					adi,source-bus-type = <2>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 					adi,destination-bus-width = <64>;
-					adi,destination-bus-type = <0>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				};
 			};
 		};
@@ -100,9 +101,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <64>;
-					adi,source-bus-type = <0>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 					adi,destination-bus-width = <128>;
-					adi,destination-bus-type = <1>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_STREAM>;
 				};
 			};
 		};

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-fmcdaq2.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-fmcdaq2.dts
@@ -10,6 +10,7 @@
  */
 
 #include "zynqmp-zcu102-rev1.0.dts"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 #include <dt-bindings/jesd204/adxcvr.h>
 
@@ -57,9 +58,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <64>;
-					adi,source-bus-type = <2>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 					adi,destination-bus-width = <64>;
-					adi,destination-bus-type = <0>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				};
 			};
 		};
@@ -79,9 +80,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <128>;
-					adi,source-bus-type = <0>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 					adi,destination-bus-width = <128>;
-					adi,destination-bus-type = <2>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				};
 			};
 		};

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-fmcdaq3.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-fmcdaq3.dts
@@ -10,6 +10,7 @@
  */
 
 #include "zynqmp-zcu102-rev1.0.dts"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 #include <dt-bindings/jesd204/adxcvr.h>
 
@@ -56,9 +57,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <64>;
-					adi,source-bus-type = <1>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_STREAM>;
 					adi,destination-bus-width = <64>;
-					adi,destination-bus-type = <0>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				};
 			};
 		};
@@ -77,9 +78,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <128>;
-					adi,source-bus-type = <0>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 					adi,destination-bus-width = <128>;
-					adi,destination-bus-type = <1>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_STREAM>;
 				};
 			};
 		};

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-fmclidar1.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-fmclidar1.dts
@@ -11,6 +11,7 @@
 /dts-v1/;
 
 #include "zynqmp-zcu102-rev1.0.dts"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 #include <dt-bindings/jesd204/adxcvr.h>
 
@@ -145,9 +146,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <256>;
-					adi,source-bus-type = <2>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 					adi,destination-bus-width = <64>;
-					adi,destination-bus-type = <0>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				};
 			};
 		};

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-revB-ad9361-fmcomms2-3.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-revB-ad9361-fmcomms2-3.dts
@@ -7,6 +7,7 @@
  */
 
 #include "zynqmp-zcu102-revB.dts"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 
 &i2c1 {
@@ -52,9 +53,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <64>;
-					adi,source-bus-type = <2>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 					adi,destination-bus-width = <64>;
-					adi,destination-bus-type = <0>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				};
 			};
 
@@ -74,9 +75,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <64>;
-					adi,source-bus-type = <0>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 					adi,destination-bus-width = <64>;
-					adi,destination-bus-type = <2>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				};
 			};
 		};

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-revB-ad9364-fmcomms4.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-revB-ad9364-fmcomms4.dts
@@ -7,6 +7,7 @@
  */
 
 #include "zynqmp-zcu102-revB.dts"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 
 &i2c1 {
@@ -52,9 +53,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <64>;
-					adi,source-bus-type = <2>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 					adi,destination-bus-width = <64>;
-					adi,destination-bus-type = <0>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				};
 			};
 		};
@@ -73,9 +74,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <64>;
-					adi,source-bus-type = <0>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 					adi,destination-bus-width = <64>;
-					adi,destination-bus-type = <2>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				};
 			};
 		};

--- a/arch/microblaze/boot/dts/vc707_fmcjesdadc1.dts
+++ b/arch/microblaze/boot/dts/vc707_fmcjesdadc1.dts
@@ -12,6 +12,7 @@
 /dts-v1/;
 
 #include "vc707.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/jesd204/adxcvr.h>
 
 #define fmc_i2c fmc1_hpc_iic
@@ -64,9 +65,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <2>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};

--- a/arch/microblaze/boot/dts/vc707_fmcomms1.dts
+++ b/arch/microblaze/boot/dts/vc707_fmcomms1.dts
@@ -1,6 +1,7 @@
 
 /dts-v1/;
 #include "vc707.dtsi"
+#include <dt-bindings/dma/axi-dmac.h>
 
 #define fmc_i2c fmc1_hpc_iic
 
@@ -46,9 +47,9 @@
 			dma-channel@0 {
 				reg = <0>;
 				adi,source-bus-width = <64>;
-				adi,source-bus-type = <2>;
+				adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 				adi,destination-bus-width = <64>;
-				adi,destination-bus-type = <0>;
+				adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 			};
 		};
 	};

--- a/arch/nios2/boot/dts/a10gx_adrv9009.dts
+++ b/arch/nios2/boot/dts/a10gx_adrv9009.dts
@@ -14,6 +14,7 @@
 
 #include <dt-bindings/iio/frequency/ad9528.h>
 #include <dt-bindings/interrupt-controller/irq.h>
+#include <dt-bindings/dma/axi-dmac.h>
 
 / {
 	model = "ALTR,system_bd";
@@ -773,9 +774,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <128>;
-					adi,source-bus-type = <0>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 					adi,destination-bus-width = <128>;
-					adi,destination-bus-type = <1>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_STREAM>;
 				};
 			};
 		};
@@ -796,9 +797,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <64>;
-					adi,source-bus-type = <2>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 					adi,destination-bus-width = <128>;
-					adi,destination-bus-type = <0>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				};
 			};
 		};
@@ -819,9 +820,9 @@
 				dma-channel@0 {
 					reg = <0>;
 					adi,source-bus-width = <64>;
-					adi,source-bus-type = <2>;
+					adi,source-bus-type = <AXI_DMAC_BUS_TYPE_FIFO>;
 					adi,destination-bus-width = <128>;
-					adi,destination-bus-type = <0>;
+					adi,destination-bus-type = <AXI_DMAC_BUS_TYPE_AXI_MM>;
 				};
 			};
 		};


### PR DESCRIPTION
## PR Description

Replace use of hardcoded values with the AXI DMA bus type macros.

There is already a dt-bindings/dma/axi-dmac.h file that defines macros for the adi,source-bus-type and adi,destination-bus-type properties. However, this was only being used in about half of the dts files that could make use of it. Update the rest of the dts files to use these macros to make it easier to see what is actually being specified.

## PR Type
cleanup

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware

