### PR TITLE
iio: buffer-dmaengine: fix cyclic transfers

### DIFF
--- a/drivers/iio/buffer/industrialio-buffer-dmaengine.c
+++ b/drivers/iio/buffer/industrialio-buffer-dmaengine.c
@@ -109,6 +109,9 @@ int iio_dmaengine_buffer_submit_block(struct iio_dma_buffer_queue *queue,
 			DMA_PREP_INTERRUPT);
 		if (!desc)
 			return -ENOMEM;
+
+		desc->callback_result = iio_dmaengine_buffer_block_done;
+		desc->callback_param = block;
 	}
 #else
 	max_size = min(block->size, dmaengine_buffer->max_size);
@@ -163,10 +166,10 @@ int iio_dmaengine_buffer_submit_block(struct iio_dma_buffer_queue *queue,
 	}
 	if (!desc)
 		return -ENOMEM;
-#endif
+
 	desc->callback_result = iio_dmaengine_buffer_block_done;
 	desc->callback_param = block;
-
+#endif
 	cookie = dmaengine_submit(desc);
 	if (dma_submit_error(cookie))
 		return dma_submit_error(cookie);


### PR DESCRIPTION
We cannot set the .callback_result() callback for cyclic transfers. If the cyclic transfer is purely done in hardware this would actually bring no issue but in cases cyclic happens in software, we would have the callback called multiple times which would lead to the DMA block to be freed ahead of time (and actually lead to a use after tree).

Fixes: 16dd49b0c5d94 ("iio: buffer-dma: sync upstream and add mmap legacy kconfig")

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
