### PR TITLE
arm64: boot: dts: remove fan-ctl gpio from jupiter dts

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-jupiter-sdr.dtsi
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-jupiter-sdr.dtsi
@@ -397,13 +397,6 @@
 		output-high;
 		line-name = "usb-reset";
 	};
-
-	fan_ctl {
-		gpio-hog;
-		gpios = <145 GPIO_ACTIVE_HIGH>;
-		output-low;
-		line-name = "fan-ctl";
-	};
 };
 
 &spi0 {


### PR DESCRIPTION
Removing fan_ctl gpio from zynqmp-jupiter-sdr devicetree because it will be used in userspace and boot scripts.

## PR Description

Removed fan_ctl gpio from zynqmp-jupiter-sdr.dtsi

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
