### PR TITLE
drivers: iio: adc: ad9361.c: Return calib err

### DIFF
--- a/drivers/iio/adc/ad9361.c
+++ b/drivers/iio/adc/ad9361.c
@@ -5254,7 +5254,7 @@ static int ad9361_setup(struct ad9361_rf_phy *phy)
 static int ad9361_do_calib_run(struct ad9361_rf_phy *phy, u32 cal, int arg)
 {
 	struct ad9361_rf_phy_state *st = phy->state;
-	int ret;
+	int ret, ret2;
 
 	dev_dbg(&phy->spi->dev, "%s: CAL %u ARG %d", __func__, cal, arg);
 
@@ -5278,11 +5278,11 @@ static int ad9361_do_calib_run(struct ad9361_rf_phy *phy, u32 cal, int arg)
 		break;
 	}
 
-	ret = ad9361_tracking_control(phy, st->bbdc_track_en,
+	ret2 = ad9361_tracking_control(phy, st->bbdc_track_en,
 			st->rfdc_track_en, st->quad_track_en);
 	ad9361_ensm_restore_prev_state(phy);
 
-	return ret;
+	return ret ? ret : ret2;
 }
 
 static int ad9361_update_rf_bandwidth(struct ad9361_rf_phy *phy,


### PR DESCRIPTION
## PR Description

Return error in case TX_QUAD_CAL or RFDC_CAL fail.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have tested the changes on the relevant hardware
- [x] I have updated the documentation outside this repo accordingly (if there is the case)
