### PR TITLE
ci: update DTS exceptions list and upload script

### DIFF
--- a/ci/travis/dtb_build_test_exceptions
+++ b/ci/travis/dtb_build_test_exceptions
@@ -150,19 +150,20 @@ arch/arm64/boot/dts/xilinx/versal-net-vn-x-b2197-00-revA.dts
 # or some DTs that never had an equivalent HDL project.
 # Either way, they are not needed on the SD-card release image.
 
-arch/arm/boot/dts/zynq-zc702-adv7511-ad9364-fmcomms4.dts
+arch/arm/boot/dts/zynq-adrv9361-z7035-packrf.dts
+arch/arm/boot/dts/zynq-adrv9364-z7020-packrf.dts
 arch/arm/boot/dts/zynq-zc706-adv7511-ad9364-fmcomms4.dts
 arch/arm/boot/dts/zynq-zed-adv7511-ad9364-fmcomms4.dts
-arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9364-fmcomms4.dts
 arch/arm/boot/dts/zynq-microzed-cn0363.dts
 arch/arm/boot/dts/zynq-coraz7s.dts
 arch/arm/boot/dts/zynq-zc702-adv7511-adrv9363.dts
 arch/arm/boot/dts/zynq-zc702-adv7511-fmcomms1.dts
+arch/arm/boot/dts/zynq-zc706-adv7511-ad9625-fmcadc2.dts
+arch/arm/boot/dts/zynq-zc706-adv7511-ad9625-fmcadc3.dts
+arch/arm/boot/dts/zynq-zc706-adv7511-ad9739a-fmc.dts
 arch/arm/boot/dts/zynq-zc706-adv7511-adrv9363.dts
 arch/arm/boot/dts/zynq-zc706-adv7511-fmcadc4.dts
 arch/arm/boot/dts/zynq-zc706-adv7511-fmcdaq1.dts
-arch/arm/boot/dts/zynq-zc706-adv7511-fmcjesdadc1.dts
-arch/arm/boot/dts/zynq-zc706-adv7511-fmcomms11.dts
 arch/arm/boot/dts/zynq-zc706-adv7511-fmcomms11-RevA.dts
 arch/arm/boot/dts/zynq-zc706-adv7511-fmcomms1.dts
 arch/arm/boot/dts/zynq-zc706-adv7511-fmcomms6.dts
@@ -179,8 +180,12 @@ arch/arm/boot/dts/zynq-zed-adv7511-pmod-ad1-da1.dts
 arch/arm/boot/dts/zynq-zed-imageon.dts
 arch/arm/boot/dts/zynq-zed-seps525.dts
 arch/arm/boot/dts/socfpga_arria10_socdk_ad9136_fmc_ebz.dts
+arch/arm/boot/dts/socfpga_arria10_socdk_fmclidar1.dts
+arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-fmclidar1.dts
 arch/arm64/boot/dts/xilinx/zynqmp-zcu102-revB-ad9361-fmcomms2-3.dts
 arch/arm64/boot/dts/xilinx/zynqmp-zcu102-revB-adrv9363.dts
 arch/arm/boot/dts/zynq-zc706-adv7511-ad9361-fmcomms5-userspace.dts
 arch/arm64/boot/dts/xilinx/zynqmp-zcu102-revB-ad9364-fmcomms4.dts
 arch/arm/boot/dts/zynq-zc706-adv7511-ad9625-fmcadc7.dts
+arch/microblaze/boot/dts/vc707_fmcadc2.dts
+arch/microblaze/boot/dts/vc707_fmcadc5.dts

--- a/ci/travis/upload_to_artifactory.py
+++ b/ci/travis/upload_to_artifactory.py
@@ -7,7 +7,7 @@
 #
 # This script is used to upload files to ADI internal artifactory server
 #
-# Copyright (C) 2019-2023 Analog Devices Inc.
+# Copyright (C) 2019-2024 Analog Devices Inc.
 #
 #######################################################################
 
@@ -22,7 +22,7 @@ from glob import glob
 
 LOCAL_PATHS_LIST = []
 # If you try to upload files in a different folder than the ones in below list, there will be printed a message and files won't be uploaded
-SERVER_FOLDERS_LIST = [ "hdl", "linux", "linux_rpi", "arm_trusted_firmware", "boot_partition", "rootfs", "u-boot", "HighSpeedConverterToolbox", "TransceiverToolbox", "SD_card_image"]
+SERVER_FOLDERS_LIST = ["linux", "linux_rpi"]
 
 ########### Define arguments and help section #################
 


### PR DESCRIPTION
## PR Description

This PR introduces the following changes:
* Update the `dtb_build_test_exceptions` file: 
  * Remove projects (DTs) that are part of the current release
  * Add projects that are obsolete
* Remove unnecessary folders from the `upload_to_artifactory.py` script and update license year.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
