### PR TITLE
ARM: dts: use upstream axi-clkgen clock-names order

### DIFF
--- a/arch/arm/boot/dts/xilinx/zynq-adrv9361-z7035-fmc.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-adrv9361-z7035-fmc.dts
@@ -182,8 +182,8 @@
 			compatible = "adi,axi-clkgen-2.00.a";
 			reg = <0x79000000 0x10000>;
 			#clock-cells = <0>;
-			clocks = <&clkc 15>, <&clkc 16>;
-			clock-names = "s_axi_aclk", "clkin1";
+			clocks = <&clkc 16>, <&clkc 15>;
+			clock-names = "clkin1", "s_axi_aclk";
 		};
 
 		axi_hdmi@70e00000 {

--- a/arch/arm/boot/dts/xilinx/zynq-coraz7s-ad7687-pmdz.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-coraz7s-ad7687-pmdz.dts
@@ -81,7 +81,7 @@
 		reg = <0x44a70000 0x10000>;
 		#clock-cells = <0>;
 		clocks = <&clkc 15>, <&clkc 15>;
-		clock-names = "s_axi_aclk", "clkin1";
+		clock-names = "clkin1", "s_axi_aclk";
 		clock-output-names = "spi_clk";
 	};
 };

--- a/arch/arm/boot/dts/xilinx/zynq-coraz7s-ad7689-ardz.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-coraz7s-ad7689-ardz.dts
@@ -104,7 +104,7 @@
 		reg = <0x44a70000 0x10000>;
 		#clock-cells = <0>;
 		clocks = <&clkc 15>, <&clkc 15>;
-		clock-names = "s_axi_aclk", "clkin1";
+		clock-names = "clkin1", "s_axi_aclk";
 		clock-output-names = "spi_clk";
 	};
 };

--- a/arch/arm/boot/dts/xilinx/zynq-coraz7s-ad7946.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-coraz7s-ad7946.dts
@@ -80,7 +80,7 @@
 		reg = <0x44a70000 0x10000>;
 		#clock-cells = <0>;
 		clocks = <&clkc 15>, <&clkc 15>;
-		clock-names = "s_axi_aclk", "clkin1";
+		clock-names = "clkin1", "s_axi_aclk";
 		clock-output-names = "spi_clk";
 	};
 };

--- a/arch/arm/boot/dts/xilinx/zynq-coraz7s-ad7984.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-coraz7s-ad7984.dts
@@ -81,7 +81,7 @@
 		reg = <0x44a70000 0x10000>;
 		#clock-cells = <0>;
 		clocks = <&clkc 15>, <&clkc 15>;
-		clock-names = "s_axi_aclk", "clkin1";
+		clock-names = "clkin1", "s_axi_aclk";
 		clock-output-names = "spi_clk";
 	};
 };

--- a/arch/arm/boot/dts/xilinx/zynq-coraz7s-adaq4003.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-coraz7s-adaq4003.dts
@@ -83,7 +83,7 @@
 		reg = <0x44a70000 0x10000>;
 		#clock-cells = <0>;
 		clocks = <&clkc 15>, <&clkc 15>;
-		clock-names = "s_axi_aclk", "clkin1";
+		clock-names = "clkin1", "s_axi_aclk";
 		clock-output-names = "spi_clk";
 	};
 };

--- a/arch/arm/boot/dts/xilinx/zynq-coraz7s-cn0540.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-coraz7s-cn0540.dts
@@ -170,7 +170,7 @@
 		reg = <0x44a70000 0x10000>;
 		#clock-cells = <0>;
 		clocks = <&clkc 15>, <&clkc 15>;
-		clock-names = "s_axi_aclk", "clkin1";
+		clock-names = "clkin1", "s_axi_aclk";
 		clock-output-names = "spi_clk";
 	};
 };

--- a/arch/arm/boot/dts/xilinx/zynq-zc702-adv7511.dtsi
+++ b/arch/arm/boot/dts/xilinx/zynq-zc702-adv7511.dtsi
@@ -93,8 +93,8 @@
 			compatible = "adi,axi-clkgen-2.00.a";
 			reg = <0x79000000 0x10000>;
 			#clock-cells = <0>;
