### PR TITLE
ci: Filter removed files, recursive Kconfig symbol look-up

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -14,7 +14,7 @@ check_checkpatch() {
 		git --no-pager show --format="%h %s" "$commit" --name-only
 		# Skip empty commits, assume cover letter
 		# and those only touching non-upstream directories .github ci and docs
-		local files=$(git diff --name-only $commit~..$commit | grep -v ^ci | grep -v ^.github | grep -v ^docs || true)
+		local files=$(git diff --diff-filter=ACM --name-only $commit~..$commit | grep -v ^ci | grep -v ^.github | grep -v ^docs || true)
 		if [[ -z "$files" ]]; then
 			echo "empty, skipped"
 			continue
@@ -641,7 +641,7 @@ compile_kernel_smatch() {
 }
 
 compile_gcc_fanalyzer () {
-	local files=$(git diff --name-only $base_sha..$head_sha)
+	local files=$(git diff --diff-filter=ACM --name-only $base_sha..$head_sha)
 	local regex='^[[:alnum:]/._-]+:[[:digit:]]+:[[:digit:]]+: .*$'
 	local mail=
 	local fail=0
@@ -728,7 +728,7 @@ compile_gcc_fanalyzer () {
 }
 
 compile_clang_analyzer () {
-	local files=$(git diff --name-only $base_sha..$head_sha)
+	local files=$(git diff --diff-filter=ACM --name-only $base_sha..$head_sha)
 	local regex='^[[:alnum:]/._-]+:[[:digit:]]+:[[:digit:]]+: .*$'
 	local mail=
 	local fail=0
@@ -823,7 +823,7 @@ compile_clang_analyzer () {
 }
 
 assert_compiled () {
-	local files=$(git diff --name-only $base_sha..$head_sha)
+	local files=$(git diff --diff-filter=ACM --name-only $base_sha..$head_sha)
 	local fail=0
 
 	echo "assert sources were compiled on range $base_sha..$head_sha"
@@ -862,7 +862,7 @@ apply_prerun() {
 	# e.g. manipulate the source code depending on run conditons or target.
 	local coccis=$(ls ci/prerun/*.cocci 2>/dev/null)
 	local bashes=$(ls ci/prerun/*.sh 2>/dev/null)
-	local files=$(git diff --name-only $base_sha..$head_sha)
+	local files=$(git diff --diff-filter=ACM --name-only $base_sha..$head_sha)
 
 	echo "apply_prerun on range $base_sha..$head_sha"
 
@@ -891,13 +891,13 @@ apply_prerun() {
 }
 
 touch_files () {
-	local files=$(git diff --name-only $base_sha..$head_sha)
+	local files=$(git diff --diff-filter=ACM --name-only $base_sha..$head_sha)
 
 	touch $files
 }
 
 auto_set_kconfig() {
-	local files=$(git diff --name-only $base_sha..$head_sha)
+	local files=$(git diff --diff-filter=ACM --name-only $base_sha..$head_sha)
 	declare -a o_files
 
 	echo "get_kconfig on range $base_sha..$head_sha"


### PR DESCRIPTION
## PR Description

Don't run checkers, compilers on files that have been deleted on the range.
Add recursive Kconfig symbol from the .o object searcher.
The following cases are supported:
```
    driver-y += devices/driver/public/src/driver_extra.o
    driver-objs += some_obj.o
    driver-$(CONFIG_OF) += driver_of.o
    obj-$(CONFIG_DRIVER) += driver.o
```

Testing is simple:
```
$base_sha=@~500 ; head_sha=@ ; source ci/build.sh ; auto_set_kconfig
  Failed to find Makefile targeting drivers/iio/adc/adrv902x/adrv9025.o
  Failed to find Makefile targeting arch/arm/mach-ep93xx/core.o
  Failed to find Makefile targeting tools/iio/iio_event_monitor.o
```
(`tools/iio/iio_event_monitor.o` should be resolved in a future PR, `drivers/iio/adc/adrv902x/adrv9025.o` is off and I would change the Makefile instead)

Sample run: https://github.com/gastmaier/adi-linux/actions/runs/15254662168/job/42899305330?pr=7

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
