### PR TITLE
Add dts for using AD4000 and similar ADCs on ZedBoard

### DIFF
--- a/arch/arm/boot/dts/xilinx/zynq-coraz7s-adaq4001.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-coraz7s-adaq4001.dts
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices ADAQ4001
+ *
+ * hdl_project: <pulsar_adc/coraz7s>
+ * Link: https://github.com/analogdevicesinc/hdl/tree/main/projects/pulsar_adc
+ * board_revision: <A>
+ *
+ * Copyright (C) 2025 Analog Devices Inc.
+ */
+/dts-v1/;
+#include "zynq-coraz7s.dtsi"
+#include <dt-bindings/interrupt-controller/irq.h>
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	adc_vref: regulator-vref {
+		compatible = "regulator-fixed";
+		regulator-name = "EVAL 5V Vref";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		regulator-always-on;
+	};
+
+	adc_vdd: regulator-vdd {
+		compatible = "regulator-fixed";
+		regulator-name = "Eval VDD supply";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		regulator-always-on;
+	};
+
+	adc_vio: regulator-vio {
+		compatible = "regulator-fixed";
+		regulator-name = "Eval VIO supply";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-always-on;
+	};
+
+	trigger_pwm: adc-pwm-trigger {
+		compatible = "pwm-trigger";
+		#trigger-source-cells = <0>;
+		pwms = <&adc_trigger 0 1000000 0>;
+	};
+};
+
+&fpga_axi {
+
+	adc_trigger: pwm@0x44b00000 {
+		compatible = "adi,axi-pwmgen-2.00.a";
+		reg = <0x44b00000 0x1000>;
+		label = "adc_conversion_trigger";
+		#pwm-cells = <2>;
+		clocks = <&spi_clk>;
+	};
+
+	spi_engine: spi@44a00000 {
+		compatible = "adi,axi-spi-engine-1.00.a";
+		reg = <0x44a00000 0x10000>;
+		interrupt-parent = <&intc>;
+		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&clkc 15 &spi_clk>;
+		clock-names = "s_axi_aclk", "spi_clk";
+
+		dmas = <&rx_dma 0>;
+		dma-names = "offload0-rx";
+		trigger-sources = <&trigger_pwm>;
+
+		#address-cells = <0x1>;
+		#size-cells = <0x0>;
+
+		adc@0 {
+			compatible = "adi,adaq4001";
+			reg = <0>;
+			spi-max-frequency = <100000000>;
+			vdd-supply = <&adc_vdd>;
+			vio-supply = <&adc_vio>;
+			ref-supply = <&adc_vref>;
+			adi,high-z-input;
+			adi,gain-milli = /bits/ 16 <454>;
+		};
+	};
+
+	rx_dma: rx-dmac@44a30000 {
+		compatible = "adi,axi-dmac-1.00.a";
+		reg = <0x44a30000 0x1000>;
+		#dma-cells = <1>;
+		interrupt-parent = <&intc>;
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&clkc 16>;
+	};
+
+	spi_clk: axi-clkgen@0x44a70000 {
+		compatible = "adi,axi-clkgen-2.00.a";
+		reg = <0x44a70000 0x10000>;
+		#clock-cells = <0>;
+		clocks = <&clkc 15>, <&clkc 15>;
+		clock-names = "clkin1", "s_axi_aclk";
+		clock-output-names = "spi_clk";
+
+		assigned-clocks = <&spi_clk>;
+		assigned-clock-rates = <200000000>;
+	};
+};

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4000.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4000.dts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD4000
+ * https://www.analog.com/en/products/ad4000.html
+ *
+ * hdl_project: <pulsar_adc/zed>
+ * Link: https://github.com/analogdevicesinc/hdl/tree/main/projects/pulsar_adc
+ * board_revision: <>
+ *
+ * Copyright (C) 2025 Analog Devices Inc.
+ */
+/dts-v1/;
+#include "zynq-zed-adv7511-ad4000.dtsi"

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4000.dtsi
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4000.dtsi
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD4000 series of ADCs
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-adc/ad400x
+ * https://wiki.analog.com/resources/eval/ad400x-eval-board
+ * https://wiki.analog.com/resources/eval/user-guides/ad400x
+ *
+ * hdl_project: <pulsar_adc/zed>
+ * Link: https://github.com/analogdevicesinc/hdl/tree/main/projects/pulsar_adc
+ * board_revision: <>
+ *
+ * Copyright (C) 2025 Analog Devices Inc.
+ */
+
+#include "zynq-zed.dtsi"
+#include "zynq-zed-adv7511.dtsi"
+#include <dt-bindings/interrupt-controller/irq.h>
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	adc_vref: regulator-vref {
+		compatible = "regulator-fixed";
+		regulator-name = "EVAL 5V Vref";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		regulator-always-on;
+	};
+
+	adc_vdd: regulator-vdd {
+		compatible = "regulator-fixed";
+		regulator-name = "Eval VDD supply";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+		regulator-always-on;
+	};
+
+	adc_vio: regulator-vio {
+		compatible = "regulator-fixed";
+		regulator-name = "Eval VIO supply";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-always-on;
+	};
+
+	trigger_pwm: adc-pwm-trigger {
+		compatible = "pwm-trigger";
+		#trigger-source-cells = <0>;
+		pwms = <&adc_trigger 0 1000000 0>;
+	};
+};
+
+&fpga_axi {
+
+	adc_trigger: pwm@0x44b00000 {
+		compatible = "adi,axi-pwmgen-2.00.a";
+		reg = <0x44b00000 0x1000>;
+		label = "adc_conversion_trigger";
+		#pwm-cells = <2>;
+		clocks = <&spi_clk>;
+	};
+
+	spi_engine: spi@0x44a00000 {
+		compatible = "adi,axi-spi-engine-1.00.a";
+		reg = <0x44a00000 0x10000>;
+		interrupt-parent = <&intc>;
+		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&clkc 15 &spi_clk>;
+		clock-names = "s_axi_aclk", "spi_clk";
+		dmas = <&rx_dma 0>;
+		dma-names = "offload0-rx";
+		trigger-sources = <&trigger_pwm>;
+
+		#address-cells = <0x1>;
+		#size-cells = <0x0>;
+
+		ad4000_adc: adc@0 {
+			compatible = "adi,ad4000";
+			reg = <0>;
+			spi-max-frequency = <80000000>;
+			vdd-supply = <&adc_vdd>;
+			vio-supply = <&adc_vio>;
+			ref-supply = <&adc_vref>;
+			adi,high-z-input;
+		};
+	};
+
+	rx_dma: rx-dmac@0x44a30000 {
+		compatible = "adi,axi-dmac-1.00.a";
+		reg = <0x44a30000 0x1000>;
+		#dma-cells = <1>;
+		interrupt-parent = <&intc>;
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&clkc 17>;
+	};
+
+	spi_clk: axi-clkgen@0x44a70000 {
+		compatible = "adi,axi-clkgen-2.00.a";
+		reg = <0x44a70000 0x10000>;
+		#clock-cells = <0>;
+		clocks = <&clkc 15>, <&clkc 15>;
+		clock-names = "s_axi_aclk", "clkin1";
+		clock-output-names = "spi_clk";
+
+		assigned-clocks = <&spi_clk>;
+		assigned-clock-rates = <200000000>;
+	};
+};

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4001.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4001.dts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD4001
+ * https://www.analog.com/en/products/ad4001.html
+ *
+ * hdl_project: <pulsar_adc/zed>
+ * Link: https://github.com/analogdevicesinc/hdl/tree/main/projects/pulsar_adc
+ * board_revision: <>
+ *
+ * Copyright (C) 2025 Analog Devices Inc.
+ */
+/dts-v1/;
+#include "zynq-zed-adv7511-ad4000.dtsi"
+
+&ad4000_adc {
+	compatible = "adi,ad4001";
+};

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4002.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4002.dts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD4002
+ * https://www.analog.com/en/products/ad4002.html
+ *
+ * hdl_project: <pulsar_adc/zed>
+ * Link: https://github.com/analogdevicesinc/hdl/tree/main/projects/pulsar_adc
+ * board_revision: <>
+ *
+ * Copyright (C) 2025 Analog Devices Inc.
+ */
+/dts-v1/;
+#include "zynq-zed-adv7511-ad4000.dtsi"
+
+&ad4000_adc {
+	compatible = "adi,ad4002";
+};

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4003.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4003.dts
@@ -3,96 +3,17 @@
  * Analog Devices AD4003
  * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-adc/ad400x
  * https://wiki.analog.com/resources/eval/user-guides/ad400x
