### PR TITLE
ADRV9009: Add Data Offload to ZC706 and ZCU102 platforms

### DIFF
--- a/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-adrv9009.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-adrv9009.dts
@@ -88,6 +88,7 @@
 		clock-names = "sampl_clk";
 		spibus-connected = <&trx0_adrv9009>;
 		adi,axi-pl-fifo-enable;
+		adi,axi-data-offload-connected = <&axi_data_offload_tx>;
 		adi,axi-interpolation-core-available;
 		interpolation-gpios = <&gpio0 116 GPIO_ACTIVE_HIGH>;
 	};
@@ -219,6 +220,11 @@
 
 		adi,sys-clk-select = <XCVR_QPLL>;
 		adi,out-clk-select = <XCVR_REFCLK>;
+	};
+
+	axi_data_offload_tx: axi-data-offload-0@7c430000 {
+		compatible = "adi,axi-data-offload-1.0.a";
+		reg = <0x7c430000 0x10000>;
 	};
 };
 

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9009.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9009.dts
@@ -114,7 +114,8 @@
 			clocks = <&trx0_adrv9009 2>;
 			clock-names = "sampl_clk";
 			spibus-connected = <&trx0_adrv9009>;
-			//adi,axi-pl-fifo-enable;
+			adi,axi-pl-fifo-enable;
+			adi,axi-data-offload-connected = <&axi_data_offload_tx>;
 			adi,axi-interpolation-core-available;
 			interpolation-gpios = <&gpio 140 GPIO_ACTIVE_HIGH>;
 		};
@@ -251,6 +252,11 @@
 		axi_sysid_0: axi-sysid-0@85000000 {
 			compatible = "adi,axi-sysid-1.00.a";
 			reg = <0x85000000 0x10000>;
+		};
+
+		axi_data_offload_tx: axi-data-offload-0@9c430000 {
+			compatible = "adi,axi-data-offload-1.0.a";
+			reg = <0x9c430000 0x10000>;
 		};
 	};
 };


### PR DESCRIPTION
## PR Description

In the HDL design for adrv9009 with zc706, respectively zcu102, the DAC_FIFO component was replaced by Data Offload.
These devicetree changes were tested together with this PR: https://github.com/analogdevicesinc/hdl/pull/1516

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