-			clocks = <&clkc 15>, <&clkc 16>;
-			clock-names = "s_axi_aclk", "clkin1";
+			clocks = <&clkc 16>, <&clkc 15>;
+			clock-names = "clkin1", "s_axi_aclk";
 		};
 
 		axi_hdmi@70e00000 {

--- a/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-adrv9008-1.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-adrv9008-1.dts
@@ -72,8 +72,8 @@
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x43c10000 0x10000>;
 		#clock-cells = <0>;
-		clocks = <&clkc 15>, <&clk0_ad9528 1>;
-		clock-names = "s_axi_aclk", "clkin1";
+		clocks = <&clk0_ad9528 1>, <&clkc 15>;
+		clock-names = "clkin1", "s_axi_aclk";
 		clock-output-names = "axi_rx_clkgen";
 	};
 

--- a/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-adrv9008-2.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-adrv9008-2.dts
@@ -112,8 +112,8 @@
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x43c00000 0x10000>;
 		#clock-cells = <0>;
-		clocks = <&clkc 15>, <&clk0_ad9528 1>;
-		clock-names = "s_axi_aclk", "clkin1";
+		clocks = <&clk0_ad9528 1>, <&clkc 15>;
+		clock-names = "clkin1", "s_axi_aclk";
 		clock-output-names = "axi_tx_clkgen";
 	};
 
@@ -121,8 +121,8 @@
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x43c20000 0x10000>;
 		#clock-cells = <0>;
-		clocks = <&clkc 15>, <&clk0_ad9528 1>;
-		clock-names = "s_axi_aclk", "clkin1";
+		clocks = <&clk0_ad9528 1>, <&clkc 15>;
+		clock-names = "clkin1", "s_axi_aclk";
 		clock-output-names = "axi_rx_os_clkgen";
 	};
 

--- a/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-adrv9009.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-adrv9009.dts
@@ -148,8 +148,8 @@
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x43c00000 0x10000>;
 		#clock-cells = <0>;
-		clocks = <&clkc 15>, <&clk0_ad9528 1>;
-		clock-names = "s_axi_aclk", "clkin1";
+		clocks = <&clk0_ad9528 1>, <&clkc 15>;
+		clock-names = "clkin1", "s_axi_aclk";
 		clock-output-names = "axi_tx_clkgen";
 	};
 
@@ -157,8 +157,8 @@
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x43c10000 0x10000>;
 		#clock-cells = <0>;
-		clocks = <&clkc 15>, <&clk0_ad9528 1>;
-		clock-names = "s_axi_aclk", "clkin1";
+		clocks = <&clk0_ad9528 1>, <&clkc 15>;
+		clock-names = "clkin1", "s_axi_aclk";
 		clock-output-names = "axi_rx_clkgen";
 	};
 
@@ -166,8 +166,8 @@
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x43c20000 0x10000>;
 		#clock-cells = <0>;
-		clocks = <&clkc 15>, <&clk0_ad9528 1>;
-		clock-names = "s_axi_aclk", "clkin1";
+		clocks = <&clk0_ad9528 1>, <&clkc 15>;
+		clock-names = "clkin1", "s_axi_aclk";
 		clock-output-names = "axi_rx_os_clkgen";
 	};
 

--- a/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-adrv9371.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-adrv9371.dts
@@ -147,8 +147,8 @@
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x43c00000 0x10000>;
 		#clock-cells = <0>;
-		clocks = <&clkc 15>, <&clk0_ad9528 1>;
-		clock-names = "s_axi_aclk", "clkin1";
+		clocks = <&clk0_ad9528 1>, <&clkc 15>;
+		clock-names = "clkin1", "s_axi_aclk";
 		clock-output-names = "axi_tx_clkgen";
 	};
 
@@ -156,8 +156,8 @@
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x43c10000 0x10000>;
 		#clock-cells = <0>;
-		clocks = <&clkc 15>, <&clk0_ad9528 1>;
-		clock-names = "s_axi_aclk", "clkin1";
+		clocks = <&clk0_ad9528 1>, <&clkc 15>;
+		clock-names = "clkin1", "s_axi_aclk";
 		clock-output-names = "axi_rx_clkgen";
 
 	};
@@ -166,8 +166,8 @@
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x43c20000 0x10000>;
 		#clock-cells = <0>;
