### PR TITLE
iio: adc: ad9361: Fix raise condition in debugfs initialize

### DIFF
--- a/drivers/iio/adc/ad9361.c
+++ b/drivers/iio/adc/ad9361.c
@@ -8281,6 +8281,10 @@ static ssize_t ad9361_debugfs_write(struct file *file,
 		clk_set_rate(phy->clks[TX_SAMPL_CLK], 1);
 		clk_set_parent(phy->clks[RX_RFPLL], phy->clk_ext_lo_rx);
 		clk_set_parent(phy->clks[TX_RFPLL], phy->clk_ext_lo_tx);
+
+		if (test_bit(0, &phy->state->flags))
+			wait_for_completion(&phy->complete);
+
 		ad9361_reset(phy);
 		ad9361_clks_resync(phy);
 		ad9361_clks_disable(phy);


### PR DESCRIPTION
## PR Description

Fix for #2775: Division by zero issue in debugfs initialize handler.
Make sure workqueue has completed before moving on.

Fixes: d95373fb89b2 ("drivers/iio/adc/ad9361: Add BIST - Loopback, PRBS and TONE")

## PR Type
- [X] Bug fix (a change that fixes an issue)

## PR Checklist
- [X] I have conducted a self-review of my own code changes
- [X] I have tested the changes on the relevant hardware

