### PR TITLE
dts: vcu118_quad_ad9081.dtsi: Add Data Offload

### DIFF
--- a/arch/microblaze/boot/dts/vcu118_quad_ad9081.dtsi
+++ b/arch/microblaze/boot/dts/vcu118_quad_ad9081.dtsi
@@ -84,6 +84,16 @@
 			clocks = <&clk_bus_0>;
 		};
 
+		axi_data_offload_tx: axi-data-offload-0@7c460000 {
+			compatible = "adi,axi-data-offload-1.0.a";
+			reg = <0x7c460000 0x10000>;
+		};
+
+		axi_data_offload_rx: axi-data-offload-1@7c450000 {
+			compatible = "adi,axi-data-offload-1.0.a";
+			reg = <0x7c450000 0x10000>;
+		};
+
 		axi_ad9081_core_rx: axi-ad9081-rx-3@44a10000 {
 			compatible = "adi,axi-ad9081-rx-1.0";
 			reg = <0x44a10000 0x8000>;
@@ -107,6 +117,7 @@
 
 			plddrbypass-gpios = <&axi_gpio 61 0>;
 			adi,axi-pl-fifo-enable;
+			adi,axi-data-offload-connected = <&axi_data_offload_tx>;
 
 			jesd204-device;
 			#jesd204-cells = <2>;


### PR DESCRIPTION
## PR Description

Add data offload in device trees to support the new HDL changes.
Related to: https://github.com/analogdevicesinc/hdl/pull/1590

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
