### PR TITLE
Update ad9208.c

### DIFF
--- a/drivers/iio/adc/ad9208.c
+++ b/drivers/iio/adc/ad9208.c
@@ -1570,9 +1570,9 @@ static int ad9208_probe(struct spi_device *spi)
 		break;
 	case CHIPID_AD9695:
 		phy->ad9208.model = 0x9208;
-		phy->ad9208.input_clk_min_hz = 625000000ULL;
+		phy->ad9208.input_clk_min_hz = 240000000ULL;
 		phy->ad9208.input_clk_max_hz = 1300000000ULL;
-		phy->ad9208.adc_clk_min_hz = 625000000ULL;
+		phy->ad9208.adc_clk_min_hz = 240000000ULL;
 		phy->ad9208.adc_clk_max_hz = 3100000000ULL;
 		phy->ad9208.slr_max_mbps = 16000;
 		phy->ad9208.slr_min_mbps = 1687;


### PR DESCRIPTION
changed clock rates to support -625 variant these were 625e6 phy->ad9208.input_clk_min_hz = 240000000ULL;
phy->ad9208.adc_clk_min_hz = 240000000ULL;

## PR Description

- Please replace this comment with a summary of your changes, and add any context
necessary to understand them. List any dependencies required for this change.
- To check the checkboxes below, insert a 'x' between square brackets (without
any space), or simply check them after publishing the PR.
- If you changes include a breaking change, please specify dependent PRs in the
description and try to push all related PRs simultaneously.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
