### PR TITLE
sc589-mini: dts: increase partition size to match actual SPI size for latest revisions

### DIFF
--- a/arch/arm/boot/dts/adi/sc589-mini.dts
+++ b/arch/arm/boot/dts/adi/sc589-mini.dts
@@ -157,7 +157,7 @@
 
 		partition@4 {
 			label = "root file system (spi)";
-			reg = <0x08e0000 0x1AC0000>;
+			reg = <0x08e0000 0x3720000>;
 		};
 	};
 };


### PR DESCRIPTION

## PR Description

sc589-mini: dts: increase partition size to match actual SPI size for latest revisions 1.5 and 2.1

## PR Type
- [x ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have tested the changes on the relevant hardware
- [x] I have updated the documentation outside this repo accordingly (if there is the case)
