### PR TITLE
spi: spi-gpio: fix bug introduced by 6.6 merge

### DIFF
--- a/drivers/spi/spi-gpio.c
+++ b/drivers/spi/spi-gpio.c
@@ -419,7 +419,7 @@ static int spi_gpio_probe(struct platform_device *pdev)
 
 	host->bits_per_word_mask = SPI_BPW_RANGE_MASK(1, 32);
 	host->mode_bits = SPI_3WIRE | SPI_3WIRE_HIZ | SPI_CPHA | SPI_CPOL |
-			  SPI_CS_HIGH | SPI_LSB_FIRST SPI_MOSI_IDLE_LOW |
+			  SPI_CS_HIGH | SPI_LSB_FIRST | SPI_MOSI_IDLE_LOW |
 			  SPI_MOSI_IDLE_HIGH;
 	if (!spi_gpio->mosi) {
 		/* HW configuration without MOSI pin


### PR DESCRIPTION
## PR Description

Fix the host->mode_bits mask. Missed to OR SPI_LSB_FIRST with SPI_MOSI_IDLE_LOW .

Fixes: d31fa3135dbe ("Merge tag 'xilinx-v2024.1' of https://github.com/Xilinx/linux-xlnx.git")

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