+ * https://www.analog.com/en/products/ad4003.html
  *
  * hdl_project: <pulsar_adc/zed>
+ * Link: https://github.com/analogdevicesinc/hdl/tree/main/projects/pulsar_adc
  * board_revision: <>
  *
- * Copyright (C) 2016-2024 Analog Devices Inc.
+ * Copyright (C) 2016-2025 Analog Devices Inc.
  */
 /dts-v1/;
+#include "zynq-zed-adv7511-ad4000.dtsi"
 
-#include "zynq-zed.dtsi"
-#include "zynq-zed-adv7511.dtsi"
-
-/ {
-	adc_vref: regulator-vref {
-		compatible = "regulator-fixed";
-		regulator-name = "EVAL 5V Vref";
-		regulator-min-microvolt = <5000000>;
-		regulator-max-microvolt = <5000000>;
-		regulator-always-on;
-	};
-
-	adc_vdd: regulator-vdd {
-		compatible = "regulator-fixed";
-		regulator-name = "Eval VDD supply";
-		regulator-min-microvolt = <1800000>;
-		regulator-max-microvolt = <1800000>;
-		regulator-always-on;
-	};
-
-	adc_vio: regulator-vio {
-		compatible = "regulator-fixed";
-		regulator-name = "Eval VIO supply";
-		regulator-min-microvolt = <3300000>;
-		regulator-max-microvolt = <3300000>;
-		regulator-always-on;
-	};
-};
-
-&fpga_axi {
-	rx_dma: rx-dmac@44a30000 {
-		compatible = "adi,axi-dmac-1.00.a";
-		reg = <0x44a30000 0x1000>;
-		#dma-cells = <1>;
-		interrupt-parent = <&intc>;
-		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
-		clocks = <&clkc 17>;
-	};
-
-	axi_pwm_gen: axi-pwm-gen@44b00000 {
-		compatible = "adi,axi-pwmgen-2.00.a";
-		reg = <0x44b00000 0x1000>;
-		label = "adc_conversion_trigger";
-		#pwm-cells = <2>;
-		clocks = <&spi_clk>;
-	};
-
-	spi_clk: axi-clkgen@44a70000 {
-		compatible = "adi,axi-clkgen-2.00.a";
-		reg = <0x44a70000 0x10000>;
-		#clock-cells = <0>;
-		clocks = <&clkc 15>, <&clkc 15>;
-		clock-names = "clkin1", "s_axi_aclk";
-		clock-output-names = "spi_clk";
-	};
-
-	axi_spi_engine_0: spi@44a00000 {
-		compatible = "adi-ex,axi-spi-engine-1.00.a";
-		reg = <0x44a00000 0x1000>;
-		interrupt-parent = <&intc>;
-		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
-		clocks = <&clkc 15 &spi_clk>;
-		clock-names = "s_axi_aclk", "spi_clk";
-		num-cs = <1>;
-
-		#address-cells = <0x1>;
-		#size-cells = <0x0>;
-
-		ad4003: adc@0 {
-			compatible = "adi,ad4003";
-			reg = <0>;
-			spi-max-frequency = <80000000>;
-			vdd-supply = <&adc_vdd>;
-			vio-supply = <&adc_vio>;
-			ref-supply = <&adc_vref>;
-			dmas = <&rx_dma 0>;
-			dma-names = "rx";
-			clocks = <&spi_clk>;
-			clock-names = "ref_clk";
-			pwms = <&axi_pwm_gen 0 0>;
-			pwm-names = "cnv";
-			adi,high-z-input;
-		};
-	};
+&ad4000_adc {
+	compatible = "adi,ad4003";
 };

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4004.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4004.dts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD4004
+ * https://www.analog.com/en/products/ad4004.html
+ *
+ * hdl_project: <pulsar_adc/zed>
+ * Link: https://github.com/analogdevicesinc/hdl/tree/main/projects/pulsar_adc
+ * board_revision: <>
+ *
+ * Copyright (C) 2025 Analog Devices Inc.
+ */
+/dts-v1/;
+#include "zynq-zed-adv7511-ad4000.dtsi"
+
+&ad4000_adc {
+	compatible = "adi,ad4004";
+};

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4005.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4005.dts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD4005
+ * https://www.analog.com/en/products/ad4005.html
+ *
+ * hdl_project: <pulsar_adc/zed>
+ * Link: https://github.com/analogdevicesinc/hdl/tree/main/projects/pulsar_adc
+ * board_revision: <>
+ *
+ * Copyright (C) 2025 Analog Devices Inc.
+ */
+/dts-v1/;
+#include "zynq-zed-adv7511-ad4000.dtsi"
+
+&ad4000_adc {
+	compatible = "adi,ad4005";
+};

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4006.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4006.dts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD4006
+ * https://www.analog.com/en/products/ad4006.html
+ *
+ * hdl_project: <pulsar_adc/zed>
+ * Link: https://github.com/analogdevicesinc/hdl/tree/main/projects/pulsar_adc
+ * board_revision: <>
+ *
+ * Copyright (C) 2025 Analog Devices Inc.
+ */
+/dts-v1/;
+#include "zynq-zed-adv7511-ad4000.dtsi"
+
+&ad4000_adc {
+	compatible = "adi,ad4006";
+};

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4007.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4007.dts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD4007
+ * https://www.analog.com/en/products/ad4007.html
+ *
+ * hdl_project: <pulsar_adc/zed>
+ * Link: https://github.com/analogdevicesinc/hdl/tree/main/projects/pulsar_adc
+ * board_revision: <>
+ *
+ * Copyright (C) 2025 Analog Devices Inc.
+ */
+/dts-v1/;
+#include "zynq-zed-adv7511-ad4000.dtsi"
+
+&ad4000_adc {
+	compatible = "adi,ad4007";
+};

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4008.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4008.dts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD4008
+ * https://www.analog.com/en/products/ad4008.html
+ *
+ * hdl_project: <pulsar_adc/zed>
+ * Link: https://github.com/analogdevicesinc/hdl/tree/main/projects/pulsar_adc
+ * board_revision: <>
+ *
+ * Copyright (C) 2025 Analog Devices Inc.
+ */
+/dts-v1/;
+#include "zynq-zed-adv7511-ad4000.dtsi"
+
+&ad4000_adc {
+	compatible = "adi,ad4008";
+};

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4010.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4010.dts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD4010
+ * https://www.analog.com/en/products/ad4010.html
+ *
+ * hdl_project: <pulsar_adc/zed>
+ * Link: https://github.com/analogdevicesinc/hdl/tree/main/projects/pulsar_adc
+ * board_revision: <>
+ *
+ * Copyright (C) 2025 Analog Devices Inc.
+ */
+/dts-v1/;
+#include "zynq-zed-adv7511-ad4000.dtsi"
+
+&ad4000_adc {
+	compatible = "adi,ad4010";
+};

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4011.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4011.dts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD4011
+ * https://www.analog.com/en/products/ad4011.html
+ *
+ * hdl_project: <pulsar_adc/zed>
+ * Link: https://github.com/analogdevicesinc/hdl/tree/main/projects/pulsar_adc
+ * board_revision: <>
+ *
+ * Copyright (C) 2025 Analog Devices Inc.
+ */
+/dts-v1/;
+#include "zynq-zed-adv7511-ad4000.dtsi"
+
+&ad4000_adc {
+	compatible = "adi,ad4011";
+};

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4020.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4020.dts
@@ -3,97 +3,17 @@
  * Analog Devices AD4020
  * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-adc/ad400x
  * https://wiki.analog.com/resources/eval/user-guides/ad400x
+ * https://www.analog.com/en/products/ad4020.html
  *
  * hdl_project: <pulsar_adc/zed>
  * Link: https://github.com/analogdevicesinc/hdl/tree/main/projects/pulsar_adc
  * board_revision: <>
  *
- * Copyright (C) 2016-2024 Analog Devices Inc.
+ * Copyright (C) 2016-2025 Analog Devices Inc.
  */
 /dts-v1/;
+#include "zynq-zed-adv7511-ad4000.dtsi"
 
-#include "zynq-zed.dtsi"
-#include "zynq-zed-adv7511.dtsi"
-
-/ {
-	adc_vref: regulator-vref {
-		compatible = "regulator-fixed";
-		regulator-name = "EVAL 5V Vref";
-		regulator-min-microvolt = <5000000>;
-		regulator-max-microvolt = <5000000>;
-		regulator-always-on;
-	};
-
-	adc_vdd: regulator-vdd {
-		compatible = "regulator-fixed";
-		regulator-name = "Eval VDD supply";
-		regulator-min-microvolt = <1800000>;
-		regulator-max-microvolt = <1800000>;
-		regulator-always-on;
-	};
-
-	adc_vio: regulator-vio {
-		compatible = "regulator-fixed";
-		regulator-name = "Eval VIO supply";
-		regulator-min-microvolt = <3300000>;
-		regulator-max-microvolt = <3300000>;
-		regulator-always-on;
-	};
-};
-
-&fpga_axi {
-	rx_dma: rx-dmac@44a30000 {
-		compatible = "adi,axi-dmac-1.00.a";
-		reg = <0x44a30000 0x1000>;
-		#dma-cells = <1>;
-		interrupt-parent = <&intc>;
-		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
-		clocks = <&clkc 17>;
-	};
-
-	axi_pwm_gen: axi-pwm-gen@44b00000 {
-		compatible = "adi,axi-pwmgen-2.00.a";
-		reg = <0x44b00000 0x1000>;
-		label = "adc_conversion_trigger";
-		#pwm-cells = <2>;
-		clocks = <&spi_clk>;
-	};
-
-	spi_clk: axi-clkgen@44a70000 {
-		compatible = "adi,axi-clkgen-2.00.a";
-		reg = <0x44a70000 0x10000>;
-		#clock-cells = <0>;
-		clocks = <&clkc 15>, <&clkc 15>;
-		clock-names = "clkin1", "s_axi_aclk";
-		clock-output-names = "spi_clk";
-	};
-
-	axi_spi_engine_0: spi@44a00000 {
-		compatible = "adi-ex,axi-spi-engine-1.00.a";
-		reg = <0x44a00000 0x1000>;
-		interrupt-parent = <&intc>;
-		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
-		clocks = <&clkc 15 &spi_clk>;
-		clock-names = "s_axi_aclk", "spi_clk";
-		num-cs = <1>;
-
-		#address-cells = <0x1>;
-		#size-cells = <0x0>;
-
-		ad4020: adc@0 {
-			compatible = "adi,ad4020";
-			reg = <0>;
-			spi-max-frequency = <80000000>;
-			vdd-supply = <&adc_vdd>;
-			vio-supply = <&adc_vio>;
-			ref-supply = <&adc_vref>;
-			dmas = <&rx_dma 0>;
-			dma-names = "rx";
-			clocks = <&spi_clk>;
-			clock-names = "ref_clk";
-			pwms = <&axi_pwm_gen 0 0>;
-			pwm-names = "cnv";
-			adi,high-z-input;
-		};
-	};
+&ad4000_adc {
+	compatible = "adi,ad4020";
 };

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4021.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4021.dts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD4021
+ * https://www.analog.com/en/products/ad4021.html
+ *
+ * hdl_project: <pulsar_adc/zed>
+ * Link: https://github.com/analogdevicesinc/hdl/tree/main/projects/pulsar_adc
+ * board_revision: <>
+ *
+ * Copyright (C) 2025 Analog Devices Inc.
+ */
+/dts-v1/;
+#include "zynq-zed-adv7511-ad4000.dtsi"
+
+&ad4000_adc {
+	compatible = "adi,ad4021";
+};

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4022.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4022.dts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD4022
+ * https://www.analog.com/en/products/ad4022.html
+ *
+ * hdl_project: <pulsar_adc/zed>
+ * Link: https://github.com/analogdevicesinc/hdl/tree/main/projects/pulsar_adc
+ * board_revision: <>
+ *
+ * Copyright (C) 2025 Analog Devices Inc.
+ */
+/dts-v1/;
+#include "zynq-zed-adv7511-ad4000.dtsi"
+
+&ad4000_adc {
+	compatible = "adi,ad4022";
+};

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq4001.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq4001.dts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices ADAQ4001
+ * https://www.analog.com/en/products/adaq4001.html
+ *
+ * hdl_project: <pulsar_adc/zed>
+ * Link: https://github.com/analogdevicesinc/hdl/tree/main/projects/pulsar_adc
+ * board_revision: <>
+ *
+ * Copyright (C) 2025 Analog Devices Inc.
+ */
+/dts-v1/;
+#include "zynq-zed-adv7511-ad4000.dtsi"
+
+&ad4000_adc {
+	compatible = "adi,adaq4001";
+	adi,gain-milli = /bits/ 16 <454>;
+};

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq4003.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq4003.dts
@@ -1,99 +1,18 @@
 // SPDX-License-Identifier: GPL-2.0
 /*
  * Analog Devices ADAQ4003
- * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-adc/ad400x
- * https://wiki.analog.com/resources/eval/user-guides/ad400x
+ * https://www.analog.com/en/products/ad4003.html
  *
  * hdl_project: <pulsar_adc/zed>
+ * Link: https://github.com/analogdevicesinc/hdl/tree/main/projects/pulsar_adc
  * board_revision: <>
  *
- * Copyright (C) 2016-2024 Analog Devices Inc.
+ * Copyright (C) 2025 Analog Devices Inc.
  */
 /dts-v1/;
+#include "zynq-zed-adv7511-ad4000.dtsi"
 
-#include "zynq-zed.dtsi"
-#include "zynq-zed-adv7511.dtsi"
-
-/ {
-	adc_vref: regulator-vref {
-		compatible = "regulator-fixed";
-		regulator-name = "EVAL 5V Vref";
-		regulator-min-microvolt = <5000000>;
-		regulator-max-microvolt = <5000000>;
-		regulator-always-on;
-	};
-
-	adc_vdd: regulator-vdd {
-		compatible = "regulator-fixed";
-		regulator-name = "Eval VDD supply";
-		regulator-min-microvolt = <1800000>;
-		regulator-max-microvolt = <1800000>;
-		regulator-always-on;
-	};
-
-	adc_vio: regulator-vio {
-		compatible = "regulator-fixed";
-		regulator-name = "Eval VIO supply";
-		regulator-min-microvolt = <3300000>;
-		regulator-max-microvolt = <3300000>;
-		regulator-always-on;
-	};
-};
-
-&fpga_axi {
-	rx_dma: rx-dmac@44a30000 {
-		compatible = "adi,axi-dmac-1.00.a";
-		reg = <0x44a30000 0x1000>;
-		#dma-cells = <1>;
-		interrupt-parent = <&intc>;
-		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
-		clocks = <&clkc 17>;
-	};
-
-	axi_pwm_gen: axi-pwm-gen@44b00000 {
-		compatible = "adi,axi-pwmgen-2.00.a";
-		reg = <0x44b00000 0x1000>;
-		label = "adc_conversion_trigger";
-		#pwm-cells = <2>;
-		clocks = <&spi_clk>;
-	};
-
-	spi_clk: axi-clkgen@44a70000 {
-		compatible = "adi,axi-clkgen-2.00.a";
-		reg = <0x44a70000 0x10000>;
-		#clock-cells = <0>;
-		clocks = <&clkc 15>, <&clkc 15>;
-		clock-names = "clkin1", "s_axi_aclk";
-		clock-output-names = "spi_clk";
-	};
-
-	axi_spi_engine_0: spi@44a00000 {
-		compatible = "adi-ex,axi-spi-engine-1.00.a";
-		reg = <0x44a00000 0x1000>;
-		interrupt-parent = <&intc>;
-		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
-		clocks = <&clkc 15 &spi_clk>;
-		clock-names = "s_axi_aclk", "spi_clk";
-		num-cs = <1>;
-
-		#address-cells = <0x1>;
-		#size-cells = <0x0>;
-
-		adaq4003: adc@0 {
-			compatible = "adi,adaq4003";
-			reg = <0>;
-			spi-max-frequency = <80000000>;
-			vdd-supply = <&adc_vdd>;
-			vio-supply = <&adc_vio>;
-			ref-supply = <&adc_vref>;
-			dmas = <&rx_dma 0>;
-			dma-names = "rx";
-			clocks = <&spi_clk>;
-			clock-names = "ref_clk";
-			pwms = <&axi_pwm_gen 0 0>;
-			pwm-names = "cnv";
-			adi,high-z-input;
-			adi,gain-milli = /bits/ 16 <454>;
-		};
-	};
+&ad4000_adc {
+	compatible = "adi,adaq4003";
+	adi,gain-milli = /bits/ 16 <454>;
 };


### PR DESCRIPTION
## PR Description

This PR updates AD4003, AD4020, and ADAQ4003 device trees to the new SPI offloading support.
It also provides dts for the remaining devices supported by the ad4000 driver.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
