### PR TITLE
vcu118_adrv9025.dts: fix hdl_project tag

### DIFF
--- a/arch/microblaze/boot/dts/vcu118_adrv9025.dts
+++ b/arch/microblaze/boot/dts/vcu118_adrv9025.dts
@@ -4,7 +4,7 @@
  * https://wiki.analog.com/resources/eval/user-guides/adrv9025
  * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9025
  *
- * hdl_project: <adrv9025/vcu118>
+ * hdl_project: <adrv9026/vcu118>
  * board_revision: <>
  *
  * Copyright (C) 2024 Analog Devices Inc.


### PR DESCRIPTION
## PR Description
Fix 'hdl_project' tag from file header to match HDL project name: adrv9026/vcu118.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