-		clocks = <&clkc 15>, <&clk0_ad9528 1>;
-		clock-names = "s_axi_aclk", "clkin1";
+		clocks = <&clk0_ad9528 1>, <&clkc 15>;
+		clock-names = "clkin1", "s_axi_aclk";
 		clock-output-names = "axi_rx_os_clkgen";
 
 	};

--- a/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511.dtsi
+++ b/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511.dtsi
@@ -121,8 +121,8 @@
 			compatible = "adi,axi-clkgen-2.00.a";
 			reg = <0x79000000 0x10000>;
 			#clock-cells = <0>;
-			clocks = <&clkc 15>, <&clkc 16>;
-			clock-names = "s_axi_aclk", "clkin1";
+			clocks = <&clkc 16>, <&clkc 15>;
+			clock-names = "clkin1", "s_axi_aclk";
 		};
 
 		axi_hdmi@70e00000 {

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4003.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4003.dts
@@ -63,7 +63,7 @@
 		reg = <0x44a70000 0x10000>;
 		#clock-cells = <0>;
 		clocks = <&clkc 15>, <&clkc 15>;
-		clock-names = "s_axi_aclk", "clkin1";
+		clock-names = "clkin1", "s_axi_aclk";
 		clock-output-names = "spi_clk";
 	};
 

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4020.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4020.dts
@@ -64,7 +64,7 @@
 		reg = <0x44a70000 0x10000>;
 		#clock-cells = <0>;
 		clocks = <&clkc 15>, <&clkc 15>;
-		clock-names = "s_axi_aclk", "clkin1";
+		clock-names = "clkin1", "s_axi_aclk";
 		clock-output-names = "spi_clk";
 	};
 

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4030-24.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4030-24.dts
@@ -63,7 +63,7 @@
 		reg = <0x44a70000 0x10000>;
 		#clock-cells = <0>;
 		clocks = <&clkc 15>, <&clkc 15>;
-		clock-names = "s_axi_aclk", "clkin1";
+		clock-names = "clkin1", "s_axi_aclk";
 		clock-output-names = "spi_clk";
 	};
 

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4032-24.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4032-24.dts
@@ -63,7 +63,7 @@
 		reg = <0x44a70000 0x10000>;
 		#clock-cells = <0>;
 		clocks = <&clkc 15>, <&clkc 15>;
-		clock-names = "s_axi_aclk", "clkin1";
+		clock-names = "clkin1", "s_axi_aclk";
 		clock-output-names = "spi_clk";
 	};
 

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4134.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4134.dts
@@ -99,7 +99,7 @@
 		reg = <0x44b10000 0x10000>;
 		#clock-cells = <0>;
 		clocks = <&clkc 15>, <&clkc 15>;
-		clock-names = "s_axi_aclk", "clkin1";
+		clock-names = "clkin1", "s_axi_aclk";
 	};
 };
 

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4630-16.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4630-16.dts
@@ -63,7 +63,7 @@
 		reg = <0x44a70000 0x10000>;
 		#clock-cells = <0>;
 		clocks = <&clkc 15>, <&clkc 15>;
-		clock-names = "s_axi_aclk", "clkin1";
+		clock-names = "clkin1", "s_axi_aclk";
 		clock-output-names = "spi_clk";
 	};
 

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4630-24.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4630-24.dts
@@ -63,7 +63,7 @@
 		reg = <0x44a70000 0x10000>;
 		#clock-cells = <0>;
 		clocks = <&clkc 15>, <&clkc 15>;
-		clock-names = "s_axi_aclk", "clkin1";
+		clock-names = "clkin1", "s_axi_aclk";
 		clock-output-names = "spi_clk";
 	};
 

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4696.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4696.dts
@@ -86,7 +86,7 @@
 		reg = <0x44a70000 0x10000>;
 		#clock-cells = <0>;
 		clocks = <&clkc 15>, <&clkc 15>;
-		clock-names = "s_axi_aclk", "clkin1";
+		clock-names = "clkin1", "s_axi_aclk";
 		clock-output-names = "spi_clk";
 	};
 

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad7768-1-evb.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad7768-1-evb.dts
@@ -48,7 +48,7 @@
 		reg = <0x44a70000 0x10000>;
 		#clock-cells = <0>;
 		clocks = <&clkc 15>, <&clkc 16>;
