### PR TITLE
ad4630:  postenable and 32 bit container 

### DIFF
--- a/drivers/iio/adc/ad4630.c
+++ b/drivers/iio/adc/ad4630.c
@@ -690,7 +690,7 @@ static int ad4630_write_raw(struct iio_dev *indio_dev,
 	}
 }
 
-static int ad4630_buffer_preenable(struct iio_dev *indio_dev)
+static int ad4630_buffer_postenable(struct iio_dev *indio_dev)
 {
 	struct ad4630_state *st = iio_priv(indio_dev);
 	int ret, read_ret;
@@ -741,7 +741,7 @@ out_error:
 	return ret;
 }
 
-static int ad4630_buffer_postdisable(struct iio_dev *indio_dev)
+static int ad4630_buffer_predisable(struct iio_dev *indio_dev)
 {
 	struct ad4630_state *st = iio_priv(indio_dev);
 	u32 dummy;
@@ -1300,8 +1300,8 @@ static int ad4630_config(struct ad4630_state *st)
 }
 
 static const struct iio_buffer_setup_ops ad4630_buffer_setup_ops = {
-	.preenable = &ad4630_buffer_preenable,
-	.postdisable = &ad4630_buffer_postdisable,
+	.postenable = &ad4630_buffer_postenable,
+	.predisable = &ad4630_buffer_predisable,
 };
 
 static const struct iio_info ad4630_info = {

--- a/drivers/iio/adc/ad4630.c
+++ b/drivers/iio/adc/ad4630.c
@@ -795,25 +795,25 @@ static int ad4630_buffer_predisable(struct iio_dev *indio_dev)
 static const struct ad4630_out_mode ad4030_24_modes[] = {
 	[AD4630_24_DIFF] = {
 		.channels = {
-			AD4630_CHAN(0, AD4630_CHAN_INFO_NONE, 64, 24, 0, AD4630_CHAN_INFO_NONE),
+			AD4630_CHAN(0, AD4630_CHAN_INFO_NONE, 32, 24, 0, AD4630_CHAN_INFO_NONE),
 		},
 		.data_width = 24,
 	},
 	[AD4630_16_DIFF_8_COM] = {
 		.channels = {
-			AD4630_CHAN(0, AD4630_CHAN_INFO_NONE, 64, 16, 8, AD4630_CHAN_INFO_NONE),
+			AD4630_CHAN(0, AD4630_CHAN_INFO_NONE, 32, 16, 8, AD4630_CHAN_INFO_NONE),
 		},
 		.data_width = 24,
 	},
 	[AD4630_24_DIFF_8_COM] = {
 		.channels = {
-			AD4630_CHAN(0, AD4630_CHAN_INFO_NONE, 64, 24, 8, AD4630_CHAN_INFO_NONE),
+			AD4630_CHAN(0, AD4630_CHAN_INFO_NONE, 32, 24, 8, AD4630_CHAN_INFO_NONE),
 		},
 		.data_width = 32,
 	},
 	[AD4630_30_AVERAGED_DIFF] = {
 		.channels = {
-			AD4630_CHAN(0, AD4630_CHAN_INFO_NONE, 64, 30, 2,
+			AD4630_CHAN(0, AD4630_CHAN_INFO_NONE, 32, 30, 2,
 				BIT(IIO_CHAN_INFO_OVERSAMPLING_RATIO)),
 		},
 		.data_width = 32,


### PR DESCRIPTION
## PR Description
2 updates related to HDL:
- use postenable to have dma start before spi engine (recommendation from HDL team)
- use 32bit container for single channel ad4030.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
