### PR TITLE
arm: dts: xilinx: Move base and no-bitstream coraz7s

### DIFF
--- a/arch/arm/boot/dts/xilinx/zynq-coraz7s-no-bitstream.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-coraz7s-no-bitstream.dts
@@ -7,12 +7,3 @@
 
 /dts-v1/;
 #include "zynq-coraz7s.dtsi"
-#include "zynq-coraz7s-iic.dtsi"
-#include "zynq-coraz7s-axi-sysid.dtsi"
-
-&axi_i2c_0 {
-	eeprom1: eeprom@50 {
-		compatible = "at24,24c02";
-		reg = <0x50>;
-	};
-};

--- a/arch/arm/boot/dts/xilinx/zynq-coraz7s.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-coraz7s.dts
@@ -1,5 +1,18 @@
 // SPDX-License-Identifier: GPL-2.0
-/* Copyright (C) 2024 Analog Devices Inc. */
+/*
+ * hdl_project: <common/coraz7s>
+ *
+ * Copyright (C) 2025 Analog Devices Inc.
+ */
 
 /dts-v1/;
 #include "zynq-coraz7s.dtsi"
+#include "zynq-coraz7s-iic.dtsi"
+#include "zynq-coraz7s-axi-sysid.dtsi"
+
+&axi_i2c_0 {
+	eeprom1: eeprom@50 {
+		compatible = "at24,24c02";
+		reg = <0x50>;
+	};
+};


### PR DESCRIPTION
## PR Description

As requested, move zynq-coraz7s-fpga-eeprom to zynq-coraz7s, because this is the usual base devicetree used. For the no-bitstream, add the hdl_project tag, even-though it doesn't relate to an hdl project, it is used for identification during the Kuiper CI.

@SRaus

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [X] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