-		clock-names = "s_axi_aclk", "clkin1";
+		clock-names = "clkin1", "s_axi_aclk";
 	};
 
 	axi_spi_engine_0: spi@0x44a00000 {

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad7944.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad7944.dts
@@ -72,7 +72,7 @@
 		reg = <0x44a70000 0x1000>;
 		#clock-cells = <0>;
 		clocks = <&clkc 15>, <&clkc 15>;
-		clock-names = "s_axi_aclk", "clkin1";
+		clock-names = "clkin1", "s_axi_aclk";
 		clock-output-names = "spi_clk";
 
 		/* needs to be high enough to allow >= 91.5MHz SCLK for turbo */

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad7985.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad7985.dts
@@ -72,7 +72,7 @@
 		reg = <0x44a70000 0x1000>;
 		#clock-cells = <0>;
 		clocks = <&clkc 15>, <&clkc 15>;
-		clock-names = "s_axi_aclk", "clkin1";
+		clock-names = "clkin1", "s_axi_aclk";
 		clock-output-names = "spi_clk";
 
 		/* needs to be high enough to allow >= 91.5MHz SCLK for turbo */

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad7986.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad7986.dts
@@ -72,7 +72,7 @@
 		reg = <0x44a70000 0x1000>;
 		#clock-cells = <0>;
 		clocks = <&clkc 15>, <&clkc 15>;
-		clock-names = "s_axi_aclk", "clkin1";
+		clock-names = "clkin1", "s_axi_aclk";
 		clock-output-names = "spi_clk";
 
 		/* needs to be high enough to allow >= 91.5MHz SCLK for turbo */

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq4003.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq4003.dts
@@ -63,7 +63,7 @@
 		reg = <0x44a70000 0x10000>;
 		#clock-cells = <0>;
 		clocks = <&clkc 15>, <&clkc 15>;
-		clock-names = "s_axi_aclk", "clkin1";
+		clock-names = "clkin1", "s_axi_aclk";
 		clock-output-names = "spi_clk";
 	};
 

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq4216.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq4216.dts
@@ -79,7 +79,7 @@
 		reg = <0x44a70000 0x10000>;
 		#clock-cells = <0>;
 		clocks = <&clkc 15>, <&clkc 15>;
-		clock-names = "s_axi_aclk", "clkin1";
+		clock-names = "clkin1", "s_axi_aclk";
 		clock-output-names = "spi_clk";
 	};
 

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq4220.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq4220.dts
@@ -90,7 +90,7 @@
 		reg = <0x44a70000 0x10000>;
 		#clock-cells = <0>;
 		clocks = <&clkc 15>, <&clkc 15>;
-		clock-names = "s_axi_aclk", "clkin1";
+		clock-names = "clkin1", "s_axi_aclk";
 		clock-output-names = "spi_clk";
 	};
 

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq4224-24.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq4224-24.dts
@@ -90,7 +90,7 @@
 		reg = <0x44a70000 0x10000>;
 		#clock-cells = <0>;
 		clocks = <&clkc 15>, <&clkc 15>;
-		clock-names = "s_axi_aclk", "clkin1";
+		clock-names = "clkin1", "s_axi_aclk";
 		clock-output-names = "spi_clk";
 	};
 

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq4224-24_cm0_sdi4_cz2.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq4224-24_cm0_sdi4_cz2.dts
@@ -77,7 +77,7 @@
 		reg = <0x44a70000 0x10000>;
 		#clock-cells = <0>;
 		clocks = <&clkc 15>, <&clkc 15>;
-		clock-names = "s_axi_aclk", "clkin1";
+		clock-names = "clkin1", "s_axi_aclk";
 		clock-output-names = "spi_clk";
 	};
 

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ltc2387.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ltc2387.dts
@@ -38,8 +38,8 @@
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x44a70000 0x10000>;
 		#clock-cells = <0>;
-		clocks = <&clkc 15>, <&ext_clk>;
-		clock-names = "s_axi_aclk", "clkin1";
+		clocks = <&ext_clk>, <&clkc 15>;
+		clock-names = "clkin1", "s_axi_aclk";
 		clock-output-names = "ref_clk";
 	};
 

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-m2k-revb.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-m2k-revb.dts
@@ -203,8 +203,8 @@
 	logic_analyzer_clkgen: clock@7000000 {
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x70000000 0x10000>;
-		clocks = <&clkc 15>, <&clkc 16>;
-		clock-names = "s_axi_aclk", "clkin1";
+		clocks = <&clkc 16>, <&clkc 15>;
+		clock-names = "clkin1", "s_axi_aclk";
 
 		#clock-cells = <0>;
 	};

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511.dtsi
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511.dtsi
@@ -91,8 +91,8 @@
 			compatible = "adi,axi-clkgen-2.00.a";
 			reg = <0x79000000 0x10000>;
 			#clock-cells = <0>;
