### PR TITLE
fix: .github: Same branch checkout

### DIFF
--- a/.github/workflows.mirror/self.yml
+++ b/.github/workflows.mirror/self.yml
@@ -15,9 +15,10 @@ jobs:
 
     - name: update-self
       run: |
+        git switch -d
         git fetch origin ${{ inputs.ci_branch }} --depth=1
         git fetch origin cron:cron -f
-        git checkout cron
+        git switch cron
         git rm .github/workflows -r
         git checkout origin/${{ inputs.ci_branch }} -- .github/workflows.mirror
         git mv .github/workflows.mirror .github/workflows

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -32,13 +32,14 @@ jobs:
 
     - name: update-mirror
       run: |
+        git switch -d
         git remote add ${{ inputs.remote_name }} ${{ inputs.fetch_url }} 2>/dev/null || \
           git remote set-url ${{ inputs.remote_name }} ${{ inputs.fetch_url }}
         target_branch=mirror/${{ inputs.remote_name }}/${{ inputs.branch }}
         git remote prune origin
         git remote prune ${{ inputs.remote_name }}
         git fetch ${{ inputs.remote_name }} ${{ inputs.branch }}:$target_branch -f
-        git checkout $target_branch
+        git switch $target_branch
 
         if [[ "${{ inputs.patch_ci }}" == "true" ]]; then
           git fetch origin "${{ inputs.ci_branch }}" --depth=1


### PR DESCRIPTION
## PR Description

Use switch to detach head, to avoid failure if current checkout branch
has the same name.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
