### PR TITLE
Added support for ADP1051 and ADP1055 on existing ADP1050 driver

### DIFF
--- a/Documentation/devicetree/bindings/hwmon/pmbus/adi,adp1050.yaml
+++ b/Documentation/devicetree/bindings/hwmon/pmbus/adi,adp1050.yaml
@@ -8,18 +8,33 @@ title: Analog Devices ADP1050 digital controller with PMBus interface
 
 maintainers:
   - Radu Sabau <radu.sabau@analog.com>
+  - Alexis Czezar Torreno <alexisczezar.torreno@analog.com>
 
 description: |
-   The ADP1050 is used to monitor system voltages, currents and temperatures.
+   The ADP1050, ADP1051, and ADP1055 are used to monitor system voltages, 
+   currents, power and temperatures.
+   
    Through the PMBus interface, the ADP1050 targets isolated power supplies
    and has four individual monitors for input/output voltage, input current
    and temperature.
    Datasheet:
      https://www.analog.com/en/products/adp1050.html
 
+   Through the PMBus interface, the ADP1051 targets isolated power supplies
+   and has six individual monitors for input/output voltage, input/output 
+   current and temperature.
+   Datasheet:
+     https://www.analog.com/en/products/adp1051.html
+
+   Through the PMBus interface, the ADP1055 targets isolated power supplies
+   and has six individual monitors for input/output voltage, input/output 
+   current, power, and temperature.
+   Datasheet:
+     https://www.analog.com/en/products/adp1055.html
+
 properties:
   compatible:
-    const: adi,adp1050
+    const: adi,adp1050 adi,adp1051 adi,adp1055
 
   reg:
     maxItems: 1
@@ -39,11 +54,20 @@ examples:
         #address-cells = <1>;
         #size-cells = <0>;
         clock-frequency = <100000>;
+        status = "okay";
 
         hwmon@70 {
-            compatible = "adi,adp1050";
+            compatible = "adi,adp1050", "adi,adp1051";
             reg = <0x70>;
             vcc-supply = <&vcc>;
+            status = "okay";
+        };
+
+        hwmon@4b {
+            compatible = "adi,adp1055";
+            reg = <0x4b>;
+            vcc-supply = <&vcc>;
+            status = "okay";
         };
     };
 ...

--- a/Documentation/hwmon/adp1050.rst
+++ b/Documentation/hwmon/adp1050.rst
@@ -12,19 +12,35 @@ Supported chips:
     Addresses scanned: I2C 0x70 - 0x77
 
     Datasheet: https://www.analog.com/media/en/technical-documentation/data-sheets/ADP1050.pdf
+    
+  * Analog Devices ADP1051
+
+    Prefix: 'adp1051'
+
+    Addresses scanned: I2C 0x70 - 0x77
+
+    Datasheet: https://www.analog.com/media/en/technical-documentation/data-sheets/ADP1051.pdf
+    
+  * Analog Devices ADP1055
+
+    Prefix: 'adp1055'
+
+    Addresses scanned: I2C 0x4B - 0x77
+
+    Datasheet: https://www.analog.com/media/en/technical-documentation/data-sheets/ADP1055.pdf
 
 Authors:
 
   - Radu Sabau <radu.sabau@analog.com>
-
+  - Alexis Czezar Torreno <alexisczezar.torreno@analog.com>
 
 Description
 -----------
 
-This driver supprts hardware monitoring for Analog Devices ADP1050 Digital
-Controller for Isolated Power Supply with PMBus interface.
+This driver supports hardware monitoring for Analog Devices ADP1050, ADP1051, and 
+ADP1055 Digital Controller for Isolated Power Supply with PMBus interface.
 
-The ADP1050 is an advanced digital controller with a PMBus™
+The ADP105X is an advanced digital controller with a PMBus™
 interface targeting high density, high efficiency dc-to-dc power
 conversion used to monitor system temperatures, voltages and currents.
 Through the PMBus interface, the device can monitor input/output voltages,
@@ -49,16 +65,45 @@ Sysfs Attributes
 in1_label         "vin"
 in1_input         Measured input voltage
 in1_alarm	  Input voltage alarm
+in1_crit          Critical maximum input voltage
+in1_crit_alarm    Input voltage high alarm
+in1_lcrit         Critical minimum input voltage
+in1_lcrit_alarm   Input voltage critical low alarm
 in2_label	  "vout1"
 in2_input	  Measured output voltage
 in2_crit	  Critical maximum output voltage
 in2_crit_alarm    Output voltage high alarm
 in2_lcrit	  Critical minimum output voltage
 in2_lcrit_alarm	  Output voltage critical low alarm
+in2_max           Critical maximum output voltage
+in2_max_alarm     Output voltage critical max alarm
+in2_min           Critical minimum output voltage
+in2_min_alarm     Output voltage critical min alarm
 curr1_label	  "iin"
-curr1_input	  Measured input current.
+curr1_input	  Measured input current
 curr1_alarm	  Input current alarm
+curr1_crit        Critical maximum input current
+curr1_crit_alarm  Input current high alarm
+curr2_label       "iout1"
+curr2_input       Measured output current
+curr2_crit        Critical maximum output current
+curr2_crit_alarm  Output current high alarm
+curr2_lcrit       Critical minimum output current
+curr2_lcrit_alarm Output current critical low alarm
+curr2_max         Critical maximum output current
+curr2_max_alarm   Output current critical max alarm
+power1_label      "pout1"
+power1_input      Measured output power
+power1_crit       Critical maximum output power
+power1_crit_alarm Output power high alarm
 temp1_input       Measured temperature
 temp1_crit	  Critical high temperature
 temp1_crit_alarm  Chip temperature critical high alarm
