### PR TITLE
arm: dts: Add AD719x dts for cora

### DIFF
--- a/arch/arm/boot/dts/zynq-coraz7s-ad7190.dts
+++ b/arch/arm/boot/dts/zynq-coraz7s-ad7190.dts
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Analog Devices AD719x
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-adc/ad7192
+ *
+ * hdl_project: <ad719x_asdz/coraz7s>
+ *
+ * Copyright (C) 2025 Analog Devices, Inc.
+ */
+/dts-v1/;
+#include "zynq-coraz7s.dtsi"
+
+/ {
+	aincom: fixedregulator@0 {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-supply0";
+		regulator-min-microvolt = <1000000>;
+		regulator-max-microvolt = <1000000>;
+		regulator-boot-on;
+	};
+
+	avdd: fixedregulator@1 {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-supply1";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		regulator-boot-on;
+	};
+
+	dvdd: fixedregulator@2 {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-supply2";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-boot-on;
+	};
+
+	vref: fixedregulator@3 {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-supply3";
+		regulator-min-microvolt = <2500000>;
+		regulator-max-microvolt = <2500000>;
+		regulator-boot-on;
+	};
+};
+
+&spi0 {
+	status = "okay";
+	ad7190: adc@0 {
+		compatible = "adi,ad7190";
+		reg = <0>;
+		spi-max-frequency = <1000000>;
+		spi-cpol;
+		spi-cpha;
+
+		interrupts = <86 0x2>;
+		interrupt-parent = <&gpio0>;
+
+		aincom-supply = <&aincom>;
+		avdd-supply = <&avdd>;
+		dvdd-supply = <&dvdd>;
+		vref-supply = <&vref>;
+	};
+};

--- a/arch/arm/boot/dts/zynq-coraz7s-ad7192.dts
+++ b/arch/arm/boot/dts/zynq-coraz7s-ad7192.dts
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Analog Devices AD719x
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-adc/ad7192
+ *
+ * hdl_project: <ad719x_asdz/coraz7s>
+ *
+ * Copyright (C) 2025 Analog Devices, Inc.
+ */
+/dts-v1/;
+#include "zynq-coraz7s.dtsi"
+
+/ {
+	aincom: fixedregulator@0 {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-supply0";
+		regulator-min-microvolt = <1000000>;
+		regulator-max-microvolt = <1000000>;
+		regulator-boot-on;
+	};
+
+	avdd: fixedregulator@1 {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-supply1";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		regulator-boot-on;
+	};
+
+	dvdd: fixedregulator@2 {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-supply2";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-boot-on;
+	};
+
+	vref: fixedregulator@3 {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-supply3";
+		regulator-min-microvolt = <2500000>;
+		regulator-max-microvolt = <2500000>;
+		regulator-boot-on;
+	};
+};
+
+&spi0 {
+	status = "okay";
+	ad7192: adc@0 {
+		compatible = "adi,ad7192";
+		reg = <0>;
+		spi-max-frequency = <1000000>;
+		spi-cpol;
+		spi-cpha;
+
+		interrupts = <86 0x2>;
+		interrupt-parent = <&gpio0>;
+
+		aincom-supply = <&aincom>;
+		avdd-supply = <&avdd>;
+		dvdd-supply = <&dvdd>;
+		vref-supply = <&vref>;
+	};
+};

--- a/arch/arm/boot/dts/zynq-coraz7s-ad7193.dts
+++ b/arch/arm/boot/dts/zynq-coraz7s-ad7193.dts
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Analog Devices AD719x
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-adc/ad7192
+ *
+ * hdl_project: <ad719x_asdz/coraz7s>
+ *
+ * Copyright (C) 2025 Analog Devices, Inc.
+ */
+/dts-v1/;
+#include "zynq-coraz7s.dtsi"
+
+/ {
+	aincom: fixedregulator@0 {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-supply0";
+		regulator-min-microvolt = <1000000>;
+		regulator-max-microvolt = <1000000>;
+		regulator-boot-on;
+	};
+
+	avdd: fixedregulator@1 {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-supply1";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-boot-on;
+	};
+
+	dvdd: fixedregulator@2 {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-supply2";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-boot-on;
+	};
+
+	vref: fixedregulator@3 {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-supply3";
+		regulator-min-microvolt = <2500000>;
+		regulator-max-microvolt = <2500000>;
+		regulator-boot-on;
+	};
+};
+
+&spi0 {
+	status = "okay";
+	ad7193: adc@0 {
+		compatible = "adi,ad7193";
+		reg = <0>;
+		spi-max-frequency = <1000000>;
+		spi-cpol;
+		spi-cpha;
+
+		interrupts = <86 0x2>;
+		interrupt-parent = <&gpio0>;
+
+		aincom-supply = <&aincom>;
+		avdd-supply = <&avdd>;
+		dvdd-supply = <&dvdd>;
+		vref-supply = <&vref>;
+	};
+};

