### PR TITLE
ci: Infeer dts affected by changed dtsi, problem match devitree compile

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -196,7 +196,6 @@ check_coccicheck() {
 					    --include include/linux/compiler-version.h \
 					    --include include/linux/kconfig.h $file || true)
 
-				found=0
 				msg=
 
 				while read -r row
@@ -470,6 +469,10 @@ compile_kernel() {
 		fi
 	done) ; err=${PIPESTATUS[1]}
 
+	if [[ $found == "1" ]]; then
+		echo $msg >> $tmp_log_file
+	fi
+
 	if [[ $err -ne 0 ]]; then
 		while read -r  line; do
 			echo $line
@@ -540,6 +543,10 @@ compile_kernel_sparse() {
 			fi
 		fi
 	done) ; err=${PIPESTATUS[1]}
+
+	if [[ $found == "1" ]]; then
+		echo $msg
+	fi
 
 	if [[ $err -ne 0 ]]; then
 		fail=1


### PR DESCRIPTION
## PR Description

Infer dts affected by changed dtsi, problem match devitree compile
Use basic '#include "$file"' matching to infer which devicetrees should be compiled when a dtsi gets edited.
The task of ensuring compile once is deferred to Makefile internal timestamp checker.

Add a problem match devicetree compile
Match for single line problems in the format
file:line.col-end_line.end_col: level reason
and
level: file:line.col-end_col reason

Finally, Flush last warning captured
These steps works by printing the last warning when a new is matched, to support muli-line errors. Resolve last warning not being printed.These steps works by printing the last warning when a new is matched, to support muli-line errors. Resolve last warning not being printed.

Sample run: https://github.com/gastmaier/adi-linux/actions/runs/15161980369/job/42630045746
Commented pr: https://github.com/gastmaier/adi-linux/pull/5/files

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
