### PR TITLE
ci: Disable hardware tests for PRs from forks

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -216,6 +216,7 @@ stages:
       condition: or(
           and(
             startsWith(variables['Build.SourceBranch'], 'refs/pull/'),
+            ne(variables['SYSTEM.PULLREQUEST.ISFORK'], 'true'),
             or(
               eq(variables['System.PullRequest.TargetBranch'], 'main'),
               eq(variables['System.PullRequest.TargetBranch'], 'next_stable'),


### PR DESCRIPTION
## PR Description

Pipelines triggered by PRs coming from forks don't have access to the secret variables used by the PushToArtifactory and TestHarness stages. From a security standpoint, it makes sense to limit those pipelines to not have access to our internal servers.
Add condition so that pipelines of PRs coming from forks skip the PushToArtifactory and TestHarness stages.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
