### PR TITLE
clk: adi: clk-ad9545: remove iio from includes

### DIFF
--- a/drivers/clk/adi/clk-ad9545-i2c.c
+++ b/drivers/clk/adi/clk-ad9545-i2c.c
@@ -5,14 +5,15 @@
  * Copyright 2020 Analog Devices Inc.
  */
 
-#include "clk-ad9545.h"
 #include <linux/device.h>
 #include <linux/err.h>
 #include <linux/i2c.h>
-#include <linux/iio/iio.h>
 #include <linux/module.h>
+#include <linux/mod_devicetable.h>
 #include <linux/regmap.h>
 #include <linux/slab.h>
+
+#include "clk-ad9545.h"
 
 static const struct regmap_config ad9545_regmap_config = {
 	.reg_bits = 16,

--- a/drivers/clk/adi/clk-ad9545-spi.c
+++ b/drivers/clk/adi/clk-ad9545-spi.c
@@ -5,15 +5,16 @@
  * Copyright 2020 Analog Devices Inc.
  */
 
-#include "clk-ad9545.h"
 #include <linux/bitfield.h>
 #include <linux/device.h>
 #include <linux/err.h>
-#include <linux/iio/iio.h>
 #include <linux/module.h>
+#include <linux/mod_devicetable.h>
 #include <linux/regmap.h>
 #include <linux/slab.h>
 #include <linux/spi/spi.h>
+
+#include "clk-ad9545.h"
 
 #define AD9545_CONFIG_0			0x0000
 


### PR DESCRIPTION
## PR Description

IIO is not needed at all for the ad9545 device (it's a clock provider). Remove it.

While at it, added mod_devicetable.h for the id tables and placed clk-ad9545.h in it's proper location.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
