### PR TITLE
cherry-pick: mfd: rp1: depends on PCI_MSI 

### DIFF
--- a/drivers/mfd/Kconfig
+++ b/drivers/mfd/Kconfig
@@ -2318,6 +2318,7 @@ config MFD_INTEL_M10_BMC_PMCI
 config MFD_RP1
 	tristate "RP1 MFD driver"
 	depends on PCI
+	depends on PCI_MSI
 	select MFD_CORE
 	help
 	  Support for the RP1 peripheral chip.


### PR DESCRIPTION
## PR Description

The driver uses pci_msi methods, only defined when CONFIG_PCI_MSI symbol
is set, and cannot be compiled without. Therefore, it depends on this
symbol.

https://github.com/raspberrypi/linux/pull/6891
cherry-pick https://github.com/raspberrypi/linux/commit/3f1c3474b306509dc901327f140f83680c1df1ab


## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
