### PR TITLE
iio: dac: ad5592r: Create ADC_BUF_EN sysfs

### DIFF
--- a/drivers/iio/dac/ad5592r-base.c
+++ b/drivers/iio/dac/ad5592r-base.c
@@ -590,7 +590,8 @@ static void ad5592r_init_scales(struct ad5592r_state *st, int vref_mV)
 }
 
 int ad5592r_probe(struct device *dev, const char *name,
-		const struct ad5592r_rw_ops *ops)
+		const struct ad5592r_rw_ops *ops,
+		const struct attribute_group **sysfs_groups)
 {
 	struct iio_dev *iio_dev;
 	struct ad5592r_state *st;
@@ -646,6 +647,12 @@ int ad5592r_probe(struct device *dev, const char *name,
 	ret = iio_device_register(iio_dev);
 	if (ret)
 		goto error_reset_ch_modes;
+
+	if (sysfs_groups) {
+		ret = device_add_groups(&iio_dev->dev, sysfs_groups);
+		if (ret)
+			goto error_dev_unregister;
+	}
 
 	ret = ad5592r_gpio_init(st);
 	if (ret)

--- a/drivers/iio/dac/ad5592r-base.h
+++ b/drivers/iio/dac/ad5592r-base.h
@@ -72,7 +72,8 @@ struct ad5592r_state {
 };
 
 int ad5592r_probe(struct device *dev, const char *name,
-		const struct ad5592r_rw_ops *ops);
+		const struct ad5592r_rw_ops *ops,
+		const struct attribute_group **sysfs_groups);
 void ad5592r_remove(struct device *dev);
 
 #endif /* __DRIVERS_IIO_DAC_AD5592R_BASE_H__ */

--- a/drivers/iio/dac/ad5592r.c
+++ b/drivers/iio/dac/ad5592r.c
@@ -9,12 +9,16 @@
 #include "ad5592r-base.h"
 
 #include <linux/bitops.h>
+#include <linux/device.h>
+#include <linux/iio/sysfs.h>
+#include <linux/iio/iio.h>
 #include <linux/module.h>
 #include <linux/mod_devicetable.h>
 #include <linux/spi/spi.h>
 
 #define AD5592R_GPIO_READBACK_EN	BIT(10)
 #define AD5592R_LDAC_READBACK_EN	BIT(6)
+#define AD5592R_GEN_CTRL_ADC_BUF_EN	BIT(8)
 
 static int ad5592r_spi_wnop_r16(struct ad5592r_state *st, __be16 *buf)
 {
@@ -30,7 +34,7 @@ static int ad5592r_spi_wnop_r16(struct ad5592r_state *st, __be16 *buf)
 	return spi_sync_transfer(spi, &t, 1);
 }
 
-static int ad5592r_write_dac(struct ad5592r_state *st, unsigned chan, u16 value)
+static int ad5592r_write_dac(struct ad5592r_state *st, unsigned int chan, u16 value)
 {
 	struct spi_device *spi = container_of(st->dev, struct spi_device, dev);
 
@@ -39,7 +43,7 @@ static int ad5592r_write_dac(struct ad5592r_state *st, unsigned chan, u16 value)
 	return spi_write(spi, &st->spi_msg, sizeof(st->spi_msg));
 }
 
-static int ad5592r_read_adc(struct ad5592r_state *st, unsigned chan, u16 *value)
+static int ad5592r_read_adc(struct ad5592r_state *st, unsigned int chan, u16 *value)
 {
 	struct spi_device *spi = container_of(st->dev, struct spi_device, dev);
 	int ret;
@@ -123,15 +127,91 @@ static const struct ad5592r_rw_ops ad5592r_rw_ops = {
 	.gpio_read = ad5592r_gpio_read,
 };
 
+static ssize_t adc_buf_en_show(struct device *dev,
+			       struct device_attribute *attr,
+			       char *buf)
+{
+	struct iio_dev *indio = dev_get_drvdata(dev);
+	struct ad5592r_state *st = iio_priv(indio);
+	u16 reg;
+	int ret;
+
+	ret = ad5592r_reg_read(st, AD5592R_REG_CTRL, &reg);
+	if (ret)
+		return ret;
+
+	return sysfs_emit(buf, "%d\n", !!(reg & AD5592R_GEN_CTRL_ADC_BUF_EN));
+}
+
+static ssize_t adc_buf_en_store(struct device *dev,
+				struct device_attribute *attr,
+				const char *buf, size_t count)
+{
+	struct iio_dev *indio = dev_get_drvdata(dev);
+	struct ad5592r_state *st = iio_priv(indio);
+	unsigned long val;
+	u16 reg;
+	int ret;
+
+	ret = kstrtoul(buf, 10, &val);
+	if (ret)
+		return ret;
+
+	mutex_lock(&st->lock);
+
+	ret = ad5592r_reg_read(st, AD5592R_REG_CTRL, &reg);
+	if (ret) {
+		mutex_unlock(&st->lock);
+		return ret;
+	}
+
+	if (val)
+		reg |= AD5592R_GEN_CTRL_ADC_BUF_EN;
+	else
+		reg &= ~AD5592R_GEN_CTRL_ADC_BUF_EN;
+
+	ret = ad5592r_reg_write(st, AD5592R_REG_CTRL, reg);
+	mutex_unlock(&st->lock);
+	if (ret)
+		return ret;
+
+	return count;
+}
+
+static IIO_DEVICE_ATTR(adc_buf_en, 0644, adc_buf_en_show, adc_buf_en_store, 0);
+
+static struct attribute *ad5592r_sysfs_attrs[] = {
+	&iio_dev_attr_adc_buf_en.dev_attr.attr,
+	NULL,
+};
+
+static const struct attribute_group ad5592r_sysfs_group = {
+	.attrs = ad5592r_sysfs_attrs,
+};
+
+static const struct attribute_group *ad5592r_sysfs_groups[] = {
+	&ad5592r_sysfs_group,
+	NULL,
+};
+
 static int ad5592r_spi_probe(struct spi_device *spi)
 {
+	int ret;
 	const struct spi_device_id *id = spi_get_device_id(spi);
 
-	return ad5592r_probe(&spi->dev, id->name, &ad5592r_rw_ops);
+	ret = ad5592r_probe(&spi->dev, id->name, &ad5592r_rw_ops, ad5592r_sysfs_groups);
+
+	if (ret)
+		return ret;
+
+	return 0;
 }
 
 static void ad5592r_spi_remove(struct spi_device *spi)
 {
+	struct iio_dev *indio = dev_get_drvdata(&spi->dev);
+
+	device_remove_groups(&indio->dev, ad5592r_sysfs_groups);
 	ad5592r_remove(&spi->dev);
 }
 

--- a/drivers/iio/dac/ad5593r.c
+++ b/drivers/iio/dac/ad5593r.c
@@ -106,7 +106,7 @@ static int ad5593r_i2c_probe(struct i2c_client *i2c)
 				     I2C_FUNC_SMBUS_BYTE | I2C_FUNC_I2C))
 		return -EOPNOTSUPP;
 
-	return ad5592r_probe(&i2c->dev, id->name, &ad5593r_rw_ops);
+	return ad5592r_probe(&i2c->dev, id->name, &ad5593r_rw_ops, NULL);
 }
 
 static void ad5593r_i2c_remove(struct i2c_client *i2c)


### PR DESCRIPTION
Add sysfs for ADC_BUF_EN

## PR Description
Adds a read/write sysfs file for the
ADC_BUF_EN bit of the GEN_CTRL_REG register

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
