### PR TITLE
iio: adc: adrv9002: Update API to 68.14.13

### DIFF
--- a/drivers/iio/adc/navassa/devices/adrv9001/private/src/adrv9001_arm.c
+++ b/drivers/iio/adc/navassa/devices/adrv9001/private/src/adrv9001_arm.c
@@ -37,11 +37,7 @@
 #include "adrv9001_bf.h"
 #include "adi_adrv9001_hal.h"
 #ifdef __KERNEL__
-#include <linux/cleanup.h>
-#include <linux/mutex.h>
 #include <linux/string.h>
-
-static DEFINE_MUTEX(dma_wr_lock);
 #endif
 
 /* Header files related to libraries */
@@ -107,8 +103,8 @@ const char* const adrv9001_error_table_CmdCtrlMboxCmdError[] =
     "Command error"
 };
 
-const char* const adrv9001_error_table_CmdError[] =
-{
+const char* const adrv9001_error_table_CmdError[] = 
+{ 
     "Error occurred during an Init Calibration. Check that no signal is being applied to the Rx ports. Check that "
         "correct external LOs are applied, and synchronized,  where appropriate",
     "Error occurred during a Tracking Calibration. Disable tracking calibrations, reset and program. If enabled "
@@ -257,7 +253,7 @@ static __maybe_unused int32_t adrv9001_DmaMemReadByte(adi_adrv9001_Device_t *dev
     }
 
     regRead |= ADRV9001_DMA_CTL_LEGACY_MODE;
-
+    
     /* bus size, 2'b00=byte; 2'b01=half-word; 2'b10=full-word; 2'b11=invalid */
     /* core_bf.bus_size.write(bf_status, 2'b10); */
     regRead |= ADRV9001_BF_ENCODE(0, ADRV9001_DMA_CTL_BUS_SIZE_MASK, ADRV9001_DMA_CTL_BUS_SIZE_SHIFT);
@@ -329,7 +325,7 @@ static __maybe_unused int32_t adrv9001_DmaMemReadByte(adi_adrv9001_Device_t *dev
             returnData[i + 1] = dataRead0;
             ADRV9001_SPIREADBYTEDMA(device, "ARM_DMA_DATA_2", ADRV9001_ADDR_ARM_DMA_DATA2, &dataRead0);
             returnData[i + 2] = dataRead0;
-
+            
             /* 'single_instruction' has to be cleared before reading DMA_DATA3 and set back after */
             ADI_EXPECT(adrv9001_NvsRegmapCore_SingleInstruction_Set, device, 0x0);
             ADRV9001_SPIREADBYTEDMA(device, "ARM_DMA_DATA_3", ADRV9001_ADDR_ARM_DMA_DATA3, &dataRead0);
@@ -1046,7 +1042,7 @@ static void adrv9001_LoadSsiConfig(adi_adrv9001_Device_t *device, uint32_t *offs
     cfgData[tempOffset++] = (uint8_t)ssiConfig->cmosClkInversionEn;
 
     cfgData[tempOffset++] = (uint8_t)ssiConfig->ddrEn;
-
+    
     cfgData[tempOffset++] = (uint8_t)ssiConfig->rxMaskStrobeEn;
 
     /* 4 bytes of padding is needed for alignment */
@@ -1567,15 +1563,15 @@ typedef struct
     duplexMode_e    duplexMode;
     uint8_t         fhModeOn;
     uint8_t         reserved1[1u];       //< Reserved for future feature
-    uint8_t         numDynamicProfile;   // Number of Profile. =1 means only one profile and no switching
+    uint8_t         numDynamicProfile;   // Number of Profile. =1 means only one profile and no switching 
     mcsMode_e       mcsMode;             // MCS mode selection: 0 - Disable, 1 - MCS Only, 2 - MCS + RFPLL phase sync
-    adcType_e       adcTypeMonitor;      // ADC type used in Monitor Mode
-    uint16_t        pllLockTime_us;      // Required lock time in microseconds for PLLs, based on ref_clk and loop bandwidth
-    pllModulus_t    pllModuli;           // PLL moduli
-    uint16_t        pllPhaseSyncWait_us; // Worst case phase sync wait time in FH
-    mcsInf_e        mcsInterfaceType;    // 0-Disabled, 1-CMOS, 2-LVDS
-    uint8_t         warmBootEnable;      // Enable WarmBoot - Load initCal cefficients instead of running initCals
-    uint32_t        reserved[1u];        // Reserved for future feature
+    adcType_e       adcTypeMonitor;      // ADC type used in Monitor Mode 
+    uint16_t        pllLockTime_us;      // Required lock time in microseconds for PLLs, based on ref_clk and loop bandwidth 
+    pllModulus_t    pllModuli;           // PLL moduli 
+    uint16_t        pllPhaseSyncWait_us; // Worst case phase sync wait time in FH 
+    mcsInf_e        mcsInterfaceType;    // 0-Disabled, 1-CMOS, 2-LVDS 
+    uint8_t         warmBootEnable;      // Enable WarmBoot - Load initCal cefficients instead of running initCals     
+    uint32_t        reserved[1u];        // Reserved for future feature 
 } deviceSysConfig_t;
 */
 static void adrv9001_DeviceSysConfigWrite(adi_adrv9001_Device_t *device, const adi_adrv9001_DeviceSysConfig_t *sysConfig, uint8_t cfgData[], uint32_t *offset)
@@ -1613,13 +1609,13 @@ static void adrv9001_DeviceSysConfigWrite(adi_adrv9001_Device_t *device, const a
     {
         adrv9001_LoadFourBytes(&tempOffset, cfgData, sysConfig->pllModulus.dmModulus[i]);
     }
-
+    
     /* PLL phase sync wait time in us */
     adrv9001_LoadTwoBytes(&tempOffset, cfgData, sysConfig->pllPhaseSyncWait_us);
 
     cfgData[tempOffset++] = sysConfig->mcsInterfaceType;
     cfgData[tempOffset++] = sysConfig->warmBootEnable;
-
+    
     /* 4 bytes padding; Reserved for future use */
     tempOffset += 4;
 
@@ -1998,7 +1994,7 @@ int32_t adrv9001_DmaMemWrite(adi_adrv9001_Device_t *device, uint32_t address, co
     int32_t recoveryAction = ADI_COMMON_ACT_NO_ACTION;
     uint8_t singleInstruction = 0;
     uint8_t spiMode = 0;
-
+    
     ADI_ENTRY_PTR_ARRAY_EXPECT(device, data, byteCount);
 
     ADRV9001_DMAINFO("ARM_MEM_WRITE", armMemAddress, byteCount);
@@ -2019,7 +2015,7 @@ int32_t adrv9001_DmaMemWrite(adi_adrv9001_Device_t *device, uint32_t address, co
     /* If Address is not on word boundary, Or ByteCount is not on Word boundary */
     if (((armMemAddress & 0x00000003) > 0) || ((byteCount & 0x00000003) > 0))
     {
-        if ((ADI_ADRV9001_ARM_SINGLE_SPI_WRITE_MODE_STANDARD_BYTES_252 == spiWriteMode) ||
+        if ((ADI_ADRV9001_ARM_SINGLE_SPI_WRITE_MODE_STANDARD_BYTES_252 == spiWriteMode) || 
             (ADI_ADRV9001_ARM_SINGLE_SPI_WRITE_MODE_STREAMING_BYTES_4 == spiWriteMode))
         {
             ADI_ERROR_REPORT(&device->common,
@@ -2063,7 +2059,7 @@ int32_t adrv9001_DmaMemWrite(adi_adrv9001_Device_t *device, uint32_t address, co
 
     /* setting up the DMA control register for a write */
     ADRV9001_SPIWRITEBYTEDMA(device, "ARM_DMA_CTL", ADRV9001_ADDR_ARM_DMA_CTL, regWrite);
-
+    
     /* Enable single instruction and disable SPI streaming mode by default.
      * If ADRV9001 SPI streming mode is selected, then single instruction and single instruction are disbled */
     ADI_EXPECT(adrv9001_NvsRegmapCore_SingleInstruction_Set, device, 0x1);
@@ -2198,7 +2194,6 @@ int32_t adrv9001_DmaMemWriteFH(adi_adrv9001_Device_t *device, adi_adrv9001_FhHop
 	static uint8_t     addrLsbArray[ADI_ADRV9001_FREQ_HOPPING_MAX_NUM_BYTES];
 	static uint8_t     dataArray[ADI_ADRV9001_FREQ_HOPPING_MAX_NUM_BYTES];
 
-    guard(mutex)(&dma_wr_lock);
     memset(addrMsbArray, 0, sizeof(addrMsbArray));
     memset(addrLsbArray, 0, sizeof(addrLsbArray));
     memset(dataArray, 0, sizeof(dataArray));
@@ -2206,7 +2201,7 @@ int32_t adrv9001_DmaMemWriteFH(adi_adrv9001_Device_t *device, adi_adrv9001_FhHop
 
 	ADI_ENTRY_PTR_ARRAY_EXPECT(device, numHopTableEntries, numHopTableEntriesByteCount);
 	ADI_ENTRY_PTR_ARRAY_EXPECT(device, hopTableBufferData, hopTableBufferDataByteCount);
-
+	
 	/* Trigger appropriate SPI Interrupt upon table load */
 	if (hopSignal == ADI_ADRV9001_FH_HOP_SIGNAL_1)
 	{
@@ -2222,7 +2217,7 @@ int32_t adrv9001_DmaMemWriteFH(adi_adrv9001_Device_t *device, adi_adrv9001_FhHop
 	}
 
 	ADRV9001_DMAINFO("ARM_MEM_WRITE", armMemAddress, byteCount);
-
+	
 	regWrite &= ~ADRV9001_DMA_CTL_RD_WRB;
 	regWrite |= ADRV9001_DMA_CTL_SYS_CODEB;
 	regWrite |= ADRV9001_BF_ENCODE(2, ADRV9001_DMA_CTL_BUS_SIZE_MASK, ADRV9001_DMA_CTL_BUS_SIZE_SHIFT);
@@ -2232,7 +2227,7 @@ int32_t adrv9001_DmaMemWriteFH(adi_adrv9001_Device_t *device, adi_adrv9001_FhHop
 	{
 		regWrite |= ADRV9001_DMA_CTL_AUTO_INCR;
 	}
-
+    
 	/* setting up the DMA control register for a write */
 	addrMsbArray[addrIndex] = (uint8_t)(((ADRV9001_SPI_WRITE_POLARITY & 0x01) << 7) | ((ADRV9001_ADDR_ARM_DMA_CTL >> 8) & 0x7F));
 	addrLsbArray[addrIndex] = (uint8_t)ADRV9001_ADDR_ARM_DMA_CTL;
@@ -2272,7 +2267,7 @@ int32_t adrv9001_DmaMemWriteFH(adi_adrv9001_Device_t *device, adi_adrv9001_FhHop
 		dataArray[addrIndex] = numHopTableEntries[dataIndex];
 		addrIndex++;
 	}
-
+    
 	addrMsbArray[addrIndex] = (uint8_t)(((ADRV9001_SPI_WRITE_POLARITY & 0x01) << 7) | ((ADRV9001_ADDR_ARM_DMA_ADDR3 >> 8) & 0x7F));
 	addrLsbArray[addrIndex] = (uint8_t)ADRV9001_ADDR_ARM_DMA_ADDR3;
 	dataArray[addrIndex] = (uint8_t)((hopTableBufferAddress) >> ADRV9001_ADDR_ARM_DMA_ADDR3_BYTE_SHIFT);
@@ -2426,7 +2421,7 @@ int32_t adrv9001_DmaMemRead(adi_adrv9001_Device_t *device, uint32_t address, uin
         returnData[i + 2] = dataRead;
         ADRV9001_SPIREADBYTEDMA(device, "ARM_DMA_DATA_1", ADRV9001_ADDR_ARM_DMA_DATA1, &dataRead);
         returnData[i + 1] = dataRead;
-
+        
         /* 'single_instruction' has to be cleared before reading DMA_DATA3 and set back after */
         ADI_EXPECT(adrv9001_NvsRegmapCore_SingleInstruction_Set, device, 0x0);
         ADRV9001_SPIREADBYTEDMA(device, "ARM_DMA_DATA_0", ADRV9001_ADDR_ARM_DMA_DATA0, &dataRead);
@@ -2496,7 +2491,7 @@ int32_t adrv9001_FlexStreamProcessorMemWrite(adi_adrv9001_Device_t *device,
     /* If Address is not on word boundary, Or ByteCount is not on Word boundary */
     if (((flexSpAddress & 0x00000003) > 0) || ((byteCount & 0x00000003) > 0))
     {
-        if ((ADI_ADRV9001_ARM_SINGLE_SPI_WRITE_MODE_STANDARD_BYTES_252 == spiWriteMode) ||
+        if ((ADI_ADRV9001_ARM_SINGLE_SPI_WRITE_MODE_STANDARD_BYTES_252 == spiWriteMode) || 
             (ADI_ADRV9001_ARM_SINGLE_SPI_WRITE_MODE_STREAMING_BYTES_4 == spiWriteMode))
         {
             ADI_ERROR_REPORT(&device->common,
@@ -2531,7 +2526,7 @@ int32_t adrv9001_FlexStreamProcessorMemWrite(adi_adrv9001_Device_t *device,
 
     /* setting up the flex SP DMA control register for a write */
     ADRV9001_SPIWRITEBYTEDMA(device, "FLEX_SP_ARM_DMA_CTL", ADRV9001_ADDR_FLEX_SP_ARM_DMA_CTL, regWrite);
-
+    
     /* Enable single instruction and disable SPI streaming mode by default.
      * If ADRV9001 SPI streming mode is selected, then single instruction and single instruction are disbled */
     ADI_EXPECT(adrv9001_NvsRegmapCore_SingleInstruction_Set, device, 0x1);
@@ -2797,7 +2792,7 @@ static const char* adrv9001_CmdErrMsgGet(uint32_t errCode)
     {
         return adrv9001_error_table_CmdError[6];
     }
-
+    
     return NULL;
 }
 
@@ -2854,7 +2849,7 @@ int32_t adrv9001_ArmCmdErrorHandler(adi_adrv9001_Device_t *device, uint32_t detE
 
             ADI_EXPECT(adrv9001_ArmMailBoxErrCodeGet, device, &mailboxErrCode);
             errorString = adrv9001_CmdErrMsgGet(mailboxErrCode);
-
+            
             ADI_ERROR_REPORT(&device->common,
                              ADI_ADRV9001_SRC_ARMCMD,
                              mailboxErrCode,
@@ -2956,7 +2951,7 @@ static uint32_t adrv9001_ArmProfileWrite_Validate(adi_adrv9001_Device_t *device,
             ADI_ERROR_RETURN(device->common.error.newAction);
         }
     }
-
+    
     /* Range check parameters in adi_adrv9001_TxSettings_t */
     for (i = 0; i < ADI_ADRV9001_MAX_TXCHANNELS; i++)
     {
@@ -2972,7 +2967,7 @@ static uint32_t adrv9001_ArmProfileWrite_Validate(adi_adrv9001_Device_t *device,
             ADI_RANGE_CHECK(device, init->tx.txProfile[i].txSsiConfig.ssiDataFormatSel, ADI_ADRV9001_SSI_FORMAT_2_BIT_SYMBOL_DATA, ADI_ADRV9001_SSI_FORMAT_22_BIT_I_Q_DATA_1_BIT_GAIN_CHANGE_8_BIT_GAIN_INDEX);
             ADI_RANGE_CHECK(device, init->tx.txProfile[i].txSsiConfig.numLaneSel, ADI_ADRV9001_SSI_1_LANE, ADI_ADRV9001_SSI_4_LANE);
             ADI_RANGE_CHECK(device, init->tx.txProfile[i].txSsiConfig.strobeType, ADI_ADRV9001_SSI_SHORT_STROBE, ADI_ADRV9001_SSI_LONG_STROBE);
-
+            
             if ((ADI_ADRV9001_SSI_TYPE_LVDS == init->tx.txProfile[i].txSsiConfig.ssiType) &&
                 (false == init->tx.txProfile[i].txSsiConfig.ddrEn) &&
                 (init->tx.txProfile[i].txInterfaceSampleRate_Hz > 30720000))
@@ -3149,7 +3144,7 @@ int32_t adrv9001_ArmProfileWrite(adi_adrv9001_Device_t *device, const adi_adrv90
     cfgData[offset++] = (uint8_t)(init->clocks.armPowerSavingClkDiv - 1);
 
     cfgData[offset++] = (uint8_t)init->clocks.refClockOutEnable;
-
+    
     cfgData[offset++] = (uint8_t)init->clocks.auxPllPower;
     cfgData[offset++] = (uint8_t)init->clocks.clkPllPower;
 
@@ -3208,14 +3203,14 @@ int32_t adrv9001_ArmProfileWrite(adi_adrv9001_Device_t *device, const adi_adrv90
     if (ADRV9001_BF_EQUAL(device->devStateInfo.profilesValid, ADI_ADRV9001_TX_PROFILE_VALID))
     {
         armChannels |= (init->tx.txInitChannelMask & (ADI_ADRV9001_TX1 | ADI_ADRV9001_TX2));
-
+        
         /* Tx channels must have a valid and enabled ILB channel unless the signaling is Direct FM/FSK */
         if(ADRV9001_BF_EQUAL(init->tx.txInitChannelMask, ADI_ADRV9001_TX1) &&
             (init->tx.txProfile[0].outputSignaling != ADI_ADRV9001_TX_DIRECT_FM_FSK))
         {
             armChannels |= (init->rx.rxInitChannelMask & ADI_ADRV9001_ILB1);
         }
-
+            
         if (ADRV9001_BF_EQUAL(init->tx.txInitChannelMask, ADI_ADRV9001_TX2) &&
             (init->tx.txProfile[1].outputSignaling != ADI_ADRV9001_TX_DIRECT_FM_FSK))
         {
@@ -3504,7 +3499,7 @@ int32_t adrv9001_DynamicProfile_Write(adi_adrv9001_Device_t *device,
     int32_t recoveryAction = ADI_COMMON_ACT_NO_ACTION;
     uint32_t offset = 0;
     uint8_t cfgData[ADRV9001_DYNAMIC_PROFILE_BLOB_SIZE] = { 0 };
-
+    
     cfgData[offset++] = dynamicProfile->dynamicProfileIndex;
     cfgData[offset++] = 0; // padding
     cfgData[offset++] = 0; // padding

--- a/drivers/iio/adc/navassa/devices/adrv9001/public/include/adi_adrv9001_version.h
+++ b/drivers/iio/adc/navassa/devices/adrv9001/public/include/adi_adrv9001_version.h
@@ -19,7 +19,7 @@ extern "C" {
 #endif
 
 /* Auto-generated version number - DO NOT MANUALLY EDIT */
-#define ADI_ADRV9001_CURRENT_VERSION "68.14.10"
+#define ADI_ADRV9001_CURRENT_VERSION "68.14.13"
 
 #ifdef __cplusplus
 }

--- a/drivers/iio/adc/navassa/devices/adrv9001/public/src/adi_adrv9001_cals.c
+++ b/drivers/iio/adc/navassa/devices/adrv9001/public/src/adi_adrv9001_cals.c
@@ -25,15 +25,10 @@
 #include "adrv9001_arm_macros.h"
 #include "adrv9001_init.h"
 #include "adrv9001_reg_addr_macros.h"
-#include "linux/mutex.h"
 #include "object_ids.h"
 
 #ifdef __KERNEL__
-#include <linux/cleanup.h>
-#include <linux/mutex.h>
 #include <linux/string.h>
-
-static DEFINE_MUTEX(warmboot_lock);
 #else
 #include <string.h>
 #endif
@@ -89,7 +84,7 @@ int32_t adi_adrv9001_cals_InitCals_Run(adi_adrv9001_Device_t *adrv9001,
 
     /* Mode to select the Init calibration algorithms to run */
     payload[1] = (uint8_t)(initCals->calMode);
-
+    
     /* A value of true will force all enabled calibrations to re-run */
     payload[2] = (uint8_t)(initCals->force);
 
@@ -601,7 +596,7 @@ int32_t adi_adrv9001_cals_InternalPathDelay_Get_Validate(adi_adrv9001_Device_t *
 {
     static uint8_t MAX_NUM_PROFILE = 6;
     adi_adrv9001_ChannelState_e state = ADI_ADRV9001_CHANNEL_STANDBY;
-
+    
     ADI_RANGE_CHECK(adrv9001, port, ADI_RX, ADI_TX);
     ADI_RANGE_CHECK(adrv9001, channel, ADI_CHANNEL_1, ADI_CHANNEL_2);
     ADI_NULL_PTR_RETURN(&adrv9001->common, internalPathDelays_ns);
@@ -609,7 +604,7 @@ int32_t adi_adrv9001_cals_InternalPathDelay_Get_Validate(adi_adrv9001_Device_t *
     ADI_EXPECT(adi_adrv9001_Radio_Channel_State_Get, adrv9001, port, channel, &state);
     if (ADI_ADRV9001_CHANNEL_STANDBY == state)
     {
-        ADI_ERROR_REPORT(&adrv9001->common,
+        ADI_ERROR_REPORT(&adrv9001->common, 
             ADI_COMMON_ERRSRC_API,
             ADI_COMMON_ERR_INV_PARAM,
             ADI_COMMON_ACT_ERR_CHECK_PARAM,
@@ -741,7 +736,7 @@ int32_t adi_adrv9001_cals_Dynamic_profiles_calibrate_Validate(adi_adrv9001_Devic
     ADI_ENTRY_PTR_EXPECT(adrv9001, initCals);
     ADI_NULL_PTR_RETURN(&adrv9001->common, errorFlag);
 
-    ADI_NULL_PTR_RETURN(&adrv9001->common, dynamicProfile);
+    ADI_NULL_PTR_RETURN(&adrv9001->common, dynamicProfile); 
     ADI_RANGE_CHECK(adrv9001, length, 1, MAX_NUM_PROFILE);
 
     for (port = ADI_RX; port <= ADI_TX; port++)
@@ -779,7 +774,7 @@ int32_t adi_adrv9001_cals_Dynamic_profiles_calibrate(adi_adrv9001_Device_t *adrv
 {
     int8_t i = 0;
     ADI_EXPECT(adi_adrv9001_cals_Dynamic_profiles_calibrate_Validate, adrv9001, initCals, errorFlag, dynamicProfile, length);
-
+    
     for (i = 0; i <= (length - 1); i++)
     {
         ADI_EXPECT(adi_adrv9001_arm_NextDynamicProfile_Set, adrv9001, &dynamicProfile[i]);
@@ -801,8 +796,6 @@ int32_t adi_adrv9001_cals_InitCals_WarmBoot_UniqueEnabledCals_Get(adi_adrv9001_D
 #else
 	static uint32_t tblSize[4];
 	static uint32_t vecTbl[ADI_ADRV9001_WB_MAX_NUM_VECTOR_TABLE_WORDS];
-
-	guard(mutex)(&warmboot_lock);
 #endif
 	int calNo;
 	int arrayIndex = 0;
@@ -810,7 +803,7 @@ int32_t adi_adrv9001_cals_InitCals_WarmBoot_UniqueEnabledCals_Get(adi_adrv9001_D
 
 	ADI_EXPECT(adi_adrv9001_arm_Memory_Read32, device, 0x20020000, tblSize, sizeof(tblSize), 0);
 	ADI_EXPECT(adi_adrv9001_arm_Memory_Read32, device, 0x20020004, vecTbl, tblSize[0] * 16, 1);
-
+	
 	for (calNo = 0; calNo < tblSize[0]; calNo++)
 	{
 		uint32_t initMask = vecTbl[(4*calNo) + 2];
@@ -857,14 +850,12 @@ int32_t adi_adrv9001_cals_InitCals_WarmBoot_Coefficients_MaxArray_Get(adi_adrv90
 	static uint32_t tblSize[4];
 	static uint32_t vecTbl[ADI_ADRV9001_WB_MAX_NUM_ENTRY];
 	static uint8_t calVal[ADI_ADRV9001_WB_MAX_NUM_COEFF];
-
-	guard(mutex)(&warmboot_lock);
 #endif
 	int calNo;
 
 	ADI_EXPECT(adi_adrv9001_arm_Memory_Read32, device, 0x20020000, tblSize, sizeof(tblSize), 0);
 	ADI_EXPECT(adi_adrv9001_arm_Memory_Read32, device, 0x20020004, vecTbl, tblSize[0] * 16, 1);
-
+	
 	for (calNo = 0; calNo < tblSize[0]; calNo++)
 	{
 		uint32_t addr = vecTbl[4*calNo];
@@ -915,13 +906,11 @@ int32_t adi_adrv9001_cals_InitCals_WarmBoot_Coefficients_UniqueArray_Get(adi_adr
 	static uint32_t tblSize[4];
 	static uint32_t vecTbl[ADI_ADRV9001_WB_MAX_NUM_ENTRY];
 	static uint8_t calVal[ADI_ADRV9001_WB_MAX_NUM_COEFF];
-
-	guard(mutex)(&warmboot_lock);
 #endif
 	int calNo;
 	ADI_EXPECT(adi_adrv9001_arm_Memory_Read32, device, 0x20020000, tblSize, sizeof(tblSize), 0);
 	ADI_EXPECT(adi_adrv9001_arm_Memory_Read32, device, 0x20020004, vecTbl, tblSize[0] * 16, 1);
-
+	
 	for (calNo = 0; calNo < tblSize[0]; calNo++)
 	{
 		uint32_t addr = vecTbl[4*calNo];
@@ -969,8 +958,6 @@ int32_t adi_adrv9001_cals_InitCals_WarmBoot_Coefficients_MaxArray_Set(adi_adrv90
 	static uint32_t tblSize[4];
 	static uint32_t vecTbl[ADI_ADRV9001_WB_MAX_NUM_ENTRY];
 	static uint8_t calVal[ADI_ADRV9001_WB_MAX_NUM_COEFF];
-
-	guard(mutex)(&warmboot_lock);
 #endif
 	int calNo;
 
@@ -1027,8 +1014,6 @@ int32_t adi_adrv9001_cals_InitCals_WarmBoot_Coefficients_UniqueArray_Set(adi_adr
 	static uint32_t tblSize[4];
 	static uint32_t vecTbl[ADI_ADRV9001_WB_MAX_NUM_ENTRY];
 	static uint8_t calVal[ADI_ADRV9001_WB_MAX_NUM_COEFF];
-
-	guard(mutex)(&warmboot_lock);
 #endif
 	int calNo;
 

--- a/drivers/iio/adc/navassa/devices/adrv9001/public/src/adi_adrv9001_fh.c
+++ b/drivers/iio/adc/navassa/devices/adrv9001/public/src/adi_adrv9001_fh.c
@@ -31,11 +31,7 @@
 #include "object_ids.h"
 
 #ifdef __KERNEL__
-#include <linux/cleanup.h>
-#include <linux/mutex.h>
 #include <linux/string.h>
-
-static DEFINE_MUTEX(fh_lock);
 #endif
 
 #define FREQ_HOPPING_SIZE_FIELD_NUM_BYTES            4u
@@ -62,7 +58,7 @@ if (device->devStateInfo.frequencyHoppingEnabled == 0) \
     ADI_API_RETURN(device); \
 }
 
-/*  TODO JP: Determine if we need to validate the whole table.
+/*  TODO JP: Determine if we need to validate the whole table. 
     It's difficult to validate the hop table due to the following:
         1) At the time of receiving the HOP table, we don't know the channel sequence. So a tx or rx gain index
            might be valid, or it might be a 'don't care' value, programmed by the user. We could potentially enforce the
@@ -70,7 +66,7 @@ if (device->devStateInfo.frequencyHoppingEnabled == 0) \
         2) There doesn't seem a nice way to validate the rx gain in API, since there is no state
            of the FH operating gain range. The best we could do would be to ensure its within the
            absolute min/max. However, this could be effected by point 1.
-        3) Validating the whole table before its written to ARM might be valuable, however, it might
+        3) Validating the whole table before its written to ARM might be valuable, however, it might 
            also waste time. Especially considering we can't validate every field in the table.
            It might be better for ARM to validate it once received, or on the fly.
 */
@@ -80,8 +76,8 @@ static __maybe_unused int32_t adi_adrv9001_fh_FrameInfo_Validate(adi_adrv9001_De
     /* Check if FH is enabled in device profile */
     ADI_FH_CHECK_FH_ENABLED(adrv9001);
 
-    ADI_RANGE_CHECK_X(adrv9001, hopFrame->hopFrequencyHz,
-                     ADI_ADRV9001_FH_MIN_CARRIER_FREQUENCY_HZ,
+    ADI_RANGE_CHECK_X(adrv9001, hopFrame->hopFrequencyHz,  
+                     ADI_ADRV9001_FH_MIN_CARRIER_FREQUENCY_HZ, 
                      ADI_ADRV9001_FH_MAX_CARRIER_FREQUENCY_HZ, "%llu");
     ADI_API_RETURN(adrv9001);
 }
@@ -100,11 +96,11 @@ static uint32_t adi_adrv9001_fh_GetHopTableBufferAddress(adi_adrv9001_Device_t *
     adrv9001_ParseFourBytes(&offset, hopTableBufferAddressBlock, &hopTableBufferAddress);
 
     return hopTableBufferAddress;
-}
+}                                                         
 
 static __maybe_unused int32_t adi_adrv9001_fh_Configure_Validate(adi_adrv9001_Device_t *adrv9001,
                                                                  adi_adrv9001_FhCfg_t  *fhConfig)
-{
+{  
     uint32_t i;
 	uint32_t j;
     uint8_t numHopSignals;
@@ -144,7 +140,7 @@ static __maybe_unused int32_t adi_adrv9001_fh_Configure_Validate(adi_adrv9001_De
     }
     /* Can be unassigned but throw an error if it's set to analog*/
     ADI_RANGE_CHECK(adrv9001, fhConfig->hopTableSelectConfig.hopTableSelectGpioConfig[0].pin, ADI_ADRV9001_GPIO_UNASSIGNED, ADI_ADRV9001_GPIO_DIGITAL_15);
-    if ((fhConfig->hopTableSelectConfig.hopTableSelectMode == ADI_ADRV9001_FHHOPTABLESELECTMODE_INDEPENDENT)
+    if ((fhConfig->hopTableSelectConfig.hopTableSelectMode == ADI_ADRV9001_FHHOPTABLESELECTMODE_INDEPENDENT) 
      && (fhConfig->mode == ADI_ADRV9001_FHMODE_LO_RETUNE_REALTIME_PROCESS_DUAL_HOP))
     {
         /* Can be unassigned but throw an error if it's set to analog*/
@@ -189,18 +185,18 @@ static __maybe_unused int32_t adi_adrv9001_fh_Configure_Validate(adi_adrv9001_De
                          "Value must be non-zero in Tx only operation");
         ADI_API_RETURN(adrv9001);
     }
-
+    
     /* Check mode*/
 	ADI_RANGE_CHECK(adrv9001, fhConfig->mode, ADI_ADRV9001_FHMODE_LO_MUX_PREPROCESS, ADI_ADRV9001_FHMODE_LO_RETUNE_REALTIME_PROCESS_PFIR_SWITCH);
 
     /* Check tableIndexCtrl_e */
     ADI_RANGE_CHECK(adrv9001, fhConfig->tableIndexCtrl, ADI_ADRV9001_TABLEINDEXCTRL_AUTO_LOOP, ADI_ADRV9001_TABLEINDEXCTRL_GPIO);
     /* Check operating frequency range */
-    ADI_RANGE_CHECK_X(adrv9001, fhConfig->minOperatingFrequency_Hz,
-                      ADI_ADRV9001_FH_MIN_CARRIER_FREQUENCY_HZ,
+    ADI_RANGE_CHECK_X(adrv9001, fhConfig->minOperatingFrequency_Hz, 
+                      ADI_ADRV9001_FH_MIN_CARRIER_FREQUENCY_HZ, 
                       ADI_ADRV9001_FH_MAX_CARRIER_FREQUENCY_HZ, "%llu");
-    ADI_RANGE_CHECK_X(adrv9001, fhConfig->maxOperatingFrequency_Hz,
-                      ADI_ADRV9001_FH_MIN_CARRIER_FREQUENCY_HZ,
+    ADI_RANGE_CHECK_X(adrv9001, fhConfig->maxOperatingFrequency_Hz, 
+                      ADI_ADRV9001_FH_MIN_CARRIER_FREQUENCY_HZ, 
                       ADI_ADRV9001_FH_MAX_CARRIER_FREQUENCY_HZ, "%llu");
 
     if (fhConfig->minOperatingFrequency_Hz >= fhConfig->maxOperatingFrequency_Hz)
@@ -214,12 +210,12 @@ static __maybe_unused int32_t adi_adrv9001_fh_Configure_Validate(adi_adrv9001_De
         ADI_API_RETURN(adrv9001);
     }
     /* Check RX gain ranges */
-    ADI_RANGE_CHECK(adrv9001, fhConfig->minRxGainIndex,
-                    ADI_ADRV9001_RX_GAIN_INDEX_MIN,
+    ADI_RANGE_CHECK(adrv9001, fhConfig->minRxGainIndex, 
+                    ADI_ADRV9001_RX_GAIN_INDEX_MIN, 
                     fhConfig->maxRxGainIndex);
     /* Max index can be equal to min and no greater than rx1MaxGainIndex */
-    ADI_RANGE_CHECK(adrv9001, fhConfig->maxRxGainIndex,
-                    fhConfig->minRxGainIndex,
+    ADI_RANGE_CHECK(adrv9001, fhConfig->maxRxGainIndex, 
+                    fhConfig->minRxGainIndex, 
                     ADI_ADRV9001_RX_GAIN_INDEX_MAX);
     /* TODO JP: Investigate requirements for TX attenuation in diversity mode.
              Will min/max be the same, or will we need a seperate field?
@@ -248,7 +244,7 @@ static __maybe_unused int32_t adi_adrv9001_fh_Configure_Validate(adi_adrv9001_De
     }
 
     /* Check frequency select pins */
-    if (ADI_ADRV9001_TABLEINDEXCTRL_GPIO == fhConfig->tableIndexCtrl)
+    if (ADI_ADRV9001_TABLEINDEXCTRL_GPIO == fhConfig->tableIndexCtrl) 
     {
         ADI_RANGE_CHECK(adrv9001, fhConfig->numTableIndexPins, 1u, ADI_ADRV9001_FH_MAX_NUM_FREQ_SELECT_PINS);
         for (i = 0; i < fhConfig->numTableIndexPins; i++)
@@ -257,13 +253,13 @@ static __maybe_unused int32_t adi_adrv9001_fh_Configure_Validate(adi_adrv9001_De
         }
     }
     /* Configure gain select pins */
-    if (true == fhConfig->gainSetupByPin)
+    if (true == fhConfig->gainSetupByPin) 
     {
 	    for (j = 0; j < ADI_ADRV9001_NUM_CHANNELS; j++)
 		{
 			if ((initializedChannelMask & (j == 0? channel1Mask:channel2Mask)) != 0x00u)
 			{
-
+				
 				ADI_RANGE_CHECK(adrv9001, fhConfig->gainSetupByPinConfig[j].numGainCtrlPins, 1u, ADI_ADRV9001_FH_MAX_NUM_GAIN_SELECT_PINS);
 				for (i = 0; i < fhConfig->gainSetupByPinConfig[j].numGainCtrlPins; i++)
 				{
@@ -272,7 +268,7 @@ static __maybe_unused int32_t adi_adrv9001_fh_Configure_Validate(adi_adrv9001_De
 				maxPossibleGainEntries = (1u << fhConfig->gainSetupByPinConfig[j].numGainCtrlPins);
 			}
 
-
+			
 			if (ADRV9001_BF_EQUAL(adrv9001->devStateInfo.initializedChannels, CHANNELS[ADI_RX][j]))
 			{
 				/* Validate Rx gain table is within range specified by fhConfig */
@@ -290,7 +286,7 @@ static __maybe_unused int32_t adi_adrv9001_fh_Configure_Validate(adi_adrv9001_De
 				{
 					ADI_RANGE_CHECK(adrv9001, fhConfig->gainSetupByPinConfig[j].txAttenTable[i], fhConfig->minTxAtten_mdB, fhConfig->maxTxAtten_mdB);
 				}
-			}
+			}  
 	    }
     }
 
@@ -299,7 +295,7 @@ static __maybe_unused int32_t adi_adrv9001_fh_Configure_Validate(adi_adrv9001_De
 
 static __maybe_unused int32_t adi_adrv9001_fh_Inspect_Validate(adi_adrv9001_Device_t *adrv9001,
                                                                adi_adrv9001_FhCfg_t  *fhConfig)
-{
+{  
     /* Check for NULL pointer */
     ADI_NULL_PTR_RETURN(&adrv9001->common, fhConfig);
     ADI_API_RETURN(adrv9001);
@@ -308,7 +304,7 @@ static __maybe_unused int32_t adi_adrv9001_fh_Inspect_Validate(adi_adrv9001_Devi
 static __maybe_unused int32_t adi_adrv9001_fh_HopTable_Static_Configure_Validate(adi_adrv9001_Device_t *adrv9001,
                                                                                  adi_adrv9001_FhMode_e mode,
                                                                                  adi_adrv9001_FhHopSignal_e hopSignal,
-                                                                                 adi_adrv9001_FhHopTable_e tableId,
+                                                                                 adi_adrv9001_FhHopTable_e tableId, 
                                                                                  adi_adrv9001_FhHopFrame_t hopTable[],
                                                                                  uint32_t tableSize)
 {
@@ -359,7 +355,7 @@ static __maybe_unused int32_t adi_adrv9001_fh_HopTable_Static_Configure_Validate
         ADI_API_RETURN(adrv9001);
     }
 
-    if ((hopSignal == ADI_ADRV9001_FH_HOP_SIGNAL_2)
+    if ((hopSignal == ADI_ADRV9001_FH_HOP_SIGNAL_2) 
      && (mode != ADI_ADRV9001_FHMODE_LO_RETUNE_REALTIME_PROCESS_DUAL_HOP))
     {
         ADI_ERROR_REPORT(&adrv9001->common,
@@ -371,7 +367,7 @@ static __maybe_unused int32_t adi_adrv9001_fh_HopTable_Static_Configure_Validate
 
         ADI_API_RETURN(adrv9001);
     }
-
+    
     /* Check fhHopTable->numHopFrames are valid */
     ADI_RANGE_CHECK(adrv9001, tableSize, 1u, maxNumHopFrequencies);
 
@@ -381,7 +377,7 @@ static __maybe_unused int32_t adi_adrv9001_fh_HopTable_Static_Configure_Validate
     }
 
     ADI_API_RETURN(adrv9001);
-}
+}          
 
 static __maybe_unused int32_t adi_adrv9001_fh_HopTable_Inspect_Validate(adi_adrv9001_Device_t *adrv9001,
                                                                         adi_adrv9001_FhHopSignal_e hopSignal,
@@ -433,7 +429,7 @@ static __maybe_unused int32_t adi_adrv9001_fh_HopTable_Inspect_Validate(adi_adrv
     }
 
     ADI_API_RETURN(adrv9001);
-}
+}     
 
 int32_t adi_adrv9001_fh_Configure(adi_adrv9001_Device_t *adrv9001,
                                      adi_adrv9001_FhCfg_t  *fhConfig)
@@ -479,7 +475,7 @@ int32_t adi_adrv9001_fh_Configure(adi_adrv9001_Device_t *adrv9001,
     armData[offset++] = fhConfig->tableIndexCtrl;
     armData[offset++] = fhConfig->gainSetupByPin;
     armData[offset++] = fhConfig->hopTableSelectConfig.hopTableSelectMode;
-
+    
     armData[offset++] = hop1SignalsPortMask;
     armData[offset++] = hop2SignalsPortMask;
 
@@ -499,14 +495,14 @@ int32_t adi_adrv9001_fh_Configure(adi_adrv9001_Device_t *adrv9001,
 	armData[offset++] = fhConfig->enableAGCGainIndexSeeding;
     offset += 1u; /* padding */
     /* If in gain select by pin mode, load Rx gain and Tx attenuation tables */
-    if (fhConfig->gainSetupByPin == true)
+    if (fhConfig->gainSetupByPin == true) 
     {
         /* Load Rx gain and Tx atten table */
         armData[offset++] = fhConfig->gainSetupByPinConfig[0].numRxGainTableEntries;
 	    armData[offset++] = fhConfig->gainSetupByPinConfig[1].numRxGainTableEntries;
         armData[offset++] = fhConfig->gainSetupByPinConfig[0].numTxAttenTableEntries;
 	    armData[offset++] = fhConfig->gainSetupByPinConfig[1].numTxAttenTableEntries;
-        /* Create a second offset variable to point to the Tx atten table location.
+        /* Create a second offset variable to point to the Tx atten table location. 
            Rx gain index is 1 byte, so second offset is offset + (ADI_ADRV9001_FH_MAX_NUM_GAIN_SELECT_ENTRIES * 1)
         */
         tempOffset = offset + 2 * ADI_ADRV9001_FH_MAX_NUM_GAIN_SELECT_ENTRIES;
@@ -581,7 +577,7 @@ int32_t adi_adrv9001_fh_Configure(adi_adrv9001_Device_t *adrv9001,
         }
     }
     /* Configure gain index pins if selected */
-    if (fhConfig->gainSetupByPin == true)
+    if (fhConfig->gainSetupByPin == true) 
     {
         /* Configure ADRV9001 GPIOs */
 	    for (j = 0; j < ADI_ADRV9001_NUM_CHANNELS; j++)
@@ -640,7 +636,7 @@ int32_t adi_adrv9001_fh_Configuration_Inspect(adi_adrv9001_Device_t *adrv9001, a
     fhConfig->tableIndexCtrl    = armData[offset++];
     fhConfig->gainSetupByPin    = armData[offset++];
     fhConfig->hopTableSelectConfig.hopTableSelectMode = armData[offset++];
-
+    
     hop1SignalsPortMask = armData[offset++];
     offset++;
     fhConfig->rxPortHopSignals[0] = ((hop1SignalsPortMask & 0x1) == 1) ? ADI_ADRV9001_FH_HOP_SIGNAL_1 : ADI_ADRV9001_FH_HOP_SIGNAL_2;
@@ -671,7 +667,7 @@ int32_t adi_adrv9001_fh_Configuration_Inspect(adi_adrv9001_Device_t *adrv9001, a
         {
             fhConfig->gainSetupByPinConfig[j].numTxAttenTableEntries = armData[offset++];
         }
-
+        
        tempOffset = offset + 2 * ADI_ADRV9001_FH_MAX_NUM_GAIN_SELECT_ENTRIES;
         /* Rx and Tx tables */
 	    for (j = 0; j < ADI_ADRV9001_NUM_CHANNELS; j++)
@@ -708,13 +704,13 @@ int32_t adi_adrv9001_fh_Configuration_Inspect(adi_adrv9001_Device_t *adrv9001, a
 
     ADI_EXPECT(adi_adrv9001_gpio_Inspect, adrv9001, ADI_ADRV9001_GPIO_SIGNAL_FH_HOP, &(fhConfig->hopSignalGpioConfig[0]));
     ADI_EXPECT(adi_adrv9001_gpio_Inspect, adrv9001, ADI_ADRV9001_GPIO_SIGNAL_FH_HOP_TABLE_SELECT, &(fhConfig->hopTableSelectConfig.hopTableSelectGpioConfig[0]));
-
+    
     if (fhConfig->mode == ADI_ADRV9001_FHMODE_LO_RETUNE_REALTIME_PROCESS_DUAL_HOP)
     {
         ADI_EXPECT(adi_adrv9001_gpio_Inspect, adrv9001, ADI_ADRV9001_GPIO_SIGNAL_FH_HOP_2, &(fhConfig->hopSignalGpioConfig[1]));
         ADI_EXPECT(adi_adrv9001_gpio_Inspect, adrv9001, ADI_ADRV9001_GPIO_SIGNAL_FH_HOP_2_TABLE_SELECT, &(fhConfig->hopTableSelectConfig.hopTableSelectGpioConfig[1]));
     }
-
+    
     /* Inspect table index pins if selected */
     if (fhConfig->tableIndexCtrl == ADI_ADRV9001_TABLEINDEXCTRL_GPIO)
     {
@@ -737,7 +733,7 @@ int32_t adi_adrv9001_fh_Configuration_Inspect(adi_adrv9001_Device_t *adrv9001, a
 int32_t adi_adrv9001_fh_HopTable_Static_Configure(adi_adrv9001_Device_t *adrv9001,
                                                      adi_adrv9001_FhMode_e mode,
                                                      adi_adrv9001_FhHopSignal_e hopSignal,
-                                                     adi_adrv9001_FhHopTable_e tableId,
+                                                     adi_adrv9001_FhHopTable_e tableId, 
                                                      adi_adrv9001_FhHopFrame_t hopTable[],
                                                      uint32_t hopTableSize)
 {
@@ -747,7 +743,7 @@ int32_t adi_adrv9001_fh_HopTable_Static_Configure(adi_adrv9001_Device_t *adrv900
     uint32_t frequencyIndex = 0;
     uint8_t numHopTableEntries[4u];
     uint32_t hopTableBufferAddress = 0;
-
+	
     /* ARM Data is written directly to ARM memory because FREQ_HOPPING_NUM_BYTES is greater than set buffer size */
 #ifndef __KERNEL__
     uint8_t armData[ADI_ADRV9001_FREQ_HOPPING_MAX_NUM_BYTES] = { 0 };
@@ -758,7 +754,6 @@ int32_t adi_adrv9001_fh_HopTable_Static_Configure(adi_adrv9001_Device_t *adrv900
      */
 	static uint8_t armData[ADI_ADRV9001_FREQ_HOPPING_MAX_NUM_BYTES];
 
-    guard(mutex)(&fh_lock);
     memset(&armData, 0, sizeof(armData));
 #endif
 	if (tableId == ADI_ADRV9001_FHHOPTABLE_A)
@@ -786,8 +781,8 @@ int32_t adi_adrv9001_fh_HopTable_Static_Configure(adi_adrv9001_Device_t *adrv900
 			hopTableAddress = adrv9001->devStateInfo.fhHopTableB2Addr;
 			hopTableBufferAddress = adrv9001->devStateInfo.fhHopTableBufferB2Addr;
 		}
-	}
-
+	}                                                            
+    
     adrv9001_LoadFourBytes(&offset, numHopTableEntries, hopTableSize);
     offset = 0;
     for (frequencyIndex = 0; frequencyIndex < hopTableSize; frequencyIndex++)
@@ -811,7 +806,7 @@ int32_t adi_adrv9001_fh_HopTable_Static_Configure(adi_adrv9001_Device_t *adrv900
 
 int32_t adi_adrv9001_fh_HopTable_Inspect(adi_adrv9001_Device_t *adrv9001,
                                             adi_adrv9001_FhHopSignal_e hopSignal,
-                                            adi_adrv9001_FhHopTable_e tableId,
+                                            adi_adrv9001_FhHopTable_e tableId, 
                                             adi_adrv9001_FhHopFrame_t hopTable[],
                                             uint32_t hopTableSize,
                                             uint32_t *numHopFramesRead)
@@ -836,10 +831,9 @@ int32_t adi_adrv9001_fh_HopTable_Inspect(adi_adrv9001_Device_t *adrv9001,
      */
 	static uint8_t armData[ADI_ADRV9001_FREQ_HOPPING_MAX_NUM_BYTES];
 
-    guard(mutex)(&fh_lock);
     memset(&armData, 0, sizeof(armData));
 #endif
-
+    
 	if (tableId == ADI_ADRV9001_FHHOPTABLE_A)
 	{
 		if (hopSignal == ADI_ADRV9001_FH_HOP_SIGNAL_1)
@@ -865,10 +859,10 @@ int32_t adi_adrv9001_fh_HopTable_Inspect(adi_adrv9001_Device_t *adrv9001,
 			hopTableAddress = adrv9001->devStateInfo.fhHopTableB2Addr;
 			hopTableBufferAddress = adrv9001->devStateInfo.fhHopTableBufferB2Addr;
 		}
-	}
+	}             
 
     ADI_PERFORM_VALIDATION(adi_adrv9001_fh_HopTable_Inspect_Validate, adrv9001, hopSignal, tableId, hopTable, hopTableSize);
-    /* Even though we are going to read directly from ARM memory, we can still use the GET protocol to
+    /* Even though we are going to read directly from ARM memory, we can still use the GET protocol to 
        tell ARM how many bytes we will read. ARM will return an error if the read size is invalid
     */
     adrv9001_LoadFourBytes(&offset, armData, sizeof(armData));
@@ -884,7 +878,7 @@ int32_t adi_adrv9001_fh_HopTable_Inspect(adi_adrv9001_Device_t *adrv9001,
                                         OBJID_GO_GET_FH_HOP_TABLE,
                                         ADI_ADRV9001_DEFAULT_TIMEOUT_US,
                                         ADI_ADRV9001_DEFAULT_INTERVAL_US);
-
+    
     /* First read number of frequencies in hop table */
     offset = 0;
     ADI_EXPECT(adi_adrv9001_arm_Memory_Read, adrv9001, hopTableAddress, numHopFrequenciesReadbackBlock, sizeof(numHopFrequenciesReadbackBlock), false);
@@ -986,7 +980,7 @@ int32_t adi_adrv9001_fh_HopTable_Get(adi_adrv9001_Device_t *adrv9001,
     ADI_API_RETURN(adrv9001);
 }
 
-int32_t adi_adrv9001_fh_FrameInfo_Inspect(adi_adrv9001_Device_t *adrv9001,
+int32_t adi_adrv9001_fh_FrameInfo_Inspect(adi_adrv9001_Device_t *adrv9001, 
 	                                         adi_adrv9001_FhHopSignal_e fhHopSignal,
                                              adi_adrv9001_FhFrameIndex_e frameIndex,
                                              adi_adrv9001_FhHopFrame_t *hopFrame)
@@ -1002,8 +996,8 @@ int32_t adi_adrv9001_fh_FrameInfo_Inspect(adi_adrv9001_Device_t *adrv9001,
     ADI_NULL_PTR_RETURN(&adrv9001->common, hopFrame);
 	ADI_RANGE_CHECK(adrv9001, fhHopSignal, ADI_ADRV9001_FH_HOP_SIGNAL_1, ADI_ADRV9001_FH_HOP_SIGNAL_2);
 	ADI_RANGE_CHECK(adrv9001, frameIndex, ADI_ADRV9001_FHFRAMEINDEX_CURRENT_FRAME, ADI_ADRV9001_FHFRAMEINDEX_UPCOMING_FRAME);
-
-
+	
+    
     /* Write the size to the GET buffer */
     adrv9001_LoadFourBytes(&offset, armData, sizeof(armData));
     ADI_EXPECT(adi_adrv9001_arm_Memory_Write, adrv9001, ADRV9001_ADDR_ARM_MAILBOX_GET, armData, sizeof(uint32_t), ADI_ADRV9001_ARM_SINGLE_SPI_WRITE_MODE_STANDARD_BYTES_4);
@@ -1036,9 +1030,9 @@ int32_t adi_adrv9001_fh_FrameInfo_Inspect(adi_adrv9001_Device_t *adrv9001,
 	hopFrame->tx1Attenuation_fifthdB = armData[offset++];
 	hopFrame->tx2Attenuation_fifthdB = armData[offset++];
     ADI_API_RETURN(adrv9001);
-}
+}                                                              
 
-int32_t adi_adrv9001_fh_Hop(adi_adrv9001_Device_t *adrv9001,
+int32_t adi_adrv9001_fh_Hop(adi_adrv9001_Device_t *adrv9001, 
                                adi_adrv9001_FhHopSignal_e hopSignal)
 {
     /* Flip the hop signal */
@@ -1075,7 +1069,7 @@ static __maybe_unused int32_t adi_adrv9001_fh_NumberOfHops_Get(adi_adrv9001_Devi
     default:
         ADI_SHOULD_NOT_EXECUTE(adrv9001);
     }
-
+    
     ADI_API_RETURN(adrv9001);
 }
 
@@ -1107,7 +1101,7 @@ static __maybe_unused int32_t adi_adrv9001_fh_HopTable_Dynamic_Configure_Validat
                 mode,
                 "FH mode must be dual hop for hopSignal to be HOP_2 ");
         }
-
+        
     }
 
     ADI_ENTRY_PTR_EXPECT(adrv9001, spiPackedFhTable);
@@ -1135,7 +1129,7 @@ static __maybe_unused int32_t adi_adrv9001_fh_HopTable_Dynamic_Configure_Validat
             ADI_COMMON_ACT_ERR_CHECK_PARAM,
             tableSize,
             "spiPackedFhTable[] size is not sufficient ");
-
+        
     }
     for (frequencyIndex = 0; frequencyIndex < tableSize; frequencyIndex++)
     {
@@ -1212,7 +1206,7 @@ static uint32_t adrv9001_HopTable_Spi_Pack(adi_adrv9001_Device_t *adrv9001,
 
     /* Issue SW interrupt 4 or 11 to load FH table A or B.  The SPI reg is self-cleared so there is no need to do read/mod/write. */
     adi_adrv9001_HopTable_Spi_DataPack(spiPackedFhTable, numWrBytes, ADRV9001_ADDR_SW_INTERRUPT_4, bitmSwInt, ADRV9001_SPI_WRITE_POLARITY);
-
+    
     /* Restore back the original values of ADRV9001 DMA control register */
     adi_adrv9001_HopTable_Spi_DataPack(spiPackedFhTable, numWrBytes, ADRV9001_ADDR_ARM_DMA_CTL, regVal, ADRV9001_SPI_WRITE_POLARITY);
 
@@ -1252,10 +1246,10 @@ int32_t adi_adrv9001_fh_HopTable_Dynamic_Configure(adi_adrv9001_Device_t *adrv90
         if (ADI_ADRV9001_FH_HOP_SIGNAL_1 == hopSignal)
         {
             bitmSwInt_A = 0x1;
-	        hopTableBufferAddress_A = adrv9001->devStateInfo.fhHopTableBufferA1Addr;
+	        hopTableBufferAddress_A = adrv9001->devStateInfo.fhHopTableBufferA1Addr; 
 	        armAddr_A = adrv9001->devStateInfo.fhHopTableA1Addr;
 
-            bitmSwInt_B = 0x80;
+            bitmSwInt_B = 0x80; 
 	        hopTableBufferAddress_B = adrv9001->devStateInfo.fhHopTableBufferB1Addr;
 	        armAddr_B = adrv9001->devStateInfo.fhHopTableB1Addr;
         }
@@ -1272,12 +1266,12 @@ int32_t adi_adrv9001_fh_HopTable_Dynamic_Configure(adi_adrv9001_Device_t *adrv90
     }
     else
     {
-        bitmSwInt_A = 0x1;
-	    hopTableBufferAddress_A = adrv9001->devStateInfo.fhHopTableBufferA1Addr;
+        bitmSwInt_A = 0x1; 
+	    hopTableBufferAddress_A = adrv9001->devStateInfo.fhHopTableBufferA1Addr; 
 	    armAddr_A = adrv9001->devStateInfo.fhHopTableA1Addr;
 
-        bitmSwInt_B = 0x2;
-	    hopTableBufferAddress_B = adrv9001->devStateInfo.fhHopTableBufferB1Addr;
+        bitmSwInt_B = 0x2; 
+	    hopTableBufferAddress_B = adrv9001->devStateInfo.fhHopTableBufferB1Addr; 
 	    armAddr_B = adrv9001->devStateInfo.fhHopTableB1Addr;
     }
 
@@ -1318,7 +1312,7 @@ int32_t adi_adrv9001_fh_HopTable_Dynamic_Configure(adi_adrv9001_Device_t *adrv90
 	        fhTable_A[offset++] = hopTable[i + j].tx2Attenuation_fifthdB;
         }
         ADI_EXPECT(adrv9001_HopTable_Spi_Pack, adrv9001, addrArray_A, fhTable_A, numberOfHops, &numWrBytes, bitmSwInt_A, spiPackedFhTable);
-
+    
         offset = 0;
         for (j = numberOfHops; j < (2 * numberOfHops); j++)
         {
@@ -1364,7 +1358,7 @@ int32_t adi_adrv9001_fh_HopTable_BytesPerTable_Get(adi_adrv9001_Device_t *adrv90
     ADI_EXPECT(adi_adrv9001_fh_NumberOfHops_Get, adrv9001, numberHopsPerDynamicLoad, &numberOfHops);
 
     spiPackBytesPerTable = spiConfigBytes + spiAddrPackLength + spiInterruptBytes;
-
+    
     payloadBytes = ((sizeof(adrv9001_FhHopFrame_t) * numberOfHops) + fhBytesLength) * 3;
     *bytesPerTable = payloadBytes + spiPackBytesPerTable;
 
@@ -1378,7 +1372,7 @@ int32_t adi_adrv9001_fh_RxOffsetFrequency_Set(adi_adrv9001_Device_t *adrv9001, a
 	adrv9001_LoadFourBytes(&offset, rxOffsetFrequencyHzArray, rx2OffsetFrequencyHz);
 	if (hopSignal == ADI_ADRV9001_FH_HOP_SIGNAL_1)
 	{
-
+		
 		ADI_EXPECT(adi_adrv9001_arm_Memory_Write, adrv9001, FREQ_HOPPING_HOP1_OFFSET_FREQ_OVERWRITE_ADDR, rxOffsetFrequencyHzArray, sizeof(rxOffsetFrequencyHzArray), ADI_ADRV9001_ARM_SINGLE_SPI_WRITE_MODE_STANDARD_BYTES_4);
 	}
 	else

--- a/drivers/iio/adc/navassa/devices/adrv9001/public/src/adi_adrv9001_rx.c
+++ b/drivers/iio/adc/navassa/devices/adrv9001/public/src/adi_adrv9001_rx.c
@@ -32,13 +32,6 @@
 #include "adrv9001_validators.h"
 #include "object_ids.h"
 
-#ifdef __KERNEL__
-#include <linux/cleanup.h>
-#include <linux/mutex.h>
-
-static DEFINE_MUTEX(lna_lock);
-#endif
-
 static __maybe_unused int32_t __maybe_unused adi_adrv9001_Rx_GainTable_Write_Validate(adi_adrv9001_Device_t *device,
                                        adi_common_Port_e port,
                                        adi_common_ChannelNumber_e channel,
@@ -129,7 +122,7 @@ static __maybe_unused int32_t __maybe_unused adi_adrv9001_Rx_GainTable_Write_Val
 			}
 		}
     }
-
+    
     /*Check that the gain index offset is within range*/
     ADI_RANGE_CHECK(device, gainIndexOffset, ADI_ADRV9001_MIN_RX_GAIN_TABLE_INDEX, ADI_ADRV9001_START_RX_GAIN_INDEX);
 
@@ -157,7 +150,7 @@ static __maybe_unused int32_t __maybe_unused adi_adrv9001_Rx_GainTable_Write_Val
     }
 
     ADI_RANGE_CHECK(device, channel, ADI_CHANNEL_1, ADI_CHANNEL_2);
-
+    
     ADI_RANGE_CHECK(device, gainTableType, ADI_ADRV9001_RX_GAIN_CORRECTION_TABLE, ADI_ADRV9001_RX_GAIN_COMPENSATION_TABLE);
 
     /*Check that Rx profile or ORx profile is valid*/
@@ -207,8 +200,6 @@ int32_t adi_adrv9001_Rx_GainTable_Write(adi_adrv9001_Device_t *device,
     uint8_t  lnaStepOffset = { 0 };
 #ifdef __KERNEL__
     static adi_adrv9001_RxGainTableRow_t lnaGainTable[235];
-
-    guard(mutex)(&lna_lock);
 #else
     adi_adrv9001_RxGainTableRow_t lnaGainTable[235] = { { 0 } };
 #endif
@@ -236,7 +227,7 @@ int32_t adi_adrv9001_Rx_GainTable_Write(adi_adrv9001_Device_t *device,
         {
             if (i == 0)
             {
-                lnaStepOffset = (gainIndexOffset - (lnaConfig->minGainIndex - 1));
+                lnaStepOffset = (gainIndexOffset - (lnaConfig->minGainIndex - 1)); 
             }
             else
             {
@@ -260,7 +251,7 @@ int32_t adi_adrv9001_Rx_GainTable_Write(adi_adrv9001_Device_t *device,
         }
         gainTablePtr = lnaGainTable;
     }
-
+    
     baseIndex = (gainIndexOffset - (numGainIndicesToWrite - 1));
     minGainIndex = (uint8_t)baseIndex;
     ADI_EXPECT(adrv9001_RxGainTableFormat, device, gainTablePtr, &armDmaData[0], numGainIndicesToWrite);
@@ -364,7 +355,7 @@ static __maybe_unused int32_t __maybe_unused adi_adrv9001_Rx_GainTable_Read_Vali
     ADI_EXPECT(adrv9001_NvsRegmapRxb_AgcMinimumGainIndex_Get, device, instance, &minGainIndex);
 
     ADI_RANGE_CHECK(device, gainIndexOffset, minGainIndex, ADI_ADRV9001_RX_GAIN_INDEX_MAX);
-
+    
     if (((ADRV9001_BF_EQUAL(device->devStateInfo.profilesValid, ADI_ADRV9001_RX_PROFILE_VALID)) == 0) &&
         ((ADRV9001_BF_EQUAL(device->devStateInfo.profilesValid, ADI_ADRV9001_ORX_PROFILE_VALID)) == 0) &&
         ((ADRV9001_BF_EQUAL(device->devStateInfo.profilesValid, ADI_ADRV9001_TX_PROFILE_VALID)) == 0))
@@ -510,7 +501,7 @@ static __maybe_unused int32_t __maybe_unused adi_adrv9001_Rx_Gain_Set_Validate(a
     ADI_RANGE_CHECK(device, channel, ADI_CHANNEL_1, ADI_CHANNEL_2);
 
     adi_common_channel_to_index(channel, &chan_idx);
-
+    
     /* Check that Rx profile is valid */
     if (0 == ADRV9001_BF_EQUAL(device->devStateInfo.initializedChannels, RX_CHANNELS[chan_idx]))
     {
@@ -529,7 +520,7 @@ static __maybe_unused int32_t __maybe_unused adi_adrv9001_Rx_Gain_Set_Validate(a
     ADI_EXPECT(adrv9001_NvsRegmapRxb_AgcMinimumGainIndex_Get, device, instance, &minGainIndex);
 
     ADI_RANGE_CHECK(device, gainIndex, minGainIndex, ADI_ADRV9001_RX_GAIN_INDEX_MAX);
-
+    
     /* Save the current gain control mode and set to the required mode */
     ADI_EXPECT(adi_adrv9001_Rx_GainControl_Mode_Get, device, channel, gainCtrlMode);
     if (ADI_ADRV9001_RX_GAIN_CONTROL_MODE_SPI != *gainCtrlMode)
@@ -723,7 +714,7 @@ static __maybe_unused int32_t adi_adrv9001_Rx_InterfaceGain_Validate(adi_adrv900
     adi_adrv9001_RxInterfaceGain_e rxInterfaceGainMax = ADI_ADRV9001_RX_INTERFACE_GAIN_NEGATIVE_36_DB;
 
     adi_common_channel_to_index(channel, &chan_index);
-
+    
     if (device->devStateInfo.rxOutputRate_kHz[chan_index] < RX_OUTPUT_RATE_kHZ)
     {
         if (gainTableType == ADI_ADRV9001_RX_GAIN_CORRECTION_TABLE)
@@ -762,7 +753,7 @@ static __maybe_unused int32_t __maybe_unused adi_adrv9001_Rx_InterfaceGain_Confi
                                                                                adi_adrv9001_RxInterfaceGainCtrl_t *rxInterfaceGainCtrl)
 {
     adi_adrv9001_ChannelState_e state = ADI_ADRV9001_CHANNEL_STANDBY;
-
+    
     ADI_RANGE_CHECK(device, channel, ADI_CHANNEL_1, ADI_CHANNEL_2);
 
     ADI_NULL_PTR_RETURN(&device->common, rxInterfaceGainCtrl);
@@ -801,11 +792,11 @@ static __maybe_unused int32_t __maybe_unused adi_adrv9001_Rx_InterfaceGain_Confi
 		            rxInterfaceGainCtrl->signalPAR,
 		            0,
 		            30);
-
+    
     ADI_EXPECT(adi_adrv9001_Radio_Channel_State_Get, device, ADI_RX, channel, &state);
     if (ADI_ADRV9001_CHANNEL_CALIBRATED != state)
     {
-        ADI_ERROR_REPORT(device,
+        ADI_ERROR_REPORT(device, 
                          ADI_COMMON_ERRSRC_API,
                          ADI_COMMON_ERR_API_FAIL,
                          ADI_COMMON_ACT_ERR_CHECK_PARAM,
@@ -885,12 +876,12 @@ static __maybe_unused int32_t __maybe_unused adi_adrv9001_Rx_InterfaceGain_Set_V
 
     /* Perform Range check of allowed gain value */
     ADI_EXPECT(adi_adrv9001_Rx_InterfaceGain_Validate, device, channel, gainTableType, gain);
-
+    
     ADI_EXPECT(adi_adrv9001_Radio_Channel_State_Get, device, ADI_RX, channel, &state);
     if ((ADI_ADRV9001_CHANNEL_PRIMED != state)
      && (ADI_ADRV9001_CHANNEL_RF_ENABLED != state))
     {
-        ADI_ERROR_REPORT(device,
+        ADI_ERROR_REPORT(device, 
                          ADI_COMMON_ERRSRC_API,
                          ADI_COMMON_ERR_API_FAIL,
                          ADI_COMMON_ACT_ERR_CHECK_PARAM,
@@ -1106,15 +1097,15 @@ static __maybe_unused int32_t __maybe_unused adi_adrv9001_Rx_InterfaceGain_SeedG
 
 		ADI_API_RETURN(device);
 	}
-
+	
 	ADI_EXPECT(adi_adrv9001_Rx_InterfaceGain_Validate, device, channel, gainTableType, seedGain);
-
+    
 	ADI_EXPECT(adi_adrv9001_Radio_Channel_State_Get, device, ADI_RX, channel, &state);
 	if ((ADI_ADRV9001_CHANNEL_CALIBRATED != state)
 	    && (ADI_ADRV9001_CHANNEL_PRIMED != state)
 	    && (ADI_ADRV9001_CHANNEL_RF_ENABLED != state))
 	{
-		ADI_ERROR_REPORT(device,
+		ADI_ERROR_REPORT(device, 
 			ADI_COMMON_ERRSRC_API,
 			ADI_COMMON_ERR_API_FAIL,
 			ADI_COMMON_ACT_ERR_CHECK_PARAM,
@@ -1133,7 +1124,7 @@ int32_t adi_adrv9001_Rx_InterfaceGain_SeedGain_Set( adi_adrv9001_Device_t *devic
 	uint32_t offset = 0;
 	adrv9001_LoadFourBytes(&offset, seedGainArray, seedGain);
 	ADI_PERFORM_VALIDATION(adi_adrv9001_Rx_InterfaceGain_SeedGain_Set_Validate, device, channel, seedGain);
-
+	
 	if (channel == ADI_CHANNEL_1)
 	{
 		ADI_EXPECT(adi_adrv9001_arm_Memory_Write, device, RX1_INTERFACE_GAIN_SEED_ADDR, seedGainArray, sizeof(seedGain), ADI_ADRV9001_ARM_SINGLE_SPI_WRITE_MODE_STANDARD_BYTES_4);
@@ -1172,7 +1163,7 @@ int32_t adi_adrv9001_Rx_InterfaceGain_EndOfFrameGain_Get(   adi_adrv9001_Device_
 	uint8_t armReadBack[4] = { 0 };
 	if (channel == ADI_CHANNEL_1)
 	{
-
+		
 		ADI_EXPECT(adi_adrv9001_arm_Memory_Read, device, RX1_INTERFACE_GAIN_END_OF_FRAME_ADDR, armReadBack, sizeof(armReadBack), false);
 	}
 	else
@@ -1655,12 +1646,12 @@ static __maybe_unused int32_t __maybe_unused adi_adrv9001_Rx_PortSwitch_Configur
     }
 
     /* NULL pointer check */
-    ADI_NULL_PTR_RETURN(&device->common, switchConfig);
+    ADI_NULL_PTR_RETURN(&device->common, switchConfig);    
 
     /* Freuqency range check */
-    ADI_RANGE_CHECK_X(device, switchConfig->minFreqPortA_Hz, ADI_ADRV9001_CARRIER_FREQUENCY_MIN_HZ, ADI_ADRV9001_CARRIER_FREQUENCY_MAX_HZ, "%llu");
-    ADI_RANGE_CHECK_X(device, switchConfig->maxFreqPortA_Hz, ADI_ADRV9001_CARRIER_FREQUENCY_MIN_HZ, ADI_ADRV9001_CARRIER_FREQUENCY_MAX_HZ, "%llu");
-    ADI_RANGE_CHECK_X(device, switchConfig->minFreqPortB_Hz, ADI_ADRV9001_CARRIER_FREQUENCY_MIN_HZ, ADI_ADRV9001_CARRIER_FREQUENCY_MAX_HZ, "%llu");
+    ADI_RANGE_CHECK_X(device, switchConfig->minFreqPortA_Hz, ADI_ADRV9001_CARRIER_FREQUENCY_MIN_HZ, ADI_ADRV9001_CARRIER_FREQUENCY_MAX_HZ, "%llu");    
+    ADI_RANGE_CHECK_X(device, switchConfig->maxFreqPortA_Hz, ADI_ADRV9001_CARRIER_FREQUENCY_MIN_HZ, ADI_ADRV9001_CARRIER_FREQUENCY_MAX_HZ, "%llu");    
+    ADI_RANGE_CHECK_X(device, switchConfig->minFreqPortB_Hz, ADI_ADRV9001_CARRIER_FREQUENCY_MIN_HZ, ADI_ADRV9001_CARRIER_FREQUENCY_MAX_HZ, "%llu");    
     ADI_RANGE_CHECK_X(device, switchConfig->maxFreqPortB_Hz, ADI_ADRV9001_CARRIER_FREQUENCY_MIN_HZ, ADI_ADRV9001_CARRIER_FREQUENCY_MAX_HZ, "%llu");
 
     /* Min frequency must be smaller than max */
@@ -1688,7 +1679,7 @@ static __maybe_unused int32_t __maybe_unused adi_adrv9001_Rx_PortSwitch_Configur
                          "Port A and B freuqency ranges cannot overlap.");
         ADI_API_RETURN(device)
     }
-
+     
     ADI_API_RETURN(device);
 }
 
@@ -1697,7 +1688,7 @@ int32_t adi_adrv9001_Rx_PortSwitch_Configure(adi_adrv9001_Device_t *device,
 {
     uint8_t armData[42] = { 0 };
     uint8_t extData[3] = { 0 };
-    uint32_t offset = 0u;
+    uint32_t offset = 0u; 
 
     ADI_PERFORM_VALIDATION(adi_adrv9001_Rx_PortSwitch_Configure_Validate, device, switchConfig);
 
@@ -1722,7 +1713,7 @@ int32_t adi_adrv9001_Rx_PortSwitch_Configure(adi_adrv9001_Device_t *device,
     extData[0] = 0;
     extData[1] = OBJID_GS_CONFIG;
     extData[2] = OBJID_CFG_RX_PORT_SWITCHING;
-
+    
     ADI_EXPECT(adi_adrv9001_arm_Config_Write, device, armData, sizeof(armData), extData, sizeof(extData))
 
     ADI_API_RETURN(device);
@@ -1745,7 +1736,7 @@ int32_t adi_adrv9001_Rx_PortSwitch_Inspect(adi_adrv9001_Device_t *device,
     ADI_PERFORM_VALIDATION(adi_adrv9001_Rx_PortSwitch_Inspect_Validate, device, switchConfig);
 
     ADI_EXPECT(adi_adrv9001_arm_Config_Read, device, OBJID_CFG_RX_PORT_SWITCHING, channelMask, offset, armReadBack, sizeof(armReadBack))
-
+    
     adrv9001_ParseEightBytes(&offset, armReadBack, &switchConfig->minFreqPortA_Hz);
     adrv9001_ParseEightBytes(&offset, armReadBack, &switchConfig->maxFreqPortA_Hz);
     adrv9001_ParseEightBytes(&offset, armReadBack, &switchConfig->minFreqPortB_Hz);
@@ -1768,7 +1759,7 @@ static __maybe_unused int32_t __maybe_unused adi_adrv9001_Rx_ExternalLna_Configu
     ADI_RANGE_CHECK(device, channel, ADI_CHANNEL_1, ADI_CHANNEL_2);
     ADI_RANGE_CHECK(device, gainTableType, ADI_ADRV9001_RX_GAIN_CORRECTION_TABLE, ADI_ADRV9001_RX_GAIN_COMPENSATION_TABLE);
     ADI_NULL_PTR_RETURN(&device->common, lnaConfig);
-
+    
     if (!lnaConfig->externalLnaPresent)
     {
         ADI_ERROR_REPORT(&device->common,
@@ -1795,7 +1786,7 @@ static __maybe_unused int32_t __maybe_unused adi_adrv9001_Rx_ExternalLna_Configu
     ADI_RANGE_CHECK(device, lnaConfig->numberLnaGainSteps, 2, 4);
     //ADI_RANGE_CHECK(device, lnaConfig->settlingDelay, 0, 0);
     //ADI_RANGE_CHECK(device, lnaConfig->lnaDigitalGainDelay, 0, 0);
-
+    
     if(0 != lnaConfig->lnaGainSteps_mdB[0])
     {
         ADI_ERROR_REPORT(&device->common,
@@ -1910,12 +1901,12 @@ int32_t adi_adrv9001_Rx_ExternalLna_Configure(adi_adrv9001_Device_t *device,
     ADI_EXPECT(adrv9001_NvsRegmapRxb_FeGainDelayIncr_Set, device, rxbAddr, (lnaConfig->lnaDigitalGainDelay + FEGAIN_INCR_FIXED_VALUE));
     ADI_EXPECT(adrv9001_NvsRegmapRxb_FeGainDelayDecr_Set, device, rxbAddr, (lnaConfig->lnaDigitalGainDelay + FEGAIN_DECR_FIXED_VALUE));
     ADI_EXPECT(adrv9001_NvsRegmapRx_ExtLnaDigitalGainDelay_Set, device, rxAddr, (lnaConfig->lnaDigitalGainDelay + EXTDIGGAIN_DELAY_FIXED_VALUE));
-
+    
     if (ADI_ADRV9001_RX_GAIN_COMPENSATION_TABLE == gainTableType)
     {
         ADI_EXPECT(adrv9001_NvsRegmapRx_GainCompForExtGain_Set, device, rxAddr, (uint8_t)lnaConfig->externalLnaPresent);
     }
-
+    
     ADI_API_RETURN(device);
 }
 
@@ -2003,11 +1994,11 @@ static __maybe_unused int32_t __maybe_unused adi_adrv9001_Rx_Loid_Configure_Vali
     adi_adrv9001_RadioState_t state = { 0 };
     uint8_t port_index = 0;
     uint8_t chan_index = 0;
-
+    
     ADI_RANGE_CHECK(adrv9001, channel, ADI_CHANNEL_1, ADI_CHANNEL_2);
 
     ADI_NULL_PTR_RETURN(&adrv9001->common, loidConfig);
-
+    
     /* Validate state is STANDBY or CALIBRATED*/
     ADI_EXPECT(adi_adrv9001_Radio_State_Get, adrv9001, &state);
     adi_common_port_to_index(ADI_RX, &port_index);
@@ -2042,7 +2033,7 @@ int32_t adi_adrv9001_Rx_Loid_Configure(adi_adrv9001_Device_t *adrv9001,
 
     /* Write LOID config to ARM mailbox */
     ADI_EXPECT(adi_adrv9001_arm_Memory_Write, adrv9001, ADRV9001_ADDR_ARM_MAILBOX_SET, &armData[0], sizeof(armData), ADI_ADRV9001_ARM_SINGLE_SPI_WRITE_MODE_STANDARD_BYTES_4);
-
+    
     extData[0] = adi_adrv9001_Radio_MailboxChannel_Get(ADI_RX, channel);
     extData[1] = OBJID_GS_LOID;
 
@@ -2054,14 +2045,14 @@ int32_t adi_adrv9001_Rx_Loid_Configure(adi_adrv9001_Device_t *adrv9001,
         extData[1],
         (uint32_t)ADI_ADRV9001_RX_INTERFACE_CONTROL_TIMEOUT_US,
         (uint32_t)ADI_ADRV9001_RX_INTERFACE_CONTROL_INTERVAL_US);
-
+    
     ADI_API_RETURN(adrv9001);
 }
 
 static __maybe_unused int32_t __maybe_unused adi_adrv9001_Rx_Loid_Inspect_Validate(adi_adrv9001_Device_t *adrv9001,
                               adi_common_ChannelNumber_e channel,
                               adi_adrv9001_RxrfdcLoidCfg_t *loidConfig)
-{
+{	
     ADI_RANGE_CHECK(adrv9001, channel, ADI_CHANNEL_1, ADI_CHANNEL_2);
 
     ADI_NULL_PTR_RETURN(&adrv9001->common, loidConfig);
@@ -2073,9 +2064,9 @@ int32_t adi_adrv9001_Rx_Loid_Inspect(adi_adrv9001_Device_t *adrv9001,
                                      adi_common_ChannelNumber_e channel,
                                      adi_adrv9001_RxrfdcLoidCfg_t *loidConfig)
 {
-    uint8_t armReadBack[4] = { 0 };
+    uint8_t armReadBack[4] = { 0 };	
     uint8_t extData[2] = { 0 };
-
+    
     extData[0] = adi_adrv9001_Radio_MailboxChannel_Get(ADI_RX, channel);
     extData[1] = OBJID_GS_LOID;
 
@@ -2094,7 +2085,7 @@ int32_t adi_adrv9001_Rx_Loid_Inspect(adi_adrv9001_Device_t *adrv9001,
 		&armReadBack[0],
 		sizeof(armReadBack),
 		ADRV9001_ARM_MEM_READ_AUTOINCR)
-
+		
 	loidConfig->loidEnable = armReadBack[0];
 	loidConfig->loidThreshold_negdBFS = armReadBack[2] + 6;
 

--- a/drivers/iio/adc/navassa/devices/adrv9001/public/src/adi_adrv9001_utilities.c
+++ b/drivers/iio/adc/navassa/devices/adrv9001/public/src/adi_adrv9001_utilities.c
@@ -13,12 +13,8 @@
 */
 
 #ifdef __KERNEL__
-#include <linux/cleanup.h>
-#include <linux/mutex.h>
 #include <linux/kernel.h>
 #include <linux/slab.h>
-
-static DEFINE_MUTEX(image_lock);
 #else
 #include <stdio.h>
 #include <string.h>
@@ -67,8 +63,6 @@ int32_t adi_adrv9001_Utilities_ArmImage_Load(adi_adrv9001_Device_t *device, cons
      * Wframe-larger-than=1024
      */
      static uint8_t armBinaryImageBuffer[ADI_ADRV9001_ARM_BINARY_IMAGE_LOAD_CHUNK_SIZE_BYTES];
-
-     guard(mutex)(&image_lock);
 #endif
 
     /* Check device pointer is not null */
@@ -117,8 +111,6 @@ int32_t adi_adrv9001_Utilities_StreamImage_Load(adi_adrv9001_Device_t *device, c
      * Wframe-larger-than=1024
      */
     static uint8_t streamBinaryImageBuffer[ADI_ADRV9001_STREAM_BINARY_IMAGE_LOAD_CHUNK_SIZE_BYTES];
-
-    guard(mutex)(&image_lock);
 #endif
 
     /* Check device pointer is not null */


### PR DESCRIPTION
The SDK is taken as is which means that compilation will likely fail.

The folloing changes were squashed in the new SDK (need to be sent to the BU):

 * 9d9cde6a64b4 ("iio: adc: adrv9002: radio: turn radio functions private")
 * 67b6d36a286d ("iio: adc: adrv9002: radio: fix pin mode")

All the FW and profiles remain the same... This was a patch release to fix an issue related with MCS

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
