### PR TITLE
Ad4630 offload update

### DIFF
--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4630-24.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4630-24.dts
@@ -39,6 +39,12 @@
 		regulator-always-on;
 	};
 
+	trigger_pwm: adc-pwm-trigger {
+		compatible = "pwm-trigger";
+		#trigger-source-cells = <0>;
+		pwms = <&adc_trigger 0 1000000 0>;
+	};
+
 	clocks {
 		cnv_ext_clk: ext-clk {
 			#clock-cells = <0x0>;
@@ -50,6 +56,13 @@
 };
 
 &fpga_axi {
+	adc_trigger: pwm@44b00000 {
+		compatible = "adi,axi-pwmgen-2.00.a";
+		reg = <0x44b00000 0x1000>;
+		#pwm-cells = <3>;
+		clocks = <&cnv_ext_clk>;
+	};
+
 	rx_dma: rx-dmac@44a30000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x44a30000 0x1000>;
@@ -67,23 +80,17 @@
 		clock-output-names = "spi_clk";
 	};
 
-	axi_pwm_gen: axi-pwm-gen@44b00000 {
-		compatible = "adi,axi-pwmgen-2.00.a";
-		reg = <0x44b00000 0x1000>;
-		label = "ad463x_cnv";
-		#pwm-cells = <2>;
-		clocks = <&cnv_ext_clk>;
-
-	};
-
 	axi_spi_engine: spi@44a00000 {
-		compatible = "adi-ex,axi-spi-engine-1.00.a";
+		compatible = "adi,axi-spi-engine-1.00.a";
 		reg = <0x44a00000 0x1FF>;
 		interrupt-parent = <&intc>;
 		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 15>, <&spi_clk>;
 		clock-names = "s_axi_aclk", "spi_clk";
-		num-cs = <1>;
+
+		dmas = <&rx_dma 0>;
+		dma-names = "offload0-rx";
+		trigger-sources = <&trigger_pwm>;
 
 		#address-cells = <0x1>;
 		#size-cells = <0x0>;
@@ -91,22 +98,17 @@
 		ad4630_24: ad4630-24@0 {
 			compatible = "adi,ad4630-24";
 			reg = <0>;
+			spi-max-frequency = <80000000>;
 			vdd-supply = <&vref>;
 			vdd_1_8-supply = <&vdd_1_8>;
 			vio-supply = <&vio>;
 			vref-supply = <&vref>;
-			spi-max-frequency = <80000000>;
+			pwm-names = "cnv";
+			pwms = <&adc_trigger 1 1000000 0>;
 			reset-gpios = <&gpio0 86 GPIO_ACTIVE_LOW>;
 			adi,lane-mode = <1>;
 			adi,clock-mode = <0>;
 			adi,out-data-mode = <0>;
-			adi,spi-trigger;
-			clocks = <&cnv_ext_clk>;
-			clock-names = "trigger_clock";
-			dmas = <&rx_dma 0>;
-			dma-names = "rx";
-			pwm-names = "spi_trigger", "cnv";
-			pwms = <&axi_pwm_gen 0 0>, <&axi_pwm_gen 1 0>;
 		};
 	};
 };

--- a/drivers/spi/spi-offload-trigger-pwm.c
+++ b/drivers/spi/spi-offload-trigger-pwm.c
@@ -51,13 +51,13 @@ static int spi_offload_trigger_pwm_validate(struct spi_offload_trigger *trigger,
 	wf.period_length_ns = DIV_ROUND_UP_ULL(NSEC_PER_SEC, periodic->frequency_hz);
 	/* REVISIT: 50% duty-cycle for now - may add config parameter later */
 	wf.duty_length_ns = wf.period_length_ns / 2;
-
+	wf.duty_offset_ns = periodic->offset_ns;
 	ret = pwm_round_waveform_might_sleep(st->pwm, &wf);
 	if (ret < 0)
 		return ret;
 
 	periodic->frequency_hz = DIV_ROUND_UP_ULL(NSEC_PER_SEC, wf.period_length_ns);
-
+	periodic->offset_ns = wf.duty_offset_ns;
 	return 0;
 }
 
@@ -77,6 +77,7 @@ static int spi_offload_trigger_pwm_enable(struct spi_offload_trigger *trigger,
 	wf.period_length_ns = DIV_ROUND_UP_ULL(NSEC_PER_SEC, periodic->frequency_hz);
 	/* REVISIT: 50% duty-cycle for now - may add config parameter later */
 	wf.duty_length_ns = wf.period_length_ns / 2;
+	wf.duty_offset_ns = periodic->offset_ns;
 
 	return pwm_set_waveform_might_sleep(st->pwm, &wf, false);
 }

--- a/include/linux/spi/offload/types.h
+++ b/include/linux/spi/offload/types.h
@@ -59,6 +59,7 @@ enum spi_offload_trigger_type {
 
 struct spi_offload_trigger_periodic {
 	u64 frequency_hz;
+	u64 offset_ns;
 };
 
 struct spi_offload_trigger_config {


### PR DESCRIPTION
This makes 4630 dirver use the recently backported upstream spi offload implementation.

Main point is to stop using axi-spi-engine-ex so we can remove it.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
