### PR TITLE
Revert "iio: adc: adrv9002: Update API to 68.14.13"

### DIFF
--- a/drivers/iio/adc/navassa/devices/adrv9001/public/include/adi_adrv9001_radio.h
+++ b/drivers/iio/adc/navassa/devices/adrv9001/public/include/adi_adrv9001_radio.h
@@ -26,7 +26,7 @@ extern "C" {
 #endif
 
 /**
- * \brief Minimum supported carrier frequency 
+ * \brief Minimum supported carrier frequency
  */
 #define ADI_ADRV9001_CARRIER_FREQUENCY_MIN_HZ 25000000llu    /* 25 MHz */
 /**
@@ -80,7 +80,7 @@ int32_t adi_adrv9001_Radio_Carrier_Inspect(adi_adrv9001_Device_t *adrv9001,
  *
  * \note Message type: \ref timing_mailbox "Mailbox command"
  *
- * \pre This function should be called before running init calibration when all the channels are in STANDBY state. 
+ * \pre This function should be called before running init calibration when all the channels are in STANDBY state.
  *
  * \param[in] adrv9001	Context variable - Pointer to the ADRV9001 device settings data structure
  * \param[in] pllId     The PLL of interest
@@ -97,7 +97,7 @@ int32_t adi_adrv9001_Radio_Carrier_Inspect(adi_adrv9001_Device_t *adrv9001,
  *
  * \note Message type: \ref timing_mailbox "Mailbox command"
  *
- * \pre Channel state any of STANDBY, CALIBRATED, PRIMED, RF_ENABLED 
+ * \pre Channel state any of STANDBY, CALIBRATED, PRIMED, RF_ENABLED
  *
  * \param[in] adrv9001	Context variable - Pointer to the ADRV9001 device settings data structure
  * \param[in] pllId     The PLL of interest
@@ -182,7 +182,7 @@ int32_t adi_adrv9001_Radio_ChannelEnableMode_Get(adi_adrv9001_Device_t *adrv9001
  * \returns A code indicating success (ADI_COMMON_ACT_NO_ACTION) or the required action to recover
  */
 int32_t adi_adrv9001_Radio_State_Get(adi_adrv9001_Device_t *adrv9001, adi_adrv9001_RadioState_t *radioState);
-    
+
 /**
  * \brief Reads the current channel state
  *
@@ -198,7 +198,7 @@ int32_t adi_adrv9001_Radio_State_Get(adi_adrv9001_Device_t *adrv9001, adi_adrv90
  *
  * \returns A code indicating success (ADI_COMMON_ACT_NO_ACTION) or the required action to recover
  */
-int32_t adi_adrv9001_Radio_Channel_State_Get(adi_adrv9001_Device_t *adrv9001, 
+int32_t adi_adrv9001_Radio_Channel_State_Get(adi_adrv9001_Device_t *adrv9001,
                                              adi_common_Port_e port,
                                              adi_common_ChannelNumber_e channel,
                                              adi_adrv9001_ChannelState_e *channelState);
@@ -373,50 +373,6 @@ int32_t adi_adrv9001_Radio_Channels_PowerUp(adi_adrv9001_Device_t *adrv9001,
                                             adi_common_ChannelNumber_e channels[],
                                             uint32_t length);
 
-/**
- * \brief Transition the specified channel to the CALIBRATED state
- *
- * This function will transition the specified channel to the CALIBRATED state from any state where it is valid to do so.
- *
- * \param[in] adrv9001  Context variable - Pointer to the ADRV9001 device data structure containing settings
- * \param[in] port      The port that the channel refers to
- * \param[in] channel   The channel of the specified port to transition to the CALIBRATED state
- *
- * \returns A code indicating success (ADI_COMMON_ACT_NO_ACTION) or the required action to recover
- */
-int32_t adi_adrv9001_Radio_Channel_ToCalibrated(adi_adrv9001_Device_t *adrv9001,
-                                                adi_common_Port_e port,
-                                                adi_common_ChannelNumber_e channel);
-
-/**
- * \brief Transition the specified channel to the PRIMED state
- *
- * This function will transition the specified channel to the PRIMED state from any state where it is valid to do so.
- *
- * \param[in] adrv9001  Context variable - Pointer to the ADRV9001 device data structure containing settings
- * \param[in] port      The port that the channel refers to
- * \param[in] channel   The channel of the specified port to transition to the PRIMED state
- *
- * \returns A code indicating success (ADI_COMMON_ACT_NO_ACTION) or the required action to recover
- */
-int32_t adi_adrv9001_Radio_Channel_ToPrimed(adi_adrv9001_Device_t *adrv9001,
-                                            adi_common_Port_e port,
-                                            adi_common_ChannelNumber_e channel);
-
-/**
- * \brief Transition the specified channel to the RF ENABLED state
- *
- * This function will transition the specified channel to the RF ENABLED state from any state where it is valid to do so.
- *
- * \param[in] adrv9001  Context variable - Pointer to the ADRV9001 device data structure containing settings
- * \param[in] port      The port that the channel refers to
- * \param[in] channel   The channel of the specified port to transition to the RF ENABLED state
- *
- * \returns A code indicating success (ADI_COMMON_ACT_NO_ACTION) or the required action to recover
- */
-int32_t adi_adrv9001_Radio_Channel_ToRfEnabled(adi_adrv9001_Device_t *adrv9001,
-                                               adi_common_Port_e port,
-                                               adi_common_ChannelNumber_e channel);
 
 /**
  * \brief Transition the specified channel to the specified state
@@ -569,10 +525,10 @@ int32_t adi_adrv9001_Radio_RfLogenDivider_Get(adi_adrv9001_Device_t *adrv9001, a
  * \brief Write the TX/RX WB/NB PFIR channel filter Banks
  *
  * \note Used with TX/RX WB/NB compensation PFIR types only
- * 
+ *
  * \pre Channel state is RF_ENABLED
  *
- * \param[in] adrv9001	Context variable - Pointer to the ADRV9001 device settings data structure                      
+ * \param[in] adrv9001	Context variable - Pointer to the ADRV9001 device settings data structure
  * \param[in] pfirCoeff PFIR configuration to write
  * \param[in] bankSel   The PFIR Bank of interest
  * \param[in] port      The port of interest
@@ -580,7 +536,7 @@ int32_t adi_adrv9001_Radio_RfLogenDivider_Get(adi_adrv9001_Device_t *adrv9001, a
  *
  * \returns A code indicating success (ADI_COMMON_ACT_NO_ACTION) or the required action to recover
  */
-int32_t adi_adrv9001_Radio_PfirWbNbCompChFilter_Set(adi_adrv9001_Device_t *adrv9001, 
+int32_t adi_adrv9001_Radio_PfirWbNbCompChFilter_Set(adi_adrv9001_Device_t *adrv9001,
 		                                            const adi_adrv9001_PfirWbNbBuffer_t *pfirCoeff,
 		                                            adi_adrv9001_PfirBank_e bankSel, adi_common_Port_e port,
 	                                                adi_common_ChannelNumber_e channel);

--- a/drivers/iio/adc/navassa/devices/adrv9001/public/include/adi_adrv9001_version.h
+++ b/drivers/iio/adc/navassa/devices/adrv9001/public/include/adi_adrv9001_version.h
@@ -19,7 +19,7 @@ extern "C" {
 #endif
 
 /* Auto-generated version number - DO NOT MANUALLY EDIT */
-#define ADI_ADRV9001_CURRENT_VERSION "68.14.13"
+#define ADI_ADRV9001_CURRENT_VERSION "68.14.10"
 
 #ifdef __cplusplus
 }

--- a/drivers/iio/adc/navassa/devices/adrv9001/public/src/adi_adrv9001_radio.c
+++ b/drivers/iio/adc/navassa/devices/adrv9001/public/src/adi_adrv9001_radio.c
@@ -612,7 +612,6 @@ int32_t adi_adrv9001_Radio_Channels_EnableRf(adi_adrv9001_Device_t *adrv9001,
     uint8_t i = 0;
     uint8_t port_index = 0;
     uint8_t chan_index = 0;
-    adi_adrv9001_ChannelEnableMode_e enableMode = ADI_ADRV9001_SPI_MODE;
     adi_adrv9001_RadioState_t currentState = { 0 };
 
     ADI_PERFORM_VALIDATION(adi_adrv9001_Channel_State_GenericValidate, adrv9001, ports, channels, length);
@@ -622,18 +621,6 @@ int32_t adi_adrv9001_Radio_Channels_EnableRf(adi_adrv9001_Device_t *adrv9001,
     ADI_EXPECT(adi_adrv9001_Radio_State_Get, adrv9001, &currentState);
     for (i = 0; i < length; i++)
     {
-        ADI_EXPECT(adi_adrv9001_Radio_ChannelEnableMode_Get, adrv9001, ports[i], channels[i], &enableMode);
-        if (ADI_ADRV9001_SPI_MODE != enableMode)
-        {
-            ADI_ERROR_REPORT(&adrv9001->common,
-                             ADI_COMMON_ERRSRC_API,
-                             ADI_COMMON_ERR_API_FAIL,
-                             ADI_COMMON_ACT_ERR_CHECK_PARAM,
-                             enableMode,
-                             "Error while attempting to enable/disable RF for channel. Channel enable mode must be ADI_ADRV9001_SPI_MODE");
-            ADI_API_RETURN(adrv9001);
-        }
-
         adi_common_port_to_index(ports[i], &port_index);
         adi_common_channel_to_index(channels[i], &chan_index);
         if (currentState.channelStates[port_index][chan_index] != ADI_ADRV9001_CHANNEL_PRIMED &&
@@ -832,9 +819,9 @@ int32_t adi_adrv9001_Radio_Channels_PowerUp(adi_adrv9001_Device_t *adrv9001,
     ADI_API_RETURN(adrv9001);
 }
 
-int32_t adi_adrv9001_Radio_Channel_ToCalibrated(adi_adrv9001_Device_t *adrv9001,
-                                                adi_common_Port_e port,
-                                                adi_common_ChannelNumber_e channel)
+static int32_t adi_adrv9001_Radio_Channel_ToCalibrated(adi_adrv9001_Device_t *adrv9001,
+						       adi_common_Port_e port,
+						       adi_common_ChannelNumber_e channel)
 {
     uint8_t port_index = 0;
     uint8_t chan_index = 0;
@@ -870,9 +857,9 @@ int32_t adi_adrv9001_Radio_Channel_ToCalibrated(adi_adrv9001_Device_t *adrv9001,
     ADI_API_RETURN(adrv9001)
 }
 
-int32_t adi_adrv9001_Radio_Channel_ToPrimed(adi_adrv9001_Device_t *adrv9001,
-                                            adi_common_Port_e port,
-                                            adi_common_ChannelNumber_e channel)
+static int32_t adi_adrv9001_Radio_Channel_ToPrimed(adi_adrv9001_Device_t *adrv9001,
+						   adi_common_Port_e port,
+						   adi_common_ChannelNumber_e channel)
 {
     uint8_t port_index = 0;
     uint8_t chan_index = 0;
@@ -909,9 +896,9 @@ int32_t adi_adrv9001_Radio_Channel_ToPrimed(adi_adrv9001_Device_t *adrv9001,
     ADI_API_RETURN(adrv9001)
 }
 
-int32_t adi_adrv9001_Radio_Channel_ToRfEnabled(adi_adrv9001_Device_t *adrv9001,
-                                               adi_common_Port_e port,
-                                               adi_common_ChannelNumber_e channel)
+static int32_t adi_adrv9001_Radio_Channel_ToRfEnabled(adi_adrv9001_Device_t *adrv9001,
+						      adi_common_Port_e port,
+						      adi_common_ChannelNumber_e channel)
 {
     uint8_t port_index = 0;
     uint8_t chan_index = 0;
@@ -964,7 +951,21 @@ int32_t adi_adrv9001_Radio_Channel_ToState(adi_adrv9001_Device_t *adrv9001,
                                            adi_common_ChannelNumber_e channel,
                                            adi_adrv9001_ChannelState_e state)
 {
+    adi_adrv9001_ChannelEnableMode_e enableMode;
+
     ADI_PERFORM_VALIDATION(adi_adrv9001_Radio_Channel_ToState_Validate, adrv9001, port, channel, state);
+
+    ADI_EXPECT(adi_adrv9001_Radio_ChannelEnableMode_Get, adrv9001, port, channel, &enableMode);
+    if (ADI_ADRV9001_SPI_MODE != enableMode)
+    {
+            ADI_ERROR_REPORT(&adrv9001->common,
+                             ADI_COMMON_ERRSRC_API,
+                             ADI_COMMON_ERR_API_FAIL,
+                             ADI_COMMON_ACT_ERR_CHECK_PARAM,
+                             enableMode,
+                             "Error while attempting to change RF State for channel. Channel enable mode must be ADI_ADRV9001_SPI_MODE");
+            ADI_API_RETURN(adrv9001);
+    }
 
     switch (state)
     {

--- a/drivers/iio/adc/navassa/devices/adrv9001/public/src/adi_adrv9001_utilities.c
+++ b/drivers/iio/adc/navassa/devices/adrv9001/public/src/adi_adrv9001_utilities.c
@@ -51,7 +51,7 @@
 #define ADI_ADRV9001_RX_GAIN_TABLE_SIZE_ROWS 256
 #define ADI_ADRV9001_TX_ATTEN_TABLE_SIZE_ROWS 1024
 
-int32_t adi_adrv9001_Utilities_ArmImage_Load(adi_adrv9001_Device_t *device, const char *armImagePath, adi_adrv9001_ArmSingleSpiWriteMode_e spiWriteMode) 
+int32_t adi_adrv9001_Utilities_ArmImage_Load(adi_adrv9001_Device_t *device, const char *armImagePath, adi_adrv9001_ArmSingleSpiWriteMode_e spiWriteMode)
 {
     int32_t recoveryAction = ADI_COMMON_ACT_NO_ACTION;
     uint32_t i = 0;
@@ -98,7 +98,7 @@ int32_t adi_adrv9001_Utilities_ArmImage_Load(adi_adrv9001_Device_t *device, cons
     return recoveryAction;
 }
 
-int32_t adi_adrv9001_Utilities_StreamImage_Load(adi_adrv9001_Device_t *device, const char *streamImagePath, adi_adrv9001_ArmSingleSpiWriteMode_e spiWriteMode) 
+int32_t adi_adrv9001_Utilities_StreamImage_Load(adi_adrv9001_Device_t *device, const char *streamImagePath, adi_adrv9001_ArmSingleSpiWriteMode_e spiWriteMode)
 {
 
     int32_t recoveryAction = ADI_COMMON_ACT_NO_ACTION;
@@ -175,7 +175,7 @@ int32_t adi_adrv9001_Utilities_RxGainTable_Load(adi_adrv9001_Device_t *device, a
     ADI_EXPECT(adrv9001_NvsRegmapRxb_AgcMinimumGainIndex_Get, device, instance, &minIndex);
 
     /*Loop until the gain table end is reached or no. of lines scanned exceeds maximum*/
-    while (lineCount <  ADI_ADRV9001_RX_GAIN_TABLE_SIZE_ROWS) 
+    while (lineCount <  ADI_ADRV9001_RX_GAIN_TABLE_SIZE_ROWS)
     {
         returnTableEntry = adi_hal_RxGainTableEntryGet(device->common.devHalInfo,
                                                        rxGainTablePath,
@@ -226,7 +226,7 @@ int32_t adi_adrv9001_Utilities_RxGainTable_Load(adi_adrv9001_Device_t *device, a
 
     maxGainIndex = prevGainIndex;
     ADI_EXPECT(adi_adrv9001_Rx_GainTable_Write, device, port, channel, maxGainIndex, &rxGainTableRowBuffer[0], lineCount, lnaConfig, gainTableType);
-    
+
     ADI_API_RETURN(device);
 }
 
@@ -247,7 +247,7 @@ int32_t adi_adrv9001_Utilities_TxAttenTable_Load(adi_adrv9001_Device_t *device, 
     ADI_ENTRY_PTR_EXPECT(device, txAttenTablePath);
 
     /*Loop until the atten table end is reached or no. of lines scanned exceeds maximum*/
-    while (lineCount < ADRV9001_TX_ATTEN_TABLE_MAX) 
+    while (lineCount < ADRV9001_TX_ATTEN_TABLE_MAX)
     {
         returnTableEntry = adi_hal_TxAttenTableEntryGet(device->common.devHalInfo,
                                                         txAttenTablePath,
@@ -296,26 +296,26 @@ int32_t adi_adrv9001_Utilities_TxAttenTable_Load(adi_adrv9001_Device_t *device, 
     tableSize = attenIndex - minAttenIndex + 1;
 
     ADI_EXPECT(adi_adrv9001_Tx_AttenuationTable_Write, device, txChannelMask, minAttenIndex, &txAttenTableRowBuffer[0], tableSize);
-    
+
     ADI_API_RETURN(device);
 }
 
 int32_t adi_adrv9001_Utilities_WaitMs(adi_adrv9001_Device_t *adrv9001, uint32_t waitInterval_ms)
 {
 	int32_t halError = 0;
-	
+
 	/* Check device pointer is not null */
 	ADI_ENTRY_EXPECT(adrv9001);
-	
+
 	halError = adi_common_hal_Wait_us(&adrv9001->common, (1000*waitInterval_ms));
-	
+
 	ADI_ERROR_REPORT(&adrv9001->common,
 		ADI_COMMON_ERRSRC_ADI_HAL,
 		halError,
 		ADI_COMMON_ACT_ERR_CHECK_TIMER,
 		device,
 		"Timer not working");
-	
+
 	return halError;
 }
 
@@ -365,26 +365,26 @@ int32_t adi_adrv9001_Utilities_SystemDebugPreCalibrate(adi_adrv9001_Device_t *ad
 	ADI_NULL_PTR_RETURN(adrv9001, init);
 	ADI_NULL_PTR_RETURN(adrv9001, armImagePath);
 	ADI_NULL_PTR_RETURN(adrv9001, streamImagePath);
-	
+
 	printf("*** ADRV9001 Pre-Calibrate System Debugging Started ***\r\n");
-	
+
 	printf("--> . Hardware Reset\r\n");
 	ADI_MSG_EXPECT("Failed to reset device and set SPI config.", adi_adrv9001_HwReset, adrv9001);
 	printf("      OK\r\n");
-	
+
 	printf("--> . API Version\r\n");
 	ADI_MSG_EXPECT("Error fetching API Version.", adi_adrv9001_ApiVersion_Get, adrv9001, &apiVersion_0);
 	printf("      OK - API Version = %u.%u.%u\r\n", apiVersion_0.major, apiVersion_0.minor, apiVersion_0.patch);
-	
+
 	printf("--> . Configure SPI\r\n");
 	ADI_MSG_EXPECT("Problem Closing HW.", adi_adrv9001_HwClose, adrv9001);
 	ADI_MSG_EXPECT("Problem Opening HW.", adi_adrv9001_HwOpen, adrv9001, &spiSettings);
 	printf("      OK\r\n");
-	
+
 	printf("--> . Check SPI\r\n");
 	ADI_MSG_EXPECT("SPI Verify failed.", adi_adrv9001_spi_Verify, adrv9001);
 	printf("      OK\r\n");
-	
+
 	printf("--> . Check Power Supplies\r\n");
 	status = adi_bf_hal_Register_Read(adrv9001, 0x01ac, &gp1LdoResistorValue);
 	ADI_ERROR_RETURN(status);
@@ -399,10 +399,10 @@ int32_t adi_adrv9001_Utilities_SystemDebugPreCalibrate(adi_adrv9001_Device_t *ad
 		printf("      NOK - Check power supply is connected correctly\r\n");
 		ADI_ERROR_RETURN(ADI_COMMON_ERR_API_FAIL);
 	}
-	
+
 	ADI_MSG_EXPECT("Problem Init Analog.", adi_adrv9001_InitAnalog, adrv9001, init, ADI_ADRV9001_DEVICECLOCKDIVISOR_2);
 	ADI_MSG_EXPECT("Problem AhbSpiBridge Enable.", adi_adrv9001_arm_AhbSpiBridge_Enable, adrv9001);
-	
+
 	printf("--> . Load Stream Processor Image\r\n");
 	ADI_MSG_EXPECT("Stream Processor Image Load Error. Check Dev_Clk, SPI and Power Supply.", adi_adrv9001_Utilities_StreamImage_Load, adrv9001, streamImagePath, spiWriteMode);
 	printf("      OK\r\n");
@@ -418,7 +418,7 @@ int32_t adi_adrv9001_Utilities_SystemDebugPreCalibrate(adi_adrv9001_Device_t *ad
 	ADI_MSG_EXPECT("ARM Start Error.", adi_adrv9001_arm_Start, adrv9001);
 	adi_adrv9001_arm_System_Program(adrv9001, (uint8_t)(init->tx.txInitChannelMask | (init->rx.rxInitChannelMask & 0x33)));
 	printf("      OK\r\n");
-	
+
 	printf("--> . Verify ARM Image Load\r\n");
 	ADI_MSG_EXPECT("ARM Start Status Check Error.", adi_adrv9001_arm_StartStatus_Check, adrv9001, armStatusCheckTimeoutUs);
 	ADI_MSG_EXPECT("ARM Check Firmware Version.", adi_adrv9001_arm_Version, adrv9001, &armVersion);
@@ -459,16 +459,18 @@ int32_t adi_adrv9001_Utilities_SystemDebugPostCalibrate(adi_adrv9001_Device_t *a
 {
 	bool pllLO1LockStatus = 0;
 	bool pllLO2LockStatus = 0;
-	
+
 	/* Check device pointer is not null */
 	ADI_ENTRY_EXPECT(adrv9001);
-	
+
 	printf("*** ADRV9001 Post-Calibrate System Debugging Started ***\r\n");
-	
+
 	printf("--> . Check RF PLLs \r\n");
-	ADI_MSG_EXPECT("RF Pll Error. Can't prime channel. The device should be calibrated", adi_adrv9001_Radio_Channel_ToPrimed, adrv9001, ADI_RX, ADI_CHANNEL_1);
-	ADI_MSG_EXPECT("RF Pll Error. Can't prime channel. The device should be calibrated", adi_adrv9001_Radio_Channel_ToPrimed, adrv9001, ADI_TX, ADI_CHANNEL_1);
-	
+	ADI_MSG_EXPECT("RF Pll Error. Can't prime channel. The device should be calibrated", adi_adrv9001_Radio_Channel_ToState, adrv9001, ADI_RX, ADI_CHANNEL_1,
+		       ADI_ADRV9001_CHANNEL_PRIMED);
+	ADI_MSG_EXPECT("RF Pll Error. Can't prime channel. The device should be calibrated", adi_adrv9001_Radio_Channel_ToState, adrv9001, ADI_TX, ADI_CHANNEL_1,
+		       ADI_ADRV9001_CHANNEL_PRIMED);
+
 	ADI_MSG_EXPECT("Error fetching PLL LO1 lock status", adi_adrv9001_Radio_PllStatus_Get, adrv9001, ADI_ADRV9001_PLL_LO1, &pllLO1LockStatus);
 	ADI_MSG_EXPECT("Error fetching PLL LO2 lock status", adi_adrv9001_Radio_PllStatus_Get, adrv9001, ADI_ADRV9001_PLL_LO2, &pllLO2LockStatus);
 
@@ -481,9 +483,9 @@ int32_t adi_adrv9001_Utilities_SystemDebugPostCalibrate(adi_adrv9001_Device_t *a
 		printf("      NOK - RF Plls can't lock\r\n");
 		ADI_ERROR_RETURN(ADI_COMMON_ERR_API_FAIL);
 	}
-	
+
 	printf("*** ADRV9001 Post-Calibrate System Debugging Completed ***\r\n");
-	
+
 	ADI_API_RETURN(adrv9001);
 }
 
@@ -498,17 +500,17 @@ int32_t adi_adrv9001_Utilities_InitCals_WarmBoot_Coefficients_VectTblChunkRead(a
 {
 	uint32_t address = 0x20020004;
 	uint32_t vecTbl[4] = { 0 };
-	
+
 	/* Check device pointer is not null */
 	ADI_ENTRY_EXPECT(adrv9001);
-	
+
 	ADI_EXPECT(adi_adrv9001_arm_Memory_Read32, adrv9001, (address + (16*calNo)), vecTbl, 16, 0);
-	
+
 	*addr = vecTbl[0];
 	*size =  vecTbl[1];
 	*initMask = vecTbl[2];
 	*profMask = vecTbl[3];
-	
+
 	ADI_API_RETURN(adrv9001);
 }
 
@@ -523,7 +525,7 @@ int32_t adi_adrv9001_Utilities_InitCals_WarmBoot_Coefficients_MaxArrayChunk_Get(
 {
 	/* Check device pointer is not null */
 	ADI_ENTRY_EXPECT(adrv9001);
-	
+
 	adi_common_ChannelNumber_e channel;
 	for (channel = ADI_CHANNEL_1; channel <= ADI_CHANNEL_2; channel++)
 	{
@@ -560,7 +562,7 @@ int32_t adi_adrv9001_Utilities_InitCals_WarmBoot_Coefficients_MaxArrayChunk_Set(
 {
 	/* Check device pointer is not null */
 	ADI_ENTRY_EXPECT(adrv9001);
-	
+
 	adi_common_ChannelNumber_e channel;
 	for (channel = ADI_CHANNEL_1; channel <= ADI_CHANNEL_2; channel++)
 	{


### PR DESCRIPTION
This reverts commit 71f053264b6006348892d19ad732487e380c3297.

As it turns out, API 68.14.13 has no meaningful fixes and this release only affects users using hdl that we do not use in the linux driver. Hence this would only raise unnecessary questions without any added value.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
