### PR TITLE
iio: imu: adis16550: rework clock range test

### DIFF
--- a/drivers/iio/imu/adis16550.c
+++ b/drivers/iio/imu/adis16550.c
@@ -920,7 +920,7 @@ static int adis16550_reset(struct adis *adis)
 static int adis16550_config_sync(struct adis16550 *st)
 {
 	struct device *dev = &st->adis.spi->dev;
-	const struct adis16550_sync *sync_mode_data;
+	const struct adis16550_sync *sync_mode_data = NULL;
 	struct clk *clk;
 	int ret, i;
 	u16 mode;
@@ -943,7 +943,7 @@ static int adis16550_config_sync(struct adis16550 *st)
 		}
 	}
 
-	if (i == st->info->num_sync)
+	if (!sync_mode_data)
 		return dev_err_probe(dev, -EINVAL, "Clk rate: %lu not in a valid range",
 				     st->clk_freq_hz);
 


### PR DESCRIPTION
This patch needs to go upstream first. I'm making a PR here to test that it does in fact fix the gcc analyzer warning.

## PR Description

Rework the clock rate range test to test if sync_mode_data != NULL instead of testing if the for loop index variable. This makes it easier for static analyzers to see that we aren't using an uninitialized sync_mode_data [1].

Link: https://github.com/analogdevicesinc/linux/pull/2831/files#diff-e60c8024905ba921f6aac624cae67d6f9bd54aa5af5a27ae60a8ca21ef120ddaR950 [1]

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
