### PR TITLE
[2023_R2] ci: travis: fix dt-bindings job

### DIFF
--- a/ci/travis/run-build.sh
+++ b/ci/travis/run-build.sh
@@ -334,7 +334,11 @@ build_dt_binding_check() {
 	fi
 
 	# install dt_binding_check dependencies
-	[ "${LOCAL_BUILD}" == "y" ] || pip3 install dtschema
+	apt_install pipx
+	[ "${LOCAL_BUILD}" == "y" ] || {
+		pipx install dtschema
+		PATH=$PATH:$HOME/.local/bin/
+	}
 
 	__update_git_ref "${ref_branch}" "${ref_branch}"
 


### PR DESCRIPTION
Make use of pix to install dtschema. This is the preferred way of installing apps from python packages (one cannot use pip anymore in distros like ubuntu 24.04 for example). This creates an isolated virtual environment and ensures the command are accessible in $PATH. It also makes sure all dependencies are met and do not interfere with OS's python packages.

Signed-off-by: Nuno Sa <nuno.sa@analog.com>
(cherry picked from commit daf69ead27dcc115bf19093f647a36b661a459fd)

## PR Description

- Please replace this comment with a summary of your changes, and add any context
necessary to understand them. List any dependencies required for this change.
- To check the checkboxes below, insert a 'x' between square brackets (without
any space), or simply check them after publishing the PR.
- If you changes include a breaking change, please specify dependent PRs in the
description and try to push all related PRs simultaneously.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
