### PR TITLE
iio: adc: ltc2387: Update calculation of duty_offset_ns value

### DIFF
--- a/drivers/iio/adc/ltc2387.c
+++ b/drivers/iio/adc/ltc2387.c
@@ -204,6 +204,10 @@ static int ltc2387_set_sampling_freq(struct ltc2387_dev *ltc, int freq)
 	clk_gate_wf.duty_length_ns = ref_clk_period_ns * clk_en_time;
 	clk_gate_wf.duty_offset_ns = LTC2387_T_FIRSTCLK_NS;
 
+	if (clk_gate_wf.duty_offset_ns > clk_gate_wf.period_length_ns)
+		div64_u64_rem(clk_gate_wf.duty_offset_ns, clk_gate_wf.period_length_ns,
+				&clk_gate_wf.duty_offset_ns);
+
 	ret = pwm_set_waveform_might_sleep(ltc->clk_en, &clk_gate_wf, false);
 	if (ret < 0)
 		return ret;


### PR DESCRIPTION
## PR Description

For the situation when the maximum sampling is used, 15MHz.

Before: duty_offset_ns = 70, period_length_ns = 67 (rounded from 66.666)

That caused "ltc2387 setup failed", because the PWM framework has a condition
if wf->duty_offset_ns >= wf->period_length_ns, which is true => fail.

In the case of LTC2387 with max sample rate,
tFIRSTCLK >= 65ns and tCONV = 63ns ([data sheet, page 5](https://www.analog.com/media/en/technical-documentation/data-sheets/238718fa.pdf)).
This doesn't go by the PWM framework condition, so the offset needs to be updated, affecting the timing of the cnv and clk_gate signals only at the max sample rate. Just the first time the conversion is affected, being delayed.

Now: duty_offset_ns = 3, period_length_ns = 67.
The first sample is junk anyway.

This doesn't affect the sampling, because it is started by the PWM core before the DMA buffer is enabled.

I tested this on a CN0577/Zed setup and it works (I can provide screenshots if necessary).

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
