### PR TITLE
.github: Run compile devicetrees after make defconfig and set git configs system wide

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,11 +54,6 @@ jobs:
         echo "CROSS_COMPILE=${{ inputs.CROSS_COMPILE }}" >> $GITHUB_ENV
         echo "ARCH=${{ inputs.ARCH }}" >> $GITHUB_ENV
 
-    - name: Compile devicetrees
-      run: |
-        source ci/build.sh
-        compile_devicetree
-
     - name: Make defconfig
       run: |
         if [[ -f "arch/$ARCH/configs/${{ inputs.DEFCONFIG }}" ]] || \
@@ -74,6 +69,11 @@ jobs:
         auto_set_kconfig
         apply_prerun
         make savedefconfig
+
+    - name: Compile devicetrees
+      run: |
+        source ci/build.sh
+        compile_devicetree
 
     - name: Compile kernel
       run: |

--- a/ci/Containerfile
+++ b/ci/Containerfile
@@ -35,17 +35,17 @@ ADD ${entrypoint_sh} .
 RUN chmod +rx github-api.sh
 RUN chmod +rx entrypoint.sh
 
+RUN git config --add --system user.name "CSE CI" ; \
+    git config --add --system user.email "cse-ci-notifications@analog.com" ; \
+    git config --add --system init.defaultBranch  "__runner_init_branch" ; \
+    git config --add --system advice.mergeConflict false ; \
+    git config --add --system advice.detachedHead false ; \
+    git config --add --system safe.directory '*'
+
 USER runner
 WORKDIR /home/runner
 RUN curl -o .bashrc -L ${bashrc} ; \
     chmod +x .bashrc
-
-RUN git config --global user.name "CSE CI" ; \
-    git config --global user.email "cse-ci-notifications@analog.com" ; \
-    git config --global init.defaultBranch  "__runner_init_branch" ; \
-    git config --global advice.mergeConflict false ; \
-    git config --global advice.detachedHead false ; \
-    git config --global --add safe.directory '*'
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 


### PR DESCRIPTION
## PR Description

Fixup trying to compile the device tree before setting the deconfig.
Related to run https://github.com/analogdevicesinc/linux/actions/runs/15075543379/job/42386997854

Also set git configs system wide for instances where running the container with the runner user is not possible.

## PR Type
- [X] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
