### PR TITLE
iio: hmc7044: Don't warn CLK_OUT_PHASES for hmc7043

### DIFF
--- a/drivers/iio/frequency/hmc7044.c
+++ b/drivers/iio/frequency/hmc7044.c
@@ -2105,7 +2105,7 @@ static int hmc7044_jesd204_clks_sync3(struct jesd204_dev *jdev,
 		if (ret < 0)
 			return ret;
 
-		if (!HMC7044_CLK_OUT_PH_STATUS(val))
+		if (hmc->device_id != HMC7043 && !HMC7044_CLK_OUT_PH_STATUS(val))
 			dev_warn(dev,
 				"%s: SYSREF of the HMC7044 is not valid; that is, its phase output is not stable (0x%X)\n",
 				__func__, val & 0xFF);


### PR DESCRIPTION
## PR Description

A bug exists on 0x007D[2] "alarm readback.clock outputs phases status" of HMC7043 and cannot be reliably used.

Resolves false/misleading
```
hmc7044 spi1.4: hmc7044_jesd204_clks_sync3: SYSREF of the HMC7044 is not valid; that is, its phase output is not stable (0x0)
```

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
