### PR TITLE
arch: arm: dts: overlays: Update cn0554 overlay

### DIFF
--- a/arch/arm/boot/dts/overlays/rpi-cn0554-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-cn0554-overlay.dts
@@ -84,41 +84,57 @@
 		channel@0 {
 			reg = <0>;
 			diff-channels = <0 1>;
+			adi,buffered-positive;
+			adi,buffered-negative;
 		};
 
 		channel@1 {
 			reg = <1>;
 			diff-channels = <2 3>;
+			adi,buffered-positive;
+			adi,buffered-negative;
 		};
 
 		channel@2 {
 			reg = <2>;
 			diff-channels = <4 5>;
+			adi,buffered-positive;
+			adi,buffered-negative;
 		};
 
 		channel@3 {
 			reg = <3>;
 			diff-channels = <6 7>;
+			adi,buffered-positive;
+			adi,buffered-negative;
 		};
 
 		channel@4 {
 			reg = <4>;
 			diff-channels = <8 9>;
+			adi,buffered-positive;
+			adi,buffered-negative;
 		};
 
 		channel@5 {
 			reg = <5>;
 			diff-channels = <10 11>;
+			adi,buffered-positive;
+			adi,buffered-negative;
 		};
 
 		channel@6 {
 			reg = <6>;
 			diff-channels = <12 13>;
+			adi,buffered-positive;
+			adi,buffered-negative;
 		};
 
 		channel@7 {
 			reg = <7>;
 			diff-channels = <14 15>;
+			adi,buffered-positive;
+			adi,buffered-negative;
 		};
 	};
 


### PR DESCRIPTION
## PR Description

Enable buffered mode of ad7124 ADC for positive and negative inputs

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [X] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [X] I have conducted a self-review of my own code changes
- [X] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
