### PR TITLE
Add AD7191 overlay

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -257,6 +257,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	rpi-ad7124-8-all-diff.dtbo \
 	rpi-ad7173.dtbo \
 	rpi-ad7190.dtbo \
+	rpi-ad7191.dtbo \
 	rpi-ad7293.dtbo \
 	rpi-ad738x.dtbo \
 	rpi-ad7746.dtbo \

--- a/arch/arm/boot/dts/overlays/rpi-ad7191-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ad7191-overlay.dts
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Overlay for AD7191 analog to digital converter
+ *
+ * Copyright 2025 Analog Devices Inc.
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			avdd: fixedregulator@0 {
+				compatible = "regulator-fixed";
+				regulator-name = "fixed-supply0";
+				regulator-min-microvolt = <5000000>;
+				regulator-max-microvolt = <5000000>;
+				regulator-boot-on;
+			};
+		};
+	};
+
+	fragment@1 {
+		target-path = "/";
+		__overlay__ {
+			dvdd: fixedregulator@1 {
+				compatible = "regulator-fixed";
+				regulator-name = "fixed-supply1";
+				regulator-min-microvolt = <3300000>;
+				regulator-max-microvolt = <3300000>;
+				regulator-boot-on;
+			};
+		};
+	};
+
+	fragment@2 {
+		target-path = "/";
+		__overlay__ {
+			vref: fixedregulator@2 {
+				compatible = "regulator-fixed";
+				regulator-name = "fixed-supply2";
+				regulator-min-microvolt = <5000000>;
+				regulator-max-microvolt = <5000000>;
+				regulator-boot-on;
+			};
+		};
+	};
+
+	fragment@3 {
+		target = <&spi0>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			ad7191@0 {
+				compatible = "adi,ad7191";
+				reg = <0>;
+				spi-max-frequency = <1000000>;
+				spi-cpol;
+				spi-cpha;
+				#interrupt-cells = <2>;
+				interrupts = <25 IRQ_TYPE_EDGE_FALLING>;
+				interrupt-parent = <&gpio>;
+				avdd-supply = <&avdd>;
+				dvdd-supply = <&dvdd>;
+				vref-supply = <&vref>;
+
+				adi,pga-value = <128>;
+				odr-gpios = <&gpio 23 GPIO_ACTIVE_HIGH>,
+					    <&gpio 24 GPIO_ACTIVE_HIGH>;
+				temp-gpios = <&gpio 22 GPIO_ACTIVE_HIGH>;
+				chan-gpios = <&gpio 27 GPIO_ACTIVE_HIGH>;
+			};
+		};
+	};
+};

--- a/include/linux/iio/iio.h
+++ b/include/linux/iio/iio.h
@@ -10,6 +10,7 @@
 #include <linux/device.h>
 #include <linux/cdev.h>
 #include <linux/cleanup.h>
+#include <linux/compiler_types.h>
 #include <linux/slab.h>
 #include <linux/iio/types.h>
 /* IIO TODO LIST */
@@ -667,6 +668,31 @@ int iio_device_claim_direct_mode(struct iio_dev *indio_dev);
 void iio_device_release_direct_mode(struct iio_dev *indio_dev);
 int iio_device_claim_buffer_mode(struct iio_dev *indio_dev);
 void iio_device_release_buffer_mode(struct iio_dev *indio_dev);
+
+/*
+ * Helper functions that allow claim and release of direct mode
+ * in a fashion that doesn't generate many false positives from sparse.
+ * Note this must remain static inline in the header so that sparse
+ * can see the __acquire() marking. Revisit when sparse supports
+ * __cond_acquires()
+ */
+static inline bool iio_device_claim_direct(struct iio_dev *indio_dev)
+{
+	int ret = iio_device_claim_direct_mode(indio_dev);
+
+	if (ret)
+		return false;
+
+	__acquire(iio_dev);
+
+	return true;
+}
+
+static inline void iio_device_release_direct(struct iio_dev *indio_dev)
+{
+	iio_device_release_direct_mode(indio_dev);
+	__release(indio_dev);
+}
 
 /*
  * This autocleanup logic is normally used via


### PR DESCRIPTION
## PR Description

Add support to rpi branch for AD7191. The ad7191 driver is already in the linux iio tree. The following commits are cherry picked from there:
    - dt-bindings: iio: adc: add AD7191
    - iio: adc: ad7191: add AD7191
    - docs: iio: add AD7191
 
Cherry pick 2 other commits from the iio tree to synchronize the driver here with the driver there. The only difference right now is:

MODULE_IMPORT_NS(IIO_AD_SIGMA_DELTA); (here)
vs
MODULE_IMPORT_NS("IIO_AD_SIGMA_DELTA");

Question: the bitmap.h file of the main branch is behind the upstream one (and also behind the one on rpi-6.6.y branch), in order to add this driver to the main branch too, should I drop the use of bitmap_write there, resulting in difference between the driver on main branch vs rpi-6.6.y branch?

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have tested the changes on the relevant hardware
- [x] I have updated the documentation outside this repo accordingly (if there is the case)
