### PR TITLE
iio: accel: adxl380: fix raw sample read

### DIFF
--- a/drivers/iio/accel/adxl380.c
+++ b/drivers/iio/accel/adxl380.c
@@ -1181,7 +1181,7 @@ static int adxl380_read_raw(struct iio_dev *indio_dev,
 			return ret;
 
 		ret = adxl380_read_chn(st, chan->address);
-		if (ret)
+		if (ret < 0)
 			return ret;
 
 		iio_device_release_direct_mode(indio_dev);


### PR DESCRIPTION
## PR Description

The adxl380_read_chn function returns either a negative value in case an error occurs or the actual sample.

Check only for negative values after a channel is read.

Link: https://lore.kernel.org/lkml/20241101095202.20121-1-antoniu.miclaus@analog.com/
Fixes: 2535e0ec3546 ("iio: accel: add ADXL380 driver")

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
