### PR TITLE
[ADRV9002]: RX Port Switch support

### DIFF
--- a/drivers/iio/adc/navassa/adrv9002.c
+++ b/drivers/iio/adc/navassa/adrv9002.c
@@ -110,6 +110,8 @@
 /* Frequency hopping */
 #define ADRV9002_FH_TABLE_COL_SZ	7
 
+#define ADRV9002_INIT_CALS_TIMEOUT_MS	(60 * MILLI)
+
 /* IRQ Masks */
 #define ADRV9002_GP_MASK_RX_DP_RECEIVE_ERROR		0x08000000
 #define ADRV9002_GP_MASK_TX_DP_TRANSMIT_ERROR		0x04000000
@@ -693,7 +695,8 @@ static int adrv9002_phy_rerun_cals(struct adrv9002_rf_phy *phy,
 	dev_dbg(&phy->spi->dev, "Re-run init cals: mask: %08X, %08X\n",
 		init_cals->chanInitCalMask[0], init_cals->chanInitCalMask[1]);
 
-	ret = api_call(phy, adi_adrv9001_cals_InitCals_Run, init_cals, 60000, &error);
+	ret = api_call(phy, adi_adrv9001_cals_InitCals_Run, init_cals,
+		       ADRV9002_INIT_CALS_TIMEOUT_MS, &error);
 	if (ret)
 		return ret;
 
@@ -2582,7 +2585,7 @@ static irqreturn_t adrv9002_irq_handler(int irq, void *p)
 		case ADI_ADRV9001_ACT_WARN_RERUN_TRCK_CAL:
 			dev_warn(&phy->spi->dev, "Re-running tracking calibrations\n");
 			api_call(phy, adi_adrv9001_cals_InitCals_Run,
-				 &phy->init_cals, 60000, &error);
+				 &phy->init_cals, ADRV9002_INIT_CALS_TIMEOUT_MS, &error);
 			break;
 		case ADI_COMMON_ACT_ERR_RESET_FULL:
 			dev_warn(&phy->spi->dev, "[%s]: Reset might be needed...\n",
@@ -2643,7 +2646,8 @@ static int adrv9002_init_cals_handle(struct adrv9002_rf_phy *phy)
 		return ret;
 
 run_cals:
-	return api_call(phy, adi_adrv9001_cals_InitCals_Run, &phy->init_cals, 60000, &errors);
+	return api_call(phy, adi_adrv9001_cals_InitCals_Run, &phy->init_cals,
+			ADRV9002_INIT_CALS_TIMEOUT_MS, &errors);
 }
 
 static int adrv9001_rx_path_config(struct adrv9002_rf_phy *phy,

--- a/drivers/iio/adc/navassa/adrv9002.h
+++ b/drivers/iio/adc/navassa/adrv9002.h
@@ -186,6 +186,7 @@ struct adrv9002_rx_chan {
 	struct adi_adrv9001_RxGainControlPinCfg *pin_cfg;
 	struct clk *tdd_clk;
 	struct gpio_desc *orx_gpio;
+	enum adi_adrv9001_RxRfInputSel manual_port;
 	u8 orx_en;
 #ifdef CONFIG_DEBUG_FS
 	struct adi_adrv9001_RxSsiTestModeCfg ssi_test;
@@ -276,6 +277,7 @@ struct adrv9002_rf_phy {
 	struct adi_adrv9001_Init	*curr_profile;
 	struct adi_adrv9001_Init	profile;
 	struct adi_adrv9001_InitCals	init_cals;
+	struct adi_adrv9001_RxPortSwitchCfg port_switch;
 	bool				run_cals;
 	u32				n_clks;
 	u32				dev_clkout_div;

--- a/drivers/iio/adc/navassa/adrv9002_debugfs.c
+++ b/drivers/iio/adc/navassa/adrv9002_debugfs.c
@@ -1539,6 +1539,18 @@ void adrv9002_debugfs_create(struct adrv9002_rf_phy *phy, struct dentry *d)
 
 	debugfs_create_u32("dev_clkout_div", 0600, d, &phy->dev_clkout_div);
 
+	/* port switch */
+	if (phy->port_switch.enable && !phy->port_switch.manualRxPortSwitch) {
+		debugfs_create_u64("rx_port_a_min_carrier_hz", 0600, d,
+				   &phy->port_switch.minFreqPortA_Hz);
+		debugfs_create_u64("rx_port_a_max_carrier_hz", 0600, d,
+				   &phy->port_switch.maxFreqPortA_Hz);
+		debugfs_create_u64("rx_port_b_min_carrier_hz", 0600, d,
+				   &phy->port_switch.minFreqPortB_Hz);
+		debugfs_create_u64("rx_port_b_max_carrier_hz", 0600, d,
+				   &phy->port_switch.maxFreqPortB_Hz);
+	}
+
 	for (chan = 0; chan < phy->chip->n_tx; chan++) {
 		struct adrv9002_tx_chan *tx = &phy->tx_channels[chan];
 


### PR DESCRIPTION
## PR Description

RX port switching is a feature where we can either manually switch between RXA and RXB or we can define a set of carrier ranges (one for RXA and another for RXB) and whenever the configured carrier falls in one range, the port configured for that range will be used.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
