### PR TITLE
iio: frequency: adf4030: fix possible unitialized 'ret'

### DIFF
--- a/drivers/iio/frequency/adf4030.c
+++ b/drivers/iio/frequency/adf4030.c
@@ -334,13 +334,13 @@ static int adf4030_chan_dir_set(const struct adf4030_state *st,
 
 	/* EN_DRIVE */
 	if (chan->num > 7)
-		regmap_update_bits(st->regmap, ADF4030_REG(0x13),
-				   BIT(chan->num - 8),
-				   chan->channel_output_en ? BIT(chan->num - 8) : 0);
+		ret = regmap_update_bits(st->regmap, ADF4030_REG(0x13),
+					 BIT(chan->num - 8),
+					 chan->channel_output_en ? BIT(chan->num - 8) : 0);
 	else
-		regmap_update_bits(st->regmap, ADF4030_REG(0x12),
-				   BIT(chan->num),
-				   chan->channel_output_en ? BIT(chan->num) : 0);
+		ret = regmap_update_bits(st->regmap, ADF4030_REG(0x12),
+					 BIT(chan->num),
+					 chan->channel_output_en ? BIT(chan->num) : 0);
 	if (ret)
 		return ret;
 


### PR DESCRIPTION
In adf4030_chan_dir_set(), every time 'initial' is false, 'ret' was being used unitialized because we're ignoring the return value from regmap_update_bits(). Make sure we don't!

Fixes: 54bbd40c03ca ("iio: frequency: support the adf4030 Synchronizer")

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
