### PR TITLE
power: supply: ltc4162l: Use GENMASK macro in bitmask operation

### DIFF
--- a/drivers/power/supply/ltc4162-l-charger.c
+++ b/drivers/power/supply/ltc4162-l-charger.c
@@ -410,7 +410,7 @@ static int ltc4162l_get_icharge(struct ltc4162l_info *info,
 	if (ret)
 		return ret;
 
-	regval &= BIT(6) - 1; /* Only the lower 5 bits */
+	regval &= GENMASK(5, 0);
 
 	/* The charge current servo level: (icharge_dac + 1) × 1mV/RSNSB */
 	++regval;
@@ -449,7 +449,7 @@ static int ltc4162l_get_vcharge(struct ltc4162l_info *info,
 	if (ret)
 		return ret;
 
-	regval &= BIT(6) - 1; /* Only the lower 5 bits */
+	regval &= GENMASK(5, 0);
 
 	/*
 	 * charge voltage setting can be computed from
@@ -500,7 +500,7 @@ static int ltc4015_get_vcharge(struct ltc4162l_info *info,
 	if (ret)
 		return ret;
 
-	regval &= BIT(6) - 1; /* Only the lower 5 bits */
+	regval &= GENMASK(5, 0);
 
 	/*
 	 * charge voltage setting can be computed from:
@@ -636,7 +636,7 @@ static int ltc4162l_get_iin_limit_dac(struct ltc4162l_info *info,
 	if (ret)
 		return ret;
 
-	regval &= BIT(6) - 1; /* Only 6 bits */
+	regval &= GENMASK(5, 0);
 
 	/* (iin_limit_dac + 1) × 500μV / RSNSI */
 	++regval;


### PR DESCRIPTION
Follow-up patch for ltc4162 driver, already applied upstream.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [X] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [X] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
