### PR TITLE
iio: beamformer: adar1000: Fix a build failure

### DIFF
--- a/drivers/iio/beamformer/adar1000.c
+++ b/drivers/iio/beamformer/adar1000.c
@@ -2635,8 +2635,8 @@ MODULE_DEVICE_TABLE(of, adar1000_of_match);
 static const struct spi_device_id adar1000_id[] = {
 	{ "adar1000" },
 	{ }
-}
-MODULE_DEVICE_TABLE(spi, adar1000_id_table);
+};
+MODULE_DEVICE_TABLE(spi, adar1000_id);
 
 static struct spi_driver adar1000_driver = {
 	.driver = {


### PR DESCRIPTION
The compiler is unhappy when the driver is configured as a module:

	In file included from drivers/iio/beamformer/adar1000.c:9:
	drivers/iio/beamformer/adar1000.c:2639:26: error: ‘adar1000_id_table’ undeclared here (not in a function); did you mean ‘adar1000_read_enable’?
	 2639 | MODULE_DEVICE_TABLE(spi, adar1000_id_table);
	      |                          ^~~~~~~~~~~~~~~~~
	include/linux/module.h:244:15: note: in definition of macro ‘MODULE_DEVICE_TABLE’
	  244 | extern typeof(name) __mod_##type##__##name##_device_table               \
	      |               ^~~~
	include/linux/module.h:244:21: error: ‘__mod_spi__adar1000_id_table_device_table’ aliased to undefined symbol ‘adar1000_id_table’
	  244 | extern typeof(name) __mod_##type##__##name##_device_table               \
	      |                     ^~~~~~
	drivers/iio/beamformer/adar1000.c:2639:1: note: in expansion of macro ‘MODULE_DEVICE_TABLE’
	 2639 | MODULE_DEVICE_TABLE(spi, adar1000_id_table);
	      | ^~~~~~~~~~~~~~~~~~~

This fixes the "more important part" of 7e7216d72564 ("iio: beamformer: adar1000: add spi_device_id table")

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
