### PR TITLE
azure-pipelines-rpi: update for new rpi branch

### DIFF
--- a/azure-pipelines-rpi.yml
+++ b/azure-pipelines-rpi.yml
@@ -4,6 +4,7 @@ trigger:
 - rpi-5.10.y
 - rpi-5.15.y
 - rpi-6.1.y
+- rpi-6.6.y
 - staging-rpi/*
 
 pr:
@@ -12,6 +13,7 @@ pr:
 - rpi-5.10.y
 - rpi-5.15.y
 - rpi-6.1.y
+- rpi-6.6.y
 
 stages:
 - stage: Builds


### PR DESCRIPTION
## PR Description

The latest supported rpi branch is rpi-6.6.y. Add support for it in CI.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