+temp1_max         Critical maximum temperature
+temp1_max_alarm   Temperature critical max alarm
+temp2_input       Measured temperature
+temp2_crit        Critical high temperature
+temp2_crit_alarm  Chip temperature critical high alarm
+temp2_max         Critical maximum temperature
+temp2_max_alarm   Temperature critical max alarm
 ================= ========================================

--- a/drivers/hwmon/pmbus/adp1050.c
+++ b/drivers/hwmon/pmbus/adp1050.c
@@ -4,12 +4,21 @@
  *
  * Copyright (C) 2024 Analog Devices, Inc.
  */
+
+
+
 #include <linux/bits.h>
 #include <linux/i2c.h>
 #include <linux/module.h>
 #include <linux/mod_devicetable.h>
 
 #include "pmbus.h"
+
+enum ADP1050_type {
+	ADP1050,
+	ADP1051,
+	ADP1055,
+};
 
 static struct pmbus_driver_info adp1050_info = {
 	.pages = 1,
@@ -18,26 +27,68 @@ static struct pmbus_driver_info adp1050_info = {
 	.format[PSC_CURRENT_IN] = linear,
 	.format[PSC_TEMPERATURE] = linear,
 	.func[0] = PMBUS_HAVE_VOUT | PMBUS_HAVE_STATUS_VOUT
-		| PMBUS_HAVE_VIN | PMBUS_HAVE_STATUS_INPUT
-		| PMBUS_HAVE_IIN | PMBUS_HAVE_TEMP
-		| PMBUS_HAVE_STATUS_TEMP,
+		   | PMBUS_HAVE_VIN | PMBUS_HAVE_STATUS_INPUT
+		   | PMBUS_HAVE_IIN | PMBUS_HAVE_TEMP
+		   | PMBUS_HAVE_STATUS_TEMP,
 };
 
-/* 6.1 probe() function still uses the second struct i2c_device_id argument */
-static int adp1050_probe(struct i2c_client *client,
-			 const struct i2c_device_id *id)
+static struct pmbus_driver_info adp1051_info = {
+	.pages = 1,
+	.format[PSC_VOLTAGE_IN] = linear,
+	.format[PSC_VOLTAGE_OUT] = linear,
+	.format[PSC_CURRENT_IN] = linear,
+	.format[PSC_TEMPERATURE] = linear,
+	.func[0] = PMBUS_HAVE_VIN | PMBUS_HAVE_IIN | PMBUS_HAVE_VOUT
+		   | PMBUS_HAVE_IOUT | PMBUS_HAVE_TEMP | PMBUS_HAVE_STATUS_VOUT
+		   | PMBUS_HAVE_STATUS_IOUT | PMBUS_HAVE_STATUS_INPUT
+		   | PMBUS_HAVE_STATUS_TEMP,
+};
+
+static struct pmbus_driver_info adp1055_info = {
+	.pages = 1,
+	.format[PSC_VOLTAGE_IN] = linear,
+	.format[PSC_VOLTAGE_OUT] = linear,
+	.format[PSC_CURRENT_IN] = linear,
+	.format[PSC_TEMPERATURE] = linear,
+	.func[0] = PMBUS_HAVE_VIN | PMBUS_HAVE_IIN | PMBUS_HAVE_VOUT
+		   | PMBUS_HAVE_IOUT | PMBUS_HAVE_TEMP2 | PMBUS_HAVE_TEMP3
+		   | PMBUS_HAVE_POUT | PMBUS_HAVE_STATUS_VOUT
+		   | PMBUS_HAVE_STATUS_IOUT | PMBUS_HAVE_STATUS_INPUT
+		   | PMBUS_HAVE_STATUS_TEMP,
+};
+
+
+static int adp1050_probe(struct i2c_client *client)
 {
-	return pmbus_do_probe(client, &adp1050_info);
+	enum ADP1050_type type;
+
+	type = (enum ADP1050_type)(uintptr_t)device_get_match_data(&client->dev);
+
+	switch (type) {
+	case ADP1050:
+		return pmbus_do_probe(client, &adp1050_info);
+	case ADP1051:
+		return pmbus_do_probe(client, &adp1051_info);
+	case ADP1055:
+		return pmbus_do_probe(client, &adp1055_info);
+	default:
+		return -EINVAL;
+	}
 }
 
 static const struct i2c_device_id adp1050_id[] = {
-	{"adp1050", 0},
+	{"adp1050", ADP1050},
+	{"adp1051", ADP1051},
+	{"adp1055", ADP1055},
 	{}
 };
+
 MODULE_DEVICE_TABLE(i2c, adp1050_id);
 
 static const struct of_device_id adp1050_of_match[] = {
-	{ .compatible = "adi,adp1050"},
+	{ .compatible = "adi,adp1050", .data = (void *)ADP1050},
+	{ .compatible = "adi,adp1051", .data = (void *)ADP1051},
+	{ .compatible = "adi,adp1055", .data = (void *)ADP1055},
 	{}
 };
 MODULE_DEVICE_TABLE(of, adp1050_of_match);


### PR DESCRIPTION
## PR Description

- This adds ADP1051 and ADP1055 driver support on existing ADP1050 Driver.
- Datasheets [ADP1051](https://www.analog.com/media/en/technical-documentation/data-sheets/ADP1051.pdf), [ADP1055](https://www.analog.com/media/en/technical-documentation/data-sheets/ADP1055.pdf).
- Tested on RPI4 using the following eval boards: [ADP1051-EVB](https://www.analog.com/media/en/technical-documentation/user-guides/UG-566.pdf), [ADP1055-EVB](https://www.analog.com/media/en/technical-documentation/user-guides/ADP1055-EVALZ_UG-710.pdf).


## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
