### PR TITLE
arch: arm64: boot: dts: xilinx: ad9694: Fix GPIO pins

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9694.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9694.dts
@@ -120,9 +120,9 @@
 	adc0_ad9694: ad9694@0 {
 		compatible = "adi,ad9694";
 
-		powerdown-gpios = <&gpio 116 0>;
-		fastdetect-a-gpios = <&gpio 113 0>;
-		fastdetect-b-gpios = <&gpio 114 0>;
+		powerdown-gpios = <&gpio 110 0>;
+		fastdetect-a-gpios = <&gpio 111 0>;
+		fastdetect-b-gpios = <&gpio 112 0>;
 
 		spi-cpol;
 		spi-cpha;


### PR DESCRIPTION
## PR Description

Corrected the GPIO numbers in the AD9694 device tree, because in [HDL](https://github.com/analogdevicesinc/hdl/blob/main/projects/ad9694_fmc/zcu102/system_top.v#L103-L108), the powerdown is GPIO 32, fda is GPIO 33 and fdb is GPIO 34.
Adding the offset of 78 (needed for UltraScale), pwdn is 110, fda is 111 and fdb is 112.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
