### PR TITLE
iio: adc: cf_axi_adc_core: relax check in register access

### DIFF
--- a/drivers/iio/adc/cf_axi_adc_core.c
+++ b/drivers/iio/adc/cf_axi_adc_core.c
@@ -49,7 +49,6 @@ struct axiadc_state {
 	struct clk 			*clk;
 	struct gpio_desc		*gpio_decimation;
 	struct jesd204_dev 		*jdev;
-	size_t				regs_size;
 	void __iomem			*regs;
 	void __iomem			*slave_regs;
 	unsigned int			max_usr_channel;
@@ -234,9 +233,8 @@ static int axiadc_reg_access(struct iio_dev *indio_dev,
 	struct axiadc_converter *conv = to_converter(st->dev_spi);
 	int ret;
 
-	/* Check that the register is in range and aligned */
-	if ((reg & DEBUGFS_DRA_PCORE_REG_MAGIC) &&
-	    ((reg & 0xffff) >= st->regs_size || (reg & 0x3)))
+	/* Check that the register is aligned */
+	if ((reg & DEBUGFS_DRA_PCORE_REG_MAGIC) && (reg & 0x3))
 		return -EINVAL;
 
 	mutex_lock(&conv->lock);


### PR DESCRIPTION
## PR Description

With commit
c5a5970bb457 ("iio: adc: cf_axi_adc_core: use devm_jesd204_fsm_start()"),

we started to use devm_platform_ioremap_resource() which means 'regs_size' will stay unchanged during probe and will be 0. Thus, checking the register to fit the mapped area will fail in the debugfs interface. Hence, relax that check and only check for proper alignment. While checking if the register fits the mapped area would be a nice thing, this is a debug interface and users are expected to know what they are doing. Hence I prefer to have simplicity during probe and not to keep 'regs_size' only to be used in the debugfs interface.

Fixes: c5a5970bb457 ("iio: adc: cf_axi_adc_core: use devm_jesd204_fsm_start()")

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
