### PR TITLE
fix broken backport of c0c0293cf7a0 ("spi: drop gpf arg from __spi_split_transfer_maxsize()")

### DIFF
--- a/drivers/spi/spi-bcm2835.c
+++ b/drivers/spi/spi-bcm2835.c
@@ -1121,8 +1121,7 @@ static int bcm2835_spi_prepare_message(struct spi_controller *ctlr,
 		 * the SPI HW due to DLEN. Split up transfers (32-bit FIFO
 		 * aligned) if the limit is exceeded.
 		 */
-		ret = spi_split_transfers_maxsize(ctlr, msg, 65532,
-						  GFP_KERNEL | GFP_DMA);
+		ret = spi_split_transfers_maxsize(ctlr, msg, 65532);
 		if (ret)
 			return ret;
 	}

--- a/drivers/spi/spi-stm32.c
+++ b/drivers/spi/spi-stm32.c
@@ -1011,7 +1011,8 @@ static int stm32_spi_prepare_msg(struct spi_controller *ctrl,
 	if (spi->cfg->set_number_of_data) {
 		int ret;
 
-		ret = spi_split_transfers_maxwords(ctrl, msg, spi->t_size_max);
+		ret = spi_split_transfers_maxwords(ctrl, msg,
+						   STM32H7_SPI_TSIZE_MAX);
 		if (ret)
 			return ret;
 	}


### PR DESCRIPTION
This fixes a FTBFS in the spi-bcm2835 and spi-stm32 driver. Both were broken by a backport of c0c0293cf7a0 ("spi: drop gpf arg from __spi_split_transfer_maxsize()") which resulted in 98847e6e1b77c7a28738722b997c16bc1ce1a427.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)