### PR TITLE
arm64: dts: xilinx: Add dts for AD9164

### DIFF
--- a/arch/arm64/boot/dts/xilinx/adi-ad9164-fmc-ebz.dtsi
+++ b/arch/arm64/boot/dts/xilinx/adi-ad9164-fmc-ebz.dtsi
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * dtsi file for AD916x-FMC-EBZ on Xilinx ZynqMP ZCU102 Rev 1.0
+ *
+ * Copyright (C) 2024 Analog Devices Inc.
+ */
+
+/ {
+	clocks {
+		adf4355_clkin: clock@0 {
+			compatible = "fixed-clock";
+			clock-frequency = <120000000>;
+			clock-output-names = "clkin";
+			#clock-cells = <0>;
+		};
+
+		adf4355_out_div4: hmc365 {
+			compatible = "fixed-factor-clock";
+
+			clock-div = <4>;
+			clock-mult = <1>;
+			clocks = <&adf4355_clk>;
+
+			#clock-cells = <0>;
+		};
+
+		ad9508_clkin: clock@1 {
+			compatible = "fixed-factor-clock";
+
+			clock-div = <1>;
+			clock-mult = <1>;
+			clocks = <&adf4355_out_div4>;
+
+			#clock-cells = <0>;
+		};
+	};
+};
+
+#include <dt-bindings/iio/frequency/ad9508.h>
+
+&fmc_spi {
+	adf4355_clk: adf4355@2 {
+		compatible = "adi,adf4355-2";
+		reg = <2>;
+
+		spi-max-frequency = <10000000>;
+
+		clocks = <&adf4355_clkin>;
+		clock-names = "clkin";
+		clock-scales = <1 1>;
+
+		clock-output-names = "adf4355_pll";
+		#clock-cells = <0>;
+
+		adi,charge-pump-current = <900>;
+		adi,muxout-select = <6>;
+		adi,output-a-power = <3>;
+		adi,output-b-power = <3>;
+		adi,charge-pump-negative-bleed-enable;
+		adi,reference-differential-input-enable;
+		adi,muxout-level-3v3-enable;
+		adi,power-up-frequency = /bits/ 64 <5000000000>;
+		adi,output-a-enable;
+		adi,output-b-enable;
+		adi,clock-shift = <1>;
+	};
+
+	ad9508_clk: ad9508@0 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		#clock-cells = <1>;
+		compatible = "adi,ad9508";
+		reg = <0>;
+		spi-cpol;
+		spi-cpha;
+
+		clocks = <&ad9508_clkin>;
+
+		spi-max-frequency = <10000000>;
+		clock-output-names = "ad9508-1_out0", "ad9508-1_out1", "ad9508-1_out2", "ad9508-1_out3";
+		jesd204-device;
+		adi,write-mode-only;
+		#jesd204-cells = <2>;
+		jesd204-sysref-provider;
+
+		ad9508_0_c0:channel@0 {
+			reg = <0>;
+			adi,extended-name = "REF_CLK";
+			adi,driver-mode = <(DRIVER_PHASE_NORMAL | DRIVER_MODE_LVDS_1_00)>;
+			adi,divider-phase = <0>;
+			adi,channel-divider = <4>;
+		};
+
+		ad9508_0_c2:channel@2 {
+			reg = <2>;
+			adi,extended-name = "SYSREF2";
+			adi,driver-mode = <(DRIVER_PHASE_NORMAL | DRIVER_MODE_LVDS_1_00)>;
+			adi,divider-phase = <0>;
+			adi,channel-divider = <32>;
+		};
+
+		ad9508_0_c3:channel@3 {
+			reg = <3>;
+			adi,extended-name = "SYSREF";
+			adi,driver-mode = <(DRIVER_PHASE_NORMAL | DRIVER_MODE_LVDS_1_00)>;
+			adi,divider-phase = <0>;
+			adi,channel-divider = <32>;
+		};
+	};
+
+	dac0_ad9164: ad9164@1 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "adi,ad9164";
+		reg = <1>;
+		spi-max-frequency = <1000000>;
+		clocks =  <&adf4355_clk 0>;
+		clock-names = "dac_clk";
+		spi-cpol;
+		spi-cpha;
+
+		adi,full-scale-current-mircoamp = <40000>;
+		dac_clk-clock-scales = <1 1>;
+		jesd204-device;
+		#jesd204-cells = <2>;
+		jesd204-top-device = <0>; /* This is the TOP device */
+		jesd204-link-ids = <0>;
+		jesd204-inputs = <&axi_ad9164_core 0 0>;
+
+		adi,jesd-subclass = <1>;
+		adi,dac-interpolation = <2>;
+		adi,channel-interpolation = <2>;
+		adi,clock-output-divider = <1>;
+		adi,syncoutb-signal-type-lvds-enable;
+		//adi,scrambling = <1>;
+		adi,sysref-mode = <2>; /* SYSREF_CONTINUOUS */
+
+		adi,subclass = <1>;			/* JESD SUBCLASS 0,1,2 */
+		adi,version = <1>;			/* JESD VERSION 0=204A,1=204B,2=204C */
+		adi,converters-per-device = <2>;	/* JESD M */
+		adi,octets-per-frame = <1>;		/* JESD F */
+		adi,frames-per-multiframe = <32>;	/* JESD K */
+		adi,converter-resolution = <16>;	/* JESD N */
+		adi,bits-per-sample = <16>;		/* JESD NP' */
+		adi,control-bits-per-sample = <0>;	/* JESD CS */
+		adi,lanes-per-device = <8>;		/* JESD L */
+		adi,samples-per-converter-per-frame = <2>; /* JESD S */
+		adi,interpolation = <2>;
+	};
+};

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9164-fmc-ebz_m2_s2.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9164-fmc-ebz_m2_s2.dts
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * AD9164-FMC-EBZ on Xilinx ZynqMP ZCU102 Rev 1.0
+ *
+ * JESD Link Mode 8 Example: M2, L8, S2, F1,  NP'16, Interpolation: 2
+ *
+ * https://analogdevicesinc.github.io/hdl/projects/dac_fmc_ebz/index.html
+ *
+ * hdl_project: <dac_fmc_ebz/zcu102>
+ * ADI_DAC_DEVICE: <AD9164>
+ * ADI_LANE_RATE: <12.5>
+ * ADI_DAC_MODE: <08>
+ * board_revision: <H>
+ *
+ * Copyright (C) 2024 Analog Devices Inc.
+ */
+
+#include "zynqmp-zcu102-rev1.0.dts"
+#include <dt-bindings/interrupt-controller/irq.h>
+#include <dt-bindings/jesd204/adxcvr.h>
+
+&i2c1 {
+	i2c-mux@75 {
+		i2c@0 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0>;
+
+			eeprom@50 {
+				compatible = "at24,24c02";
+				reg = <0x50>;
+			};
+
+		};
+	};
+};
+
+/ {
+
+	ad9164_control@0 {
+		compatible = "adi,one-bit-adc-dac";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		out-gpios = <&gpio 99 0>, <&gpio 100 0>, <&gpio 101 0>, <&gpio 102 0>, <&gpio 103 0>;
+		label = "ad9164_control";
+		channel@0 {
+			reg = <0>;
+			label = "dac_ctrl_0";
+		};
+		channel@1 {
+			reg = <1>;
+			label = "dac_ctrl_1";
+		};
+		channel@2 {
+			reg = <2>;
+			label = "dac_ctrl_2";
+		};
+		channel@3 {
+			reg = <3>;
+			label = "dac_ctrl_3";
+		};
+		channel@4 {
+			reg = <4>;
+			label = "dac_ctrl_4";
+		};
+	};
+
+	fpga_axi: fpga-axi@0 {
+		interrupt-parent = <&gic>;
+		compatible = "simple-bus";
+		#address-cells = <0x1>;
+		#size-cells = <0x1>;
+		ranges = <0 0 0 0xffffffff>;
+
+		tx_dma: tx-dmac@9c420000 {
+			#dma-cells = <1>;
+			compatible = "adi,axi-dmac-1.00.a";
+			adi,cyclic;
+			reg = <0x9c420000 0x10000>;
+			interrupts = <0 108 IRQ_TYPE_LEVEL_HIGH>;
+			clocks = <&zynqmp_clk 71>;
+		};
+
+		axi_ad9164_core: axi-ad9164-hpc@84a04000 {
+			compatible = "adi,axi-ad9162-1.0";
+			reg = <0x84a04000 0x10000>;
+			dmas = <&tx_dma 0>;
+			dma-names = "tx";
+			spibus-connected = <&dac0_ad9164>;
+			adi,axi-pl-fifo-enable;
+			/* jesd204-fsm support */
+			jesd204-device;
+			#jesd204-cells = <2>;
+			jesd204-inputs = <&axi_ad9164_jesd 0 0>;
+		};
+
+		axi_ad9164_jesd: axi-jesd204-tx@84a90000 {
+			compatible = "adi,axi-jesd204-tx-1.0";
+			reg = <0x84a90000 0x4000>;
+
+			interrupts = <0 106 IRQ_TYPE_LEVEL_HIGH>;
+
+			clocks = <&zynqmp_clk 71>, <&axi_ad9164_adxcvr 1>, <&axi_ad9164_adxcvr 0>;
+			clock-names = "s_axi_aclk", "device_clk", "lane_clk";
+
+			#clock-cells = <0>;
+			clock-output-names = "jesd_dac_lane_clk";
+
+			/* jesd204-fsm support */
+			jesd204-device;
+			#jesd204-cells = <2>;
+			jesd204-inputs = <&axi_ad9164_adxcvr 0 0>;
+		};
+
+		axi_ad9164_adxcvr: axi-adxcvr-tx@84a60000 {
+			compatible = "adi,axi-adxcvr-1.0";
+			reg = <0x84a60000 0x1000>;
+
+			clocks = <&ad9508_clk 0>;
+			clock-names = "conv";
+
+			adi,sys-clk-select = <XCVR_QPLL>;
+			adi,out-clk-select = <XCVR_REFCLK>;
+			adi,use-lpm-enable;
+
+			#clock-cells = <1>;
+			clock-output-names = "dac_gt_clk", "tx_out_clk";
+
+			/* jesd204-fsm support */
+			jesd204-device;
+			#jesd204-cells = <2>;
+		};
+
+		axi_sysid_0: axi-sysid-0@85000000 {
+			compatible = "adi,axi-sysid-1.00.a";
+			reg = <0x85000000 0x10000>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+};
+
+#define fmc_spi spi0
+
+#include "adi-ad9164-fmc-ebz.dtsi"


### PR DESCRIPTION

## PR Description

The device trees were added for the EVAL-AD9164 board on the ZCU102.

JESD Link Mode 8 Example: M2, L8, S2, F1, NP'16, Interpolation: 2 : [zynqmp-zcu102-rev10-ad9164-fmc-ebz_m2_s2.dts](https://github.com/analogdevicesinc/linux/compare/main...ad9164_zcu102_dts#diff-fec5122f173d7b2d224ba67a75a98c04e214875e7fe4114a14a7e604dd9c5247)

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
