### PR TITLE
m2k: Update hdl project path

### DIFF
--- a/arch/arm/boot/dts/xilinx/zynq-m2k-reva.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-m2k-reva.dts
@@ -6,10 +6,10 @@
  * https://wiki.analog.com/university/tools/adalm2000/devs/intro
  * https://wiki.analog.com/university/tools/m2k/users/quick_start
  *
- * hdl_project: <m2k/standalone>
+ * hdl_project: <m2k>
  * board_revision: <A>
  *
- * Copyright (C) 2018-2019 Analog Devices Inc.
+ * Copyright (C) 2018-2019, 2025 Analog Devices Inc.
  */
 /dts-v1/;
 

--- a/arch/arm/boot/dts/xilinx/zynq-m2k-revb.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-m2k-revb.dts
@@ -6,10 +6,10 @@
  * https://wiki.analog.com/university/tools/adalm2000/devs/intro
  * https://wiki.analog.com/university/tools/m2k/users/quick_start
  *
- * hdl_project: <m2k/standalone>
+ * hdl_project: <m2k>
  * board_revision: <B>
  *
- * Copyright (C) 2018-2019 Analog Devices Inc.
+ * Copyright (C) 2018-2019, 2025 Analog Devices Inc.
  */
 /*
  * 	Summary of RevA -> RevB hardware changes which require firmware changes:

--- a/arch/arm/boot/dts/xilinx/zynq-m2k-revc.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-m2k-revc.dts
@@ -6,10 +6,10 @@
  * https://wiki.analog.com/university/tools/adalm2000/devs/intro
  * https://wiki.analog.com/university/tools/m2k/users/quick_start
  *
- * hdl_project: <m2k/standalone>
+ * hdl_project: <m2k>
  * board_revision: <C>
  *
- * Copyright (C) 2018-2019 Analog Devices Inc.
+ * Copyright (C) 2018-2019, 2025 Analog Devices Inc.
  */
 /*
  * 	Summary of RevB -> RevC hardware changes which require firmware changes:

--- a/arch/arm/boot/dts/xilinx/zynq-m2k-revd.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-m2k-revd.dts
@@ -6,10 +6,10 @@
  * https://wiki.analog.com/university/tools/adalm2000/devs/intro
  * https://wiki.analog.com/university/tools/m2k/users/quick_start
  *
- * hdl_project: <m2k/standalone>
+ * hdl_project: <m2k>
  * board_revision: <D>
  *
- * Copyright (C) 2018-2019 Analog Devices Inc.
+ * Copyright (C) 2018-2019, 2025 Analog Devices Inc.
  */
 /*
  * 	Summary of RevC -> RevD hardware changes which require firmware changes:

--- a/arch/arm/boot/dts/xilinx/zynq-m2k-reve.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-m2k-reve.dts
@@ -6,10 +6,10 @@
  * https://wiki.analog.com/university/tools/adalm2000/devs/intro
  * https://wiki.analog.com/university/tools/m2k/users/quick_start
  *
- * hdl_project: <m2k/standalone>
+ * hdl_project: <m2k>
  * board_revision: <E>
  *
- * Copyright (C) 2018-2019 Analog Devices Inc.
+ * Copyright (C) 2018-2019, 2025 Analog Devices Inc.
  */
 /*
  * 	Summary of RevD -> RevE hardware changes which require firmware changes:

--- a/arch/arm/boot/dts/xilinx/zynq-m2k-revf.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-m2k-revf.dts
@@ -6,10 +6,10 @@
  * https://wiki.analog.com/university/tools/adalm2000/devs/intro
  * https://wiki.analog.com/university/tools/m2k/users/quick_start
  *
- * hdl_project: <m2k/standalone>
+ * hdl_project: <m2k>
  * board_revision: <F>
  *
- * Copyright (C) 2018-2019 Analog Devices Inc.
+ * Copyright (C) 2018-2019, 2025 Analog Devices Inc.
  */
 /*
  * 	Summary of RevE -> RevF hardware changes which require firmware changes:


### PR DESCRIPTION
## PR Description

Based on the HDL changes, the path for the m2k project files changed:
https://github.com/analogdevicesinc/hdl/pull/1634

Update the affected dts descriptions.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [x] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [x] I have updated the documentation outside this repo accordingly (if there is the case)
