### PR TITLE
iio: adc: adrv9002_of: refactor DPD external path delay property

### DIFF
--- a/drivers/iio/adc/navassa/adrv9002_of.c
+++ b/drivers/iio/adc/navassa/adrv9002_of.c
@@ -644,6 +644,8 @@ static int adrv9002_parse_dpd(const struct adrv9002_rf_phy *phy,
 	tx->dpd_init->amplifierType = ADI_ADRV9001_DPDAMPLIFIER_DEFAULT;
 	tx->dpd_init->model = ADI_ADRV9001_DPDMODEL_4;
 
+	tx->ext_path_calib = of_property_read_bool(node, "adi,external-path-delay-calibrate");
+
 	dpd = of_parse_phandle(node, "adi,dpd-config", 0);
 	if (!dpd) {
 		/* set default parameters */
@@ -664,8 +666,6 @@ static int adrv9002_parse_dpd(const struct adrv9002_rf_phy *phy,
 		tx->dpd->immediateLutSwitching = true;
 		return 0;
 	}
-
-	tx->ext_path_calib = of_property_read_bool(dpd, "adi,external-path-delay-calibrate");
 
 	ret = adrv9002_parse_dpd_pre_calib(phy, dpd, tx);
 	if (ret)

--- a/drivers/iio/adc/navassa/adrv9002_of.c
+++ b/drivers/iio/adc/navassa/adrv9002_of.c
@@ -956,7 +956,7 @@ static const struct {
 	case 4:							\
 		*(u32 *)((void *)(agc) + __off) = (val);	\
 		break;						\
-	};							\
+	}							\
 }
 
 static void adrv9002_set_agc_defaults(struct adi_adrv9001_GainControlCfg *agc)
@@ -1367,7 +1367,7 @@ static int adrv9002_parse_channels_dt(struct adrv9002_rf_phy *phy, const struct 
 			dev_err(dev, "Unknown port: %d\n", port);
 			ret = -EINVAL;
 			break;
-		};
+		}
 
 		if (ret)
 			goto of_error_put;


### PR DESCRIPTION
Instead of forcing the 'adi,dpd-config' node to be given in order to add the external path delay boolean property, take it out of that node and allow to add it at the TX node level. This is done because often we want to do the calibration and still have the default DPD settings.

Obviously, the property still depends on 'adi,dpd'.


## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
