### PR TITLE
arm: dts: xilinx: add example for ADAQ4380-4 eval board

### DIFF
--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq4380-4.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq4380-4.dts
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices ADAQ4380-4
+ * https://www.analog.com/media/en/technical-documentation/data-sheets/adaq4380-4.pdf
+ * https://www.analog.com/media/en/technical-documentation/user-guides/eval-adaq4380-4-4370-4-4381-4-ug-2224.pdf
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-adc/ad738x
+ * http://analogdevicesinc.github.io/hdl/projects/ad738x_fmc/index.html
+ *
+ * hdl_project: <ad738x_fmc/zed>
+ * board_revision: <>
+ *
+ * Copyright (C) 2025 Analog Devices Inc.
+ */
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+
+#include "zynq-zed.dtsi"
+#include "zynq-zed-adv7511.dtsi"
+
+/ {
+	eval_u3: eval-board-u3-regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "EVAL +5V supply (U3)";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		regulator-always-on;
+	};
+
+	eval_gnd: eval-board-gnd-regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "EVAL GND (0V) supply";
+		regulator-always-on;
+	};
+
+	// technically, the ADC node should be a regulator provider instead of this
+	adc_ldo: adc-ldo-regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "ADC LDO output";
+		regulator-always-on;
+	};
+
+	trigger_pwm: adc-pwm-trigger {
+		compatible = "pwm-trigger";
+		#trigger-source-cells = <0>;
+		pwms = <&adc_trigger 0 10000 0>;
+	};
+};
+
+&fpga_axi {
+	adc_trigger: pwm@44b00000 {
+		compatible = "adi,axi-pwmgen-2.00.a";
+		reg = <0x44b00000 0x1000>;
+		#pwm-cells = <3>;
+		clocks = <&spi_clk>;
+	};
+
+	spi_clk: clock-controller@44a70000 {
+		compatible = "adi,axi-clkgen-2.00.a";
+		reg = <0x44a70000 0x1000>;
+		#clock-cells = <0>;
+		clocks = <&clkc 15>, <&clkc 15>;
+		clock-names = "clkin1", "s_axi_aclk";
+		clock-output-names = "spi_clk";
+		assigned-clocks = <&spi_clk>;
+		assigned-clock-rates = <160000000>;
+	};
+
+	rx_dma: dma-controller@44a30000 {
+		compatible = "adi,axi-dmac-1.00.a";
+		reg = <0x44a30000 0x1000>;
+		#dma-cells = <1>;
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&clkc 15>;
+	};
+
+	axi_spi_engine_0: spi@44a00000 {
+		compatible = "adi,axi-spi-engine-1.00.a";
+		reg = <0x44a00000 0x1000>;
+		interrupt-parent = <&intc>;
+		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&clkc 15>, <&spi_clk>;
+		clock-names = "s_axi_aclk", "spi_clk";
+
+		dmas = <&rx_dma 0>;
+		dma-names = "offload0-rx";
+		trigger-sources = <&trigger_pwm>;
+
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		adc@0 {
+			compatible = "adi,adaq4380-4";
+			reg = <0>;
+
+			spi-cpol;
+			spi-max-frequency = <80000000>;
+
+			/*
+			 * ADI tree extension (not mainline). Set this based on
+			 * HDL NUM_OF_SDI compile argument. Can omit if =1.
+			 * REVISIT: replace this upstream equivalent when it
+			 * becomes available.
+			 */
+			adi,num-sdi = <4>;
+
+			vcc-supply = <&adc_ldo>;
+			vlogic-supply = <&adc_ldo>;
+			refin-supply = <&eval_u3>;
+			vs-p-supply = <&eval_u3>;
+			vs-n-supply = <&eval_gnd>;
+			ldo-supply = <&eval_u3>;
+
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			channel@0 {
+				reg = <0>;
+				// depends on LKA jumper positions
+				adi,gain-milli = /bits/ 16 <300>;
+			};
+
+			channel@1 {
+				reg = <1>;
+				// depends on LKB jumper positions
+				adi,gain-milli = /bits/ 16 <300>;
+			};
+
+			channel@2 {
+				reg = <2>;
+				// depends on LKC jumper positions
+				adi,gain-milli = /bits/ 16 <300>;
+			};
+
+			channel@3 {
+				reg = <3>;
+				// depends on LKD jumper positions
+				adi,gain-milli = /bits/ 16 <300>;
+			};
+		};
+	};
+};


### PR DESCRIPTION

## PR Description

Add an example for the EVAL-ADAQ4380-4 (FMCZ) evaluation board. These are similar to AD738x, but have different power supply requirements, so worth a separate example.


## PR Type
Example DTS

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