-			clocks = <&clkc 15>, <&clkc 16>;
-			clock-names = "s_axi_aclk", "clkin1";
+			clocks = <&clkc 16>, <&clkc 15>;
+			clock-names = "clkin1", "s_axi_aclk";
 		};
 
 		axi_hdmi@70e00000 {

--- a/arch/arm/boot/dts/xilinx/zynq-zed-imageon.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-imageon.dts
@@ -132,8 +132,8 @@
 			compatible = "adi,axi-clkgen-2.00.a";
 			reg = <0x79000000 0x10000>;
 			#clock-cells = <0>;
-			clocks = <&clkc 15>, <&clkc 16>;
-			clock-names = "s_axi_aclk", "clkin1";
+			clocks = <&clkc 16>, <&clkc 15>;
+			clock-names = "clkin1", "s_axi_aclk";
 		};
 
 		axi_hdmi_core: axi-hdmi-tx@70e00000 {

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9008-1.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9008-1.dts
@@ -81,8 +81,8 @@
 			compatible = "adi,axi-clkgen-2.00.a";
 			reg = <0x83c10000 0x10000>;
 			#clock-cells = <0>;
-			clocks = <&zynqmp_clk 71>, <&clk0_ad9528 1>;
-			clock-names = "s_axi_aclk", "clkin1";
+			clocks = <&clk0_ad9528 1>, <&zynqmp_clk 71>;
+			clock-names = "clkin1", "s_axi_aclk";
 			clock-output-names = "axi_rx_clkgen";
 		};
 

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9008-2.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9008-2.dts
@@ -123,8 +123,8 @@
 			compatible = "adi,axi-clkgen-2.00.a";
 			reg = <0x83c00000 0x10000>;
 			#clock-cells = <0>;
-			clocks = <&zynqmp_clk 71>, <&clk0_ad9528 1>;
-			clock-names = "s_axi_aclk", "clkin1";
+			clocks = <&clk0_ad9528 1>, <&zynqmp_clk 71>;
+			clock-names = "clkin1", "s_axi_aclk";
 			clock-output-names = "axi_tx_clkgen";
 		};
 
@@ -132,8 +132,8 @@
 			compatible = "adi,axi-clkgen-2.00.a";
 			reg = <0x83c20000 0x10000>;
 			#clock-cells = <0>;
-			clocks = <&zynqmp_clk 71>, <&clk0_ad9528 1>;
-			clock-names = "s_axi_aclk", "clkin1";
+			clocks = <&clk0_ad9528 1>, <&zynqmp_clk 71>;
+			clock-names = "clkin1", "s_axi_aclk";
 			clock-output-names = "axi_rx_os_clkgen";
 		};
 

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9009.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9009.dts
@@ -175,8 +175,8 @@
 			compatible = "adi,axi-clkgen-2.00.a";
 			reg = <0x83c00000 0x10000>;
 			#clock-cells = <0>;
-			clocks = <&zynqmp_clk 71>, <&clk0_ad9528 1>;
-			clock-names = "s_axi_aclk", "clkin1";
+			clocks = <&clk0_ad9528 1>, <&zynqmp_clk 71>;
+			clock-names = "clkin1", "s_axi_aclk";
 			clock-output-names = "axi_tx_clkgen";
 		};
 
@@ -184,8 +184,8 @@
 			compatible = "adi,axi-clkgen-2.00.a";
 			reg = <0x83c10000 0x10000>;
 			#clock-cells = <0>;
-			clocks = <&zynqmp_clk 71>, <&clk0_ad9528 1>;
-			clock-names = "s_axi_aclk", "clkin1";
+			clocks = <&clk0_ad9528 1>, <&zynqmp_clk 71>;
+			clock-names = "clkin1", "s_axi_aclk";
 			clock-output-names = "axi_rx_clkgen";
 		};
 
