### PR TITLE
Small improvements on jesd204 and users

### DIFF
--- a/drivers/iio/adc/ad9081.c
+++ b/drivers/iio/adc/ad9081.c
@@ -5250,7 +5250,7 @@ static int ad9081_probe(struct spi_device *spi)
 		 conv->id, phy->chip_id.dev_revision,
 		 phy->chip_id.prod_grade, api_rev[0], api_rev[1], api_rev[2]);
 
-	ret = jesd204_fsm_start(jdev, JESD204_LINKS_ALL);
+	ret = devm_jesd204_fsm_start(&spi->dev, jdev, JESD204_LINKS_ALL);
 	if (ret)
 		goto out_clk_del_provider;
 

--- a/drivers/iio/adc/ad9083.c
+++ b/drivers/iio/adc/ad9083.c
@@ -1051,7 +1051,10 @@ static int ad9083_probe(struct spi_device *spi)
 	if (ret < 0)
 		return ret;
 
-	return jesd204_fsm_start(jdev, JESD204_LINKS_ALL);
+	if (!jdev)
+		return 0;
+
+	return devm_jesd204_fsm_start(&spi->dev, jdev, JESD204_LINKS_ALL);
 }
 
 static const struct spi_device_id ad9083_id[] = {

--- a/drivers/iio/adc/ad9371.c
+++ b/drivers/iio/adc/ad9371.c
@@ -5109,10 +5109,12 @@ static int ad9371_probe(struct spi_device *spi)
 	if (ret < 0)
 		dev_warn(&spi->dev, "%s: failed to register debugfs", __func__);
 
-	if (!phy->jdev)
+	if (!phy->jdev) {
 		ad9371_info(phy);
+		return 0;
+	}
 
-	ret = jesd204_fsm_start(phy->jdev, JESD204_LINKS_ALL);
+	ret = devm_jesd204_fsm_start(&spi->dev, phy->jdev, JESD204_LINKS_ALL);
 	if (ret)
 		goto out_iio_device_unregister;
 

--- a/drivers/iio/adc/adrv9009.c
+++ b/drivers/iio/adc/adrv9009.c
@@ -6832,10 +6832,12 @@ static int adrv9009_probe(struct spi_device *spi)
 		}
 	}
 
-	if (!phy->jdev)
+	if (!phy->jdev) {
 		adrv9009_info(phy);
+		return 0;
+	}
 
-	ret = jesd204_fsm_start(phy->jdev, JESD204_LINKS_ALL);
+	ret = devm_jesd204_fsm_start(&spi->dev, phy->jdev, JESD204_LINKS_ALL);
 	if (ret)
 		goto out_remove_sysfs_bin;
 

--- a/drivers/iio/adc/adrv902x/adrv9025.c
+++ b/drivers/iio/adc/adrv902x/adrv9025.c
@@ -2750,7 +2750,7 @@ static int adrv9025_probe(struct spi_device *spi)
 		 apiVersion.majorVer, apiVersion.minorVer,
 		 apiVersion.maintenanceVer, apiVersion.buildVer);
 
-	ret = jesd204_fsm_start(phy->jdev, JESD204_LINKS_ALL);
+	ret = devm_jesd204_fsm_start(&spi->dev, phy->jdev, JESD204_LINKS_ALL);
 	if (ret)
 		goto out_iio_device_unregister;
 

--- a/drivers/iio/frequency/ad9144.c
+++ b/drivers/iio/frequency/ad9144.c
@@ -1477,7 +1477,11 @@ static int ad9144_probe(struct spi_device *spi)
 done:
 	spi_set_drvdata(spi, conv);
 	dev_dbg(&spi->dev, "Probed.\n");
-	return jesd204_fsm_start(st->jdev, JESD204_LINKS_ALL);
+
+	if (!st->jdev)
+		return 0;
+
+	return devm_jesd204_fsm_start(&spi->dev, st->jdev, JESD204_LINKS_ALL);
 out:
 	return ret;
 }

--- a/drivers/iio/frequency/ad9162.c
+++ b/drivers/iio/frequency/ad9162.c
@@ -1136,7 +1136,10 @@ static int ad9162_probe(struct spi_device *spi)
 
 	dev_info(&spi->dev, "Probed.\n");
 
-	return jesd204_fsm_start(st->jdev, JESD204_LINKS_ALL);
+	if (!st->jdev)
+		return 0;
+
+	return devm_jesd204_fsm_start(&spi->dev, st->jdev, JESD204_LINKS_ALL);
 out:
 	return ret;
 }

