### PR TITLE
iio: adc: adrv9002: Update API to 68.14.13

### DIFF
--- a/drivers/iio/adc/navassa/devices/adrv9001/public/include/adi_adrv9001_version.h
+++ b/drivers/iio/adc/navassa/devices/adrv9001/public/include/adi_adrv9001_version.h
@@ -19,7 +19,7 @@ extern "C" {
 #endif
 
 /* Auto-generated version number - DO NOT MANUALLY EDIT */
-#define ADI_ADRV9001_CURRENT_VERSION "68.14.10"
+#define ADI_ADRV9001_CURRENT_VERSION "68.14.13"
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The SDK is taken as is which means that compilation will likely fail.

The folloing changes were squashed in the new SDK (need to be sent to the BU):

 * 9d9cde6a64b4 ("iio: adc: adrv9002: radio: turn radio functions private")
 * 67b6d36a286d ("iio: adc: adrv9002: radio: fix pin mode")

Same as #2730 

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
