### PR TITLE
arm64: dts: xilinx: AD9162 small fix

### DIFF
--- a/arch/arm64/boot/dts/xilinx/adi-ad9162-fmc-ebz.dtsi
+++ b/arch/arm64/boot/dts/xilinx/adi-ad9162-fmc-ebz.dtsi
@@ -2,7 +2,7 @@
 /*
  * dtsi file for AD916x-FMC-EBZ on Xilinx ZynqMP ZCU102 Rev 1.0
  *
- * Copyright (C) 2024 Analog Devices Inc.
+ * Copyright (C) 2025 Analog Devices Inc.
  */
 
 / {

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9162-fmc-ebz_m2_s2.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9162-fmc-ebz_m2_s2.dts
@@ -12,7 +12,7 @@
  * ADI_DAC_MODE: <08>
  * board_revision: <C>
  *
- * Copyright (C) 2024 Analog Devices Inc.
+ * Copyright (C) 2025 Analog Devices Inc.
  */
 
 #include "zynqmp-zcu102-rev1.0.dts"


### PR DESCRIPTION
## PR Description

Updated copyright year.

The devicetree was added for the
EVAL-AD9162 board working in
MODE 8 on the ZCU102.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
