### PR TITLE
dt-bindings: iio: jesd204: adi,iio-fakedev: fix example, misspelling

### DIFF
--- a/Documentation/devicetree/bindings/iio/jesd204/adi,iio-fakedev.yaml
+++ b/Documentation/devicetree/bindings/iio/jesd204/adi,iio-fakedev.yaml
@@ -24,12 +24,16 @@ properties:
   adi,faked-dev:
     $ref: /schemas/types.yaml#/definitions/phandle
     description:
-      A reference (phandle) to a the actual device to which the fake device links attribues from.
+      A reference (phandle) to the actual device to where the fake device links its attributes.
 
   adi,attribute-names:
     $ref: /schemas/types.yaml#/definitions/string-array
     description:
       List of device sysfs attribute strings.
+
+  label:
+    description:
+      Names the iio fake device.
 
 required:
   - compatible
@@ -49,11 +53,11 @@ examples:
       label = "axi-jesd204-rx";
     };
 
-    axi-jesd204-rx@1 {
+    axi-jesd204-tx@1 {
       compatible = "adi,iio-fake-platform-device";
       adi,faked-dev = <&axi_ad9081_tx_jesd>;
       adi,attribute-names = "status", "encoder";
-      label = "axi-jesd204-rx";
+      label = "axi-jesd204-tx";
     };
 
     axi-adxcvr-rx@2 {


### PR DESCRIPTION
## PR Description

The axi-jesd204-rx label was duplicated and wording was off.
Add information that the label sets the iio device name.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
