### PR TITLE
arm: dts: xilinx: coraz7s no-bitstream compatible

### DIFF
--- a/arch/arm/boot/dts/xilinx/zynq-coraz7s-ad7689-ardz.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-coraz7s-ad7689-ardz.dts
@@ -11,6 +11,7 @@
  */
 /dts-v1/;
 #include "zynq-coraz7s.dtsi"
+#include "zynq-coraz7s-axi-sysid.dtsi"
 #include <dt-bindings/interrupt-controller/irq.h>
 #include <dt-bindings/gpio/gpio.h>
 

--- a/arch/arm/boot/dts/xilinx/zynq-coraz7s-ad7946.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-coraz7s-ad7946.dts
@@ -11,6 +11,7 @@
  */
 /dts-v1/;
 #include "zynq-coraz7s.dtsi"
+#include "zynq-coraz7s-axi-sysid.dtsi"
 #include <dt-bindings/interrupt-controller/irq.h>
 #include <dt-bindings/gpio/gpio.h>
 

--- a/arch/arm/boot/dts/xilinx/zynq-coraz7s-ad7984.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-coraz7s-ad7984.dts
@@ -11,6 +11,7 @@
  */
 /dts-v1/;
 #include "zynq-coraz7s.dtsi"
+#include "zynq-coraz7s-axi-sysid.dtsi"
 #include <dt-bindings/interrupt-controller/irq.h>
 #include <dt-bindings/gpio/gpio.h>
 

--- a/arch/arm/boot/dts/xilinx/zynq-coraz7s-adaq4001.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-coraz7s-adaq4001.dts
@@ -10,6 +10,7 @@
  */
 /dts-v1/;
 #include "zynq-coraz7s.dtsi"
+#include "zynq-coraz7s-axi-sysid.dtsi"
 #include <dt-bindings/interrupt-controller/irq.h>
 #include <dt-bindings/gpio/gpio.h>
 

--- a/arch/arm/boot/dts/xilinx/zynq-coraz7s-adaq4003.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-coraz7s-adaq4003.dts
@@ -10,6 +10,7 @@
  */
 /dts-v1/;
 #include "zynq-coraz7s.dtsi"
+#include "zynq-coraz7s-axi-sysid.dtsi"
 #include <dt-bindings/interrupt-controller/irq.h>
 #include <dt-bindings/gpio/gpio.h>
 

--- a/arch/arm/boot/dts/xilinx/zynq-coraz7s-axi-sysid.dtsi
+++ b/arch/arm/boot/dts/xilinx/zynq-coraz7s-axi-sysid.dtsi
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0
+/* Copyright (C) 2025 Analog Devices Inc. */
+
+&fpga_axi {
+	axi_sysid_0: axi-sysid-0@45000000 {
+		compatible = "adi,axi-sysid-1.00.a";
+		reg = <0x45000000 0x10000>;
+	};
+};

--- a/arch/arm/boot/dts/xilinx/zynq-coraz7s-cn0540.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-coraz7s-cn0540.dts
@@ -13,6 +13,7 @@
 /dts-v1/;
 #include "zynq-coraz7s.dtsi"
 #include "zynq-coraz7s-iic.dtsi"
+#include "zynq-coraz7s-axi-sysid.dtsi"
 #include <dt-bindings/interrupt-controller/irq.h>
 #include <dt-bindings/gpio/gpio.h>
 

--- a/arch/arm/boot/dts/xilinx/zynq-coraz7s-cn0579_i2c.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-coraz7s-cn0579_i2c.dts
@@ -11,6 +11,7 @@
 /dts-v1/;
 #include "zynq-coraz7s.dtsi"
 #include "zynq-coraz7s-iic.dtsi"
+#include "zynq-coraz7s-axi-sysid.dtsi"
 #include <dt-bindings/interrupt-controller/irq.h>
 #include <dt-bindings/gpio/gpio.h>
 

--- a/arch/arm/boot/dts/xilinx/zynq-coraz7s-fpga-eeprom.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-coraz7s-fpga-eeprom.dts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * hdl_project: <common/coraz7s>
+ *
+ * Copyright (C) 2025 Analog Devices Inc.
+ */
+
+/dts-v1/;
+#include "zynq-coraz7s.dtsi"
+#include "zynq-coraz7s-iic.dtsi"
+#include "zynq-coraz7s-axi-sysid.dtsi"
+
+&axi_i2c_0 {
+	eeprom1: eeprom@50 {
+		compatible = "at24,24c02";
+		reg = <0x50>;
+	};
+};

--- a/arch/arm/boot/dts/xilinx/zynq-coraz7s-pulsar.dtsi
+++ b/arch/arm/boot/dts/xilinx/zynq-coraz7s-pulsar.dtsi
@@ -9,6 +9,7 @@
  * Copyright (C) 2025 Analog Devices Inc.
  */
 #include "zynq-coraz7s.dtsi"