@@ -193,8 +193,8 @@
 			compatible = "adi,axi-clkgen-2.00.a";
 			reg = <0x83c20000 0x10000>;
 			#clock-cells = <0>;
-			clocks = <&zynqmp_clk 71>, <&clk0_ad9528 1>;
-			clock-names = "s_axi_aclk", "clkin1";
+			clocks = <&clk0_ad9528 1>, <&zynqmp_clk 71>;
+			clock-names = "clkin1", "s_axi_aclk";
 			clock-output-names = "axi_rx_os_clkgen";
 		};
 

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9371.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9371.dts
@@ -156,8 +156,8 @@
 			compatible = "adi,axi-clkgen-2.00.a";
 			reg = <0x83c00000 0x10000>;
 			#clock-cells = <0>;
-			clocks = <&zynqmp_clk 71>, <&clk0_ad9528 1>;
-			clock-names = "s_axi_aclk", "clkin1";
+			clocks = <&clk0_ad9528 1>, <&zynqmp_clk 71>;
+			clock-names = "clkin1", "s_axi_aclk";
 			clock-output-names = "axi_tx_clkgen";
 		};
 
@@ -165,8 +165,8 @@
 			compatible = "adi,axi-clkgen-2.00.a";
 			reg = <0x83c10000 0x10000>;
 			#clock-cells = <0>;
-			clocks = <&zynqmp_clk 71>, <&clk0_ad9528 1>;
-			clock-names = "s_axi_aclk", "clkin1";
+			clocks = <&clk0_ad9528 1>, <&zynqmp_clk 71>;
+			clock-names = "clkin1", "s_axi_aclk";
 			clock-output-names = "axi_rx_clkgen";
 		};
 
@@ -174,8 +174,8 @@
 			compatible = "adi,axi-clkgen-2.00.a";
 			reg = <0x83c20000 0x10000>;
 			#clock-cells = <0>;
-			clocks = <&zynqmp_clk 71>, <&clk0_ad9528 1>;
-			clock-names = "s_axi_aclk", "clkin1";
+			clocks = <&clk0_ad9528 1>, <&zynqmp_clk 71>;
+			clock-names = "clkin1", "s_axi_aclk";
 			clock-output-names = "axi_rx_os_clkgen";
 		};
 

--- a/arch/microblaze/boot/dts/kcu105_adrv9371x.dts
+++ b/arch/microblaze/boot/dts/kcu105_adrv9371x.dts
@@ -83,24 +83,24 @@
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x43c10000 0x10000>;
 		#clock-cells = <0>;
-		clocks = <&clk_bus_0>, <&clk0_ad9528 1>;
-		clock-names = "s_axi_aclk", "clkin1";
+		clocks = <&clk0_ad9528 1>, <&clk_bus_0>;
+		clock-names = "clkin1", "s_axi_aclk";
 		clock-output-names = "axi_rx_clkgen";
 	};
 	axi_rx_os_clkgen: axi-clkgen@43c20000  {
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x43c20000 0x10000>;
 		#clock-cells = <0>;
-		clocks = <&clk_bus_0>, <&clk0_ad9528 1>;
-		clock-names = "s_axi_aclk", "clkin1";
+		clocks = <&clk0_ad9528 1>, <&clk_bus_0>;
+		clock-names = "clkin1", "s_axi_aclk";
 		clock-output-names = "axi_rx_os_clkgen";
 	};
 	axi_tx_clkgen: axi-clkgen@43c00000  {
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x43c00000 0x10000>;
 		#clock-cells = <0>;
-		clocks = <&clk_bus_0>, <&clk0_ad9528 1>;
-		clock-names = "s_axi_aclk", "clkin1";
+		clocks = <&clk0_ad9528 1>, <&clk_bus_0>;
+		clock-names = "clkin1", "s_axi_aclk";
 		clock-output-names = "axi_tx_clkgen";
 	};
 	axi_ad9371_adxcvr_rx: axi-adxcvr-rx@44a60000 {


### PR DESCRIPTION

## PR Description
Change the order of clocks and clock-names in "adi,axi-clkgen-2.00.a" node to match the order specified in the binding documentation.

This order was formalized upstream in [1].

[1]: https://lore.kernel.org/all/20241029-axi-clkgen-fix-axiclk-v2-1-bc5e0733ad76@analog.com/

## PR Type
cleanup

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