--- a/drivers/iio/frequency/ad9172.c
+++ b/drivers/iio/frequency/ad9172.c
@@ -1191,7 +1191,10 @@ static int ad9172_probe(struct spi_device *spi)
 
 	dev_info(&spi->dev, "Probed.\n");
 
-	return jesd204_fsm_start(st->jdev, JESD204_LINKS_ALL);
+	if (!st->jdev)
+		return 0;
+
+	return devm_jesd204_fsm_start(&spi->dev, st->jdev, JESD204_LINKS_ALL);
 out:
 	return ret;
 }

--- a/drivers/iio/frequency/ad9528.c
+++ b/drivers/iio/frequency/ad9528.c
@@ -1747,7 +1747,7 @@ static int ad9528_probe(struct spi_device *spi)
 	if (ret)
 		return ret;
 
-	return jesd204_fsm_start(st->jdev, JESD204_LINKS_ALL);
+	return devm_jesd204_fsm_start(&spi->dev, st->jdev, JESD204_LINKS_ALL);
 }
 
 static const struct spi_device_id ad9528_id[] = {

--- a/drivers/iio/frequency/cf_axi_dds.c
+++ b/drivers/iio/frequency/cf_axi_dds.c
@@ -2572,9 +2572,11 @@ static int cf_axi_dds_probe(struct platform_device *pdev)
 
 	platform_set_drvdata(pdev, indio_dev);
 
-	ret = jesd204_fsm_start(st->jdev, JESD204_LINKS_ALL);
-	if (ret)
-		return ret;
+	if (st->jdev) {
+		ret = devm_jesd204_fsm_start(&pdev->dev, st->jdev, JESD204_LINKS_ALL);
+		if (ret)
+			return ret;
+	}
 
 	dev_info(&pdev->dev,
 		 "Analog Devices CF_AXI_DDS_DDS %s (%d.%.2d.%c) at 0x%08llX mapped to 0x%p, probed DDS %s\n",

--- a/drivers/iio/jesd204/altera_adxcvr.c
+++ b/drivers/iio/jesd204/altera_adxcvr.c
@@ -612,7 +612,7 @@ static int adxcvr_probe(struct platform_device *pdev)
 	if (ret)
 		dev_err(&pdev->dev, "Can't create the sysfs group\n");
 
-	ret = jesd204_fsm_start(st->jdev, JESD204_LINKS_ALL);
+	ret = devm_jesd204_fsm_start(&pdev->dev, st->jdev, JESD204_LINKS_ALL);
 	if (ret)
 		return ret;
 

--- a/drivers/iio/jesd204/axi_jesd204_rx.c
+++ b/drivers/iio/jesd204/axi_jesd204_rx.c
@@ -1172,11 +1172,6 @@ static void axi_jesd204_rx_rmattr(void *data)
 	axi_jesd204_rx_create_remove_devattrs(jesd->dev, jesd, false);
 }
 
-static void axi_jesd204_stop_fsm(void *jdev)
-{
-	jesd204_fsm_stop(jdev, JESD204_LINKS_ALL);
-}
-
 static int axi_jesd204_rx_probe(struct platform_device *pdev)
 {
 	struct axi_jesd204_rx *jesd;
@@ -1331,11 +1326,7 @@ static int axi_jesd204_rx_probe(struct platform_device *pdev)
 		return ret;
 
 	if (jesd->jdev) {
-		ret = jesd204_fsm_start(jesd->jdev, JESD204_LINKS_ALL);
-		if (ret)
-			return ret;
-
-		ret = devm_add_action_or_reset(&pdev->dev, axi_jesd204_stop_fsm, jesd->jdev);
+		ret = devm_jesd204_fsm_start(&pdev->dev, jesd->jdev, JESD204_LINKS_ALL);
 		if (ret)
 			return ret;
 	}

--- a/drivers/iio/jesd204/axi_jesd204_tx.c
+++ b/drivers/iio/jesd204/axi_jesd204_tx.c
@@ -908,11 +908,6 @@ static void axi_jesd204_tx_rmattr(void *data)
 	device_remove_file(jesd->dev, &dev_attr_encoder);
 }
 
-static void axi_jesd204_stop_fsm(void *jdev)
-{
-	jesd204_fsm_stop(jdev, JESD204_LINKS_ALL);
-}
-
 static int axi_jesd204_tx_probe(struct platform_device *pdev)
 {
 	struct axi_jesd204_tx *jesd;
@@ -1055,11 +1050,7 @@ static int axi_jesd204_tx_probe(struct platform_device *pdev)
 		return ret;
 
 	if (jesd->jdev) {
-		ret = jesd204_fsm_start(jesd->jdev, JESD204_LINKS_ALL);
-		if (ret)
-			return ret;
-
-		ret = devm_add_action_or_reset(&pdev->dev, axi_jesd204_stop_fsm, jesd->jdev);
+		ret = devm_jesd204_fsm_start(&pdev->dev, jesd->jdev, JESD204_LINKS_ALL);
 		if (ret)
 			return ret;
 	}

--- a/drivers/jesd204/jesd204-fsm.c
+++ b/drivers/jesd204/jesd204-fsm.c
@@ -1103,6 +1103,33 @@ int jesd204_fsm_start(struct jesd204_dev *jdev, unsigned int link_idx)
 }
 EXPORT_SYMBOL_GPL(jesd204_fsm_start);
 
+static void __jesd204_fsm_stop(void *jdev)
+{
+	jesd204_fsm_stop(jdev, JESD204_LINKS_ALL);
+}
+
+/**
+ * devm_jesd204_fsm_start() - Managed Device version of jesd204_fsm_start()
+ * @jdev:      Pointer to the JESD204 device structure.
+ * @link_idx:  Index of the link to start.
+ *
+ * See jesd204_fsm_start()
+ *
+ * Return: 0 on success, negative error code on failure.
+ */
+int devm_jesd204_fsm_start(struct device *dev, struct jesd204_dev *jdev,
+			   unsigned int link_idx)
+{
+	int ret;
+
+	ret = __jesd204_fsm_start(jdev, link_idx, false);
+	if (ret)
+		return ret;
+
+	return devm_add_action_or_reset(dev, __jesd204_fsm_stop, jdev);
+}
+EXPORT_SYMBOL_GPL(devm_jesd204_fsm_start);
+
 /**
  * jesd204_fsm_resume() - Resume the JESD204 state machine for a specific link
  * @jdev:      Pointer to the JESD204 device structure.

--- a/drivers/jesd204/jesd204_top_device.c
+++ b/drivers/jesd204/jesd204_top_device.c
@@ -381,7 +381,7 @@ static int jesd204_top_device_probe(struct platform_device *pdev)
 	dev_info(&pdev->dev, "JESD204-GENERIC-TOP-DEVICE probed %d links\n",
 		tdev->jesd204_dev_data.max_num_links);
 
-	return jesd204_fsm_start(jdev, JESD204_LINKS_ALL);
+	return devm_jesd204_fsm_start(&pdev->dev, jdev, JESD204_LINKS_ALL);
 }
 
 static struct platform_driver jesd204_top_device_driver = {

--- a/include/linux/jesd204/jesd204.h
+++ b/include/linux/jesd204/jesd204.h
@@ -262,6 +262,8 @@ int jesd204_get_links_data(struct jesd204_dev *jdev,
 			   const unsigned int num_links);
 
 int jesd204_fsm_start(struct jesd204_dev *jdev, unsigned int link_idx);
+int devm_jesd204_fsm_start(struct device *dev, struct jesd204_dev *jdev,
+			   unsigned int link_idx);
 void jesd204_fsm_stop(struct jesd204_dev *jdev, unsigned int link_idx);
 
 int jesd204_fsm_resume(struct jesd204_dev *jdev, unsigned int link_idx);
@@ -316,6 +318,13 @@ static inline int jesd204_get_links_data(struct jesd204_dev *jdev,
 
 static inline int jesd204_fsm_start(struct jesd204_dev *jdev,
 				    unsigned int link_idx)
+{
+	return 0;
+}
+
+static inline int devm_jesd204_fsm_start(struct device *dev,
+					 struct jesd204_dev *jdev,
+					 unsigned int link_idx)
 {
 	return 0;
 }


### PR DESCRIPTION
## PR Description

This PR improves devm_jesd204_dev_register() and adds a new devm_jesd204_fsm_start() API so we make sure to stop the FSM on unbind. Then, we update all users jesd204_fsm_start() () to use the new variant. ALong the way some drivers were completely converted to a full devm probe (meaning that we do not need any driver .remove() hook)

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
