### PR TITLE
iio: adc: adrv9009: Propagate PLL-RF-LO clock

### DIFF
--- a/drivers/iio/adc/adrv9009.h
+++ b/drivers/iio/adc/adrv9009.h
@@ -25,6 +25,7 @@
 #include "talise/talise_user.h"
 #include "talise/talise_gpio.h"
 
+#include <linux/clk/clkscale.h>
 #include <linux/jesd204/jesd204.h>
 #include <linux/mutex.h>
 
@@ -138,6 +139,7 @@ enum adrv9009_clocks {
 	RX_SAMPL_CLK,
 	OBS_SAMPL_CLK,
 	TX_SAMPL_CLK,
+	TRX_LO_CLK,
 	NUM_ADRV9009_CLKS,
 };
 
@@ -215,6 +217,7 @@ struct adrv9009_rf_phy {
 	struct clk 		*clk_ext_lo_tx;
 	struct clk 		*clks[NUM_ADRV9009_CLKS];
 	struct adrv9009_clock	clk_priv[NUM_ADRV9009_CLKS];
+	struct clock_scale	trx_lo_clkscale;
 	struct clk_onecell_data	clk_data;
 	struct adrv9009_debugfs_entry debugfs_entry[344];
 	struct bin_attribute 	bin;


### PR DESCRIPTION
## PR Description

Adds a feature to propagate the PLL-TRX-RF-LO clock rate to the clock system. The scale may be set in the device tree node with trx-lo-clock-scales = <mult div>;

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
