### PR TITLE
arm: dts: zynq: remove dt-bindings/dma/axi-dmac.h include

### DIFF
--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad4696.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad4696.dts
@@ -8,7 +8,6 @@
  */
 /dts-v1/;
 
-#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/iio/adi,ad4695.h>

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad7944.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad7944.dts
@@ -11,7 +11,6 @@
  */
 /dts-v1/;
 
-#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad7985.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad7985.dts
@@ -11,7 +11,6 @@
  */
 /dts-v1/;
 
-#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 

--- a/arch/arm/boot/dts/zynq-zed-adv7511-ad7986.dts
+++ b/arch/arm/boot/dts/zynq-zed-adv7511-ad7986.dts
@@ -11,7 +11,6 @@
  */
 /dts-v1/;
 
-#include <dt-bindings/dma/axi-dmac.h>
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 


### PR DESCRIPTION

## PR Description

Remove the include of dt-bindings/dma/axi-dmac.h from all .dts files. This is no longer needed since patch 6a36624bf174 "tree-wide: dts: remove adi,channels node for AXI DMAC".

This was missed in #2622.

## PR Type
cleanup

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
