### PR TITLE
Ci problem match compile

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -422,9 +422,7 @@ compile_kernel() {
 
 compile_kernel_sparse() {
 	local err=0
-	local checks=
 	local regex='^[[:alnum:]/._-]+:[[:digit:]]+:[[:digit:]]+: .*$'
-	local mail=
 	local fail=0
 	local warn=0
 
@@ -488,9 +486,7 @@ compile_kernel_sparse() {
 
 compile_kernel_smatch() {
 	local err=0
-	local checks=
 	local regex='^([[:alnum:]/._-]+):([[:digit:]]+) (.*) ([[:alpha:]]+): (.*)$'
-	local mail=
 	local fail=0
 	local warn=0
 
@@ -599,7 +595,6 @@ compile_gcc_fanalyzer () {
 			mail=$($compile_cmd 2>&1 || (
 				echo "::error file=$file,line=0::gcc_fanalayzer: Exited with code '$?'" ; true)
 			)
-			echo $exit_code
 			found=0
 			msg=
 
@@ -688,7 +683,6 @@ compile_clang_analyzer () {
 			mail=$($compile_cmd 2>&1 || (
 				echo "::error file=$file,line=0::clang_analyzer: Exited with code '$?'" ; true)
 			)
-			echo $exit_code
 			found=0
 			msg=
 


### PR DESCRIPTION
## PR Description

At the compile_step step, we only problem match if it exits with an error code
because we don't want duplicated errors/warnings on sparse,
neither warnings unrelated to the patch, but if the kernel
does not even compile, the checkers don't run and the reason
is at this step.

Also clean-up some unused vars.

Sample run succeed to compile: https://github.com/gastmaier/adi-linux/actions/runs/15118116546/job/42493841013
Sample run fail to compile:  https://github.com/gastmaier/adi-linux/actions/runs/15118118572/job/42493848122

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