--- a/arch/arm/boot/dts/zynq-coraz7s-ad7194.dts
+++ b/arch/arm/boot/dts/zynq-coraz7s-ad7194.dts
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Analog Devices AD719x
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-adc/ad7192
+ *
+ * hdl_project: <ad719x_asdz/coraz7s>
+ *
+ * Copyright (C) 2025 Analog Devices, Inc.
+ */
+/dts-v1/;
+#include "zynq-coraz7s.dtsi"
+
+/ {
+	aincom: fixedregulator@0 {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-supply0";
+		regulator-min-microvolt = <1000000>;
+		regulator-max-microvolt = <1000000>;
+		regulator-boot-on;
+	};
+
+	avdd: fixedregulator@1 {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-supply1";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-boot-on;
+	};
+
+	dvdd: fixedregulator@2 {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-supply2";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-boot-on;
+	};
+
+	vref: fixedregulator@3 {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-supply3";
+		regulator-min-microvolt = <2500000>;
+		regulator-max-microvolt = <2500000>;
+		regulator-boot-on;
+	};
+};
+
+&spi0 {
+	status = "okay";
+	ad7194: adc@0 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "adi,ad7194";
+		reg = <0>;
+		spi-max-frequency = <1000000>;
+		spi-cpol;
+		spi-cpha;
+
+		interrupts = <86 0x2>;
+		interrupt-parent = <&gpio0>;
+
+		aincom-supply = <&aincom>;
+		avdd-supply = <&avdd>;
+		dvdd-supply = <&dvdd>;
+		vref-supply = <&vref>;
+
+		channel@0 {
+			reg = <0>;
+			diff-channels = <1 6>;
+		};
+
+		channel@1 {
+			reg = <1>;
+			single-channel = <1>;
+		};
+	};
+};

--- a/arch/arm/boot/dts/zynq-coraz7s-ad7195.dts
+++ b/arch/arm/boot/dts/zynq-coraz7s-ad7195.dts
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Analog Devices AD719x
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-adc/ad7192
+ *
+ * hdl_project: <ad719x_asdz/coraz7s>
+ *
+ * Copyright (C) 2025 Analog Devices, Inc.
+ */
+/dts-v1/;
+#include "zynq-coraz7s.dtsi"
+
+/ {
+	aincom: fixedregulator@0 {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-supply0";
+		regulator-min-microvolt = <1000000>;
+		regulator-max-microvolt = <1000000>;
+		regulator-boot-on;
+	};
+
+	avdd: fixedregulator@1 {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-supply1";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		regulator-boot-on;
+	};
+
+	dvdd: fixedregulator@2 {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-supply2";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-boot-on;
+	};
+
+	vref: fixedregulator@3 {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-supply3";
+		regulator-min-microvolt = <2500000>;
+		regulator-max-microvolt = <2500000>;
+		regulator-boot-on;
+	};
+};
+
+&spi0 {
+	status = "okay";
+	ad7195: adc@0 {
+		compatible = "adi,ad7195";
+		reg = <0>;
+		spi-max-frequency = <1000000>;
+		spi-cpol;
+		spi-cpha;
+
+		interrupts = <86 0x2>;
+		interrupt-parent = <&gpio0>;
+
+		aincom-supply = <&aincom>;
+		avdd-supply = <&avdd>;
+		dvdd-supply = <&dvdd>;
+		vref-supply = <&vref>;
+	};
+};


### PR DESCRIPTION
Add AD7190, AD7192, AD7193, AD7194 and AD7195 devicetrees for Cora z7s board.

## PR Type
- [x] New feature (a change that adds new functionality)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have tested the changes on the relevant hardware