+#include "zynq-coraz7s-axi-sysid.dtsi"
 #include <dt-bindings/interrupt-controller/irq.h>
 #include <dt-bindings/gpio/gpio.h>
 

--- a/arch/arm/boot/dts/xilinx/zynq-coraz7s.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-coraz7s.dts
@@ -4,6 +4,7 @@
 /dts-v1/;
 #include "zynq-coraz7s.dtsi"
 #include "zynq-coraz7s-iic.dtsi"
+#include "zynq-coraz7s-axi-sysid.dtsi"
 
 &axi_i2c_0 {
 	eeprom1: eeprom@50 {

--- a/arch/arm/boot/dts/xilinx/zynq-coraz7s.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-coraz7s.dts
@@ -3,12 +3,3 @@
 
 /dts-v1/;
 #include "zynq-coraz7s.dtsi"
-#include "zynq-coraz7s-iic.dtsi"
-#include "zynq-coraz7s-axi-sysid.dtsi"
-
-&axi_i2c_0 {
-	eeprom1: eeprom@50 {
-		compatible = "at24,24c02";
-		reg = <0x50>;
-	};
-};

--- a/arch/arm/boot/dts/xilinx/zynq-coraz7s.dtsi
+++ b/arch/arm/boot/dts/xilinx/zynq-coraz7s.dtsi
@@ -33,10 +33,6 @@
 		#size-cells = <0x1>;
 		ranges;
 
-		axi_sysid_0: axi-sysid-0@45000000 {
-			compatible = "adi,axi-sysid-1.00.a";
-			reg = <0x45000000 0x10000>;
-		};
 	};
 };
 


### PR DESCRIPTION
## PR Description

Remove axi-sysid from base zynq-coraz7s.dtsi so it can be used to
generate a devicetree compatible with BOOT.BIN with not bitstream with:

```
make xilinx/zynq-coraz7z.dtb
```

Since  xilinx/zynq-coraz7z.dts is now xilinx/zynq-coraz7s-fpga-eeprom.dts, somewhere in the pipeline for kuiper should break.

Follow-up to #2657

<details>
<summary>The ci run seems to compiled all dts:</summary>

```
DTC arch/arm/boot/dts/xilinx/zynq-coraz7s.dtb
DTC arch/arm/boot/dts/xilinx/zynq-coraz7s-fpga-eeprom.dtb
DTC arch/arm/boot/dts/xilinx/zynq-coraz7s-cn0579_i2c.dtb
DTC arch/arm/boot/dts/xilinx/zynq-coraz7s-cn0540.dtb
DTC arch/arm/boot/dts/xilinx/zynq-coraz7s-adaq4003.dtb
DTC arch/arm/boot/dts/xilinx/zynq-coraz7s-adaq4001.dtb
DTC arch/arm/boot/dts/xilinx/zynq-coraz7s-ad7984.dtb
DTC arch/arm/boot/dts/xilinx/zynq-coraz7s-ad7946.dtb
DTC arch/arm/boot/dts/xilinx/zynq-coraz7s-ad7689-ardz.dtb
DTC arch/arm/boot/dts/xilinx/zynq-coraz7s-ad7988-5-pmdz.dtb
DTC arch/arm/boot/dts/xilinx/zynq-coraz7s-ad7988-1-pmdz.dtb
DTC arch/arm/boot/dts/xilinx/zynq-coraz7s-ad7984-pmdz.dtb
DTC arch/arm/boot/dts/xilinx/zynq-coraz7s-ad7983-pmdz.dtb
DTC arch/arm/boot/dts/xilinx/zynq-coraz7s-ad7982-pmdz.dtb
DTC arch/arm/boot/dts/xilinx/zynq-coraz7s-ad7980-pmdz.dtb
DTC arch/arm/boot/dts/xilinx/zynq-coraz7s-ad7946-pmdz.dtb
DTC arch/arm/boot/dts/xilinx/zynq-coraz7s-ad7942-pmdz.dtb
DTC arch/arm/boot/dts/xilinx/zynq-coraz7s-ad7693-pmdz.dtb
DTC arch/arm/boot/dts/xilinx/zynq-coraz7s-ad7691-pmdz.dtb
DTC arch/arm/boot/dts/xilinx/zynq-coraz7s-ad7690-pmdz.dtb
DTC arch/arm/boot/dts/xilinx/zynq-coraz7s-ad7688-pmdz.dtb
DTC arch/arm/boot/dts/xilinx/zynq-coraz7s-ad7687-pmdz.dtb
DTC arch/arm/boot/dts/xilinx/zynq-coraz7s-ad7686-pmdz.dtb
DTC arch/arm/boot/dts/xilinx/zynq-coraz7s-ad7685-pmdz.dtb
```
</details>

Note to self: bring `* doesn't contain an 'hdl_project:' tag` to ghactions.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [x] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
