### PR TITLE
iio: adf4030: Add adf4030_fwnode_xlate() for non-1:1 map

### DIFF
--- a/drivers/iio/frequency/adf4030.c
+++ b/drivers/iio/frequency/adf4030.c
@@ -887,10 +887,24 @@ static int adf4030_read_avail(struct iio_dev *indio_dev,
 	}
 }
 
+static int adf4030_fwnode_xlate(struct iio_dev *indio_dev,
+				const struct fwnode_reference_args *iiospec)
+{
+	struct adf4030_state *st = iio_priv(indio_dev);
+
+	for (int i = 0; i < st->num_channels; i++) {
+		if (st->channels[i].num == iiospec->args[0])
+			return i;
+	}
+
+	return -EINVAL;
+}
+
 static const struct iio_info adf4030_iio_info = {
 	.read_raw = &adf4030_read_raw,
 	.write_raw = &adf4030_write_raw,
 	.read_avail = &adf4030_read_avail,
+	.fwnode_xlate = &adf4030_fwnode_xlate,
 	.debugfs_reg_access = &adf4030_reg_access,
 };
 


### PR DESCRIPTION
Adds method to map the fwnode_reference_args->args[0] value to the iio_channel index, instead of relying on __fwnode_iio_simple_xlate() that supports only 1:1 mapped channels. Allows to not describe and skip channels in the devicetree.

## PR Description

- Please replace this comment with a summary of your changes, and add any context
necessary to understand them. List any dependencies required for this change.
- To check the checkboxes below, insert a 'x' between square brackets (without
any space), or simply check them after publishing the PR.
- If you changes include a breaking change, please specify dependent PRs in the
description and try to push all related PRs simultaneously.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
