### PR TITLE
iio: adc: ad9081: adi_ad9081_jesd: JRX PHY PRBS toggle LINK_EN

### DIFF
--- a/drivers/iio/adc/ad9081.c
+++ b/drivers/iio/adc/ad9081.c
@@ -3078,6 +3078,9 @@ static int ad9081_status_show(struct seq_file *file, void *offset)
 	return 0;
 }
 
+
+
+
 static void ad9081_work_func(struct work_struct *work)
 {
 	u8 status;
@@ -3612,10 +3615,14 @@ static ssize_t ad9081_debugfs_write(struct file *file,
 			val2 = 1; /* 1 second */
 
 		if (val == 0)
-			adi_ad9081_jesd_rx_phy_prbs_test_disable_set(&phy->ad9081);
+			ret = adi_ad9081_jesd_rx_phy_prbs_test_disable_set(&phy->ad9081);
 		else
-			adi_ad9081_jesd_rx_phy_prbs_test(&phy->ad9081,
+			ret = adi_ad9081_jesd_rx_phy_prbs_test(&phy->ad9081,
 				ad9081_val_to_prbs(val), val2);
+
+		if (ret)
+			return ret;
+
 		entry->val = val;
 
 		return count;


### PR DESCRIPTION


## PR Description

Make sure we enable the link after the PRBS after it is configured and the error counters are cleared. The adi_ad9081_jesd_rx_phy_prbs_test() function assumes the Links to be enabled, log error and return in case no link is enabled.

## PR Type
- [X] Bug fix (a change that fixes an issue)

## PR Checklist
- [X] I have conducted a self-review of my own code changes
- [X] I have tested the changes on the relevant hardware
- [X] I have updated the documentation outside this repo accordingly (if there is the case)
