### PR TITLE
Staging/dt binbings fix

### DIFF
--- a/ci/travis/run-build.sh
+++ b/ci/travis/run-build.sh
@@ -335,7 +335,11 @@ build_dt_binding_check() {
 	fi
 
 	# install dt_binding_check dependencies
-	[ "${LOCAL_BUILD}" == "y" ] || pip3 install dtschema
+	apt_install pipx
+	[ "${LOCAL_BUILD}" == "y" ] || {
+		pipx install dtschema
+		PATH=$PATH:$HOME/.local/bin/
+	}
 
 	__update_git_ref "${ref_branch}" "${ref_branch}"
 


### PR DESCRIPTION
## PR Description

Make use of pix to install dtschema. This is the preferred way of installing apps from python packages (one cannot use pip anymore in distros like ubuntu 24.04 for example). This creates an isolated virtual environment and ensures the command are accessible in $PATH. It also makes sure all dependencies are met and do not interfere with OS's python packages.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
