### PR TITLE
iio: adc: ad7768: Fix scale reading

### DIFF
--- a/drivers/iio/adc/ad7768.c
+++ b/drivers/iio/adc/ad7768.c
@@ -103,9 +103,9 @@ struct ad7768_avail_freq {
 struct ad7768_state {
 	struct spi_device *spi;
 	struct mutex lock;
-	struct regulator *vref;
 	struct clk *mclk;
 	struct gpio_chip gpiochip;
+	u64 vref_nv;
 	unsigned int datalines;
 	unsigned int sampling_freq;
 	enum ad7768_power_modes power_mode;
@@ -473,16 +473,9 @@ static ssize_t ad7768_scale(struct device *dev,
 	struct iio_dev *indio_dev = dev_to_iio_dev(dev);
 	const struct iio_chan_spec *chan = &indio_dev->channels[0];
 	struct ad7768_state *st = ad7768_get_data(indio_dev);
-	u64 vref_nv;
 	u64 scale;
-	int ret;
 
-	ret = regulator_get_voltage(st->vref);
-	if (ret < 0)
-		return ret;
-
-	vref_nv = (u64)ret * NANO * 2;
-	scale = div64_ul(vref_nv, BIT(chan->scan_type.realbits));
+	scale = div64_ul(st->vref_nv, BIT(chan->scan_type.realbits));
 
 	return scnprintf(buf, PAGE_SIZE, "0.%012llu\n", scale);
 }
@@ -806,9 +799,11 @@ static int ad7768_probe(struct spi_device *spi)
 	if (!st->chip_info)
 		return -ENODEV;
 
-	ret = devm_regulator_get_enable(&spi->dev, "vref");
-	if (ret)
+	ret = devm_regulator_get_enable_read_voltage(&spi->dev, "vref");
+	if (ret < 0)
 		return ret;
+
+	st->vref_nv = (u64)ret * NANO * 2;
 
 	st->mclk = devm_clk_get_enabled(&spi->dev, "mclk");
 	if (IS_ERR(st->mclk))


### PR DESCRIPTION
ad7768_scale() is dependent on st->vref.

Fixes: 92cc452e8f13 ("iio: adc: ad7768: simplify probe")

## PR Description

- Please replace this comment with a summary of your changes, and add any context
necessary to understand them. List any dependencies required for this change.
- To check the checkboxes below, insert a 'x' between square brackets (without
any space), or simply check them after publishing the PR.
- If you changes include a breaking change, please specify dependent PRs in the
description and try to push all related PRs simultaneously.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
