### PR TITLE
iio: adc: ad7768-1: use static for local functions

### DIFF
--- a/drivers/iio/adc/ad7768-1.c
+++ b/drivers/iio/adc/ad7768-1.c
@@ -378,7 +378,7 @@ static int ad7768_set_dig_fil(struct ad7768_state *st,
 	return 0;
 }
 
-int ad7768_gpio_direction_input(struct gpio_chip *chip, unsigned int offset)
+static int ad7768_gpio_direction_input(struct gpio_chip *chip, unsigned int offset)
 {
 	struct ad7768_state *st = gpiochip_get_data(chip);
 	int ret;
@@ -393,8 +393,8 @@ int ad7768_gpio_direction_input(struct gpio_chip *chip, unsigned int offset)
 	return ret;
 }
 
-int ad7768_gpio_direction_output(struct gpio_chip *chip,
-				 unsigned int offset, int value)
+static int ad7768_gpio_direction_output(struct gpio_chip *chip,
+					unsigned int offset, int value)
 {
 	struct ad7768_state *st = gpiochip_get_data(chip);
 	int ret;
@@ -409,7 +409,7 @@ int ad7768_gpio_direction_output(struct gpio_chip *chip,
 	return ret;
 }
 
-int ad7768_gpio_get(struct gpio_chip *chip, unsigned int offset)
+static int ad7768_gpio_get(struct gpio_chip *chip, unsigned int offset)
 {
 	struct ad7768_state *st = gpiochip_get_data(chip);
 	unsigned int val;
@@ -435,7 +435,7 @@ gpio_get_err:
 	return ret;
 }
 
-void ad7768_gpio_set(struct gpio_chip *chip, unsigned int offset, int value)
+static void ad7768_gpio_set(struct gpio_chip *chip, unsigned int offset, int value)
 {
 	struct ad7768_state *st = gpiochip_get_data(chip);
 	unsigned int val;
@@ -456,7 +456,7 @@ gpio_set_err:
 	mutex_unlock(&st->lock);
 }
 
-int ad7768_gpio_request(struct gpio_chip *chip, unsigned int offset)
+static int ad7768_gpio_request(struct gpio_chip *chip, unsigned int offset)
 {
 	struct ad7768_state *st = gpiochip_get_data(chip);
 
@@ -468,7 +468,7 @@ int ad7768_gpio_request(struct gpio_chip *chip, unsigned int offset)
 	return 0;
 }
 
-int ad7768_gpio_init(struct ad7768_state *st)
+static int ad7768_gpio_init(struct ad7768_state *st)
 {
 	int ret;
 


### PR DESCRIPTION
All of the gpio functions are not exported or meant to be user by another source file or driver. Therefore define them as static.

This was spotted when preparing a 6.12 RPI branch as we'll start getting warnings regarding this. So better fix it now.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
