### PR TITLE
[main] iio: adc: ad_sigma_delta: fix spi engine offload

### DIFF
--- a/drivers/iio/adc/ad_sigma_delta.c
+++ b/drivers/iio/adc/ad_sigma_delta.c
@@ -420,7 +420,8 @@ static int ad_sd_buffer_postenable(struct iio_dev *indio_dev)
 	sigma_delta->active_slots = slot;
 	sigma_delta->current_slot = 0;
 
-	if (sigma_delta->active_slots > 1) {
+	if (iio_device_get_current_mode(indio_dev) != INDIO_BUFFER_HARDWARE &&
+	    sigma_delta->active_slots > 1) {
 		ret = ad_sigma_delta_append_status(sigma_delta, true);
 		if (ret)
 			return ret;


### PR DESCRIPTION
Enabling append status breaks projects that also use SPI engine offload (cn0363). Append status is only necessary when using CPU for reading samples.

Check if SPI engine offload is used before enabling append status.

Fixes: 27b588fc154f ("Merge tag 'xilinx-v2023.1' of https://github.com/Xilinx/linux-xlnx.git")

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
