### PR TITLE
arm: dts: zynq: fix ad7380 DMA clock

### DIFF
--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad7380.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad7380.dts
@@ -79,7 +79,7 @@
 		reg = <0x44a30000 0x1000>;
 		#dma-cells = <1>;
 		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
-		clocks = <&clkc 17>;
+		clocks = <&clkc 15>;
 	};
 
 	axi_spi_engine_0: spi@44a00000 {


### PR DESCRIPTION

## PR Description

Fix the DMA clock phandle in the ad7380 devicetree. The DMA controller is connected to the same system clock as all of the other IP blocks.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
