### PR TITLE
AD9081 dev

### DIFF
--- a/drivers/iio/adc/ad9081.c
+++ b/drivers/iio/adc/ad9081.c
@@ -3532,7 +3532,7 @@ static ssize_t ad9081_debugfs_read(struct file *file, char __user *userbuf,
 	struct ad9081_phy *phy = conv->phy;
 	adi_ad9081_deser_mode_e dmode;
 	adi_cms_jesd_prbs_pattern_e prbs;
-	s16 eye_data[192];
+	s16 eye_data[195];
 	u64 val = 0;
 	ssize_t len = 0;
 	int ret, i, j, spo_steps;
@@ -3622,7 +3622,7 @@ static ssize_t ad9081_debugfs_read(struct file *file, char __user *userbuf,
 
 			switch (dmode) {
 			case AD9081_QUART_RATE:
-				spo_steps = 32;
+				spo_steps = 33;
 
 				ret = adi_ad9081_jesd_cal_bg_cal_pause(&phy->ad9081);
 				if (ret)
@@ -3634,7 +3634,7 @@ static ssize_t ad9081_debugfs_read(struct file *file, char __user *userbuf,
 				ret = adi_ad9081_jesd_cal_bg_cal_start(&phy->ad9081);
 				break;
 			case AD9081_HALF_RATE:
-				spo_steps = 64;
+				spo_steps = 65;
 				ret = adi_ad9081_jesd_rx_hr_two_dim_eye_scan(&phy->ad9081,
 					lane, prbs, duration, eye_data);
 				break;
@@ -3654,7 +3654,7 @@ static ssize_t ad9081_debugfs_read(struct file *file, char __user *userbuf,
 				lane, spo_steps, phy->jrx_link_tx[0].lane_rate_kbps);
 
 			for (i = 0; i < (spo_steps * 3); i += 3)
-				if (eye_data[i])
+				if (eye_data[i + 1] || eye_data[i + 2])
 					len += snprintf(phy->dbuf + len,
 						sizeof(phy->dbuf),
 						"%d,%d,%d\n", eye_data[i],

--- a/drivers/iio/adc/ad9081/adi_ad9081.h
+++ b/drivers/iio/adc/ad9081/adi_ad9081.h
@@ -610,6 +610,24 @@ typedef enum {
 } adi_ad9081_adc_pfir_gain_e;
 
 /*!
+*@brief Enumerates ADC PFIR Coefficient Load Select
+*/
+typedef enum {
+	AD9081_ADC_PFIR_REAL_I_LOAD =
+		0x1, /*!< Set the coefficients streamed type to real I */
+	AD9081_ADC_PFIR_REAL_Q_LOAD =
+		0x2, /*!< Set the coefficients streamed type to real Q */
+	AD9081_ADC_PFIR_REAL_CROSS_I_LOAD =
+		0x4, /*!< Set the coefficients streamed type to real cross I */
+	AD9081_ADC_PFIR_REAL_CROSS_Q_LOAD =
+		0x8, /*!< Set the coefficients streamed type to real cross Q */
+	AD9081_ADC_PFIR_COMPLEX_LOAD =
+		0x10, /*!< Set the coefficients streamed type to complex mode */
+	AD9081_ADC_PFIR_COEFF_CLEAR =
+		0x20 /*!< Clear currently selected main coefficient bank */
+} adi_ad9081_adc_pfir_coeff_load_sel_e;
+
+/*!
  *@brief Enumerates ADC Bypass mode
  */
 typedef enum {
@@ -774,6 +792,21 @@ typedef enum {
 	AD9081_CAL_MODE_BYPASS =
 		2 /*!< Bypass 204C QR Calibration and load CTLE Coefficients*/
 } adi_ad9081_cal_mode_e;
+
+/*!
+ * @brief Programmable gain scaling on PFIR Structure
+ */
+typedef struct {
+	adi_ad9081_adc_pfir_gain_e
+		ix_gain; /*!< Programmable scalar gain at the output of A(z) FIR filter  */
+	adi_ad9081_adc_pfir_gain_e
+		iy_gain; /*!< Programmable scalar gain at the output of B(z) FIR filter  */
+	adi_ad9081_adc_pfir_gain_e
+		qx_gain; /*!< Programmable scalar gain at the output of C(z) FIR filter  */
+	adi_ad9081_adc_pfir_gain_e
+		qy_gain; /*!< Programmable scalar gain at the output of D(z) FIR filter  */
+} adi_ad9081_adc_pfir_gain_t;
+
 /*!
  * @brief Per lane JESD Serializer Settings
  */
@@ -806,7 +839,7 @@ typedef struct {
 	uint8_t ctle_coeffs[8][4]; /*Per lane CTLE coefficient settings */
 	uint8_t lane_mapping
 		[2]
-		[8]; /*Deserialise Lane Mapping, Map Virtual Converter to Physical Lane, index is logical lane, value is physical lane*/
+		[8]; /*Deserialise Lane Mapping, Map Virtual Converter to Physical Lane, index is physical lane, value is logical lane, register flip adjusted for in funct*/
 } adi_ad9081_des_settings_t;
 
 /*!
@@ -1172,6 +1205,7 @@ int32_t adi_ad9081_device_main_auto_clk_gen_enable(adi_ad9081_device_t *device,
  * @ingroup tx_data_path_setup
  * @brief  System Top Level API. \n Startup Tx As NCO Test Mode
  *         This API will be called after adi_ad9081_device_clk_config_set().
+ * @deprecated call adi_ad9081_device_startup_nco_test_mode
  *
  * @param  device         Pointer to the device structure
  * @param  main_interp    Main interpolator
@@ -1189,6 +1223,28 @@ adi_ad9081_device_startup_nco_test(adi_ad9081_device_t *device,
 				   uint8_t main_interp, uint8_t chan_interp,
 				   uint8_t dac_chan[4], int64_t main_shift[4],
 				   int64_t chan_shift[8], uint16_t dc_offset);
+
+/**
+ * @ingroup tx_data_path_setup
+ * @brief  System Top Level API. \n Startup Tx As NCO Test Mode
+ *         This API will be called after adi_ad9081_device_clk_config_set().
+ *
+ * @param  device         Pointer to the device structure
+ * @param  main_interp    Main interpolator
+ * @param  chan_interp    Channel interpolator
+ * @param  dac_chan       Enabled channels for each DAC
+ * @param  main_shift     Main NCO shift
+ * @param  chan_shift     Channel NCO shift
+ * @param  jesd_param     JRX JESD link settings
+ * @param  dc_offset      DC offset for NCO test mode
+ *
+ * @return API_CMS_ERROR_OK                     API Completed Successfully
+ * @return <0                                   Failed. @see adi_cms_error_e for details.
+ */
+int32_t adi_ad9081_device_startup_nco_test_mode(
+	adi_ad9081_device_t *device, uint8_t main_interp, uint8_t chan_interp,
+	uint8_t dac_chan[4], int64_t main_shift[4], int64_t chan_shift[8],
+	adi_cms_jesd_param_t *jesd_param, uint16_t dc_offset);
 
 /**
  * @ingroup tx_data_path_setup
@@ -2814,6 +2870,29 @@ int32_t adi_ad9081_adc_pfir_config_set(
 	adi_ad9081_adc_pfir_gain_e qy_gain, uint8_t coeff_load_sel,
 	uint16_t *coeffs, uint8_t coeffs_size);
 
+/**
+ * @ingroup rx_pfilt_low_level_setup
+ * @brief  Set PFIR config as per coefficients mode table
+ *
+ * @param  device         Pointer to the device structure
+ * @param  ctl_pages      PFIR control pages @see adi_ad9081_adc_pfir_ctl_page_e
+ * @param  coeff_pages    PFIR coefficient pages @see adi_ad9081_adc_pfir_ctl_page_e
+ * @param  i_mode         PFIR i-mode @see adi_ad9081_adc_pfir_i_mode_e
+ * @param  q_mode         PFIR q-mode @see adi_ad9081_adc_pfir_q_mode_e
+ * @param  gain           PFIR gain structure for each filter @see adi_ad9081_adc_pfir_gain_e
+ * @param  coeffs         Coefficient value array pointer, must contain 192 elements
+ * @param  clear_coeffs   Clear coefficients in bank enable, Disable if bank hopping
+ *
+ * @return API_CMS_ERROR_OK                     API Completed Successfully
+ * @return <0                                   Failed. @see adi_cms_error_e for details.
+ */
+int32_t adi_ad9081_adc_pfir_coeff_table_load_set(
+	adi_ad9081_device_t *device, adi_ad9081_adc_pfir_ctl_page_e ctl_pages,
+	adi_ad9081_adc_pfir_coeff_page_e coeff_pages,
+	adi_ad9081_adc_pfir_i_mode_e i_mode,
+	adi_ad9081_adc_pfir_q_mode_e q_mode, adi_ad9081_adc_pfir_gain_t *gain,
+	int16_t *coeffs, uint8_t clear_coeffs);
+
 /*===== 3 . 4   R E C E I V E  P A T H  N C O S =====*/
 /**
  * @ingroup rx_nco_setup
@@ -4273,7 +4352,6 @@ int32_t adi_ad9081_jesd_rx_link_select_set(adi_ad9081_device_t *device,
  * @param  device          Pointer to the device structure
  * @param  links           Target link
  * @param  logical_lanes   Logical lane to physical lane mapping array (0~7)
- *                          Where the index is logical lane, value is physical lane
  *
  * @return API_CMS_ERROR_OK                     API Completed Successfully
  * @return <0                                   Failed. @see adi_cms_error_e for details.
@@ -5050,7 +5128,7 @@ int32_t adi_ad9081_jesd_rx_qr_vertical_eye_scan(adi_ad9081_device_t *device,
  */
 int32_t adi_ad9081_jesd_rx_qr_two_dim_eye_scan(adi_ad9081_device_t *device,
 					       uint8_t lane,
-					       uint16_t eye_scan_data[96]);
+					       int16_t eye_scan_data[99]);
 
 /**
  * @ingroup appdx_serdes_jrx_tm
@@ -5087,7 +5165,7 @@ int32_t adi_ad9081_jesd_rx_hr_vertical_eye_scan(
 int32_t adi_ad9081_jesd_rx_hr_two_dim_eye_scan(
 	adi_ad9081_device_t *device, uint8_t lane,
 	adi_cms_jesd_prbs_pattern_e prbs_pattern, uint32_t prbs_delay_ms,
-	uint16_t eye_scan_data[192]);
+	int16_t eye_scan_data[195]);
 
 /*===== A 1 . 2   J T X  S E R D E S  L I N K  T E S T  M O D E S   =====*/
 /**
@@ -5725,6 +5803,7 @@ int32_t adi_ad9081_sync_calc_jtx_lmfc_lemc(uint64_t adc_clk,
  *
  * @param device                        Pointer to device struct
  * @param sysref_freq                   Pointer to variable that holds calculated lmfc/lemc (JESD204B/JESD204C) value
+ * @param dev_ref                       Variable that holds the current device reference clock freq in Hz
  * @param dac_clk                       Variable that holds current dac clock freq in Hz
  * @param adc_clk                       Variable that holds current adc clock freq in Hz
  * @param main_interp                   Main interpolator
@@ -5739,9 +5818,9 @@ int32_t adi_ad9081_sync_calc_jtx_lmfc_lemc(uint64_t adc_clk,
  * @return <0                           Failed. @see adi_cms_error_e for details.
  */
 int32_t adi_ad9081_sync_sysref_frequency_set(
-	adi_ad9081_device_t *device, uint64_t *sysref_freq, uint64_t dac_clk,
-	uint64_t adc_clk, uint8_t main_interp, uint8_t ch_interp,
-	uint8_t cddc_dcm[4], uint8_t fddc_dcm[8],
+	adi_ad9081_device_t *device, uint64_t *sysref_freq, uint64_t dev_ref,
+	uint64_t dac_clk, uint64_t adc_clk, uint8_t main_interp,
+	uint8_t ch_interp, uint8_t cddc_dcm[4], uint8_t fddc_dcm[8],
 	adi_ad9081_jesd_link_select_e jtx_links,
 	adi_cms_jesd_param_t *jrx_param, adi_cms_jesd_param_t jtx_param[2]);
 

--- a/drivers/iio/adc/ad9081/adi_ad9081_adc.c
+++ b/drivers/iio/adc/ad9081/adi_ad9081_adc.c
@@ -3524,14 +3524,7 @@ int32_t adi_ad9081_adc_pfir_coeff_table_load_set(
 			device, ctl_pages, coeff_pages, i_mode, q_mode,
 			gain->ix_gain, gain->iy_gain, gain->qx_gain,
 			gain->qy_gain, AD9081_ADC_PFIR_COMPLEX_LOAD,
-			(uint16_t *)coeffs, 64);
-		AD9081_ERROR_RETURN(err);
-		incr_coeffs = (uint16_t *)&coeffs[96];
-		err = adi_ad9081_adc_pfir_config_set(
-			device, ctl_pages, coeff_pages, i_mode, q_mode,
-			gain->ix_gain, gain->iy_gain, gain->qx_gain,
-			gain->qy_gain, AD9081_ADC_PFIR_COMPLEX_LOAD,
-			incr_coeffs, 64);
+			(uint16_t *)coeffs, 128);
 		AD9081_ERROR_RETURN(err);
 	} else if (i_mode == AD9081_ADC_PFIR_I_MODE_COMPLEX_HALF &&
 		   q_mode == AD9081_ADC_PFIR_Q_MODE_REAL_N2) {

--- a/drivers/iio/adc/ad9081/adi_ad9081_config.h
+++ b/drivers/iio/adc/ad9081/adi_ad9081_config.h
@@ -40,7 +40,7 @@
 #define __FUNCTION_NAME__ __FUNCTION__
 #endif
 
-#define AD9081_API_REV 0x00010600
+#define AD9081_API_REV 0x00010700
 #define AD9081_API_HW_RESET_LOW 600000
 #define AD9081_API_RESET_WAIT 500000
 #define AD9081_PLL_LOCK_TRY 75
@@ -439,6 +439,23 @@ int32_t adi_ad9081_dac_duc_nco_ftw0_set(adi_ad9081_device_t *device,
 					uint8_t dacs, uint8_t channels,
 					uint64_t ftw);
 
+#if AD9081_USE_FLOATING_TYPE > 0
+/**
+ * \brief  Block Top Level API. \n Configure NCO Shift Freq.
+ *         Call after adi_ad9081_device_startup_tx().
+ *
+ * \param[in]  device       Pointer to the device structure
+ * \param[in]  dacs         DAC mask, like AD9081_DAC_0, ...
+ * \param[in]  channels     Channel mask, like AD9081_DAC_CH_0, ...
+ * \param[in]  nco_shift_hz NCO shift freq in Hz
+ *
+ * \returns API_CMS_ERROR_OK                     API Completed Successfully
+ * \returns <0                                   Failed. @see adi_cms_error_e for details.
+ */
+int32_t adi_ad9081_dac_duc_nco_set_f(adi_ad9081_device_t *device, uint8_t dacs,
+				     uint8_t channels, double nco_shift_hz);
+#endif
+
 /**
  * \brief Enables soft off gain block for specified DACs.
  *
@@ -582,6 +599,23 @@ int32_t adi_ad9081_adc_power_up_set(adi_ad9081_device_t *device, uint8_t adcs,
 uint8_t
 adi_ad9081_adc_ddc_coarse_dcm_decode(adi_ad9081_adc_coarse_ddc_dcm_e cddc_dcm);
 
+#if AD9081_USE_FLOATING_TYPE > 0
+/**
+ * /brief  Configure NCO frequency for the coarse DDCs
+ *         Call after adi_ad9081_device_startup_rx().
+ *
+ * \param[in]  device        Pointer to the device structure
+ * \param[in]  cddcs         Coarse DDCs selection, @see adi_ad9081_adc_coarse_ddc_select_e
+ * \param[in]  cddc_shift_hz Value of frequency shift in Hz
+ *
+ * \returns API_CMS_ERROR_OK                     API Completed Successfully
+ * \returns <0                                   Failed. @see adi_cms_error_e for details.
+ */
+int32_t adi_ad9081_adc_ddc_coarse_nco_set_f(adi_ad9081_device_t *device,
+					    uint8_t cddcs,
+					    double cddc_shift_hz);
+#endif
+
 /**
  * \brief Decodes ADC fine DDC decimation values.
  *
@@ -594,6 +628,22 @@ adi_ad9081_adc_ddc_coarse_dcm_decode(adi_ad9081_adc_coarse_ddc_dcm_e cddc_dcm);
  */
 uint8_t
 adi_ad9081_adc_ddc_fine_dcm_decode(adi_ad9081_adc_fine_ddc_dcm_e fddc_dcm);
+
+#if AD9081_USE_FLOATING_TYPE > 0
+/**
+ * \brief  Configure NCO frequency for fine DDCs
+ *         Call after adi_ad9081_device_startup_rx().
+ *
+ * \param[in]  device        Pointer to the device structure
+ * \param[in]  fddcs         Fine DDCs selection, @see adi_ad9081_adc_fine_ddc_select_e
+ * \param[in]  fddc_shift_hz Value of frequency shift in Hz
+ *
+ * \returns API_CMS_ERROR_OK                     API Completed Successfully
+ * \returns <0                                   Failed. @see adi_cms_error_e for details.
+ */
+int32_t adi_ad9081_adc_ddc_fine_nco_set_f(adi_ad9081_device_t *device,
+					  uint8_t fddcs, double fddc_shift_hz);
+#endif
 
 /**
  * \brief Selects the GPIOs to which PERI_I_SEL21/22 are connected.

--- a/drivers/iio/adc/ad9081/adi_ad9081_jesd.c
+++ b/drivers/iio/adc/ad9081/adi_ad9081_jesd.c
@@ -4026,7 +4026,7 @@ int32_t adi_ad9081_jesd_rx_qr_vertical_eye_scan(adi_ad9081_device_t *device,
 
 int32_t adi_ad9081_jesd_rx_qr_two_dim_eye_scan(adi_ad9081_device_t *device,
 					       uint8_t lane,
-					       uint16_t eye_scan_data[96])
+					       int16_t eye_scan_data[99])
 {
 	int32_t err;
 	uint8_t en_flash_src_des_rc, comp_setting, data, spo, quad1, quad2,
@@ -4077,8 +4077,8 @@ int32_t adi_ad9081_jesd_rx_qr_two_dim_eye_scan(adi_ad9081_device_t *device,
 		AD9081_ERROR_RETURN(err);
 
 		eye_scan_data[i] = -(128 - spo);
-		eye_scan_data[i + 1] = quad2;
-		eye_scan_data[i + 2] = -quad3;
+		eye_scan_data[i + 1] = quad2 * 4;
+		eye_scan_data[i + 2] = -quad3 * 4;
 		i += 3;
 	}
 	for (spo = 113; spo < 128; spo++) {
@@ -4089,8 +4089,8 @@ int32_t adi_ad9081_jesd_rx_qr_two_dim_eye_scan(adi_ad9081_device_t *device,
 	err = adi_ad9081_jesd_rx_spo_set(device, lane, 0);
 	AD9081_ERROR_RETURN(err);
 
-	/* Sweeping SPO from 1 to 16 */
-	for (spo = 1; spo < 17; spo++) {
+	/* Sweeping SPO from 0 to 16 */
+	for (spo = 0; spo < 17; spo++) {
 		err = adi_ad9081_jesd_rx_spo_set(device, lane, spo);
 		AD9081_ERROR_RETURN(err);
 
@@ -4111,8 +4111,8 @@ int32_t adi_ad9081_jesd_rx_qr_two_dim_eye_scan(adi_ad9081_device_t *device,
 		AD9081_ERROR_RETURN(err);
 
 		eye_scan_data[i] = spo;
-		eye_scan_data[i + 1] = quad1;
-		eye_scan_data[i + 2] = -quad4;
+		eye_scan_data[i + 1] = quad1 * 4;
+		eye_scan_data[i + 2] = -quad4 * 4;
 		i += 3;
 	}
 
@@ -4197,7 +4197,7 @@ int32_t adi_ad9081_jesd_rx_hr_vertical_eye_scan(
 int32_t adi_ad9081_jesd_rx_hr_two_dim_eye_scan(
 	adi_ad9081_device_t *device, uint8_t lane,
 	adi_cms_jesd_prbs_pattern_e prbs_pattern, uint32_t prbs_delay_ms,
-	uint16_t eye_scan_data[192])
+	int16_t eye_scan_data[195])
 {
 	int32_t err;
 	int8_t i;
@@ -4266,7 +4266,7 @@ int32_t adi_ad9081_jesd_rx_hr_two_dim_eye_scan(
 		AD9081_ERROR_RETURN(err);
 	}
 	/* Right Horizontal eye scan */
-	for (i = 1; i < (spo_size + 1); i++) {
+	for (i = 0; i < (spo_size + 1); i++) {
 		err = adi_ad9081_jesd_rx_gen_2s_comp(device, i, 7, &spo_value);
 		AD9081_ERROR_RETURN(err);
 		err = adi_ad9081_jesd_rx_spo_set(device, lane, spo_value);

--- a/drivers/iio/adc/ad9081/adi_ad9081_sync.c
+++ b/drivers/iio/adc/ad9081/adi_ad9081_sync.c
@@ -564,28 +564,77 @@ int32_t adi_ad9081_sync_calc_jtx_lmfc_lemc(uint64_t adc_clk,
 }
 
 int32_t adi_ad9081_sync_sysref_frequency_set(
-	adi_ad9081_device_t *device, uint64_t *sysref_freq, uint64_t dac_clk,
-	uint64_t adc_clk, uint8_t main_interp, uint8_t ch_interp,
-	uint8_t cddc_dcm[4], uint8_t fddc_dcm[8],
+	adi_ad9081_device_t *device, uint64_t *sysref_freq, uint64_t dev_ref,
+	uint64_t dac_clk, uint64_t adc_clk, uint8_t main_interp,
+	uint8_t ch_interp, uint8_t cddc_dcm[4], uint8_t fddc_dcm[8],
 	adi_ad9081_jesd_link_select_e jtx_links,
 	adi_cms_jesd_param_t *jrx_param, adi_cms_jesd_param_t jtx_param[2])
 {
-	uint64_t jrx_lmfc, jtx_lmfc, max_lmfc, min_lmfc, gcd = 0;
+	uint64_t jrx_lmfc = 0, jtx_lmfc = 0, max_lmfc = 0, min_lmfc = 0,
+		 gcd = 0, rem1, rem2;
 	int32_t err;
 	AD9081_NULL_POINTER_RETURN(device);
 	AD9081_NULL_POINTER_RETURN(sysref_freq);
 	AD9081_NULL_POINTER_RETURN(jrx_param);
+
 	AD9081_LOG_FUNC();
 
 	/* jrx */
-	err = adi_ad9081_sync_calc_jrx_lmfc_lemc(
-		dac_clk, main_interp, ch_interp, jrx_param, &jrx_lmfc);
-	AD9081_ERROR_RETURN(err);
+	if (jrx_param->jesd_l > 0) {
+		AD9081_INVALID_PARAM_RETURN(jrx_param->jesd_s == 0 ||
+					    jrx_param->jesd_k == 0 ||
+					    main_interp == 0 || ch_interp == 0);
+		err = adi_ad9081_sync_calc_jrx_lmfc_lemc(
+			dac_clk, main_interp, ch_interp, jrx_param, &jrx_lmfc);
+		AD9081_ERROR_RETURN(err);
+		if (jrx_lmfc == 0) {
+			AD9081_LOG_ERR("LMFC/LEMC = 0, missing input params");
+		}
+
+#ifdef __KERNEL__
+		div64_u64_rem(dev_ref, jrx_lmfc, &rem1);
+		div64_u64_rem(jrx_lmfc, dev_ref, &rem2);
+#else
+		rem1 = dev_ref % jrx_lmfc;
+		rem2 = jrx_lmfc % dev_ref;
+#endif
+		/* Internal PLL requires LMFC and dev_ref to be integer multiples*/
+		if (dev_ref != dac_clk && rem1 != 0 && rem2 != 0) {
+			AD9081_LOG_WARN(
+				"JRx LMFC/LEMC and dev_ref clock are not integer multiples. DL will not be achieved.");
+		}
+	}
 
 	/* jtx */
-	err = adi_ad9081_sync_calc_jtx_lmfc_lemc(
-		adc_clk, cddc_dcm, fddc_dcm, jtx_links, jtx_param, &jtx_lmfc);
-	AD9081_ERROR_RETURN(err);
+	if (jtx_param[0].jesd_l > 0) {
+		AD9081_INVALID_PARAM_RETURN(jtx_param[0].jesd_s == 0 ||
+					    jtx_param[0].jesd_k == 0);
+		if (jtx_param[0].jesd_duallink == 1) {
+			AD9081_INVALID_PARAM_RETURN(jtx_param[1].jesd_s == 0 ||
+						    jtx_param[1].jesd_k == 0);
+		}
+		err = adi_ad9081_sync_calc_jtx_lmfc_lemc(adc_clk, cddc_dcm,
+							 fddc_dcm, jtx_links,
+							 jtx_param, &jtx_lmfc);
+		AD9081_ERROR_RETURN(err);
+		if (jtx_lmfc == 0) {
+			AD9081_LOG_ERR("LMFC/LEMC = 0, missing input params");
+		}
+
+#ifdef __KERNEL__
+		div64_u64_rem(dev_ref, jtx_lmfc, &rem1);
+		div64_u64_rem(jtx_lmfc, dev_ref, &rem2);
+#else
+		rem1 = dev_ref % jtx_lmfc;
+		rem2 = jtx_lmfc % dev_ref;
+#endif
+
+		/* Internal PLL requires LMFC and dev_ref to be integer multiples*/
+		if (dev_ref != dac_clk && rem1 != 0 && rem2 != 0) {
+			AD9081_LOG_WARN(
+				"JTx LMFC/LEMC and dev_ref clock are not integer multiples. DL will not be achieved.");
+		}
+	}
 
 	/* gcd */
 	max_lmfc = (jrx_lmfc >= jtx_lmfc) ? jrx_lmfc : jtx_lmfc;

--- a/drivers/iio/frequency/ad9528.c
+++ b/drivers/iio/frequency/ad9528.c
@@ -1411,6 +1411,7 @@ static int ad9528_jesd204_clks_sync(struct jesd204_dev *jdev,
 {
 	struct device *dev = jesd204_dev_to_device(jdev);
 	struct iio_dev *indio_dev = dev_get_drvdata(dev);
+	struct ad9528_state *st = iio_priv(indio_dev);
 	int ret;
 
 	if (reason != JESD204_STATE_OP_REASON_INIT)
@@ -1418,6 +1419,9 @@ static int ad9528_jesd204_clks_sync(struct jesd204_dev *jdev,
 
 	dev_dbg(dev, "%s:%d reason %s\n", __func__, __LINE__,
 		jesd204_state_op_reason_str(reason));
+
+	if (st->pdata->jdev_skip_clk_sync)
+		return JESD204_STATE_CHANGE_DONE;
 
 	ret = ad9528_sync(indio_dev);
 	if (ret)
@@ -1536,6 +1540,9 @@ static struct ad9528_platform_data *ad9528_parse_dt(struct device *dev)
 
 	of_property_read_u32(np, "adi,jesd204-desired-sysref-frequency-hz",
 			     &pdata->jdev_desired_sysref_freq);
+
+	pdata->jdev_skip_clk_sync =
+		of_property_read_bool(np, "adi,jesd204-skip-clock-sync");
 
 	/* PLL2 Setting */
 	of_property_read_u32(np, "adi,pll2-charge-pump-current-nA",

--- a/include/linux/iio/frequency/ad9528.h
+++ b/include/linux/iio/frequency/ad9528.h
@@ -60,6 +60,7 @@ struct ad9528_channel_spec {
  * @sysref_nshot_mode: SYSREF pattern NSHOT mode
  * @sysref_req_trigger_mode: SYSREF request trigger mode
  * @sysref_req_en: SYSREF request pin mode enable (default SPI mode)
+ * @jdev_skip_clk_sync: Skip/omit clock synchronisation FSM step
  * @jdev_max_sysref_freq: Maximum SYSREF frequency allowed (Hz)
  * @dev_desired_sysref_freq: Desired SYSREF frequency (Hz)
  * @pll2_charge_pump_current_nA: Magnitude of PLL2 charge pump current (nA).
@@ -116,6 +117,7 @@ struct ad9528_platform_data {
 	unsigned char			sysref_nshot_mode;
 	unsigned char			sysref_req_trigger_mode;
 	bool				sysref_req_en;
+	bool				jdev_skip_clk_sync;
 	u32				jdev_max_sysref_freq;
 	u32				jdev_desired_sysref_freq;
 


### PR DESCRIPTION
## PR Description

iio: adc: ad9081: Update API v1.7.0
iio: adc: ad9081: Update eyescan vector to include SPO=0
iio: adc: ad9081: Switch to guarded mutex and mutex to direct_reg_access
iio: frequency: ad9528: Add option to skip the jesd204-fsm clock sync step
iio: adc: ad9081: adi_ad9081_adc: Fix PFIR COMPLEX FULL load
iio: adc: ad9081: Use API function to load PFIR

## PR Type
- [X] New feature (a change that adds new functionality)

## PR Checklist
- [X] I have conducted a self-review of my own code changes
- [X] I have tested the changes on the relevant hardware
- [X] I have updated the documentation outside this repo accordingly (if there is the case)
