### PR TITLE
Move to kstrtobool()

### DIFF
--- a/drivers/iio/adc/ad9081.c
+++ b/drivers/iio/adc/ad9081.c
@@ -1437,7 +1437,7 @@ static ssize_t ad9081_ext_info_write(struct iio_dev *indio_dev,
 			phy->dac_cache.chan_gain[fddc_num] = readin_32;
 		break;
 	case CDDC_6DB_GAIN:
-		ret = strtobool(buf, &enable);
+		ret = kstrtobool(buf, &enable);
 		if (ret)
 			return ret;
 
@@ -1449,7 +1449,7 @@ static ssize_t ad9081_ext_info_write(struct iio_dev *indio_dev,
 		ret = 0;
 		break;
 	case FDDC_6DB_GAIN:
-		ret = strtobool(buf, &enable);
+		ret = kstrtobool(buf, &enable);
 		if (ret)
 			return ret;
 		ret = adi_ad9081_adc_ddc_fine_gain_set(
@@ -1460,7 +1460,7 @@ static ssize_t ad9081_ext_info_write(struct iio_dev *indio_dev,
 		ret = 0;
 		break;
 	case DAC_MAIN_TEST_TONE_EN:
-		ret = strtobool(buf, &enable);
+		ret = kstrtobool(buf, &enable);
 		if (ret)
 			return ret;
 
@@ -1470,7 +1470,7 @@ static ssize_t ad9081_ext_info_write(struct iio_dev *indio_dev,
 			phy->dac_cache.main_test_tone_en[fddc_num] = enable;
 		break;
 	case DAC_CHAN_TEST_TONE_EN:
-		ret = strtobool(buf, &enable);
+		ret = kstrtobool(buf, &enable);
 		if (ret)
 			return ret;
 
@@ -1570,7 +1570,7 @@ static ssize_t ad9081_ext_info_write(struct iio_dev *indio_dev,
 			ret = -EOPNOTSUPP;
 			break;
 		}
-		ret = strtobool(buf, &enable);
+		ret = kstrtobool(buf, &enable);
 		if (ret)
 			return ret;
 
@@ -2720,7 +2720,7 @@ static ssize_t ad9081_phy_store(struct device *dev,
 			break;
 		}
 
-		ret = strtobool(buf, &bres);
+		ret = kstrtobool(buf, &bres);
 		if (ret < 0) {
 			ret = -EINVAL;
 			break;
@@ -2756,7 +2756,7 @@ static ssize_t ad9081_phy_store(struct device *dev,
 			break;
 		}
 
-		ret = strtobool(buf, &enable);
+		ret = kstrtobool(buf, &enable);
 		if (ret)
 			break;
 
@@ -2774,7 +2774,7 @@ static ssize_t ad9081_phy_store(struct device *dev,
 
 		break;
 	case AD9081_POWER_DOWN:
-		ret = strtobool(buf, &enable);
+		ret = kstrtobool(buf, &enable);
 		if (ret)
 			break;
 		ret = ad9081_set_power_state(phy, !enable);

--- a/drivers/iio/adc/ad9083.c
+++ b/drivers/iio/adc/ad9083.c
@@ -465,7 +465,7 @@ static ssize_t ad9083_phy_store(struct device *dev,
 			break;
 		}
 
-		ret = strtobool(buf, &enable);
+		ret = kstrtobool(buf, &enable);
 		if (ret)
 			break;
 

--- a/drivers/iio/adc/ad9208.c
+++ b/drivers/iio/adc/ad9208.c
@@ -533,7 +533,7 @@ static ssize_t ad9208_ext_info_write(struct iio_dev *indio_dev,
 	bool enable;
 	int ret;
 
-	ret = strtobool(buf, &enable);
+	ret = kstrtobool(buf, &enable);
 	if (ret)
 		return ret;
 

--- a/drivers/iio/adc/ad9361.c
+++ b/drivers/iio/adc/ad9361.c
@@ -6879,7 +6879,7 @@ static ssize_t ad9361_phy_store(struct device *dev,
 			ret = -EINVAL;
 		break;
 	case AD9361_FIR_TRX_ENABLE:
-		ret = strtobool(buf, &res);
+		ret = kstrtobool(buf, &res);
 		if (ret < 0)
 			break;
 
@@ -6897,7 +6897,7 @@ static ssize_t ad9361_phy_store(struct device *dev,
 
 		break;
 	case AD9361_FIR_RX_ENABLE:
-		ret = strtobool(buf, &res);
+		ret = kstrtobool(buf, &res);
 		if (ret < 0)
 			break;
 
@@ -6913,7 +6913,7 @@ static ssize_t ad9361_phy_store(struct device *dev,
 
 		break;
 	case AD9361_FIR_TX_ENABLE:
-		ret = strtobool(buf, &res);
+		ret = kstrtobool(buf, &res);
 		if (ret < 0)
 			break;
 
@@ -6998,21 +6998,21 @@ static ssize_t ad9361_phy_store(struct device *dev,
 			ret = -EINVAL;
 		break;
 	case AD9361_BBDC_OFFS_ENABLE:
-		ret = strtobool(buf, &st->bbdc_track_en);
+		ret = kstrtobool(buf, &st->bbdc_track_en);
 		if (ret < 0)
 			break;
 		ret = ad9361_tracking_control(phy, st->bbdc_track_en,
 				st->rfdc_track_en, st->quad_track_en);
 		break;
 	case AD9361_RFDC_OFFS_ENABLE:
-		ret = strtobool(buf, &st->rfdc_track_en);
+		ret = kstrtobool(buf, &st->rfdc_track_en);
 		if (ret < 0)
 			break;
 		ret = ad9361_tracking_control(phy, st->bbdc_track_en,
 				st->rfdc_track_en, st->quad_track_en);
 		break;
 	case AD9361_QUAD_ENABLE:
-		ret = strtobool(buf, &st->quad_track_en);
+		ret = kstrtobool(buf, &st->quad_track_en);
 		if (ret < 0)
 			break;
 		ret = ad9361_tracking_control(phy, st->bbdc_track_en,
@@ -7432,7 +7432,7 @@ static ssize_t ad9361_phy_lo_write(struct iio_dev *indio_dev,
 			break;
 		case LOEXT_EXTERNAL:
 		case LOEXT_PD:
-			ret = strtobool(buf, &res);
+			ret = kstrtobool(buf, &res);
 			if (ret < 0)
 				return ret;
 			break;

--- a/drivers/iio/adc/ad9371.c
+++ b/drivers/iio/adc/ad9371.c
@@ -1185,7 +1185,7 @@ static ssize_t ad9371_phy_store(struct device *dev,
 		ret = ad9371_set_radio_state(phy, val);
 		break;
 	case AD9371_INIT_CAL:
-		ret = strtobool(buf, &enable);
+		ret = kstrtobool(buf, &enable);
 		if (ret)
 			break;
 
@@ -1210,7 +1210,7 @@ static ssize_t ad9371_phy_store(struct device *dev,
 		}
 		break;
 	case AD9371_LARGE_LO_STEP_CAL:
-		ret = strtobool(buf, &phy->large_freq_step_cal_en);
+		ret = kstrtobool(buf, &phy->large_freq_step_cal_en);
 		break;
 	default:
 		ret = -EINVAL;
@@ -1625,7 +1625,7 @@ static ssize_t ad9371_phy_rx_write(struct iio_dev *indio_dev,
 
 		break;
 	case RX_QEC:
-		ret = strtobool(buf, &enable);
+		ret = kstrtobool(buf, &enable);
 
 		switch (chan->channel) {
 		case CHAN_RX1:
@@ -2007,7 +2007,7 @@ static ssize_t ad9371_phy_tx_write(struct iio_dev *indio_dev,
 	case TX_DPD:
 	case TX_CLGC:
 	case TX_VSWR:
-		ret = strtobool(buf, &enable);
+		ret = kstrtobool(buf, &enable);
 		if (ret)
 			break;
 
@@ -2026,7 +2026,7 @@ static ssize_t ad9371_phy_tx_write(struct iio_dev *indio_dev,
 
 		break;
 	case TX_DPD_ACT_EN:
-		ret = strtobool(buf, &enable);
+		ret = kstrtobool(buf, &enable);
 		if (ret)
 			break;
 

--- a/drivers/iio/adc/admc_ctrl.c
+++ b/drivers/iio/adc/admc_ctrl.c
@@ -217,7 +217,7 @@ static ssize_t mc_ctrl_store(struct device *dev,
 	mutex_lock(&st->lock);
 	switch ((u32)this_attr->address) {
 	case MC_RUN:
-		ret = strtobool(buf, &setting);
+		ret = kstrtobool(buf, &setting);
 		if (ret < 0)
 			break;
 		reg_val = axiadc_read(st, MC_REG_CONTROL);
@@ -226,7 +226,7 @@ static ssize_t mc_ctrl_store(struct device *dev,
 		axiadc_write(st, MC_REG_CONTROL, reg_val);
 		break;
 	case MC_RESET_OVR_CURR:
-		ret = strtobool(buf, &setting);
+		ret = kstrtobool(buf, &setting);
 		if (ret < 0)
 			break;
 		reg_val = axiadc_read(st, MC_REG_CONTROL);
@@ -235,7 +235,7 @@ static ssize_t mc_ctrl_store(struct device *dev,
 		axiadc_write(st, MC_REG_CONTROL, reg_val);
 		break;
 	case MC_BREAK:
-		ret = strtobool(buf, &setting);
+		ret = kstrtobool(buf, &setting);
 		if (ret < 0)
 			break;
 		reg_val = axiadc_read(st, MC_REG_CONTROL);
@@ -244,7 +244,7 @@ static ssize_t mc_ctrl_store(struct device *dev,
 		axiadc_write(st, MC_REG_CONTROL, reg_val);
 		break;
 	case MC_DIRECTION:
-		ret = strtobool(buf, &setting);
+		ret = kstrtobool(buf, &setting);
 		if (ret < 0)
 			break;
 		reg_val = axiadc_read(st, MC_REG_CONTROL);
@@ -253,7 +253,7 @@ static ssize_t mc_ctrl_store(struct device *dev,
 		axiadc_write(st, MC_REG_CONTROL, reg_val);
 		break;
 	case MC_DELTA:
-		ret = strtobool(buf, &setting);
+		ret = kstrtobool(buf, &setting);
 		if (ret < 0)
 			break;
 		reg_val = axiadc_read(st, MC_REG_CONTROL);
@@ -276,7 +276,7 @@ static ssize_t mc_ctrl_store(struct device *dev,
 		axiadc_write(st, MC_REG_CONTROL, reg_val);
 		break;
 	case MC_MATLAB:
-		ret = strtobool(buf, &setting);
+		ret = kstrtobool(buf, &setting);
 		if (ret < 0)
 			break;
 		reg_val = axiadc_read(st, MC_REG_CONTROL);
@@ -285,7 +285,7 @@ static ssize_t mc_ctrl_store(struct device *dev,
 		axiadc_write(st, MC_REG_CONTROL, reg_val);
 		break;
 	case MC_CALIB_ADC:
-		ret = strtobool(buf, &setting);
+		ret = kstrtobool(buf, &setting);
 		if (ret < 0)
 			break;
 		reg_val = axiadc_read(st, MC_REG_CONTROL);

--- a/drivers/iio/adc/adrv9009.c
+++ b/drivers/iio/adc/adrv9009.c
@@ -1511,7 +1511,7 @@ static ssize_t adrv9009_phy_store(struct device *dev,
 			return -EBUSY;
 		}
 
-		ret = strtobool(buf, &enable);
+		ret = kstrtobool(buf, &enable);
 		if (ret)
 			break;
 
@@ -1574,7 +1574,7 @@ static ssize_t adrv9009_phy_store(struct device *dev,
 			break;
 		}
 
-		ret = strtobool(buf, &enable);
+		ret = kstrtobool(buf, &enable);
 		if (ret)
 			break;
 
@@ -1595,7 +1595,7 @@ static ssize_t adrv9009_phy_store(struct device *dev,
 			return -EBUSY;
 		}
 
-		ret = strtobool(buf, &enable);
+		ret = kstrtobool(buf, &enable);
 		if (ret)
 			break;
 		ret = TALISE_setRadioCtlPinMode(phy->talDevice,
@@ -1958,7 +1958,7 @@ static ssize_t adrv9009_phy_lo_write(struct iio_dev *indio_dev,
 		adrv9009_set_radio_state(phy, RADIO_RESTORE_STATE);
 		break;
 	case FHM_ENABLE:
-		ret = strtobool(buf, &enable);
+		ret = kstrtobool(buf, &enable);
 		if (ret)
 			return ret;
 
@@ -2165,7 +2165,7 @@ static ssize_t adrv9009_phy_rx_write(struct iio_dev *indio_dev,
 	if (!phy->is_initialized)
 		return -EBUSY;
 
-	ret = strtobool(buf, &enable);
+	ret = kstrtobool(buf, &enable);
 	if (ret)
 		return ret;
 
@@ -2627,7 +2627,7 @@ static ssize_t adrv9009_phy_tx_write(struct iio_dev *indio_dev,
 	if (chan->channel > CHAN_TX2)
 		return -EINVAL;
 
-	ret = strtobool(buf, &enable);
+	ret = kstrtobool(buf, &enable);
 	if (ret)
 		return ret;
 

--- a/drivers/iio/adc/adrv902x/adrv9025.c
+++ b/drivers/iio/adc/adrv902x/adrv9025.c
@@ -327,7 +327,7 @@ static ssize_t adrv9025_phy_store(struct device *dev,
 
 	switch ((u32)this_attr->address & 0xFF) {
 	case ADRV9025_INIT_CAL:
-		ret = strtobool(buf, &enable);
+		ret = kstrtobool(buf, &enable);
 		if (ret)
 			break;
 
@@ -375,7 +375,7 @@ static ssize_t adrv9025_phy_store(struct device *dev,
 			break;
 		}
 
-		ret = strtobool(buf, &enable);
+		ret = kstrtobool(buf, &enable);
 		if (ret)
 			break;
 
@@ -752,7 +752,7 @@ static ssize_t adrv9025_phy_rx_write(struct iio_dev *indio_dev,
 	u64 mask;
 	u16 mask16;
 
-	ret = strtobool(buf, &enable);
+	ret = kstrtobool(buf, &enable);
 	if (ret)
 		return ret;
 
@@ -930,7 +930,7 @@ static ssize_t adrv9025_phy_tx_write(struct iio_dev *indio_dev,
 	if (chan->channel > CHAN_TX4)
 		return -EINVAL;
 
-	ret = strtobool(buf, &enable);
+	ret = kstrtobool(buf, &enable);
 	if (ret)
 		return ret;
 

--- a/drivers/iio/frequency/ad9508.c
+++ b/drivers/iio/frequency/ad9508.c
@@ -215,7 +215,7 @@ static ssize_t ad9508_store(struct device *dev,
 	bool state;
 	int ret;
 
-	ret = strtobool(buf, &state);
+	ret = kstrtobool(buf, &state);
 	if (ret < 0)
 		return ret;
 

--- a/drivers/iio/frequency/ad9528.c
+++ b/drivers/iio/frequency/ad9528.c
@@ -414,7 +414,7 @@ static ssize_t ad9528_store(struct device *dev,
 	bool state;
 	int ret;
 
-	ret = strtobool(buf, &state);
+	ret = kstrtobool(buf, &state);
 	if (ret < 0)
 		return ret;
 

--- a/drivers/iio/frequency/hmc7044.c
+++ b/drivers/iio/frequency/hmc7044.c
@@ -533,7 +533,7 @@ static ssize_t hmc7044_store(struct device *dev,
 	int ret;
 	u32 val, write_val;
 
-	ret = strtobool(buf, &state);
+	ret = kstrtobool(buf, &state);
 	if (ret < 0)
 		return ret;
 

--- a/drivers/iio/frequency/m2k-dac.c
+++ b/drivers/iio/frequency/m2k-dac.c
@@ -321,7 +321,7 @@ static ssize_t m2k_dac_write_dma_sync(struct device *dev,
 	bool val;
 	int ret;
 
-	ret = strtobool(buf, &val);
+	ret = kstrtobool(buf, &val);
 	if (ret < 0)
 		return ret;
 
@@ -353,7 +353,7 @@ static ssize_t m2k_dac_write_dma_sync_start(struct device *dev,
 	bool val;
 	int ret;
 
-	ret = strtobool(buf, &val);
+	ret = kstrtobool(buf, &val);
 	if (ret < 0)
 		return ret;
 

--- a/drivers/iio/jesd204/axi_adxcvr.c
+++ b/drivers/iio/jesd204/axi_adxcvr.c
@@ -299,7 +299,7 @@ static ssize_t adxcvr_prbs_counter_reset_store(struct device *dev,
 	bool reset;
 	int ret;
 
-	ret = strtobool(buf, &reset);
+	ret = kstrtobool(buf, &reset);
 	if (ret)
 		return ret;
 
@@ -352,7 +352,7 @@ static ssize_t adxcvr_prbs_error_inject_store(struct device *dev,
 	bool inject;
 	int ret;
 
-	ret = strtobool(buf, &inject);
+	ret = kstrtobool(buf, &inject);
 	if (ret)
 		return ret;
 

--- a/drivers/iio/logic/m2k-fabric.c
+++ b/drivers/iio/logic/m2k-fabric.c
@@ -268,7 +268,7 @@ static ssize_t m2k_fabric_user_supply_write(struct iio_dev *indio_dev,
 	bool state;
 	int ret;
 
-	ret = strtobool(buf, &state);
+	ret = kstrtobool(buf, &state);
 	if (ret)
 		return ret;
 
@@ -313,7 +313,7 @@ static ssize_t m2k_fabric_powerdown_write(struct iio_dev *indio_dev,
 	bool state;
 	int ret;
 
-	ret = strtobool(buf, &state);
+	ret = kstrtobool(buf, &state);
 	if (ret)
 		return ret;
 

--- a/drivers/iio/logic/m2k-logic-analyzer.c
+++ b/drivers/iio/logic/m2k-logic-analyzer.c
@@ -763,7 +763,7 @@ static ssize_t m2k_la_write_powerdown(struct iio_dev *indio_dev,
 	bool powerdown;
 	int ret;
 
-	ret = strtobool(buf, &powerdown);
+	ret = kstrtobool(buf, &powerdown);
 	if (ret)
 		return ret;
 

--- a/drivers/jesd204/jesd204_top_device.c
+++ b/drivers/jesd204/jesd204_top_device.c
@@ -251,7 +251,7 @@ static ssize_t jesd204_fsm_ctrl_store(struct device *dev,
 	if (!tdev->jdev)
 		return -EOPNOTSUPP;
 
-	ret = strtobool(buf, &enable);
+	ret = kstrtobool(buf, &enable);
 	if (ret)
 		return ret;
 
@@ -281,7 +281,7 @@ static ssize_t jesd204_fsm_resume_store(struct device *dev,
 	if (!tdev->jdev)
 		return -EOPNOTSUPP;
 
-	ret = strtobool(buf, &enable);
+	ret = kstrtobool(buf, &enable);
 	if (ret)
 		return ret;
 


### PR DESCRIPTION
## PR Description

Minor series to move our out of tree drivers to use kstrtobool(). strtobool() is no longer available in 6.12 so better remove it sooner rather than later.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
