### PR TITLE
iio: adc: ad7768: Fix scale reading

### DIFF
--- a/drivers/iio/adc/ad7768.c
+++ b/drivers/iio/adc/ad7768.c
@@ -806,7 +806,10 @@ static int ad7768_probe(struct spi_device *spi)
 	if (!st->chip_info)
 		return -ENODEV;
 
-	ret = devm_regulator_get_enable(&spi->dev, "vref");
+	st->vref = devm_regulator_get(&spi->dev, "vref");
+	if (IS_ERR(st->vref))
+		return PTR_ERR(st->vref);
+	ret = regulator_enable(st->vref);
 	if (ret)
 		return ret;
 


### PR DESCRIPTION
ad7768_scale() is dependent on st->vref.

Fixes: 75497689e144 ("iio: adc: ad7768: simplify probe")

## PR Description

- Please replace this comment with a summary of your changes, and add any context
necessary to understand them. List any dependencies required for this change.
- To check the checkboxes below, insert a 'x' between square brackets (without
any space), or simply check them after publishing the PR.
- If you changes include a breaking change, please specify dependent PRs in the
description and try to push all related PRs simultaneously.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
