### PR TITLE
Use generic DT node names

### DIFF
--- a/arch/arm/boot/dts/intel/socfpga/adi-intel-dac-fmc-ebz.dtsi
+++ b/arch/arm/boot/dts/intel/socfpga/adi-intel-dac-fmc-ebz.dtsi
@@ -38,7 +38,7 @@
 				#size-cells = <0x0>;
 			};
 
-			dac_dma: dmac@40000 {
+			dac_dma: dma-controller@40000 {
 				compatible = "adi,axi-dmac-1.00.a";
 				reg = <0x40000 0x4000>;
 				#dma-cells = <1>;

--- a/arch/arm/boot/dts/intel/socfpga/socfpga_arria10_socdk_ad9081.dts
+++ b/arch/arm/boot/dts/intel/socfpga/socfpga_arria10_socdk_ad9081.dts
@@ -116,7 +116,7 @@
 				clock-output-names = "jesd204_tx_link_clock";
 			};
 
-			tx_dma: tx-dmac@DC000 {
+			tx_dma: dma-controller@DC000 {
 				compatible = "adi,axi-dmac-1.00.a";
 				reg = <0x000DC000 0x00004000>;
 				interrupt-parent = <&intc>;
@@ -172,7 +172,7 @@
 				clock-output-names = "jesd204_rx_link_clock";
 			};
 
-			rx_dma: rx-dmac@D8000 {
+			rx_dma: dma-controller@D8000 {
 				compatible = "adi,axi-dmac-1.00.a";
 				reg = <0x000D8000 0x00004000>;
 				interrupt-parent = <&intc>;

--- a/arch/arm/boot/dts/intel/socfpga/socfpga_arria10_socdk_ad9083_fmc_ebz.dts
+++ b/arch/arm/boot/dts/intel/socfpga/socfpga_arria10_socdk_ad9083_fmc_ebz.dts
@@ -121,7 +121,7 @@
 				clock-output-names = "jesd204_rx_link_clock";
 			};
 
-			rx_dma: rx-dmac@4c000 {
+			rx_dma: dma-controller@4c000 {
 				compatible = "adi,axi-dmac-1.00.a";
 				reg = <0x0004c000 0x00004000>;
 				interrupt-parent = <&intc>;

--- a/arch/arm/boot/dts/intel/socfpga/socfpga_arria10_socdk_adrv9002.dts
+++ b/arch/arm/boot/dts/intel/socfpga/socfpga_arria10_socdk_adrv9002.dts
@@ -61,7 +61,7 @@
 				gpio-controller;
 			};
 
-			rx1_dma: dma@40000 {
+			rx1_dma: dma-controller@40000 {
 				compatible = "adi,axi-dmac-1.00.a";
 				reg = <0x00040000 0x800>;
 				#dma-cells = <1>;
@@ -70,7 +70,7 @@
 				clocks = <&dma_clk>;
 			};
 
-			rx2_dma: dma@41000 {
+			rx2_dma: dma-controller@41000 {
 				compatible = "adi,axi-dmac-1.00.a";
 				reg = <0x00041000 0x800>;
 				#dma-cells = <1>;
@@ -79,7 +79,7 @@
 				clocks = <&dma_clk>;
 			};
 
-			tx1_dma: dma@44000 {
+			tx1_dma: dma-controller@44000 {
 				compatible = "adi,axi-dmac-1.00.a";
 				reg = <0x00044000 0x00000800>;
 				#dma-cells = <1>;
@@ -88,7 +88,7 @@
 				clocks = <&dma_clk>;
 			};
 
-			tx2_dma: dma@45000 {
+			tx2_dma: dma-controller@45000 {
 				compatible = "adi,axi-dmac-1.00.a";
 				reg = <0x00045000 0x00000800>;
 				#dma-cells = <1>;

--- a/arch/arm/boot/dts/intel/socfpga/socfpga_arria10_socdk_adrv9002_rx2tx2.dts
+++ b/arch/arm/boot/dts/intel/socfpga/socfpga_arria10_socdk_adrv9002_rx2tx2.dts
@@ -61,7 +61,7 @@
 				gpio-controller;
 			};
 
-			rx_dma: dma@40000 {
+			rx_dma: dma-controller@40000 {
 				compatible = "adi,axi-dmac-1.00.a";
 				reg = <0x00040000 0x1000>;
 				#dma-cells = <1>;
@@ -70,7 +70,7 @@
 				clocks = <&dma_clk>;
 			};
 
-			tx_dma: dma@44000 {
+			tx_dma: dma-controller@44000 {
 				compatible = "adi,axi-dmac-1.00.a";
 				reg = <0x00044000 0x00000800>;
 				#dma-cells = <1>;

--- a/arch/arm/boot/dts/intel/socfpga/socfpga_arria10_socdk_adrv9009.dts
+++ b/arch/arm/boot/dts/intel/socfpga/socfpga_arria10_socdk_adrv9009.dts
@@ -113,7 +113,7 @@
 				clock-output-names = "jesd204_tx_link_clock";
 			};
 
-			tx_dma: tx-dmac@2c000 {
+			tx_dma: dma-controller@2c000 {
 				compatible = "adi,axi-dmac-1.00.a";
 				reg = <0x00032000 0x00004000>;
 				interrupt-parent = <&intc>;
@@ -162,7 +162,7 @@
 				clock-output-names = "jesd204_rx_link_clock";
 			};
 
-			rx_dma: rx-dmac@3c000 {
+			rx_dma: dma-controller@3c000 {
 				compatible = "adi,axi-dmac-1.00.a";
 				reg = <0x0004c000 0x00004000>;
 				interrupt-parent = <&intc>;
@@ -211,7 +211,7 @@
 				clock-output-names = "jesd204_rx_os_link_clock";
 			};
 
-			rx_obs_dma: rx-obs-dmac@4c000  {
+			rx_obs_dma: dma-controller@4c000 {
 				compatible = "adi,axi-dmac-1.00.a";
 				reg = <0x0005c000 0x00004000>;
 				interrupt-parent = <&intc>;

--- a/arch/arm/boot/dts/intel/socfpga/socfpga_arria10_socdk_adrv9025.dts
+++ b/arch/arm/boot/dts/intel/socfpga/socfpga_arria10_socdk_adrv9025.dts
@@ -312,7 +312,7 @@
 				spibus-connected = <&trx0_adrv9025>;
 			};
 
-			tx_dma: tx-dmac@32000 {
+			tx_dma: dma-controller@32000 {
 				compatible = "adi,axi-dmac-1.00.a";
 				reg = <0x00032000 0x00004000>;
 				interrupt-parent = <&intc>;
@@ -321,7 +321,7 @@
 				clocks = <&dma_clk>;
 			};
 
-			rx_dma: rx-dmac@4c000 {
+			rx_dma: dma-controller@4c000 {
 				compatible = "adi,axi-dmac-1.00.a";
 				reg = <0x0004c000 0x00004000>;
 				interrupt-parent = <&intc>;

--- a/arch/arm/boot/dts/intel/socfpga/socfpga_arria10_socdk_adrv9371.dts
+++ b/arch/arm/boot/dts/intel/socfpga/socfpga_arria10_socdk_adrv9371.dts
@@ -171,7 +171,7 @@
 				clock-output-names = "jesd204_rx_os_lane_clock";
 			};
 
-			axi_ad9371_tx_dma: axi-ad9371-tx-dma@2c000 {
+			axi_ad9371_tx_dma: dma-controller@2c000 {
 				compatible = "adi,axi-dmac-1.00.a";
 				reg = <0x0002c000 0x00004000>;
 				interrupt-parent = <&intc>;
@@ -180,7 +180,7 @@
 				clocks = <&dma_clk>;
 			};
 
-			axi_ad9371_rx_dma: axi-ad9371-rx-dma@3c000 {
+			axi_ad9371_rx_dma: dma-controller@3c000 {
 				compatible = "adi,axi-dmac-1.00.a";
 				reg = <0x0003c000 0x00004000>;
 				interrupt-parent = <&intc>;
@@ -189,7 +189,7 @@
 				clocks = <&dma_clk>;
 			};
 
-			axi_ad9371_rx_os_dma: axi-ad9371-rx-os-dma@4c000 {
+			axi_ad9371_rx_os_dma: dma-controller@4c000 {
 				compatible = "adi,axi-dmac-1.00.a";
 				reg = <0x0004c000 0x00004000>;
 				interrupt-parent = <&intc>;

--- a/arch/arm/boot/dts/intel/socfpga/socfpga_arria10_socdk_daq2.dts
+++ b/arch/arm/boot/dts/intel/socfpga/socfpga_arria10_socdk_daq2.dts
@@ -70,7 +70,7 @@
 				#size-cells = <0x0>;
 			};
 
-			rx_dma: rx-dmac@4c000 {
+			rx_dma: dma-controller@4c000 {
 				compatible = "adi,axi-dmac-1.00.a";
 				reg = <0x4c000 0x4000>;
 				#dma-cells = <1>;
@@ -79,7 +79,7 @@
 				clocks = <&dma_clk>;
 			};
 
-			tx_dma: tx-dmac@2c000 {
+			tx_dma: dma-controller@2c000 {
 				compatible = "adi,axi-dmac-1.00.a";
 				reg = <0x2c000 0x4000>;
 				#dma-cells = <1>;

--- a/arch/arm/boot/dts/intel/socfpga/socfpga_arria10_socdk_fmclidar1.dts
+++ b/arch/arm/boot/dts/intel/socfpga/socfpga_arria10_socdk_fmclidar1.dts
@@ -136,7 +136,7 @@
 				clock-output-names = "jesd204_rx_link_clock";
 			};
 
-			rx_dma: rx-dmac@4c000 {
+			rx_dma: dma-controller@4c000 {
 				compatible = "adi,axi-dmac-1.00.a";
 				reg = <0x0004c000 0x00004000>;
 				interrupt-parent = <&intc>;

--- a/arch/arm/boot/dts/intel/socfpga/socfpga_arria10_socdk_fmcomms8.dts
+++ b/arch/arm/boot/dts/intel/socfpga/socfpga_arria10_socdk_fmcomms8.dts
@@ -200,7 +200,7 @@
 				jesd204-inputs = <&axi_adrv9009_adxcvr_tx 0 DEFRAMER_LINK_TX>;
 			};
 
-			rx_dma: rx-dmac@3c000 {
+			rx_dma: dma-controller@3c000 {
 				compatible = "adi,axi-dmac-1.00.a";
 				reg = <0x0003c000 0x00004000>;
 				interrupt-parent = <&intc>;
@@ -209,7 +209,7 @@
 				clocks = <&dma_clk>;
 			};
 
-			rx_obs_dma: rx-obs-dmac@4c000  {
+			rx_obs_dma: dma-controller@4c000 {
 				compatible = "adi,axi-dmac-1.00.a";
 				reg = <0x0004c000 0x00004000>;
 				interrupt-parent = <&intc>;
@@ -218,7 +218,7 @@
 				clocks = <&dma_clk>;
 			};
 
-			tx_dma: tx-dmac@70000 {
+			tx_dma: dma-controller@70000 {
 				compatible = "adi,axi-dmac-1.00.a";
 				reg = <0x00070000 0x00004000>;
 				interrupt-parent = <&intc>;

--- a/arch/arm/boot/dts/intel/socfpga/socfpga_cyclone5_de10_nano_ad5791.dts
+++ b/arch/arm/boot/dts/intel/socfpga/socfpga_cyclone5_de10_nano_ad5791.dts
@@ -48,7 +48,7 @@
 		clocks = <&spi_clk 0>;
 	};
 
-	tx_dma: tx-dma@30000 {
+	tx_dma: dma-controller@30000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x00030000 0x00000800>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/intel/socfpga/socfpga_cyclone5_de10_nano_cn0501.dts
+++ b/arch/arm/boot/dts/intel/socfpga/socfpga_cyclone5_de10_nano_cn0501.dts
@@ -43,7 +43,7 @@
 };
 
 &fpga_axi {
-	rx_dma: rx-dmac@28000 {
+	rx_dma: dma-controller@28000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x00028000 0x00000800>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/intel/socfpga/socfpga_cyclone5_de10_nano_cn0540.dts
+++ b/arch/arm/boot/dts/intel/socfpga/socfpga_cyclone5_de10_nano_cn0540.dts
@@ -88,7 +88,7 @@
 };
 
 &fpga_axi {
-	axi_dmac_0: rx-dma@20000 {
+	axi_dmac_0: dma-controller@20000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x00020000 0x00000800>;
 		interrupt-parent = <&intc>;

--- a/arch/arm/boot/dts/intel/socfpga/socfpga_cyclone5_de10_nano_cn0579_i2c.dts
+++ b/arch/arm/boot/dts/intel/socfpga/socfpga_cyclone5_de10_nano_cn0579_i2c.dts
@@ -68,7 +68,7 @@
 };
 
 &fpga_axi {
-	rx_dma: dma@28000 {
+	rx_dma: dma-controller@28000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x00028000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/intel/socfpga/socfpga_cyclone5_de10_nano_hps.dtsi
+++ b/arch/arm/boot/dts/intel/socfpga/socfpga_cyclone5_de10_nano_hps.dtsi
@@ -60,7 +60,7 @@
 		reg = <0x00018000 0x8000>;
 	};
 
-	hdmi_tx_dma: dma@80000 {
+	hdmi_tx_dma: dma-controller@80000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x00080000 0x00000800>;
 		interrupt-parent = <&intc>;

--- a/arch/arm/boot/dts/intel/socfpga/socfpga_cyclone5_sockit_arradio.dts
+++ b/arch/arm/boot/dts/intel/socfpga/socfpga_cyclone5_sockit_arradio.dts
@@ -151,7 +151,7 @@
 					clock-names = "sampl_clk";
 				};
 
-				tx_dma: dma@4000 {
+				tx_dma: dma-controller@4000 {
 					compatible = "adi,axi-dmac-1.00.a";
 					reg = <0x00004000 0x00004000>;
 					interrupt-parent = <&intc>;
@@ -160,7 +160,7 @@
 					clocks = <&dma_clk>;
 				};
 
-				rx_dma: dma@0 {
+				rx_dma: dma-controller@0 {
 					compatible = "adi,axi-dmac-1.00.a";
 					reg = <0x00000000 0x00004000>;
 					interrupt-parent = <&intc>;

--- a/arch/arm/boot/dts/intel/socfpga/socfpga_cyclone5_sockit_dc2677a.dts
+++ b/arch/arm/boot/dts/intel/socfpga/socfpga_cyclone5_sockit_dc2677a.dts
@@ -126,7 +126,7 @@
 					<0x00040000 0x00000001 0x00140000 0x00001000>,
 					<0x00009000 0x00000001 0x00109000 0x00000010>;
 
-				rx_dma: dma@0 {
+				rx_dma: dma-controller@0 {
 					compatible = "adi,axi-dmac-1.00.a";
 					reg = <0x00000000 0x00004000>;
 					interrupt-parent = <&intc>;

--- a/arch/arm/boot/dts/intel/socfpga/socfpga_cyclone5_sockit_dc2677a.dts
+++ b/arch/arm/boot/dts/intel/socfpga/socfpga_cyclone5_sockit_dc2677a.dts
@@ -135,7 +135,7 @@
 					clocks = <&sys_clk>;
 				};
 
-				axi_pwm_gen: axi-pwm-gen@40000 {
+				axi_pwm_gen: pwm@40000 {
 					compatible = "adi,axi-pwmgen-2.00.a";
 					reg = <0x00040000 0x1000>;
 					#pwm-cells = <2>;

--- a/arch/arm/boot/dts/xilinx/adi-xilinx-dac-fmc-ebz.dtsi
+++ b/arch/arm/boot/dts/xilinx/adi-xilinx-dac-fmc-ebz.dtsi
@@ -4,7 +4,7 @@
 #include <dt-bindings/jesd204/adxcvr.h>
 
 &fpga_axi {
-	dac_dma: dma@7c420000 {
+	dac_dma: dma-controller@7c420000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x10000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/adi-zynq-cn0363.dtsi
+++ b/arch/arm/boot/dts/xilinx/adi-zynq-cn0363.dtsi
@@ -16,7 +16,7 @@
 
 &fpga_axi {
 
-	rx_dma: dma@44a30000 {
+	rx_dma: dma-controller@44a30000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x44a30000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-adrv9002-rx2tx2.dtsi
+++ b/arch/arm/boot/dts/xilinx/zynq-adrv9002-rx2tx2.dtsi
@@ -5,7 +5,7 @@
 #include <dt-bindings/gpio/gpio.h>
 
 &fpga_axi {
-	rx_dma: dma@44A30000 {
+	rx_dma: dma-controller@44A30000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x44a30000 0x1000>;
 		#dma-cells = <1>;
@@ -14,7 +14,7 @@
 		clocks = <&clkc 15>, <&clkc 16>, <&misc_clk_0>;
 	};
 
-	tx_dma: dma@44A50000 {
+	tx_dma: dma-controller@44A50000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x44A50000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-adrv9002.dtsi
+++ b/arch/arm/boot/dts/xilinx/zynq-adrv9002.dtsi
@@ -5,7 +5,7 @@
 #include <dt-bindings/gpio/gpio.h>
 
 &fpga_axi {
-	rx1_dma: dma@44A30000 {
+	rx1_dma: dma-controller@44A30000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x44a30000 0x1000>;
 		#dma-cells = <1>;
@@ -14,7 +14,7 @@
 		clocks = <&clkc 15>, <&clkc 16>, <&misc_clk_0>;
 	};
 
-	rx2_dma: dma@44A40000 {
+	rx2_dma: dma-controller@44A40000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x44A40000 0x1000>;
 		#dma-cells = <1>;
@@ -23,7 +23,7 @@
 		clocks = <&clkc 15>, <&clkc 16>, <&misc_clk_0>;
 	};
 
-	tx1_dma: dma@44A50000 {
+	tx1_dma: dma-controller@44A50000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x44A50000 0x1000>;
 		#dma-cells = <1>;
@@ -32,7 +32,7 @@
 		clocks = <&clkc 15>, <&clkc 16>, <&misc_clk_0>;
 	};
 
-	tx2_dma: dma@44A6000 {
+	tx2_dma: dma-controller@44A6000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x44A60000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-adrv9361-z7035-fmc.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-adrv9361-z7035-fmc.dts
@@ -178,7 +178,7 @@
 			clocks = <&clkc 16>;
 		};
 
-		hdmi_clock: axi-clkgen@79000000 {
+		hdmi_clock: clock-controller@79000000 {
 			compatible = "adi,axi-clkgen-2.00.a";
 			reg = <0x79000000 0x10000>;
 			#clock-cells = <0>;

--- a/arch/arm/boot/dts/xilinx/zynq-adrv9361-z7035-fmc.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-adrv9361-z7035-fmc.dts
@@ -170,7 +170,7 @@
 		#size-cells = <0x1>;
 		ranges;
 
-		hdmi_dma: dma@43000000 {
+		hdmi_dma: dma-controller@43000000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x43000000 0x1000>;
 			#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-adrv9361-z7035.dtsi
+++ b/arch/arm/boot/dts/xilinx/zynq-adrv9361-z7035.dtsi
@@ -136,7 +136,7 @@
 			};
 		};
 
-		rx_dma: dma@7c400000 {
+		rx_dma: dma-controller@7c400000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x7c400000 0x1000>;
 			#dma-cells = <1>;
@@ -144,7 +144,7 @@
 			clocks = <&clkc 16>;
 		};
 
-		tx_dma: dma@7c420000 {
+		tx_dma: dma-controller@7c420000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x7c420000 0x1000>;
 			#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-adrv9364-z7020.dtsi
+++ b/arch/arm/boot/dts/xilinx/zynq-adrv9364-z7020.dtsi
@@ -128,7 +128,7 @@
 			};
 		};
 
-		rx_dma: dma@7c400000 {
+		rx_dma: dma-controller@7c400000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x7c400000 0x1000>;
 			#dma-cells = <1>;
@@ -136,7 +136,7 @@
 			clocks = <&clkc 16>;
 		};
 
-		tx_dma: dma@7c420000 {
+		tx_dma: dma-controller@7c420000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x7c420000 0x1000>;
 			#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-coraz7s-ad7689-ardz.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-coraz7s-ad7689-ardz.dts
@@ -99,7 +99,7 @@
 		clocks = <&clkc 16>;
 	};
 
-	spi_clk: axi-clkgen@44a70000 {
+	spi_clk: clock-controller@44a70000 {
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x44a70000 0x10000>;
 		#clock-cells = <0>;

--- a/arch/arm/boot/dts/xilinx/zynq-coraz7s-ad7689-ardz.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-coraz7s-ad7689-ardz.dts
@@ -90,7 +90,7 @@
 		};
 	};
 
-	rx_dma: rx-dmac@44a30000 {
+	rx_dma: dma-controller@44a30000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x44a30000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-coraz7s-ad7946.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-coraz7s-ad7946.dts
@@ -75,7 +75,7 @@
 		clocks = <&clkc 16>;
 	};
 
-	spi_clk: axi-clkgen@44a70000 {
+	spi_clk: clock-controller@44a70000 {
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x44a70000 0x10000>;
 		#clock-cells = <0>;

--- a/arch/arm/boot/dts/xilinx/zynq-coraz7s-ad7946.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-coraz7s-ad7946.dts
@@ -66,7 +66,7 @@
 		};
 	};
 
-	rx_dma: rx-dmac@44a30000 {
+	rx_dma: dma-controller@44a30000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x44a30000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-coraz7s-ad7984.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-coraz7s-ad7984.dts
@@ -67,7 +67,7 @@
 		};
 	};
 
-	rx_dma: rx-dmac@44a30000 {
+	rx_dma: dma-controller@44a30000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x44a30000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-coraz7s-ad7984.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-coraz7s-ad7984.dts
@@ -76,7 +76,7 @@
 		clocks = <&clkc 16>;
 	};
 
-	spi_clk: axi-clkgen@44a70000 {
+	spi_clk: clock-controller@44a70000 {
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x44a70000 0x10000>;
 		#clock-cells = <0>;

--- a/arch/arm/boot/dts/xilinx/zynq-coraz7s-adaq4001.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-coraz7s-adaq4001.dts
@@ -82,7 +82,7 @@
 		};
 	};
 
-	rx_dma: rx-dmac@44a30000 {
+	rx_dma: dma-controller@44a30000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x44a30000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-coraz7s-adaq4001.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-coraz7s-adaq4001.dts
@@ -91,7 +91,7 @@
 		clocks = <&clkc 16>;
 	};
 
-	spi_clk: axi-clkgen@0x44a70000 {
+	spi_clk: clock-controller@0x44a70000 {
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x44a70000 0x10000>;
 		#clock-cells = <0>;

--- a/arch/arm/boot/dts/xilinx/zynq-coraz7s-adaq4003.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-coraz7s-adaq4003.dts
@@ -82,7 +82,7 @@
 		};
 	};
 
-	rx_dma: rx-dmac@44a30000 {
+	rx_dma: dma-controller@44a30000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x44a30000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-coraz7s-adaq4003.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-coraz7s-adaq4003.dts
@@ -91,7 +91,7 @@
 		clocks = <&clkc 16>;
 	};
 
-	spi_clk: axi-clkgen@0x44a70000 {
+	spi_clk: clock-controller@0x44a70000 {
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x44a70000 0x10000>;
 		#clock-cells = <0>;

--- a/arch/arm/boot/dts/xilinx/zynq-coraz7s-cn0540.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-coraz7s-cn0540.dts
@@ -149,7 +149,7 @@
 		};
 	};
 
-	spi_clk: axi-clkgen@44a70000 {
+	spi_clk: clock-controller@44a70000 {
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x44a70000 0x10000>;
 		#clock-cells = <0>;

--- a/arch/arm/boot/dts/xilinx/zynq-coraz7s-cn0540.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-coraz7s-cn0540.dts
@@ -109,7 +109,7 @@
 };
 
 &fpga_axi {
-	rx_dma: rx-dmac@44a30000 {
+	rx_dma: dma-controller@44a30000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x44a30000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-coraz7s-cn0579_i2c.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-coraz7s-cn0579_i2c.dts
@@ -62,7 +62,7 @@
 };
 
 &fpga_axi {
-	rx_dma: dma@44a30000 {
+	rx_dma: dma-controller@44a30000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x44a30000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-coraz7s-pulsar.dtsi
+++ b/arch/arm/boot/dts/xilinx/zynq-coraz7s-pulsar.dtsi
@@ -102,7 +102,7 @@
 		};
 	};
 
-	spi_clk: axi-clkgen@44a70000 {
+	spi_clk: clock-controller@44a70000 {
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x44a70000 0x10000>;
 		#clock-cells = <0>;

--- a/arch/arm/boot/dts/xilinx/zynq-coraz7s-pulsar.dtsi
+++ b/arch/arm/boot/dts/xilinx/zynq-coraz7s-pulsar.dtsi
@@ -80,7 +80,7 @@
 		};
 	};
 
-	rx_dma: rx-dmac@44a30000 {
+	rx_dma: dma-controller@44a30000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x44a30000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-e310.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-e310.dts
@@ -133,7 +133,7 @@
 
 		};
 
-		rx_dma: dma@7c400000 {
+		rx_dma: dma-controller@7c400000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x7c400000 0x1000>;
 			#dma-cells = <1>;
@@ -141,7 +141,7 @@
 			clocks = <&clkc 16>;
 		};
 
-		tx_dma: dma@7c420000 {
+		tx_dma: dma-controller@7c420000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x7c420000 0x1000>;
 			#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-m2k-reva.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-m2k-reva.dts
@@ -214,7 +214,7 @@
 			};
 		};
 
-		rx_dma0: dma@7c440000 {
+		rx_dma0: dma-controller@7c440000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x7c440000 0x1000>;
 			#dma-cells = <1>;
@@ -222,7 +222,7 @@
 			clocks = <&clkc 15>;
 		};
 	/*
-		rx_dma1: dma@7c440000 {
+		rx_dma1: dma-controller@7c440000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x7c460000 0x1000>;
 			#dma-cells = <1>;
@@ -230,7 +230,7 @@
 			clocks = <&clkc 15>;
 		};
 	*/
-		tx_dma0: dma@7c480000 {
+		tx_dma0: dma-controller@7c480000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x7c480000 0x1000>;
 			#dma-cells = <1>;
@@ -238,7 +238,7 @@
 			clocks = <&clkc 15>;
 		};
 
-		tx_dma1: dma@7c460000 {
+		tx_dma1: dma-controller@7c460000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x7c460000 0x1000>;
 			#dma-cells = <1>;
@@ -275,7 +275,7 @@
 			dds-connected = <&dds>;
 		};
 
-		logic_analyzer_rx_dma: dma@7c400000 {
+		logic_analyzer_rx_dma: dma-controller@7c400000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x7c400000 0x1000>;
 
@@ -284,7 +284,7 @@
 			clocks = <&clkc 15>;
 		};
 
-		logic_analyzer_tx_dma: dma@7c420000 {
+		logic_analyzer_tx_dma: dma-controller@7c420000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x7c420000 0x1000>;
 

--- a/arch/arm/boot/dts/xilinx/zynq-pluto-sdr.dtsi
+++ b/arch/arm/boot/dts/xilinx/zynq-pluto-sdr.dtsi
@@ -109,7 +109,7 @@
 
 		};
 
-		rx_dma: dma@7c400000 {
+		rx_dma: dma-controller@7c400000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x7c400000 0x1000>;
 			#dma-cells = <1>;
@@ -117,7 +117,7 @@
 			clocks = <&clkc 16>;
 		};
 
-		tx_dma: dma@7c420000 {
+		tx_dma: dma-controller@7c420000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x7c420000 0x1000>;
 			#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zc702-adv7511-ad9361-fmcomms2-3.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zc702-adv7511-ad9361-fmcomms2-3.dts
@@ -26,7 +26,7 @@
 #define pmod_spi spi1
 
 &fpga_axi {
-	rx_dma: dma@7c400000 {
+	rx_dma: dma-controller@7c400000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x1000>;
 		#dma-cells = <1>;
@@ -34,7 +34,7 @@
 		clocks = <&clkc 16>;
 	};
 
-	tx_dma: dma@7c420000 {
+	tx_dma: dma-controller@7c420000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zc702-adv7511-ad9361-fmcomms5.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zc702-adv7511-ad9361-fmcomms5.dts
@@ -20,7 +20,7 @@
 #define fmc_spi spi0
 
 &fpga_axi {
-	rx_dma: dma@7c400000 {
+	rx_dma: dma-controller@7c400000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x1000>;
 		#dma-cells = <1>;
@@ -28,7 +28,7 @@
 		clocks = <&clkc 16>;
 	};
 
-	tx_dma: dma@7c420000 {
+	tx_dma: dma-controller@7c420000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zc702-adv7511-ad9364-fmcomms4.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zc702-adv7511-ad9364-fmcomms4.dts
@@ -14,7 +14,7 @@
 #include "zynq-zc702-adv7511.dtsi"
 
 &fpga_axi {
-	rx_dma: dma@7c400000 {
+	rx_dma: dma-controller@7c400000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x1000>;
 		#dma-cells = <1>;
@@ -22,7 +22,7 @@
 		clocks = <&clkc 16>;
 	};
 
-	tx_dma: dma@7c420000 {
+	tx_dma: dma-controller@7c420000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zc702-adv7511-fmcomms1.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zc702-adv7511-fmcomms1.dts
@@ -7,7 +7,7 @@
 #include "zynq-zc702-adv7511.dtsi"
 
 &fpga_axi {
-	rx_dma: dma@7c400000 {
+	rx_dma: dma-controller@7c400000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x1000>;
 		#dma-cells = <1>;
@@ -15,7 +15,7 @@
 		clocks = <&clkc 16>;
 	};
 
-	tx_dma: dma@7c420000 {
+	tx_dma: dma-controller@7c420000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zc702-adv7511.dtsi
+++ b/arch/arm/boot/dts/xilinx/zynq-zc702-adv7511.dtsi
@@ -81,7 +81,7 @@
 
 		};
 
-		hdmi_dma: dma@43000000 {
+		hdmi_dma: dma-controller@43000000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x43000000 0x1000>;
 			#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zc702-adv7511.dtsi
+++ b/arch/arm/boot/dts/xilinx/zynq-zc702-adv7511.dtsi
@@ -89,7 +89,7 @@
 			clocks = <&clkc 16>;
 		};
 
-		hdmi_clock: axi-clkgen@79000000 {
+		hdmi_clock: clock-controller@79000000 {
 			compatible = "adi,axi-clkgen-2.00.a";
 			reg = <0x79000000 0x10000>;
 			#clock-cells = <0>;

--- a/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-ad6676-fmc.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-ad6676-fmc.dts
@@ -88,7 +88,7 @@
 };
 
 &fpga_axi {
-	rx_dma: rx-dmac@7c420000 {
+	rx_dma: dma-controller@7c420000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-ad9081.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-ad9081.dts
@@ -59,7 +59,7 @@
 };
 
 &fpga_axi {
-		rx_dma: dma@7c420000 {
+		rx_dma: dma-controller@7c420000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x7c420000 0x1000>;
 			#dma-cells = <1>;
@@ -68,7 +68,7 @@
 			clocks = <&clkc 16>;
 		};
 
-		tx_dma: dma@7c430000  {
+		tx_dma: dma-controller@7c430000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x7c430000 0x1000>;
 			#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-ad9172-fmc-ebz.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-ad9172-fmc-ebz.dts
@@ -29,7 +29,7 @@
 };
 
 &fpga_axi {
-	tx_dma: tx-dmac@7c420000 {
+	tx_dma: dma-controller@7c420000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-ad9172-fmc-ebz.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-ad9172-fmc-ebz.dts
@@ -30,9 +30,9 @@
 
 &fpga_axi {
 	tx_dma: tx-dmac@7c420000 {
-		#dma-cells = <1>;
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x1000>;
+		#dma-cells = <1>;
 		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 	};

--- a/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-ad9265-fmc-125ebz.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-ad9265-fmc-125ebz.dts
@@ -15,7 +15,7 @@
 #include "zynq-zc706-adv7511.dtsi"
 
 &fpga_axi {
-	rx_dma: rx-dmac@44a30000 {
+	rx_dma: dma-controller@44a30000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x44a30000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-ad9361-fmcomms2-3.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-ad9361-fmcomms2-3.dts
@@ -23,7 +23,7 @@
 };
 
 &fpga_axi  {
-	rx_dma: dma@7c400000 {
+	rx_dma: dma-controller@7c400000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x1000>;
 		#dma-cells = <1>;
@@ -31,7 +31,7 @@
 		clocks = <&clkc 16>;
 	};
 
-	tx_dma: dma@7c420000 {
+	tx_dma: dma-controller@7c420000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-ad9361-fmcomms2-3.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-ad9361-fmcomms2-3.dts
@@ -22,7 +22,7 @@
 	};
 };
 
-&fpga_axi  {
+&fpga_axi {
 	rx_dma: dma-controller@7c400000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x1000>;

--- a/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-ad9361-fmcomms5.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-ad9361-fmcomms5.dts
@@ -22,7 +22,7 @@
 };
 
 &fpga_axi {
-	rx_dma: dma@7c400000 {
+	rx_dma: dma-controller@7c400000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x1000>;
 		#dma-cells = <1>;
@@ -30,7 +30,7 @@
 		clocks = <&clkc 16>;
 	};
 
-	tx_dma: dma@7c420000 {
+	tx_dma: dma-controller@7c420000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-ad9364-fmcomms4.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-ad9364-fmcomms4.dts
@@ -22,7 +22,7 @@
 };
 
 &fpga_axi {
-	rx_dma: dma@7c400000 {
+	rx_dma: dma-controller@7c400000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x1000>;
 		#dma-cells = <1>;
@@ -30,7 +30,7 @@
 		clocks = <&clkc 16>;
 	};
 
-	tx_dma: dma@7c420000 {
+	tx_dma: dma-controller@7c420000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-ad9434-fmc-500ebz.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-ad9434-fmc-500ebz.dts
@@ -15,7 +15,7 @@
 #include "zynq-zc706-adv7511.dtsi"
 
 &fpga_axi {
-	rx_dma: rx-dmac@44a30000 {
+	rx_dma: dma-controller@44a30000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x44a30000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-ad9625-fmcadc2.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-ad9625-fmcadc2.dts
@@ -62,7 +62,7 @@
 };
 
 &fpga_axi {
-	rx_dma: rx-dmac@7c420000 {
+	rx_dma: dma-controller@7c420000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-ad9625-fmcadc7.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-ad9625-fmcadc7.dts
@@ -97,7 +97,7 @@
 };
 
 &fpga_axi {
-	rx_dma: rx-dmac@7c420000 {
+	rx_dma: dma-controller@7c420000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-ad9739a-fmc.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-ad9739a-fmc.dts
@@ -43,7 +43,7 @@
 };
 
 &fpga_axi {
-	tx_dma: tx-dmac@7c420000 {
+	tx_dma: dma-controller@7c420000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-adrv9008-1.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-adrv9008-1.dts
@@ -35,7 +35,7 @@
 };
 
 &fpga_axi {
-	rx_dma: dma@7c400000 {
+	rx_dma: dma-controller@7c400000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-adrv9008-1.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-adrv9008-1.dts
@@ -68,7 +68,7 @@
 		adi,frames-per-multiframe = <32>;
 	};
 
-	axi_rx_clkgen: axi-clkgen@43c10000  {
+	axi_rx_clkgen: clock-controller@43c10000 {
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x43c10000 0x10000>;
 		#clock-cells = <0>;

--- a/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-adrv9008-2.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-adrv9008-2.dts
@@ -108,7 +108,7 @@
 		adi,frames-per-multiframe = <32>;
 	};
 
-	axi_tx_clkgen: axi-clkgen@43c00000  {
+	axi_tx_clkgen: clock-controller@43c00000 {
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x43c00000 0x10000>;
 		#clock-cells = <0>;
@@ -117,7 +117,7 @@
 		clock-output-names = "axi_tx_clkgen";
 	};
 
-	axi_rx_os_clkgen: axi-clkgen@43c20000  {
+	axi_rx_os_clkgen: clock-controller@43c20000 {
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x43c20000 0x10000>;
 		#clock-cells = <0>;

--- a/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-adrv9008-2.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-adrv9008-2.dts
@@ -35,7 +35,7 @@
 };
 
 &fpga_axi {
-	rx_obs_dma: dma@7c440000 {
+	rx_obs_dma: dma-controller@7c440000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c440000 0x1000>;
 		#dma-cells = <1>;
@@ -43,7 +43,7 @@
 		interrupts = <0 55 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 16>;
 	};
-	tx_dma: dma@7c420000  {
+	tx_dma: dma-controller@7c420000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-adrv9009.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-adrv9009.dts
@@ -36,7 +36,7 @@
 };
 
 &fpga_axi {
-	rx_dma: rx-dmac@7c400000 {
+	rx_dma: dma-controller@7c400000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x1000>;
 		#dma-cells = <1>;
@@ -44,7 +44,7 @@
 		clocks = <&clkc 16>;
 	};
 
-	rx_obs_dma: rx-obs-dmac@7c440000  {
+	rx_obs_dma: dma-controller@7c440000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c440000  0x1000>;
 		#dma-cells = <1>;
@@ -52,7 +52,7 @@
 		clocks = <&clkc 16>;
 	};
 
-	tx_dma: tx-dmac@7c420000 {
+	tx_dma: dma-controller@7c420000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-adrv9009.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-adrv9009.dts
@@ -145,7 +145,7 @@
 		adi,frames-per-multiframe = <32>;
 	};
 
-	axi_tx_clkgen: axi-clkgen@43c00000  {
+	axi_tx_clkgen: clock-controller@43c00000 {
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x43c00000 0x10000>;
 		#clock-cells = <0>;
@@ -154,7 +154,7 @@
 		clock-output-names = "axi_tx_clkgen";
 	};
 
-	axi_rx_clkgen: axi-clkgen@43c10000  {
+	axi_rx_clkgen: clock-controller@43c10000 {
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x43c10000 0x10000>;
 		#clock-cells = <0>;
@@ -163,7 +163,7 @@
 		clock-output-names = "axi_rx_clkgen";
 	};
 
-	axi_rx_os_clkgen: axi-clkgen@43c20000  {
+	axi_rx_os_clkgen: clock-controller@43c20000 {
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x43c20000 0x10000>;
 		#clock-cells = <0>;

--- a/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-adrv9371.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-adrv9371.dts
@@ -143,7 +143,7 @@
 		adi,frames-per-multiframe = <32>;
 	};
 
-	axi_tx_clkgen: axi-clkgen@43c00000  {
+	axi_tx_clkgen: clock-controller@43c00000 {
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x43c00000 0x10000>;
 		#clock-cells = <0>;
@@ -152,7 +152,7 @@
 		clock-output-names = "axi_tx_clkgen";
 	};
 
-	axi_rx_clkgen: axi-clkgen@43c10000  {
+	axi_rx_clkgen: clock-controller@43c10000 {
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x43c10000 0x10000>;
 		#clock-cells = <0>;
@@ -162,7 +162,7 @@
 
 	};
 
-	axi_rx_os_clkgen: axi-clkgen@43c20000  {
+	axi_rx_os_clkgen: clock-controller@43c20000 {
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x43c20000 0x10000>;
 		#clock-cells = <0>;

--- a/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-adrv9371.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-adrv9371.dts
@@ -35,7 +35,7 @@
 };
 
 &fpga_axi {
-	rx_dma: rx-dmac@7c400000 {
+	rx_dma: dma-controller@7c400000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x1000>;
 		#dma-cells = <1>;
@@ -43,7 +43,7 @@
 		clocks = <&clkc 16>;
 	};
 
-	rx_obs_dma: rx-obs-dmac@7c440000  {
+	rx_obs_dma: dma-controller@7c440000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c440000  0x1000>;
 		#dma-cells = <1>;
@@ -51,7 +51,7 @@
 		clocks = <&clkc 16>;
 	};
 
-	tx_dma: tx-dmac@7c420000 {
+	tx_dma: dma-controller@7c420000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-fmcadc4.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-fmcadc4.dts
@@ -8,7 +8,7 @@
 #include <dt-bindings/jesd204/adxcvr.h>
 
 &fpga_axi {
-	rx_dma0: rx-dmac@7c400000 {
+	rx_dma0: dma-controller@7c400000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-fmcdaq1.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-fmcdaq1.dts
@@ -7,7 +7,7 @@
 #include "zynq-zc706-adv7511.dtsi"
 
 &fpga_axi {
-	rx_dma: dma@44a60000 {
+	rx_dma: dma-controller@44a60000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x44a60000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-fmcdaq2.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-fmcdaq2.dts
@@ -34,7 +34,7 @@
 
 
 &fpga_axi {
-	rx_dma: rx-dmac@7c400000 {
+	rx_dma: dma-controller@7c400000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x1000>;
 		#dma-cells = <1>;
@@ -42,7 +42,7 @@
 		clocks = <&clkc 16>;
 	};
 
-	tx_dma: tx-dmac@7c420000 {
+	tx_dma: dma-controller@7c420000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-fmcdaq3.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-fmcdaq3.dts
@@ -33,7 +33,7 @@
 };
 
 &fpga_axi {
-	rx_dma: rx-dmac@7c400000 {
+	rx_dma: dma-controller@7c400000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x1000>;
 		#dma-cells = <1>;
@@ -41,7 +41,7 @@
 		clocks = <&clkc 16>;
 	};
 
-	tx_dma: tx-dmac@7c420000 {
+	tx_dma: dma-controller@7c420000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-fmcjesdadc1.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-fmcjesdadc1.dts
@@ -33,7 +33,7 @@
 };
 
 &fpga_axi {
-	rx_dma: rx-dmac@7c420000 {
+	rx_dma: dma-controller@7c420000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-fmclidar1.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-fmclidar1.dts
@@ -69,7 +69,7 @@
 		clocks = <&axi_ad9094_adxcvr 1>;
 	};
 
-	rx_dma: rx-dmac@7c400000 {
+	rx_dma: dma-controller@7c400000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-fmcomms1.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-fmcomms1.dts
@@ -15,7 +15,7 @@
 };
 
 &fpga_axi {
-	rx_dma: dma@7c400000 {
+	rx_dma: dma-controller@7c400000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x1000>;
 		#dma-cells = <1>;
@@ -23,7 +23,7 @@
 		clocks = <&clkc 16>;
 	};
 
-	tx_dma: dma@7c420000 {
+	tx_dma: dma-controller@7c420000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-fmcomms11-RevA.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-fmcomms11-RevA.dts
@@ -26,7 +26,7 @@
 };
 
 &fpga_axi {
-	rx_dma: rx-dmac@7c400000 {
+	rx_dma: dma-controller@7c400000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x1000>;
 		#dma-cells = <1>;
@@ -35,7 +35,7 @@
 
 	};
 
-	tx_dma: tx-dmac@7c420000 {
+	tx_dma: dma-controller@7c420000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-fmcomms11.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-fmcomms11.dts
@@ -34,7 +34,7 @@
 };
 
 &fpga_axi {
-	rx_dma: rx-dmac@7c400000 {
+	rx_dma: dma-controller@7c400000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x1000>;
 		#dma-cells = <1>;
@@ -42,7 +42,7 @@
 		clocks = <&clkc 16>;
 	};
 
-	tx_dma: tx-dmac@7c420000 {
+	tx_dma: dma-controller@7c420000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-fmcomms6.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-fmcomms6.dts
@@ -15,7 +15,7 @@
 };
 
 &fpga_axi {
-	rx_dma: rx-dmac@7c420000 {
+	rx_dma: dma-controller@7c420000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511.dtsi
+++ b/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511.dtsi
@@ -117,7 +117,7 @@
 			clocks = <&clkc 16>;
 		};
 
-		hdmi_clock: axi-clkgen@79000000 {
+		hdmi_clock: clock-controller@79000000 {
 			compatible = "adi,axi-clkgen-2.00.a";
 			reg = <0x79000000 0x10000>;
 			#clock-cells = <0>;

--- a/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511.dtsi
+++ b/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511.dtsi
@@ -109,7 +109,7 @@
 			};
 		};
 
-		hdmi_dma: dma@43000000 {
+		hdmi_dma: dma-controller@43000000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x43000000 0x1000>;
 			#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad3552r-hs.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad3552r-hs.dts
@@ -50,7 +50,7 @@
 };
 
 &fpga_axi {
-	ref_clk: clk@44B00000 {
+	ref_clk: clock-controller@44B00000 {
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x44B00000 0x10000>;
 		#clock-cells = <0>;

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4000.dtsi
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4000.dtsi
@@ -84,7 +84,7 @@
 		};
 	};
 
-	rx_dma: rx-dmac@0x44a30000 {
+	rx_dma: dma-controller@0x44a30000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x44a30000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4000.dtsi
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4000.dtsi
@@ -93,7 +93,7 @@
 		clocks = <&clkc 17>;
 	};
 
-	spi_clk: axi-clkgen@0x44a70000 {
+	spi_clk: clock-controller@0x44a70000 {
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x44a70000 0x10000>;
 		#clock-cells = <0>;

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4030-24.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4030-24.dts
@@ -58,7 +58,7 @@
 		clocks = <&clkc 15>;
 	};
 
-	spi_clk: axi-clkgen@44a70000 {
+	spi_clk: clock-controller@44a70000 {
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x44a70000 0x10000>;
 		#clock-cells = <0>;

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4030-24.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4030-24.dts
@@ -50,7 +50,7 @@
 };
 
 &fpga_axi {
-	rx_dma: rx-dmac@44a30000 {
+	rx_dma: dma-controller@44a30000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x44a30000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4030-24.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4030-24.dts
@@ -67,7 +67,7 @@
 		clock-output-names = "spi_clk";
 	};
 
-	axi_pwm_gen: axi-pwm-gen@44b00000 {
+	axi_pwm_gen: pwm@44b00000 {
 		compatible = "adi,axi-pwmgen-2.00.a";
 		reg = <0x44b00000 0x1000>;
 		label = "ad463x_cnv";

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4032-24.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4032-24.dts
@@ -58,7 +58,7 @@
 		clocks = <&clkc 15>;
 	};
 
-	spi_clk: axi-clkgen@44a70000 {
+	spi_clk: clock-controller@44a70000 {
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x44a70000 0x10000>;
 		#clock-cells = <0>;

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4032-24.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4032-24.dts
@@ -50,7 +50,7 @@
 };
 
 &fpga_axi {
-	rx_dma: rx-dmac@44a30000 {
+	rx_dma: dma-controller@44a30000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x44a30000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4032-24.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4032-24.dts
@@ -67,7 +67,7 @@
 		clock-output-names = "spi_clk";
 	};
 
-	axi_pwm_gen: axi-pwm-gen@44b00000 {
+	axi_pwm_gen: pwm@44b00000 {
 		compatible = "adi,axi-pwmgen-2.00.a";
 		reg = <0x44b00000 0x1000>;
 		label = "ad463x_cnv";

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4134.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4134.dts
@@ -87,7 +87,7 @@
 		};
 	};
 
-	ad4134_odr_generator: odr_generator@44b00000 {
+	ad4134_odr_generator: pwm@44b00000 {
 		compatible = "adi,axi-pwmgen-2.00.a";
 		reg = <0x44b00000 0x10000>;
 		#pwm-cells = <2>;

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4134.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4134.dts
@@ -94,7 +94,7 @@
 		clocks = <&clkc 15>;
 	};
 
-	spi_clk: axi_clkgen@44b10000 {
+	spi_clk: clock-controller@44b10000 {
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x44b10000 0x10000>;
 		#clock-cells = <0>;

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4134.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4134.dts
@@ -56,7 +56,7 @@
 };
 
 &fpga_axi {
-	rx_dma: rx-dmac@44a30000 {
+	rx_dma: dma-controller@44a30000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x44a30000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4630-16.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4630-16.dts
@@ -58,7 +58,7 @@
 		clocks = <&clkc 15>;
 	};
 
-	spi_clk: axi-clkgen@44a70000 {
+	spi_clk: clock-controller@44a70000 {
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x44a70000 0x10000>;
 		#clock-cells = <0>;

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4630-16.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4630-16.dts
@@ -50,7 +50,7 @@
 };
 
 &fpga_axi {
-	rx_dma: rx-dmac@44a30000 {
+	rx_dma: dma-controller@44a30000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x44a30000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4630-16.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4630-16.dts
@@ -67,7 +67,7 @@
 		clock-output-names = "spi_clk";
 	};
 
-	axi_pwm_gen: axi-pwm-gen@44b00000 {
+	axi_pwm_gen: pwm@44b00000 {
 		compatible = "adi,axi-pwmgen-2.00.a";
 		reg = <0x44b00000 0x1000>;
 		label = "ad463x_cnv";

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4630-24.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4630-24.dts
@@ -63,7 +63,7 @@
 		clocks = <&cnv_ext_clk>;
 	};
 
-	rx_dma: rx-dmac@44a30000 {
+	rx_dma: dma-controller@44a30000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x44a30000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4630-24.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4630-24.dts
@@ -71,7 +71,7 @@
 		clocks = <&clkc 15>;
 	};
 
-	spi_clk: axi-clkgen@44a70000 {
+	spi_clk: clock-controller@44a70000 {
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x44a70000 0x10000>;
 		#clock-cells = <0>;

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4696.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4696.dts
@@ -73,7 +73,7 @@
 		clocks = <&spi_clk>;
 	};
 
-	spi_clk: axi-clkgen@44a70000 {
+	spi_clk: clock-controller@44a70000 {
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x44a70000 0x10000>;
 		#clock-cells = <0>;

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4696.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4696.dts
@@ -58,7 +58,7 @@
 };
 
 &fpga_axi {
-	rx_dma: rx-dmac@44a30000 {
+	rx_dma: dma-controller@44a30000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x44a30000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad7380.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad7380.dts
@@ -74,7 +74,7 @@
 		assigned-clock-rates = <160000000>;
 	};
 
-	rx_dma: rx-dmac@44a30000 {
+	rx_dma: dma-controller@44a30000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x44a30000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad7625.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad7625.dts
@@ -67,7 +67,7 @@
 		clocks = <&clkc 15>;
 	};
 
-	ref_clk: clock@44a80000 {
+	ref_clk: clock-controller@44a80000 {
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x44a80000 0x10000>;
 		#clock-cells = <0>;

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad7768-1-evb.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad7768-1-evb.dts
@@ -34,7 +34,7 @@
 };
 
 &fpga_axi {
-	rx_dma: rx-dmac@44a30000 {
+	rx_dma: dma-controller@44a30000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x44a30000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad7768-1-evb.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad7768-1-evb.dts
@@ -43,7 +43,7 @@
 		clocks = <&clkc 16>;
 	};
 
-	spi_clock: spieng-axi-clkgen@44a70000 {
+	spi_clock: clock-controller@44a70000 {
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x44a70000 0x10000>;
 		#clock-cells = <0>;

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad7768-4-axi-adc.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad7768-4-axi-adc.dts
@@ -33,7 +33,7 @@
 };
 
 &fpga_axi {
-	rx_dma: dma@7c480000 {
+	rx_dma: dma-controller@7c480000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c480000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad7768-axi-adc.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad7768-axi-adc.dts
@@ -33,7 +33,7 @@
 };
 
 &fpga_axi {
-	rx_dma: dma@7c480000 {
+	rx_dma: dma-controller@7c480000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c480000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad7768.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad7768.dts
@@ -33,7 +33,7 @@
 };
 
 &fpga_axi {
-	rx_dma: rx-dmac@7c400000 {
+	rx_dma: dma-controller@7c400000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad7944.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad7944.dts
@@ -59,7 +59,7 @@
 		clocks = <&spi_clk>;
 	};
 
-	rx_dma: rx-dmac@44a30000 {
+	rx_dma: dma-controller@44a30000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x44a30000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad7960.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad7960.dts
@@ -69,7 +69,7 @@
 		clocks = <&clkc 15>;
 	};
 
-	ref_clk: clock@44a80000 {
+	ref_clk: clock-controller@44a80000 {
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x44a80000 0x10000>;
 		#clock-cells = <0>;

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad7985.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad7985.dts
@@ -59,7 +59,7 @@
 		clocks = <&spi_clk>;
 	};
 
-	rx_dma: rx-dmac@44a30000 {
+	rx_dma: dma-controller@44a30000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x44a30000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad7986.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad7986.dts
@@ -59,7 +59,7 @@
 		clocks = <&spi_clk>;
 	};
 
-	rx_dma: rx-dmac@44a30000 {
+	rx_dma: dma-controller@44a30000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x44a30000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad8460.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad8460.dts
@@ -81,7 +81,7 @@
 
 &fpga_axi {
 
-	tx_dma: tx_dmac@44000000 {
+	tx_dma: dma-controller@44000000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x44000000 0x1000>;
 		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad9265-fmc-125ebz.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad9265-fmc-125ebz.dts
@@ -15,7 +15,7 @@
 #include "zynq-zed-adv7511.dtsi"
 
 &fpga_axi {
-	rx_dma: rx-dmac@44a30000 {
+	rx_dma: dma-controller@44a30000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x44a30000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad9361-fmcomms2-3.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad9361-fmcomms2-3.dts
@@ -27,7 +27,7 @@
 		#address-cells = <1>;
 	};
 
-	rx_dma: dma@7c400000 {
+	rx_dma: dma-controller@7c400000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x1000>;
 		#dma-cells = <1>;
@@ -35,7 +35,7 @@
 		clocks = <&clkc 16>;
 	};
 
-	tx_dma: dma@7c420000 {
+	tx_dma: dma-controller@7c420000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad9364-fmcomms4.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad9364-fmcomms4.dts
@@ -27,7 +27,7 @@
 		#address-cells = <1>;
 	};
 
-	rx_dma: dma@7c400000 {
+	rx_dma: dma-controller@7c400000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x1000>;
 		#dma-cells = <1>;
@@ -35,7 +35,7 @@
 		clocks = <&clkc 16>;
 	};
 
-	tx_dma: dma@7c420000 {
+	tx_dma: dma-controller@7c420000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad9434-fmc-500ebz.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad9434-fmc-500ebz.dts
@@ -15,7 +15,7 @@
 #include "zynq-zed-adv7511.dtsi"
 
 &fpga_axi {
-	rx_dma: rx-dmac@44a30000 {
+	rx_dma: dma-controller@44a30000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x44a30000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad9467-fmc-250ebz.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad9467-fmc-250ebz.dts
@@ -16,7 +16,7 @@
 #include "zynq-zed-adv7511.dtsi"
 
 &fpga_axi {
-	rx_dma: rx-dmac@44a30000 {
+	rx_dma: dma-controller@44a30000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x44A30000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq4216.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq4216.dts
@@ -74,7 +74,7 @@
 		clocks = <&clkc 15>;
 	};
 
-	spi_clk: axi-clkgen@44a70000 {
+	spi_clk: clock-controller@44a70000 {
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x44a70000 0x10000>;
 		#clock-cells = <0>;

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq4216.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq4216.dts
@@ -66,7 +66,7 @@
 		};
 	};
 
-	rx_dma: rx-dmac@44a30000 {
+	rx_dma: dma-controller@44a30000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x44a30000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq4216.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq4216.dts
@@ -83,7 +83,7 @@
 		clock-output-names = "spi_clk";
 	};
 
-	axi_pwm_gen: axi-pwm-gen@44b00000 {
+	axi_pwm_gen: pwm@44b00000 {
 		compatible = "adi,axi-pwmgen-2.00.a";
 		reg = <0x44b00000 0x1000>;
 		label = "ad463x_cnv";

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq4220.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq4220.dts
@@ -85,7 +85,7 @@
 		clocks = <&clkc 15>;
 	};
 
-	spi_clk: axi-clkgen@44a70000 {
+	spi_clk: clock-controller@44a70000 {
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x44a70000 0x10000>;
 		#clock-cells = <0>;

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq4220.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq4220.dts
@@ -77,7 +77,7 @@
 		};
 	};
 
-	rx_dma: rx-dmac@44a30000 {
+	rx_dma: dma-controller@44a30000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x44a30000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq4220.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq4220.dts
@@ -94,7 +94,7 @@
 		clock-output-names = "spi_clk";
 	};
 
-	axi_pwm_gen: axi-pwm-gen@44b00000 {
+	axi_pwm_gen: pwm@44b00000 {
 		compatible = "adi,axi-pwmgen-2.00.a";
 		reg = <0x44b00000 0x1000>;
 		label = "ad463x_cnv";

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq4224-24.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq4224-24.dts
@@ -85,7 +85,7 @@
 		clocks = <&clkc 15>;
 	};
 
-	spi_clk: axi-clkgen@44a70000 {
+	spi_clk: clock-controller@44a70000 {
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x44a70000 0x10000>;
 		#clock-cells = <0>;

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq4224-24.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq4224-24.dts
@@ -77,7 +77,7 @@
 		};
 	};
 
-	rx_dma: rx-dmac@44a30000 {
+	rx_dma: dma-controller@44a30000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x44a30000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq4224-24.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq4224-24.dts
@@ -94,7 +94,7 @@
 		clock-output-names = "spi_clk";
 	};
 
-	axi_pwm_gen: axi-pwm-gen@44b00000 {
+	axi_pwm_gen: pwm@44b00000 {
 		compatible = "adi,axi-pwmgen-2.00.a";
 		reg = <0x44b00000 0x1000>;
 		label = "ad463x_cnv";

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq4224-24_cm0_sdi4_cz2.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq4224-24_cm0_sdi4_cz2.dts
@@ -81,7 +81,7 @@
 		clock-output-names = "spi_clk";
 	};
 
-	axi_pwm_gen: axi-pwm-gen@44b00000 {
+	axi_pwm_gen: pwm@44b00000 {
 		compatible = "adi,axi-pwmgen-2.00.a";
 		reg = <0x44b00000 0x1000>;
 		label = "ad463x_cnv";

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq4224-24_cm0_sdi4_cz2.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq4224-24_cm0_sdi4_cz2.dts
@@ -72,7 +72,7 @@
 		clocks = <&clkc 15>;
 	};
 
-	spi_clk: axi-clkgen@44a70000 {
+	spi_clk: clock-controller@44a70000 {
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x44a70000 0x10000>;
 		#clock-cells = <0>;

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq4224-24_cm0_sdi4_cz2.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq4224-24_cm0_sdi4_cz2.dts
@@ -64,7 +64,7 @@
 };
 
 &fpga_axi {
-	rx_dma: rx-dmac@44a30000 {
+	rx_dma: dma-controller@44a30000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x44a30000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq8092.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq8092.dts
@@ -44,7 +44,7 @@
 };
 
 &fpga_axi {
-	rx_dma: rx-dmac@44a30000 {
+	rx_dma: dma-controller@44a30000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x44a30000 0x10000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-cn0577.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-cn0577.dts
@@ -48,7 +48,7 @@
 };
 
 &fpga_axi {
-	rx_dma: dmac@44a30000 {
+	rx_dma: dma-controller@44a30000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x44a30000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-fmcmotcon2.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-fmcmotcon2.dts
@@ -66,7 +66,7 @@
 		dmas = <&ad_mc_speed_dma 0>;
 		dma-names = "ad-mc-speed-dma";
 	};
-	ad_mc_speed_dma: dma@40510000 {
+	ad_mc_speed_dma: dma-controller@40510000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x40510000 0x1000>;
 		#dma-cells = <1>;
@@ -80,7 +80,7 @@
 		dmas = <&ad_mc_adc_dma 0>;
 		dma-names = "ad-mc-adc-dma";
 	};
-	ad_mc_adc_dma: dma@40520000 {
+	ad_mc_adc_dma: dma-controller@40520000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x40520000 0x1000>;
 		#dma-cells = <1>;
@@ -99,7 +99,7 @@
 		dmas = <&ad_mc_speed_dma_m2 0>;
 		dma-names = "ad-mc-speed-dma";
 	};
-	ad_mc_speed_dma_m2: dma@40540000 {
+	ad_mc_speed_dma_m2: dma-controller@40540000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x40540000 0x1000>;
 		#dma-cells = <1>;
@@ -113,7 +113,7 @@
 		dmas = <&ad_mc_adc_dma_m2 0>;
 		dma-names = "ad-mc-adc-dma";
 	};
-	ad_mc_adc_dma_m2: dma@40550000 {
+	ad_mc_adc_dma_m2: dma-controller@40550000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x40550000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-fmcomms1.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-fmcomms1.dts
@@ -19,7 +19,7 @@
 		#address-cells = <1>;
 	};
 
-	rx_dma: dma@7c400000 {
+	rx_dma: dma-controller@7c400000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x1000>;
 		#dma-cells = <1>;
@@ -27,7 +27,7 @@
 		clocks = <&clkc 16>;
 	};
 
-	tx_dma: dma@7c420000 {
+	tx_dma: dma-controller@7c420000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ltc2387.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ltc2387.dts
@@ -34,7 +34,7 @@
 		clocks = <&clkc 15>;
 	};
 
-	ref_clk: clk@44a70000 {
+	ref_clk: clock-controller@44a70000 {
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x44a70000 0x10000>;
 		#clock-cells = <0>;

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ltc2387.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ltc2387.dts
@@ -26,7 +26,7 @@
 };
 
 &fpga_axi {
-	rx_dma: dmac@44a30000 {
+	rx_dma: dma-controller@44a30000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x44a30000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-m2k-revb.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-m2k-revb.dts
@@ -151,7 +151,7 @@
 		};
 	};
 
-	rx_dma0: dma@7c440000 {
+	rx_dma0: dma-controller@7c440000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c440000 0x1000>;
 		#dma-cells = <1>;
@@ -159,7 +159,7 @@
 		clocks = <&clkc 15>;
 	};
 /*
-	rx_dma1: dma@7c440000 {
+	rx_dma1: dma-controller@7c440000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c460000 0x1000>;
 		#dma-cells = <1>;
@@ -172,7 +172,7 @@
 		};
 	};
 */
-	tx_dma: dma@7c480000 {
+	tx_dma: dma-controller@7c480000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c480000 0x1000>;
 		#dma-cells = <1>;
@@ -209,7 +209,7 @@
 		#clock-cells = <0>;
 	};
 
-	logic_analyzer_rx_dma: dma@7c400000 {
+	logic_analyzer_rx_dma: dma-controller@7c400000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x1000>;
 
@@ -218,7 +218,7 @@
 		clocks = <&clkc 15>;
 	};
 
-	logic_analyzer_tx_dma: dma@7c420000 {
+	logic_analyzer_tx_dma: dma-controller@7c420000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x1000>;
 

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-m2k-revb.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-m2k-revb.dts
@@ -200,7 +200,7 @@
 		adi,axi-dds-default-frequency = <1000000>;
 	};
 
-	logic_analyzer_clkgen: clock@7000000 {
+	logic_analyzer_clkgen: clock-controller@7000000 {
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x70000000 0x10000>;
 		clocks = <&clkc 16>, <&clkc 15>;

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-m2k-revc.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-m2k-revc.dts
@@ -169,7 +169,7 @@
 		};
 	};
 
-	rx_dma0: dma@7c440000 {
+	rx_dma0: dma-controller@7c440000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c440000 0x1000>;
 		#dma-cells = <1>;
@@ -177,7 +177,7 @@
 		clocks = <&clkc 15>;
 	};
 /*
-	rx_dma1: dma@7c440000 {
+	rx_dma1: dma-controller@7c440000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c460000 0x1000>;
 		#dma-cells = <1>;
@@ -190,7 +190,7 @@
 		};
 	};
 */
-	tx_dma0: dma@7c480000 {
+	tx_dma0: dma-controller@7c480000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c480000 0x1000>;
 		#dma-cells = <1>;
@@ -198,7 +198,7 @@
 		clocks = <&clkc 15>;
 	};
 
-	tx_dma1: dma@7c460000 {
+	tx_dma1: dma-controller@7c460000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c460000 0x1000>;
 		#dma-cells = <1>;
@@ -235,7 +235,7 @@
 		dds-connected = <&dds>;
 	};
 
-	logic_analyzer_rx_dma: dma@7c400000 {
+	logic_analyzer_rx_dma: dma-controller@7c400000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x1000>;
 
@@ -244,7 +244,7 @@
 		clocks = <&clkc 15>;
 	};
 
-	logic_analyzer_tx_dma: dma@7c420000 {
+	logic_analyzer_tx_dma: dma-controller@7c420000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x1000>;
 

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511.dtsi
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511.dtsi
@@ -87,7 +87,7 @@
 			clocks = <&clkc 16>;
 		};
 
-		hdmi_clock: axi-clkgen@79000000 {
+		hdmi_clock: clock-controller@79000000 {
 			compatible = "adi,axi-clkgen-2.00.a";
 			reg = <0x79000000 0x10000>;
 			#clock-cells = <0>;

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511.dtsi
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511.dtsi
@@ -79,7 +79,7 @@
 
 		};
 
-		hdmi_dma: dma@43000000 {
+		hdmi_dma: dma-controller@43000000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x43000000 0x1000>;
 			#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zed-imageon.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-imageon.dts
@@ -120,7 +120,7 @@
 			};
 		};
 
-		hdmi_dma: dma@43000000 {
+		hdmi_dma: dma-controller@43000000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x43000000 0x1000>;
 			#dma-cells = <1>;
@@ -179,7 +179,7 @@
 			};
 		};
 
-		axi_dmac: dmac@43c20000 {
+		axi_dmac: dma-controller@43c20000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x43c20000 0x1000>;
 			#dma-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zed-imageon.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-imageon.dts
@@ -128,7 +128,7 @@
 			clocks = <&clkc 16>;
 		};
 
-		axi_hdmi_clkgen: axi-clkgen@79000000 {
+		axi_hdmi_clkgen: clock-controller@79000000 {
 			compatible = "adi,axi-clkgen-2.00.a";
 			reg = <0x79000000 0x10000>;
 			#clock-cells = <0>;

--- a/arch/arm64/boot/dts/xilinx/versal-vck190-reva-ad9081.dts
+++ b/arch/arm64/boot/dts/xilinx/versal-vck190-reva-ad9081.dts
@@ -95,7 +95,7 @@
 			xlnx,tri-default-2 = <0xFFFFFFFF>;
 		};
 
-		rx_dma: dma@bc420000 {
+		rx_dma: dma-controller@bc420000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0xbc420000 0x10000>;
 			#dma-cells = <1>;
@@ -104,7 +104,7 @@
 			clocks = <&versal_clk PMC_PL1_REF>;
 		};
 
-		tx_dma: dma@bc430000  {
+		tx_dma: dma-controller@bc430000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0xbc430000 0x10000>;
 			#dma-cells = <1>;

--- a/arch/arm64/boot/dts/xilinx/versal-vck190-reva-ad9209.dts
+++ b/arch/arm64/boot/dts/xilinx/versal-vck190-reva-ad9209.dts
@@ -77,7 +77,7 @@
 			xlnx,tri-default-2 = <0xFFFFFFFF>;
 		};
 
-		rx_dma: dma@bc420000 {
+		rx_dma: dma-controller@bc420000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0xbc420000 0x10000>;
 			#dma-cells = <1>;

--- a/arch/arm64/boot/dts/xilinx/versal-vck190-reva-adrv9025.dts
+++ b/arch/arm64/boot/dts/xilinx/versal-vck190-reva-adrv9025.dts
@@ -95,7 +95,7 @@
 			xlnx,tri-default-2 = <0xFFFFFFFF>;
 		};
 
-		rx_dma: dma@bc400000 {
+		rx_dma: dma-controller@bc400000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0xbc400000 0x10000>;
 			#dma-cells = <1>;
@@ -115,7 +115,7 @@
 			};
 		};
 
-		tx_dma: dma@bc420000  {
+		tx_dma: dma-controller@bc420000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0xbc420000 0x10000>;
 			#dma-cells = <1>;

--- a/arch/arm64/boot/dts/xilinx/versal-vpk180-reva-ad9081.dts
+++ b/arch/arm64/boot/dts/xilinx/versal-vpk180-reva-ad9081.dts
@@ -95,7 +95,7 @@
 			xlnx,tri-default-2 = <0xFFFFFFFF>;
 		};
 
-		rx_dma: dma@bc420000 {
+		rx_dma: dma-controller@bc420000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0xbc420000 0x10000>;
 			#dma-cells = <1>;
@@ -104,7 +104,7 @@
 			clocks = <&versal_clk PMC_PL1_REF>;
 		};
 
-		tx_dma: dma@bc430000  {
+		tx_dma: dma-controller@bc430000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0xbc430000 0x10000>;
 			#dma-cells = <1>;

--- a/arch/arm64/boot/dts/xilinx/versal-vpk180-reva-ad9082-m1-l8.dts
+++ b/arch/arm64/boot/dts/xilinx/versal-vpk180-reva-ad9082-m1-l8.dts
@@ -95,7 +95,7 @@
 			xlnx,tri-default-2 = <0xFFFFFFFF>;
 		};
 
-		rx_dma: dma@bc420000 {
+		rx_dma: dma-controller@bc420000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0xbc420000 0x10000>;
 			#dma-cells = <1>;
@@ -104,7 +104,7 @@
 			clocks = <&versal_clk PMC_PL1_REF>;
 		};
 
-		tx_dma: dma@bc430000  {
+		tx_dma: dma-controller@bc430000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0xbc430000 0x10000>;
 			#dma-cells = <1>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-reva-adrv2crr-fmc-reva.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-reva-adrv2crr-fmc-reva.dts
@@ -556,7 +556,7 @@
 };
 
 &fpga_axi {
-	i2s_tx_dma: dma@81001000  {
+	i2s_tx_dma: dma-controller@81001000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x0 0x81001000 0x1000>;
 		#dma-cells = <1>;
@@ -565,7 +565,7 @@
 		clocks = <&zynqmp_clk 73>;
 	};
 
-	i2s_rx_dma: dma@81000000  {
+	i2s_rx_dma: dma-controller@81000000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x0 0x81000000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-reva.dtsi
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-adrv9009-zu11eg-reva.dtsi
@@ -1324,7 +1324,7 @@
 			pulses-per-revolution = <2>;
 		};
 
-		rx_dma: dma@9c420000 {
+		rx_dma: dma-controller@9c420000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x0 0x9c420000 0x10000>;
 			#dma-cells = <1>;
@@ -1334,7 +1334,7 @@
 			clocks = <&zynqmp_clk 73>;
 		};
 
-		rx_obs_dma: dma@9c440000 {
+		rx_obs_dma: dma-controller@9c440000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x0 0x9c440000 0x10000>;
 			#dma-cells = <1>;
@@ -1344,7 +1344,7 @@
 			clocks = <&zynqmp_clk 73>;
 		};
 
-		tx_dma: dma@9c400000  {
+		tx_dma: dma-controller@9c400000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x0 0x9c400000 0x10000>;
 			#dma-cells = <1>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-jupiter-sdr.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-jupiter-sdr.dts
@@ -13,7 +13,7 @@
 #include "zynqmp-jupiter-sdr.dtsi"
 
 &fpga_axi {
-	rx2_dma: dma@84A40000 {
+	rx2_dma: dma-controller@84A40000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x84A40000 0x10000>;
 		#dma-cells = <1>;
@@ -22,7 +22,7 @@
 		clocks = <&zynqmp_clk 71>;
 	};
 
-	tx2_dma: dma@84A6000 {
+	tx2_dma: dma-controller@84A6000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x84A60000 0x10000>;
 		#dma-cells = <1>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-jupiter-sdr.dtsi
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-jupiter-sdr.dtsi
@@ -431,7 +431,7 @@
 		#size-cells = <0x1>;
 		ranges = <0 0 0 0xffffffff>;
 
-		rx1_dma: dma@84A30000 {
+		rx1_dma: dma-controller@84A30000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x84A30000 0x10000>;
 			#dma-cells = <1>;
@@ -440,7 +440,7 @@
 			clocks = <&zynqmp_clk 71>;
 		};
 
-		tx1_dma: dma@84A50000 {
+		tx1_dma: dma-controller@84A50000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x84A50000 0x10000>;
 			#dma-cells = <1>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9081-default.dtsi
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9081-default.dtsi
@@ -35,7 +35,7 @@
 		#size-cells = <0x1>;
 		ranges = <0 0 0 0xffffffff>;
 
-		rx_dma: dma@9c420000 {
+		rx_dma: dma-controller@9c420000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c420000 0x10000>;
 			#dma-cells = <1>;
@@ -45,7 +45,7 @@
 			clocks = <&zynqmp_clk 73>;
 		};
 
-		tx_dma: dma@9c430000  {
+		tx_dma: dma-controller@9c430000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c430000 0x10000>;
 			#dma-cells = <1>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9081-m8-l4-overlay.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9081-m8-l4-overlay.dts
@@ -410,7 +410,7 @@
 				reg = <0x0 0x85000000 0x0 0x10000>;
 			};
 
-			rx_dma: dma@9c420000 {
+			rx_dma: dma-controller@9c420000 {
 				compatible = "adi,axi-dmac-1.00.a";
 				reg = <0x0 0x9c420000 0x0 0x10000>;
 				#dma-cells = <1>;
@@ -420,7 +420,7 @@
 				clocks = <&zynqmp_clk 73>;
 			};
 
-			tx_dma: dma@9c430000  {
+			tx_dma: dma-controller@9c430000 {
 				compatible = "adi,axi-dmac-1.00.a";
 				reg = <0x0 0x9c430000  0x0 0x10000>;
 				#dma-cells = <1>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9082-204c-txmode22-rxmode23-dual-multi-top.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9082-204c-txmode22-rxmode23-dual-multi-top.dts
@@ -124,7 +124,7 @@
 		xlnx,kind-of-intr = <0xfff0>;
 		xlnx,num-intr-inputs = <0x4>;
 	};
-	rx_dma2: dma2@80010000 {
+	rx_dma2: dma-controller@80010000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x80010000 0x10000>;
 		#dma-cells = <1>;
@@ -133,7 +133,7 @@
 		interrupts = <0 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&zynqmp_clk 73>;
 	};
-	tx_dma2: dma2@80040000  {
+	tx_dma2: dma-controller@80040000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x80040000 0x10000>;
 		#dma-cells = <1>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9082-204c-txmode22-rxmode23-dual.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9082-204c-txmode22-rxmode23-dual.dts
@@ -54,7 +54,7 @@
 		xlnx,num-intr-inputs = <0x4>;
 	};
 
-	rx_dma2: dma2@80010000 {
+	rx_dma2: dma-controller@80010000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x80010000 0x10000>;
 		#dma-cells = <1>;
@@ -63,7 +63,7 @@
 		interrupts = <0 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&zynqmp_clk 73>;
 	};
-	tx_dma2: dma2@80040000  {
+	tx_dma2: dma-controller@80040000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x80040000 0x10000>;
 		#dma-cells = <1>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9083-fmc-ebz.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9083-fmc-ebz.dts
@@ -31,7 +31,7 @@
 		#size-cells = <0x1>;
 		ranges = <0 0 0 0xffffffff>;
 
-		rx_dma: dma@9c400000 {
+		rx_dma: dma-controller@9c400000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c400000 0x10000>;
 			#dma-cells = <1>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9083-vna-15p625msps.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9083-vna-15p625msps.dts
@@ -22,7 +22,7 @@
 		#size-cells = <0x1>;
 		ranges = <0 0 0 0xffffffff>;
 
-		rx_dma: dma@9c400000 {
+		rx_dma: dma-controller@9c400000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c400000 0x10000>;
 			#dma-cells = <1>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9144-fmc-ebz.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9144-fmc-ebz.dts
@@ -43,9 +43,9 @@
 		ranges = <0 0 0 0xffffffff>;
 
 		tx_dma: tx-dmac@9c420000 {
-			#dma-cells = <1>;
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c420000 0x10000>;
+			#dma-cells = <1>;
 			interrupts = <0 108 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&zynqmp_clk 71>;
 		};

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9144-fmc-ebz.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9144-fmc-ebz.dts
@@ -42,7 +42,7 @@
 		#size-cells = <0x1>;
 		ranges = <0 0 0 0xffffffff>;
 
-		tx_dma: tx-dmac@9c420000 {
+		tx_dma: dma-controller@9c420000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c420000 0x10000>;
 			#dma-cells = <1>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9154-fmc-ebz.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9154-fmc-ebz.dts
@@ -43,9 +43,9 @@
 		ranges = <0 0 0 0xffffffff>;
 
 		tx_dma: tx-dmac@9c420000 {
-			#dma-cells = <1>;
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c420000 0x10000>;
+			#dma-cells = <1>;
 			interrupts = <0 108 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&zynqmp_clk 71>;
 		};

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9154-fmc-ebz.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9154-fmc-ebz.dts
@@ -42,7 +42,7 @@
 		#size-cells = <0x1>;
 		ranges = <0 0 0 0xffffffff>;
 
-		tx_dma: tx-dmac@9c420000 {
+		tx_dma: dma-controller@9c420000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c420000 0x10000>;
 			#dma-cells = <1>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9161-fmc-ebz_m2_s2.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9161-fmc-ebz_m2_s2.dts
@@ -72,11 +72,11 @@
 		ranges = <0 0 0 0xffffffff>;
 
 		tx_dma: tx-dmac@9c420000 {
+			compatible = "adi,axi-dmac-1.00.a";
+			reg = <0x9c420000 0x10000>;
 			#dma-cells = <1>;
 			dma-coherent;
-			compatible = "adi,axi-dmac-1.00.a";
 			adi,cyclic;
-			reg = <0x9c420000 0x10000>;
 			interrupts = <0 108 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&zynqmp_clk 71>;
 		};

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9161-fmc-ebz_m2_s2.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9161-fmc-ebz_m2_s2.dts
@@ -71,7 +71,7 @@
 		#size-cells = <0x1>;
 		ranges = <0 0 0 0xffffffff>;
 
-		tx_dma: tx-dmac@9c420000 {
+		tx_dma: dma-controller@9c420000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c420000 0x10000>;
 			#dma-cells = <1>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9162-fmc-ebz_m2_s2.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9162-fmc-ebz_m2_s2.dts
@@ -72,7 +72,7 @@
 		#size-cells = <0x1>;
 		ranges = <0 0 0 0xffffffff>;
 
-		tx_dma: tx-dmac@9c420000 {
+		tx_dma: dma-controller@9c420000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c420000 0x10000>;
 			#dma-cells = <1>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9162-fmc-ebz_m2_s2.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9162-fmc-ebz_m2_s2.dts
@@ -73,11 +73,11 @@
 		ranges = <0 0 0 0xffffffff>;
 
 		tx_dma: tx-dmac@9c420000 {
+			compatible = "adi,axi-dmac-1.00.a";
+			reg = <0x9c420000 0x10000>;
 			#dma-cells = <1>;
 			dma-coherent;
-			compatible = "adi,axi-dmac-1.00.a";
 			adi,cyclic;
-			reg = <0x9c420000 0x10000>;
 			interrupts = <0 108 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&zynqmp_clk 71>;
 		};

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9163-fmc-ebz_m2_l8.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9163-fmc-ebz_m2_l8.dts
@@ -72,11 +72,11 @@
 		ranges = <0 0 0 0xffffffff>;
 
 		tx_dma: tx-dmac@9c420000 {
+			compatible = "adi,axi-dmac-1.00.a";
+			reg = <0x9c420000 0x10000>;
 			#dma-cells = <1>;
 			dma-coherent;
-			compatible = "adi,axi-dmac-1.00.a";
 			adi,cyclic;
-			reg = <0x9c420000 0x10000>;
 			interrupts = <0 108 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&zynqmp_clk 71>;
 		};

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9163-fmc-ebz_m2_l8.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9163-fmc-ebz_m2_l8.dts
@@ -71,7 +71,7 @@
 		#size-cells = <0x1>;
 		ranges = <0 0 0 0xffffffff>;
 
-		tx_dma: tx-dmac@9c420000 {
+		tx_dma: dma-controller@9c420000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c420000 0x10000>;
 			#dma-cells = <1>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9164-fmc-ebz_m2_s2.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9164-fmc-ebz_m2_s2.dts
@@ -72,7 +72,7 @@
 		#size-cells = <0x1>;
 		ranges = <0 0 0 0xffffffff>;
 
-		tx_dma: tx-dmac@9c420000 {
+		tx_dma: dma-controller@9c420000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c420000 0x10000>;
 			#dma-cells = <1>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9164-fmc-ebz_m2_s2.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9164-fmc-ebz_m2_s2.dts
@@ -73,11 +73,11 @@
 		ranges = <0 0 0 0xffffffff>;
 
 		tx_dma: tx-dmac@9c420000 {
+			compatible = "adi,axi-dmac-1.00.a";
+			reg = <0x9c420000 0x10000>;
 			#dma-cells = <1>;
 			dma-coherent;
-			compatible = "adi,axi-dmac-1.00.a";
 			adi,cyclic;
-			reg = <0x9c420000 0x10000>;
 			interrupts = <0 108 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&zynqmp_clk 71>;
 		};

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9172-fmc-ebz.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9172-fmc-ebz.dts
@@ -44,10 +44,10 @@
 		ranges = <0 0 0 0xffffffff>;
 
 		tx_dma: tx-dmac@9c420000 {
-			#dma-cells = <1>;
-			dma-coherent;
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c420000 0x10000>;
+			#dma-cells = <1>;
+			dma-coherent;
 			interrupts = <0 108 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&zynqmp_clk 71>;
 		};

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9172-fmc-ebz.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9172-fmc-ebz.dts
@@ -43,7 +43,7 @@
 		#size-cells = <0x1>;
 		ranges = <0 0 0 0xffffffff>;
 
-		tx_dma: tx-dmac@9c420000 {
+		tx_dma: dma-controller@9c420000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c420000 0x10000>;
 			#dma-cells = <1>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9208.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9208.dts
@@ -46,7 +46,7 @@
 			clock-output-names = "ad9208_clk";
 		};
 
-		rx_dma: rx-dmac@9c420000 {
+		rx_dma: dma-controller@9c420000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c420000 0x10000>;
 			#dma-cells = <1>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9208.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9208.dts
@@ -47,9 +47,9 @@
 		};
 
 		rx_dma: rx-dmac@9c420000 {
-			#dma-cells = <1>;
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c420000 0x10000>;
+			#dma-cells = <1>;
 			interrupts = <0 109 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&zynqmp_clk 71>;
 		};

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9361-fmcomms2-3.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9361-fmcomms2-3.dts
@@ -42,7 +42,7 @@
 		#size-cells = <0x1>;
 		ranges = <0 0 0 0xffffffff>;
 
-		rx_dma: dma@9c400000 {
+		rx_dma: dma-controller@9c400000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c400000 0x10000>;
 			#dma-cells = <1>;
@@ -52,7 +52,7 @@
 			clocks = <&zynqmp_clk 71>;
 		};
 
-		tx_dma: dma@9c420000  {
+		tx_dma: dma-controller@9c420000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c420000 0x10000>;
 			#dma-cells = <1>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9361-fmcomms5.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9361-fmcomms5.dts
@@ -30,7 +30,7 @@
 		#size-cells = <0x1>;
 		ranges = <0 0 0 0xffffffff>;
 
-		rx_dma: dma@9c400000 {
+		rx_dma: dma-controller@9c400000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c400000 0x10000>;
 			#dma-cells = <1>;
@@ -40,7 +40,7 @@
 			clocks = <&zynqmp_clk 73>;
 		};
 
-		tx_dma: dma@9c420000  {
+		tx_dma: dma-controller@9c420000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c420000 0x10000>;
 			#dma-cells = <1>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9364-fmcomms4.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9364-fmcomms4.dts
@@ -41,7 +41,7 @@
 		#size-cells = <0x1>;
 		ranges = <0 0 0 0xffffffff>;
 
-		rx_dma: dma@9c400000 {
+		rx_dma: dma-controller@9c400000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c400000 0x10000>;
 			#dma-cells = <1>;
@@ -51,7 +51,7 @@
 			clocks = <&zynqmp_clk 71>;
 		};
 
-		tx_dma: dma@9c420000  {
+		tx_dma: dma-controller@9c420000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c420000 0x10000>;
 			#dma-cells = <1>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9694.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9694.dts
@@ -61,7 +61,7 @@
 		#size-cells = <0x1>;
 		ranges = <0 0 0 0xffffffff>;
 
-		rx_dma: rx-dmac@9c400000 {
+		rx_dma: dma-controller@9c400000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c400000 0x1000>;
 			#dma-cells = <1>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9694.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9694.dts
@@ -62,10 +62,10 @@
 		ranges = <0 0 0 0xffffffff>;
 
 		rx_dma: rx-dmac@9c400000 {
-			#dma-cells = <1>;
-			dma-coherent;
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c400000 0x1000>;
+			#dma-cells = <1>;
+			dma-coherent;
 			interrupts = <0 109 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&zynqmp_clk 71>;
 		};

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9695.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9695.dts
@@ -61,7 +61,7 @@
 		#size-cells = <0x1>;
 		ranges = <0 0 0 0xffffffff>;
 
-		rx_dma: rx-dmac@9c400000 {
+		rx_dma: dma-controller@9c400000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c400000 0x1000>;
 			#dma-cells = <1>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9695.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9695.dts
@@ -62,10 +62,10 @@
 		ranges = <0 0 0 0xffffffff>;
 
 		rx_dma: rx-dmac@9c400000 {
-			#dma-cells = <1>;
-			dma-coherent;
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c400000 0x1000>;
+			#dma-cells = <1>;
+			dma-coherent;
 			interrupts = <0 109 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&zynqmp_clk 71>;
 		};

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9783.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9783.dts
@@ -44,7 +44,7 @@
 		#size-cells = <0x1>;
 		ranges = <0 0 0 0xffffffff>;
 
-		tx_dma: tx-dmac@9c420000 {
+		tx_dma: dma-controller@9c420000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c420000 0x10000>;
 			#dma-cells = <1>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9002-rx2tx2.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9002-rx2tx2.dts
@@ -35,7 +35,7 @@
 		#size-cells = <0x1>;
 		ranges = <0 0 0 0xffffffff>;
 
-		rx_dma: dma@84A30000 {
+		rx_dma: dma-controller@84A30000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x84A30000 0x10000>;
 			#dma-cells = <1>;
@@ -44,7 +44,7 @@
 			clocks = <&zynqmp_clk 71>;
 		};
 
-		tx_dma: dma@84A50000 {
+		tx_dma: dma-controller@84A50000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x84A50000 0x10000>;
 			#dma-cells = <1>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9002-rx2tx2.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9002-rx2tx2.dts
@@ -28,7 +28,7 @@
 };
 
 / {
-	fpga_axi  {
+	fpga_axi {
 		interrupt-parent = <&gic>;
 		compatible = "simple-bus";
 		#address-cells = <0x1>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9002.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9002.dts
@@ -27,7 +27,7 @@
 };
 
 / {
-	fpga_axi  {
+	fpga_axi {
 		interrupt-parent = <&gic>;
 		compatible = "simple-bus";
 		#address-cells = <0x1>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9002.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9002.dts
@@ -34,7 +34,7 @@
 		#size-cells = <0x1>;
 		ranges = <0 0 0 0xffffffff>;
 
-		rx1_dma: dma@84A30000 {
+		rx1_dma: dma-controller@84A30000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x84A30000 0x10000>;
 			#dma-cells = <1>;
@@ -43,7 +43,7 @@
 			clocks = <&zynqmp_clk 71>;
 		};
 
-		rx2_dma: dma@84A40000 {
+		rx2_dma: dma-controller@84A40000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x84A40000 0x10000>;
 			#dma-cells = <1>;
@@ -52,7 +52,7 @@
 			clocks = <&zynqmp_clk 71>;
 		};
 
-		tx1_dma: dma@84A50000 {
+		tx1_dma: dma-controller@84A50000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x84A50000 0x10000>;
 			#dma-cells = <1>;
@@ -61,7 +61,7 @@
 			clocks = <&zynqmp_clk 71>;
 		};
 
-		tx2_dma: dma@84A6000 {
+		tx2_dma: dma-controller@84A6000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x84A60000 0x10000>;
 			#dma-cells = <1>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9008-1.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9008-1.dts
@@ -42,7 +42,7 @@
 		#size-cells = <0x1>;
 		ranges = <0 0 0 0xffffffff>;
 
-		rx_dma: dma@9c400000 {
+		rx_dma: dma-controller@9c400000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c400000 0x10000>;
 			#dma-cells = <1>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9008-1.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9008-1.dts
@@ -78,7 +78,7 @@
 			adi,frames-per-multiframe = <32>;
 		};
 
-		axi_rx_clkgen: axi-clkgen@83c10000  {
+		axi_rx_clkgen: clock-controller@83c10000 {
 			compatible = "adi,axi-clkgen-2.00.a";
 			reg = <0x83c10000 0x10000>;
 			#clock-cells = <0>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9008-2.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9008-2.dts
@@ -42,7 +42,7 @@
 		#size-cells = <0x1>;
 		ranges = <0 0 0 0xffffffff>;
 
-		rx_obs_dma: dma@9c440000 {
+		rx_obs_dma: dma-controller@9c440000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c440000 0x10000>;
 			#dma-cells = <1>;
@@ -52,7 +52,7 @@
 			clocks = <&zynqmp_clk 73>;
 		};
 
-		tx_dma: dma@9c420000  {
+		tx_dma: dma-controller@9c420000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c420000 0x10000>;
 			#dma-cells = <1>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9008-2.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9008-2.dts
@@ -121,7 +121,7 @@
 			adi,frames-per-multiframe = <32>;
 		};
 
-		axi_tx_clkgen: axi-clkgen@83c00000  {
+		axi_tx_clkgen: clock-controller@83c00000 {
 			compatible = "adi,axi-clkgen-2.00.a";
 			reg = <0x83c00000 0x10000>;
 			#clock-cells = <0>;
@@ -130,7 +130,7 @@
 			clock-output-names = "axi_tx_clkgen";
 		};
 
-		axi_rx_os_clkgen: axi-clkgen@83c20000  {
+		axi_rx_os_clkgen: clock-controller@83c20000 {
 			compatible = "adi,axi-clkgen-2.00.a";
 			reg = <0x83c20000 0x10000>;
 			#clock-cells = <0>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9009-fmcomms8.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9009-fmcomms8.dts
@@ -201,7 +201,7 @@
 			adi,control-bits-per-sample = <2>;
 		};
 
-		rx_dma: dma@9d420000 {
+		rx_dma: dma-controller@9d420000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9d420000 0x10000>;
 			#dma-cells = <1>;
@@ -211,7 +211,7 @@
 			clocks = <&zynqmp_clk 73>;
 		};
 
-		rx_obs_dma: dma@9d440000 {
+		rx_obs_dma: dma-controller@9d440000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9d440000 0x10000>;
 			#dma-cells = <1>;
@@ -221,7 +221,7 @@
 			clocks = <&zynqmp_clk 73>;
 		};
 
-		tx_dma: dma@9d400000  {
+		tx_dma: dma-controller@9d400000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9d400000 0x10000>;
 			#dma-cells = <1>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9009.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9009.dts
@@ -60,7 +60,7 @@
 		#size-cells = <0x1>;
 		ranges = <0 0 0 0xffffffff>;
 
-		rx_dma: dma@9c400000 {
+		rx_dma: dma-controller@9c400000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c400000 0x10000>;
 			#dma-cells = <1>;
@@ -70,7 +70,7 @@
 			clocks = <&zynqmp_clk 73>;
 		};
 
-		rx_obs_dma: dma@9c440000 {
+		rx_obs_dma: dma-controller@9c440000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c440000 0x10000>;
 			#dma-cells = <1>;
@@ -80,7 +80,7 @@
 			clocks = <&zynqmp_clk 73>;
 		};
 
-		tx_dma: dma@9c420000  {
+		tx_dma: dma-controller@9c420000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c420000 0x10000>;
 			#dma-cells = <1>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9009.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9009.dts
@@ -175,7 +175,7 @@
 			adi,frames-per-multiframe = <32>;
 		};
 
-		axi_tx_clkgen: axi-clkgen@83c00000  {
+		axi_tx_clkgen: clock-controller@83c00000 {
 			compatible = "adi,axi-clkgen-2.00.a";
 			reg = <0x83c00000 0x10000>;
 			#clock-cells = <0>;
@@ -184,7 +184,7 @@
 			clock-output-names = "axi_tx_clkgen";
 		};
 
-		axi_rx_clkgen: axi-clkgen@83c10000  {
+		axi_rx_clkgen: clock-controller@83c10000 {
 			compatible = "adi,axi-clkgen-2.00.a";
 			reg = <0x83c10000 0x10000>;
 			#clock-cells = <0>;
@@ -193,7 +193,7 @@
 			clock-output-names = "axi_rx_clkgen";
 		};
 
-		axi_rx_os_clkgen: axi-clkgen@83c20000  {
+		axi_rx_os_clkgen: clock-controller@83c20000 {
 			compatible = "adi,axi-clkgen-2.00.a";
 			reg = <0x83c20000 0x10000>;
 			#clock-cells = <0>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9025.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9025.dts
@@ -252,7 +252,7 @@
 		#size-cells = <0x1>;
 		ranges = <0 0 0 0xffffffff>;
 
-		rx_dma: dma@9c400000 {
+		rx_dma: dma-controller@9c400000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c400000 0x10000>;
 			#dma-cells = <1>;
@@ -262,7 +262,7 @@
 			clocks = <&zynqmp_clk 73>;
 		};
 
-		tx_dma: dma@9c420000  {
+		tx_dma: dma-controller@9c420000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c420000 0x10000>;
 			#dma-cells = <1>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9371.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9371.dts
@@ -41,7 +41,7 @@
 		#size-cells = <0x1>;
 		ranges = <0 0 0 0xffffffff>;
 
-		rx_dma: dma@9c400000 {
+		rx_dma: dma-controller@9c400000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c400000 0x10000>;
 			#dma-cells = <1>;
@@ -51,7 +51,7 @@
 			clocks = <&zynqmp_clk 73>;
 		};
 
-		rx_obs_dma: dma@9c440000 {
+		rx_obs_dma: dma-controller@9c440000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c440000 0x10000>;
 			#dma-cells = <1>;
@@ -61,7 +61,7 @@
 			clocks = <&zynqmp_clk 73>;
 		};
 
-		tx_dma: dma@9c420000  {
+		tx_dma: dma-controller@9c420000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c420000 0x10000>;
 			#dma-cells = <1>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9371.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9371.dts
@@ -155,7 +155,7 @@
 			adi,frames-per-multiframe = <32>;
 		};
 
-		axi_tx_clkgen: axi-clkgen@83c00000  {
+		axi_tx_clkgen: clock-controller@83c00000 {
 			compatible = "adi,axi-clkgen-2.00.a";
 			reg = <0x83c00000 0x10000>;
 			#clock-cells = <0>;
@@ -164,7 +164,7 @@
 			clock-output-names = "axi_tx_clkgen";
 		};
 
-		axi_rx_clkgen: axi-clkgen@83c10000  {
+		axi_rx_clkgen: clock-controller@83c10000 {
 			compatible = "adi,axi-clkgen-2.00.a";
 			reg = <0x83c10000 0x10000>;
 			#clock-cells = <0>;
@@ -173,7 +173,7 @@
 			clock-output-names = "axi_rx_clkgen";
 		};
 
-		axi_rx_os_clkgen: axi-clkgen@83c20000  {
+		axi_rx_os_clkgen: clock-controller@83c20000 {
 			compatible = "adi,axi-clkgen-2.00.a";
 			reg = <0x83c20000 0x10000>;
 			#clock-cells = <0>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-fmcdaq2.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-fmcdaq2.dts
@@ -42,7 +42,7 @@
 		#size-cells = <0x1>;
 		ranges = <0 0 0 0xffffffff>;
 
-		rx_dma: dma@9c400000 {
+		rx_dma: dma-controller@9c400000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c400000 0x10000>;
 			#dma-cells = <1>;
@@ -52,7 +52,7 @@
 			clocks = <&zynqmp_clk 71>;
 		};
 
-		tx_dma: dma@9c420000  {
+		tx_dma: dma-controller@9c420000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c420000 0x10000>;
 			#dma-cells = <1>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-fmcdaq3.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-fmcdaq3.dts
@@ -43,19 +43,19 @@
 		ranges = <0 0 0 0xffffffff>;
 
 		rx_dma: rx-dmac@9c400000 {
-			#dma-cells = <1>;
-			dma-coherent;
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c400000 0x10000>;
+			#dma-cells = <1>;
+			dma-coherent;
 			interrupts = <0 109 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&zynqmp_clk 71>;
 		};
 
 		tx_dma: tx-dmac@9c420000 {
-			#dma-cells = <1>;
-			dma-coherent;
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c420000 0x10000>;
+			#dma-cells = <1>;
+			dma-coherent;
 			interrupts = <0 108 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&zynqmp_clk 71>;
 		};

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-fmcdaq3.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-fmcdaq3.dts
@@ -42,7 +42,7 @@
 		#size-cells = <0x1>;
 		ranges = <0 0 0 0xffffffff>;
 
-		rx_dma: rx-dmac@9c400000 {
+		rx_dma: dma-controller@9c400000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c400000 0x10000>;
 			#dma-cells = <1>;
@@ -51,7 +51,7 @@
 			clocks = <&zynqmp_clk 71>;
 		};
 
-		tx_dma: tx-dmac@9c420000 {
+		tx_dma: dma-controller@9c420000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c420000 0x10000>;
 			#dma-cells = <1>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-fmclidar1.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-fmclidar1.dts
@@ -131,7 +131,7 @@
 			clocks = <&axi_ad9094_adxcvr 1>;
 		};
 
-		rx_dma: rx-dmac@9c400000 {
+		rx_dma: dma-controller@9c400000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c400000 0x10000>;
 			#dma-cells = <1>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-revB-ad9361-fmcomms2-3.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-revB-ad9361-fmcomms2-3.dts
@@ -37,7 +37,7 @@
 		#size-cells = <0x1>;
 		ranges = <0 0 0 0xffffffff>;
 
-		rx_dma: dma@9c400000 {
+		rx_dma: dma-controller@9c400000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c400000 0x10000>;
 			#dma-cells = <1>;
@@ -46,7 +46,7 @@
 
 		};
 
-		tx_dma: dma@9c420000  {
+		tx_dma: dma-controller@9c420000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c420000 0x10000>;
 			#dma-cells = <1>;

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-revB-ad9364-fmcomms4.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-revB-ad9364-fmcomms4.dts
@@ -37,7 +37,7 @@
 		#size-cells = <0x1>;
 		ranges = <0 0 0 0xffffffff>;
 
-		rx_dma: dma@80010000 {
+		rx_dma: dma-controller@80010000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x80010000 0x10000>;
 			#dma-cells = <1>;
@@ -45,7 +45,7 @@
 			clocks = <&zynqmp_clk 71>;
 		};
 
-		tx_dma: dma@80020000  {
+		tx_dma: dma-controller@80020000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x80020000 0x10000>;
 			#dma-cells = <1>;

--- a/arch/microblaze/boot/dts/kc705_ad9467_fmc.dts
+++ b/arch/microblaze/boot/dts/kc705_ad9467_fmc.dts
@@ -35,7 +35,7 @@
 		spibus-connected = <&adc_ad9467>;
 	};
 
-	rx_dma: dma@44a30000 {
+	rx_dma: dma-controller@44a30000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x44a30000 0x10000>;
 		#dma-cells = <1>;

--- a/arch/microblaze/boot/dts/kc705_ad9467_fmc.dts
+++ b/arch/microblaze/boot/dts/kc705_ad9467_fmc.dts
@@ -36,9 +36,9 @@
 	};
 
 	rx_dma: dma@44a30000 {
-		#dma-cells = <1>;
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x44a30000 0x10000>;
+		#dma-cells = <1>;
 		interrupt-parent = <&axi_intc>;
 		interrupts = <12 2>;
 		clocks = <&clk_bus_0>;

--- a/arch/microblaze/boot/dts/kc705_fmcdaq2.dts
+++ b/arch/microblaze/boot/dts/kc705_fmcdaq2.dts
@@ -27,17 +27,17 @@
 
 &amba_pl {
 	rx_dma: rx-dmac@7c400000 {
-		#dma-cells = <1>;
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x1000>;
+		#dma-cells = <1>;
 		interrupt-parent = <&axi_intc>;
 		interrupts = <12 2>;
 		clocks = <&clk_bus_0>;
 	};
 	tx_dma: tx-dmac@7c420000 {
-		#dma-cells = <1>;
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x1000>;
+		#dma-cells = <1>;
 		interrupt-parent = <&axi_intc>;
 		interrupts = <13 2>;
 		clocks = <&clk_bus_0>;

--- a/arch/microblaze/boot/dts/kc705_fmcdaq2.dts
+++ b/arch/microblaze/boot/dts/kc705_fmcdaq2.dts
@@ -26,7 +26,7 @@
 };
 
 &amba_pl {
-	rx_dma: rx-dmac@7c400000 {
+	rx_dma: dma-controller@7c400000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x1000>;
 		#dma-cells = <1>;
@@ -34,7 +34,7 @@
 		interrupts = <12 2>;
 		clocks = <&clk_bus_0>;
 	};
-	tx_dma: tx-dmac@7c420000 {
+	tx_dma: dma-controller@7c420000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/microblaze/boot/dts/kc705_fmcjesdadc1.dts
+++ b/arch/microblaze/boot/dts/kc705_fmcjesdadc1.dts
@@ -34,7 +34,7 @@
 		dma-names = "rx";
 		spibus-connected = <&adc0_ad9250>;
 	};
-	rx_dma0: rx-dmac@7c420000 {
+	rx_dma0: dma-controller@7c420000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		interrupt-parent = <&axi_intc>;
 		interrupts = <13 2>;
@@ -49,7 +49,7 @@
 		dma-names = "rx";
 		spibus-connected = <&adc1_ad9250>;
 	};
-	rx_dma1: rx-dmac@7c430000 {
+	rx_dma1: dma-controller@7c430000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		interrupt-parent = <&axi_intc>;
 		interrupts = <12 2>;

--- a/arch/microblaze/boot/dts/kc705_fmcomms1.dts
+++ b/arch/microblaze/boot/dts/kc705_fmcomms1.dts
@@ -21,7 +21,7 @@
 		dmas = <&axi_ad9122_dma 0>;
 		dma-names = "tx";
 	};
-	axi_ad9122_dma: axi_dmac@7c420000 {
+	axi_ad9122_dma: dma-controller@7c420000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		interrupt-parent = <&axi_intc>;
 		interrupts = <12 2>;
@@ -36,7 +36,7 @@
 		dma-names = "rx";
 		spibus-connected = <&adc0_ad9467>;
 	};
-	axi_ad9643_dma: axi_dmac@7c400000 {
+	axi_ad9643_dma: dma-controller@7c400000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		interrupt-parent = <&axi_intc>;
 		interrupts = <13 2>;

--- a/arch/microblaze/boot/dts/kc705_fmcomms2-3.dts
+++ b/arch/microblaze/boot/dts/kc705_fmcomms2-3.dts
@@ -25,7 +25,7 @@
 };
 
 &amba_pl {
-	rx_dma: dma@7c400000 {
+	rx_dma: dma-controller@7c400000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x10000>;
 		#dma-cells = <1>;
@@ -33,7 +33,7 @@
 		interrupts = <12 2>;
 		clocks = <&clk_bus_0>;
 	};
-	tx_dma: dma@7c420000 {
+	tx_dma: dma-controller@7c420000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x10000>;
 		#dma-cells = <1>;

--- a/arch/microblaze/boot/dts/kc705_fmcomms2-3.dts
+++ b/arch/microblaze/boot/dts/kc705_fmcomms2-3.dts
@@ -26,17 +26,17 @@
 
 &amba_pl {
 	rx_dma: dma@7c400000 {
-		#dma-cells = <1>;
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x10000>;
+		#dma-cells = <1>;
 		interrupt-parent = <&axi_intc>;
 		interrupts = <12 2>;
 		clocks = <&clk_bus_0>;
 	};
 	tx_dma: dma@7c420000 {
-		#dma-cells = <1>;
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x10000>;
+		#dma-cells = <1>;
 		interrupt-parent = <&axi_intc>;
 		interrupts = <13 2>;
 		clocks = <&clk_bus_0>;

--- a/arch/microblaze/boot/dts/kc705_fmcomms4.dts
+++ b/arch/microblaze/boot/dts/kc705_fmcomms4.dts
@@ -27,17 +27,17 @@
 
 &amba_pl {
 	rx_dma: dma@7c400000 {
-		#dma-cells = <1>;
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x10000>;
+		#dma-cells = <1>;
 		interrupt-parent = <&axi_intc>;
 		interrupts = <12 2>;
 		clocks = <&clk_bus_0>;
 	};
 	tx_dma: dma@7c420000 {
-		#dma-cells = <1>;
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x10000>;
+		#dma-cells = <1>;
 		interrupt-parent = <&axi_intc>;
 		interrupts = <13 2>;
 		clocks = <&clk_bus_0>;

--- a/arch/microblaze/boot/dts/kc705_fmcomms4.dts
+++ b/arch/microblaze/boot/dts/kc705_fmcomms4.dts
@@ -26,7 +26,7 @@
 
 
 &amba_pl {
-	rx_dma: dma@7c400000 {
+	rx_dma: dma-controller@7c400000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x10000>;
 		#dma-cells = <1>;
@@ -34,7 +34,7 @@
 		interrupts = <12 2>;
 		clocks = <&clk_bus_0>;
 	};
-	tx_dma: dma@7c420000 {
+	tx_dma: dma-controller@7c420000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x10000>;
 		#dma-cells = <1>;

--- a/arch/microblaze/boot/dts/kcu105_adrv9009.dts
+++ b/arch/microblaze/boot/dts/kcu105_adrv9009.dts
@@ -66,7 +66,7 @@
 		jesd204-inputs = <&axi_adrv9009_tx_jesd 0 DEFRAMER_LINK_TX>;
 	};
 
-	rx_dma: rx-dmac@7c400000 {
+	rx_dma: dma-controller@7c400000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		interrupt-parent = <&axi_intc>;
 		interrupts = <12 2>;
@@ -75,7 +75,7 @@
 		clocks = <&clk_bus_0>;
 	};
 
-	rx_obs_dma: rx-obs-dmac@7c440000  {
+	rx_obs_dma: dma-controller@7c440000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		interrupt-parent = <&axi_intc>;
 		interrupts = <14 2>;
@@ -84,7 +84,7 @@
 		clocks = <&clk_bus_0>;
 	};
 
-	tx_dma: tx-dmac@7c420000 {
+	tx_dma: dma-controller@7c420000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		interrupt-parent = <&axi_intc>;
 		interrupts = <13 2>;

--- a/arch/microblaze/boot/dts/kcu105_adrv9009.dts
+++ b/arch/microblaze/boot/dts/kcu105_adrv9009.dts
@@ -93,7 +93,7 @@
 		clocks = <&clk_bus_0>;
 	};
 
-	axi_rx_clkgen: axi-clkgen@43c10000  {
+	axi_rx_clkgen: clock-controller@43c10000 {
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x43c10000 0x10000>;
 		#clock-cells = <0>;
@@ -102,7 +102,7 @@
 		clock-output-names = "axi_rx_clkgen";
 	};
 
-	axi_rx_os_clkgen: axi-clkgen@43c20000  {
+	axi_rx_os_clkgen: clock-controller@43c20000 {
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x43c20000 0x10000>;
 		#clock-cells = <0>;
@@ -111,7 +111,7 @@
 		clock-output-names = "axi_rx_os_clkgen";
 	};
 
-	axi_tx_clkgen: axi-clkgen@43c00000  {
+	axi_tx_clkgen: clock-controller@43c00000 {
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x43c00000 0x10000>;
 		#clock-cells = <0>;

--- a/arch/microblaze/boot/dts/kcu105_adrv9371x.dts
+++ b/arch/microblaze/boot/dts/kcu105_adrv9371x.dts
@@ -79,7 +79,7 @@
 		#dma-cells = <1>;
 		clocks = <&clk_bus_0>;
 	};
-	axi_rx_clkgen: axi-clkgen@43c10000  {
+	axi_rx_clkgen: clock-controller@43c10000 {
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x43c10000 0x10000>;
 		#clock-cells = <0>;
@@ -87,7 +87,7 @@
 		clock-names = "clkin1", "s_axi_aclk";
 		clock-output-names = "axi_rx_clkgen";
 	};
-	axi_rx_os_clkgen: axi-clkgen@43c20000  {
+	axi_rx_os_clkgen: clock-controller@43c20000 {
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x43c20000 0x10000>;
 		#clock-cells = <0>;
@@ -95,7 +95,7 @@
 		clock-names = "clkin1", "s_axi_aclk";
 		clock-output-names = "axi_rx_os_clkgen";
 	};
-	axi_tx_clkgen: axi-clkgen@43c00000  {
+	axi_tx_clkgen: clock-controller@43c00000 {
 		compatible = "adi,axi-clkgen-2.00.a";
 		reg = <0x43c00000 0x10000>;
 		#clock-cells = <0>;

--- a/arch/microblaze/boot/dts/kcu105_adrv9371x.dts
+++ b/arch/microblaze/boot/dts/kcu105_adrv9371x.dts
@@ -55,7 +55,7 @@
 		adi,axi-interpolation-core-available;
 		interpolation-gpios = <&axi_gpio 62 GPIO_ACTIVE_HIGH>;
 	};
-	rx_dma: rx-dmac@7c400000 {
+	rx_dma: dma-controller@7c400000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		interrupt-parent = <&axi_intc>;
 		interrupts = <12 2>;
@@ -63,7 +63,7 @@
 		#dma-cells = <1>;
 		clocks = <&clk_bus_0>;
 	};
-	rx_obs_dma: rx-obs-dmac@7c440000  {
+	rx_obs_dma: dma-controller@7c440000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		interrupt-parent = <&axi_intc>;
 		interrupts = <14 2>;
@@ -71,7 +71,7 @@
 		#dma-cells = <1>;
 		clocks = <&clk_bus_0>;
 	};
-	tx_dma: tx-dmac@7c420000 {
+	tx_dma: dma-controller@7c420000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		interrupt-parent = <&axi_intc>;
 		interrupts = <13 2>;

--- a/arch/microblaze/boot/dts/kcu105_fmcdaq2.dts
+++ b/arch/microblaze/boot/dts/kcu105_fmcdaq2.dts
@@ -27,17 +27,17 @@
 
 &amba_pl {
 	rx_dma: rx-dmac@7c400000 {
-		#dma-cells = <1>;
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x1000>;
+		#dma-cells = <1>;
 		interrupt-parent = <&axi_intc>;
 		interrupts = <12 2>;
 		clocks = <&clk_bus_0>;
 	};
 	tx_dma: tx-dmac@7c420000 {
-		#dma-cells = <1>;
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x1000>;
+		#dma-cells = <1>;
 		interrupt-parent = <&axi_intc>;
 		interrupts = <13 2>;
 		clocks = <&clk_bus_0>;

--- a/arch/microblaze/boot/dts/kcu105_fmcdaq2.dts
+++ b/arch/microblaze/boot/dts/kcu105_fmcdaq2.dts
@@ -26,7 +26,7 @@
 };
 
 &amba_pl {
-	rx_dma: rx-dmac@7c400000 {
+	rx_dma: dma-controller@7c400000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x1000>;
 		#dma-cells = <1>;
@@ -34,7 +34,7 @@
 		interrupts = <12 2>;
 		clocks = <&clk_bus_0>;
 	};
-	tx_dma: tx-dmac@7c420000 {
+	tx_dma: dma-controller@7c420000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/microblaze/boot/dts/kcu105_fmcdaq3.dts
+++ b/arch/microblaze/boot/dts/kcu105_fmcdaq3.dts
@@ -25,7 +25,7 @@
 };
 
 &amba_pl {
-	rx_dma: rx-dmac@7c400000 {
+	rx_dma: dma-controller@7c400000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x1000>;
 		#dma-cells = <1>;
@@ -33,7 +33,7 @@
 		interrupts = <12 2>;
 		clocks = <&clk_bus_0>;
 	};
-	tx_dma: tx-dmac@7c420000 {
+	tx_dma: dma-controller@7c420000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/microblaze/boot/dts/kcu105_fmcdaq3.dts
+++ b/arch/microblaze/boot/dts/kcu105_fmcdaq3.dts
@@ -26,17 +26,17 @@
 
 &amba_pl {
 	rx_dma: rx-dmac@7c400000 {
-		#dma-cells = <1>;
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x1000>;
+		#dma-cells = <1>;
 		interrupt-parent = <&axi_intc>;
 		interrupts = <12 2>;
 		clocks = <&clk_bus_0>;
 	};
 	tx_dma: tx-dmac@7c420000 {
-		#dma-cells = <1>;
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x1000>;
+		#dma-cells = <1>;
 		interrupt-parent = <&axi_intc>;
 		interrupts = <13 2>;
 		clocks = <&clk_bus_0>;

--- a/arch/microblaze/boot/dts/kcu105_fmcomms2-3.dts
+++ b/arch/microblaze/boot/dts/kcu105_fmcomms2-3.dts
@@ -25,7 +25,7 @@
 };
 
 &amba_pl {
-	rx_dma: dma@7c400000 {
+	rx_dma: dma-controller@7c400000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x10000>;
 		#dma-cells = <1>;
@@ -33,7 +33,7 @@
 		interrupts = <12 2>;
 		clocks = <&clk_bus_0>;
 	};
-	tx_dma: dma@7c420000 {
+	tx_dma: dma-controller@7c420000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x10000>;
 		#dma-cells = <1>;

--- a/arch/microblaze/boot/dts/kcu105_fmcomms2-3.dts
+++ b/arch/microblaze/boot/dts/kcu105_fmcomms2-3.dts
@@ -26,17 +26,17 @@
 
 &amba_pl {
 	rx_dma: dma@7c400000 {
-		#dma-cells = <1>;
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x10000>;
+		#dma-cells = <1>;
 		interrupt-parent = <&axi_intc>;
 		interrupts = <12 2>;
 		clocks = <&clk_bus_0>;
 	};
 	tx_dma: dma@7c420000 {
-		#dma-cells = <1>;
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x10000>;
+		#dma-cells = <1>;
 		interrupt-parent = <&axi_intc>;
 		interrupts = <13 2>;
 		clocks = <&clk_bus_0>;

--- a/arch/microblaze/boot/dts/kcu105_fmcomms4.dts
+++ b/arch/microblaze/boot/dts/kcu105_fmcomms4.dts
@@ -25,7 +25,7 @@
 };
 
 &amba_pl {
-	rx_dma: dma@7c400000 {
+	rx_dma: dma-controller@7c400000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x10000>;
 		#dma-cells = <1>;
@@ -33,7 +33,7 @@
 		interrupts = <12 2>;
 		clocks = <&clk_bus_0>;
 	};
-	tx_dma: dma@7c420000 {
+	tx_dma: dma-controller@7c420000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x10000>;
 		#dma-cells = <1>;

--- a/arch/microblaze/boot/dts/kcu105_fmcomms4.dts
+++ b/arch/microblaze/boot/dts/kcu105_fmcomms4.dts
@@ -26,17 +26,17 @@
 
 &amba_pl {
 	rx_dma: dma@7c400000 {
-		#dma-cells = <1>;
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x10000>;
+		#dma-cells = <1>;
 		interrupt-parent = <&axi_intc>;
 		interrupts = <12 2>;
 		clocks = <&clk_bus_0>;
 	};
 	tx_dma: dma@7c420000 {
-		#dma-cells = <1>;
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x10000>;
+		#dma-cells = <1>;
 		interrupt-parent = <&axi_intc>;
 		interrupts = <13 2>;
 		clocks = <&clk_bus_0>;

--- a/arch/microblaze/boot/dts/vc707_ad6676evb.dts
+++ b/arch/microblaze/boot/dts/vc707_ad6676evb.dts
@@ -45,7 +45,7 @@
 		dma-names = "rx";
 		spibus-connected = <&adc0_ad6676>;
 	};
-	axi_ad6676_dma: axi_dmac@7c420000 {
+	axi_ad6676_dma: dma-controller@7c420000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		interrupt-parent = <&axi_intc>;
 		interrupts = <13 2>;

--- a/arch/microblaze/boot/dts/vc707_fmcadc2.dts
+++ b/arch/microblaze/boot/dts/vc707_fmcadc2.dts
@@ -55,7 +55,7 @@
 		dma-names = "rx";
 		spibus-connected = <&adc0_ad9625>;
 	};
-	axi_ad9625_dma: axi_dmac@7c420000 {
+	axi_ad9625_dma: dma-controller@7c420000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		interrupt-parent = <&axi_intc>;
 		interrupts = <12 2>;

--- a/arch/microblaze/boot/dts/vc707_fmcadc5.dts
+++ b/arch/microblaze/boot/dts/vc707_fmcadc5.dts
@@ -131,7 +131,7 @@
 		adi,out-clk-select = <XCVR_OUTCLK_PMA>;
 		adi,use-lpm-enable;
 	};
-	axi_ad9625_dma: axi_dmac@7c420000 {
+	axi_ad9625_dma: dma-controller@7c420000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		interrupt-parent = <&axi_intc>;
 		interrupts = <12 2>;

--- a/arch/microblaze/boot/dts/vc707_fmcdaq2.dts
+++ b/arch/microblaze/boot/dts/vc707_fmcdaq2.dts
@@ -22,17 +22,17 @@
 
 &amba_pl {
 	rx_dma: rx-dmac@7c400000 {
-		#dma-cells = <1>;
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x1000>;
+		#dma-cells = <1>;
 		interrupt-parent = <&axi_intc>;
 		interrupts = <12 2>;
 		clocks = <&clk_bus_0>;
 	};
 	tx_dma: tx-dmac@7c420000 {
-		#dma-cells = <1>;
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x1000>;
+		#dma-cells = <1>;
 		interrupt-parent = <&axi_intc>;
 		interrupts = <13 2>;
 		clocks = <&clk_bus_0>;

--- a/arch/microblaze/boot/dts/vc707_fmcdaq2.dts
+++ b/arch/microblaze/boot/dts/vc707_fmcdaq2.dts
@@ -21,7 +21,7 @@
 };
 
 &amba_pl {
-	rx_dma: rx-dmac@7c400000 {
+	rx_dma: dma-controller@7c400000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x1000>;
 		#dma-cells = <1>;
@@ -29,7 +29,7 @@
 		interrupts = <12 2>;
 		clocks = <&clk_bus_0>;
 	};
-	tx_dma: tx-dmac@7c420000 {
+	tx_dma: dma-controller@7c420000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/microblaze/boot/dts/vc707_fmcjesdadc1.dts
+++ b/arch/microblaze/boot/dts/vc707_fmcjesdadc1.dts
@@ -34,7 +34,7 @@
 		dma-names = "rx";
 		spibus-connected = <&adc0_ad9250>;
 	};
-	rx_dma0: rx-dmac@7c420000 {
+	rx_dma0: dma-controller@7c420000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		interrupt-parent = <&axi_intc>;
 		interrupts = <13 2>;
@@ -49,7 +49,7 @@
 		dma-names = "rx";
 		spibus-connected = <&adc1_ad9250>;
 	};
-	rx_dma1: rx-dmac@7c430000 {
+	rx_dma1: dma-controller@7c430000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		interrupt-parent = <&axi_intc>;
 		interrupts = <12 2>;

--- a/arch/microblaze/boot/dts/vc707_fmcomms1.dts
+++ b/arch/microblaze/boot/dts/vc707_fmcomms1.dts
@@ -18,7 +18,7 @@
 		dmas = <&axi_ad9122_dma 0>;
 		dma-names = "tx";
 	};
-	axi_ad9122_dma: axi_dmac@7c420000 {
+	axi_ad9122_dma: dma-controller@7c420000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		interrupt-parent = <&axi_intc>;
 		interrupts = <12 2>;
@@ -33,7 +33,7 @@
 		dma-names = "rx";
 		spibus-connected = <&adc0_ad9467>;
 	};
-	axi_ad9643_dma: axi_dmac@7c400000 {
+	axi_ad9643_dma: dma-controller@7c400000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		interrupt-parent = <&axi_intc>;
 		interrupts = <13 2>;

--- a/arch/microblaze/boot/dts/vc707_fmcomms2-3.dts
+++ b/arch/microblaze/boot/dts/vc707_fmcomms2-3.dts
@@ -25,7 +25,7 @@
 };
 
 &amba_pl {
-	rx_dma: dma@7c400000 {
+	rx_dma: dma-controller@7c400000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x10000>;
 		#dma-cells = <1>;
@@ -33,7 +33,7 @@
 		interrupts = <12 2>;
 		clocks = <&clk_bus_0>;
 	};
-	tx_dma: dma@7c420000 {
+	tx_dma: dma-controller@7c420000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x10000>;
 		#dma-cells = <1>;

--- a/arch/microblaze/boot/dts/vc707_fmcomms2-3.dts
+++ b/arch/microblaze/boot/dts/vc707_fmcomms2-3.dts
@@ -26,17 +26,17 @@
 
 &amba_pl {
 	rx_dma: dma@7c400000 {
-		#dma-cells = <1>;
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x10000>;
+		#dma-cells = <1>;
 		interrupt-parent = <&axi_intc>;
 		interrupts = <12 2>;
 		clocks = <&clk_bus_0>;
 	};
 	tx_dma: dma@7c420000 {
-		#dma-cells = <1>;
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x10000>;
+		#dma-cells = <1>;
 		interrupt-parent = <&axi_intc>;
 		interrupts = <13 2>;
 		clocks = <&clk_bus_0>;

--- a/arch/microblaze/boot/dts/vc707_fmcomms4.dts
+++ b/arch/microblaze/boot/dts/vc707_fmcomms4.dts
@@ -25,7 +25,7 @@
 };
 
 &amba_pl {
-	rx_dma: dma@7c400000 {
+	rx_dma: dma-controller@7c400000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x10000>;
 		#dma-cells = <1>;
@@ -33,7 +33,7 @@
 		interrupts = <12 2>;
 		clocks = <&clk_bus_0>;
 	};
-	tx_dma: dma@7c420000 {
+	tx_dma: dma-controller@7c420000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x10000>;
 		#dma-cells = <1>;

--- a/arch/microblaze/boot/dts/vc707_fmcomms4.dts
+++ b/arch/microblaze/boot/dts/vc707_fmcomms4.dts
@@ -26,17 +26,17 @@
 
 &amba_pl {
 	rx_dma: dma@7c400000 {
-		#dma-cells = <1>;
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x10000>;
+		#dma-cells = <1>;
 		interrupt-parent = <&axi_intc>;
 		interrupts = <12 2>;
 		clocks = <&clk_bus_0>;
 	};
 	tx_dma: dma@7c420000 {
-		#dma-cells = <1>;
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x10000>;
+		#dma-cells = <1>;
 		interrupt-parent = <&axi_intc>;
 		interrupts = <13 2>;
 		clocks = <&clk_bus_0>;

--- a/arch/microblaze/boot/dts/vcu118_ad9081.dts
+++ b/arch/microblaze/boot/dts/vcu118_ad9081.dts
@@ -32,7 +32,7 @@
 };
 
 &amba_pl {
-	rx_dma: dma@7c420000 {
+	rx_dma: dma-controller@7c420000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x10000>;
 		#dma-cells = <1>;
@@ -43,7 +43,7 @@
 		clocks = <&clk_bus_0>;
 	};
 
-	tx_dma: dma@7c430000  {
+	tx_dma: dma-controller@7c430000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c430000 0x10000>;
 		#dma-cells = <1>;

--- a/arch/microblaze/boot/dts/vcu118_ad9082.dts
+++ b/arch/microblaze/boot/dts/vcu118_ad9082.dts
@@ -32,7 +32,7 @@
 };
 
 &amba_pl {
-	rx_dma: dma@7c420000 {
+	rx_dma: dma-controller@7c420000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x10000>;
 		#dma-cells = <1>;
@@ -43,7 +43,7 @@
 		clocks = <&clk_bus_0>;
 	};
 
-	tx_dma: dma@7c430000  {
+	tx_dma: dma-controller@7c430000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c430000 0x10000>;
 		#dma-cells = <1>;

--- a/arch/microblaze/boot/dts/vcu118_adrv9025.dts
+++ b/arch/microblaze/boot/dts/vcu118_adrv9025.dts
@@ -34,7 +34,7 @@
 
 &amba_pl {
 
-	rx_dma: dma@7c400000 {
+	rx_dma: dma-controller@7c400000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x10000>;
 		#dma-cells = <1>;
@@ -44,7 +44,7 @@
 		clocks = <&clk_bus_0>;
 	};
 
-	tx_dma: dma@7c420000  {
+	tx_dma: dma-controller@7c420000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x10000>;
 		#dma-cells = <1>;

--- a/arch/microblaze/boot/dts/vcu118_dual_ad9208.dts
+++ b/arch/microblaze/boot/dts/vcu118_dual_ad9208.dts
@@ -25,9 +25,9 @@
 
 &amba_pl {
 	rx_dma: rx-dmac@7c420000 {
-		#dma-cells = <1>;
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x1000>;
+		#dma-cells = <1>;
 		interrupt-parent = <&axi_intc>;
 		interrupts = <12 2>;
 		clocks = <&clk_bus_0>;

--- a/arch/microblaze/boot/dts/vcu118_dual_ad9208.dts
+++ b/arch/microblaze/boot/dts/vcu118_dual_ad9208.dts
@@ -24,7 +24,7 @@
 };
 
 &amba_pl {
-	rx_dma: rx-dmac@7c420000 {
+	rx_dma: dma-controller@7c420000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/microblaze/boot/dts/vcu118_fmcdaq3.dts
+++ b/arch/microblaze/boot/dts/vcu118_fmcdaq3.dts
@@ -27,17 +27,17 @@
 
 &amba_pl {
 	rx_dma: rx-dmac@7c400000 {
-		#dma-cells = <1>;
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x1000>;
+		#dma-cells = <1>;
 		interrupt-parent = <&axi_intc>;
 		interrupts = <12 2>;
 		clocks = <&clk_bus_0>;
 	};
 	tx_dma: tx-dmac@7c420000 {
-		#dma-cells = <1>;
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x1000>;
+		#dma-cells = <1>;
 		interrupt-parent = <&axi_intc>;
 		interrupts = <13 2>;
 		clocks = <&clk_bus_0>;

--- a/arch/microblaze/boot/dts/vcu118_fmcdaq3.dts
+++ b/arch/microblaze/boot/dts/vcu118_fmcdaq3.dts
@@ -26,7 +26,7 @@
 };
 
 &amba_pl {
-	rx_dma: rx-dmac@7c400000 {
+	rx_dma: dma-controller@7c400000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c400000 0x1000>;
 		#dma-cells = <1>;
@@ -34,7 +34,7 @@
 		interrupts = <12 2>;
 		clocks = <&clk_bus_0>;
 	};
-	tx_dma: tx-dmac@7c420000 {
+	tx_dma: dma-controller@7c420000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x1000>;
 		#dma-cells = <1>;

--- a/arch/microblaze/boot/dts/vcu118_quad_ad9081.dtsi
+++ b/arch/microblaze/boot/dts/vcu118_quad_ad9081.dtsi
@@ -64,7 +64,7 @@
 			xlnx,spi-mode = <0>;
 		};
 
-		rx_dma: dma@7c420000 {
+		rx_dma: dma-controller@7c420000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x7c420000 0x10000>;
 			#dma-cells = <1>;
@@ -74,7 +74,7 @@
 			clocks = <&clk_bus_0>;
 		};
 
-		tx_dma: dma@7c430000  {
+		tx_dma: dma-controller@7c430000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x7c430000 0x10000>;
 			#dma-cells = <1>;

--- a/arch/microblaze/boot/dts/vcu128_ad9081.dts
+++ b/arch/microblaze/boot/dts/vcu128_ad9081.dts
@@ -32,7 +32,7 @@
 };
 
 &amba_pl {
-	rx_dma: dma@7c420000 {
+	rx_dma: dma-controller@7c420000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c420000 0x10000>;
 		#dma-cells = <1>;
@@ -42,7 +42,7 @@
 		clocks = <&clk_bus_0>;
 	};
 
-	tx_dma: dma@7c430000  {
+	tx_dma: dma-controller@7c430000 {
 		compatible = "adi,axi-dmac-1.00.a";
 		reg = <0x7c430000 0x10000>;
 		#dma-cells = <1>;

--- a/arch/nios2/boot/dts/a10gx_adrv9009.dts
+++ b/arch/nios2/boot/dts/a10gx_adrv9009.dts
@@ -757,7 +757,7 @@
 			clock-output-names = "jesd204_rx_os_lane_clock";
 		};
 
-		tx_dma: tx-dmac@10032000 {
+		tx_dma: dma-controller@10032000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x10032000 0x00004000>;
 			interrupt-parent = <&sys_cpu>;
@@ -767,7 +767,7 @@
 			clock-names = "dma_clkin";
 		};
 
-		rx_dma: rx-dmac@1004c000 {
+		rx_dma: dma-controller@1004c000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x1004c000 0x00004000>;
 			interrupt-parent = <&sys_cpu>;
@@ -777,7 +777,7 @@
 			clock-names = "dma_clkin";
 		};
 
-		rx_os_dma: rx-obs-dmac@1005c000  {
+		rx_os_dma: dma-controller@1005c000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x1005c000 0x00004000>;
 			interrupt-parent = <&sys_cpu>;

--- a/arch/nios2/boot/dts/a10gx_adrv9371.dts
+++ b/arch/nios2/boot/dts/a10gx_adrv9371.dts
@@ -419,7 +419,7 @@
 			clock-output-names = "jesd204_rx_os_lane_clock";
 		};
 
-		axi_ad9371_tx_dma: axi-ad9371-tx-dma@1002c000 {
+		axi_ad9371_tx_dma: dma-controller@1002c000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x1002c000 0x00004000>;
 			interrupt-parent = <&sys_cpu>;
@@ -429,7 +429,7 @@
 			clock-names = "dma_clkin";
 		};
 
-		axi_ad9371_rx_dma: axi-ad9371-rx-dma@1003c000 {
+		axi_ad9371_rx_dma: dma-controller@1003c000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x1003c000 0x00004000>;
 			interrupt-parent = <&sys_cpu>;
@@ -439,7 +439,7 @@
 			clock-names = "dma_clkin";
 		};
 
-		axi_ad9371_rx_os_dma: axi-ad9371-rx-os-dma@1004c000 {
+		axi_ad9371_rx_os_dma: dma-controller@1004c000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x1004c000 0x00004000>;
 			interrupt-parent = <&sys_cpu>;

--- a/arch/nios2/boot/dts/a10gx_daq2.dts
+++ b/arch/nios2/boot/dts/a10gx_daq2.dts
@@ -301,7 +301,7 @@
 			};
 		};
 
-		rx_dma: rx-dmac@1004c000 {
+		rx_dma: dma-controller@1004c000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x1004c000 0x4000>;
 			#dma-cells = <1>;
@@ -310,7 +310,7 @@
 			clocks = <&dma_clk>;
 		};
 
-		tx_dma: tx-dmac@1002c000 {
+		tx_dma: dma-controller@1002c000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x1002c000 0x4000>;
 			#dma-cells = <1>;


### PR DESCRIPTION
## PR Description
This cleans up the usage of some of the most common HDL IP blocks to use the preferred generic node names in the .dts files.

## PR Type
cleanup

## PR Checklist
- [x] I have conducted a self-review of my own code changes
