### PR TITLE
iio: adc: adrv9002: fix tx2 scale for rx2tx2

### DIFF
--- a/drivers/iio/adc/navassa/adrv9002.c
+++ b/drivers/iio/adc/navassa/adrv9002.c
@@ -3864,20 +3864,33 @@ static void adrv9002_fill_profile_read(struct adrv9002_rf_phy *phy)
  * Obviuosly, this is an awful workaround and we need to understand the root cause of
  * the issue and properly fix things. Hopefully this won't one those things where
  * "we fix it later" means never!
+ *
+ * Update: Now we do the fixup for all TX channels and for rx2tx2 mode.
  */
-int adrv9002_tx2_fixup(const struct adrv9002_rf_phy *phy)
+int adrv9002_tx_fixup(const struct adrv9002_rf_phy *phy, unsigned int chan)
 {
-	const struct adrv9002_chan *tx = &phy->tx_channels[ADRV9002_CHANN_2].channel;
+	const struct adrv9002_chan *tx = &phy->tx_channels[chan].channel;
 	struct  adi_adrv9001_TxSsiTestModeCfg ssi_cfg = {
 		.testData = ADI_ADRV9001_SSI_TESTMODE_DATA_FIXED_PATTERN,
 	};
 	struct adi_adrv9001_TxSsiTestModeStatus dummy;
 
-	if (phy->chip->n_tx < ADRV9002_CHANN_MAX || phy->rx2tx2)
-		return 0;
-
 	return api_call(phy, adi_adrv9001_Ssi_Tx_TestMode_Status_Inspect, tx->number, phy->ssi_type,
 			ADI_ADRV9001_SSI_FORMAT_16_BIT_I_Q_DATA, &ssi_cfg, &dummy);
+}
+
+int adrv9002_tx_fixup_all(const struct adrv9002_rf_phy *phy)
+{
+	int ret;
+	u32 c;
+
+	for (c = 0; c < phy->chip->n_tx; c++) {
+		ret = adrv9002_tx_fixup(phy, c);
+		if (ret)
+			return ret;
+	}
+
+	return 0;
 }
 
 int adrv9002_init(struct adrv9002_rf_phy *phy, struct adi_adrv9001_Init *profile)
@@ -3930,7 +3943,7 @@ int adrv9002_init(struct adrv9002_rf_phy *phy, struct adi_adrv9001_Init *profile
 
 	adrv9002_fill_profile_read(phy);
 
-	return adrv9002_tx2_fixup(phy);
+	return adrv9002_tx_fixup_all(phy);
 error:
 	/*
 	 * Leave the device in a reset state in case of error. There's not much we can do if

--- a/drivers/iio/adc/navassa/adrv9002.h
+++ b/drivers/iio/adc/navassa/adrv9002.h
@@ -312,7 +312,8 @@ int adrv9002_intf_test_cfg(const struct adrv9002_rf_phy *phy, const int chann, c
 int adrv9002_check_tx_test_pattern(const struct adrv9002_rf_phy *phy, const int chann);
 int adrv9002_intf_change_delay(const struct adrv9002_rf_phy *phy, const int channel, u8 clk_delay,
 			       u8 data_delay, const bool tx);
-int adrv9002_tx2_fixup(const struct adrv9002_rf_phy *phy);
+int adrv9002_tx_fixup(const struct adrv9002_rf_phy *phy, unsigned int chan);
+int adrv9002_tx_fixup_all(const struct adrv9002_rf_phy *phy);
 adi_adrv9001_SsiTestModeData_e adrv9002_get_test_pattern(const struct adrv9002_rf_phy *phy,
 							 unsigned int chan, bool rx, bool stop);
 /* phy lock must be held before entering the API */

--- a/drivers/iio/adc/navassa/adrv9002_conv.c
+++ b/drivers/iio/adc/navassa/adrv9002_conv.c
@@ -516,11 +516,12 @@ int adrv9002_axi_intf_tune(const struct adrv9002_rf_phy *phy, const bool tx, con
 				return ret;
 
 			if (tx) {
-				if (chann) {
-					ret = adrv9002_tx2_fixup(phy);
-					if (ret)
-						return ret;
-				}
+				if (phy->rx2tx2)
+					ret = adrv9002_tx_fixup_all(phy);
+				else
+					ret = adrv9002_tx_fixup(phy, chann);
+				if (ret)
+					return ret;
 				/*
 				 * we need to restart the tx test for every iteration since it's
 				 * the only way to reset the counters.


### PR DESCRIPTION
## PR Description

Similar to

commit 7ebe866977d4 ("iio: adc: adrv9002: fixup tx2 power level")

we need to apply the same fixup even in rx2tx2. The reasoning for not doing it at the time was that if the channels are tuned together and have the same SSI delays, it should not be needed. Well...

While at it (and as advised by HW folks), we're now doing the fixup for all TX channels.

Reported and tested:

https://ez.analog.com/linux-software-drivers/f/q-a/588904/adrv9002-tx-at-full-scale-distortion

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
