### PR TITLE
iio: adc: ad4130: Fix clock init and GPIO init.

### DIFF
--- a/drivers/iio/adc/ad4130.c
+++ b/drivers/iio/adc/ad4130.c
@@ -1863,7 +1863,7 @@ static int ad4130_setup_int_clk(struct ad4130_state *st)
 {
 	struct device *dev = &st->spi->dev;
 	struct device_node *of_node = dev_of_node(dev);
-	struct clk_init_data init;
+	struct clk_init_data init = {};
 	const char *clk_name;
 	struct clk *clk;
 	int ret;
@@ -1940,7 +1940,12 @@ static int ad4130_setup(struct iio_dev *indio_dev)
 	 * Configure all GPIOs for output. If configured, the interrupt function
 	 * of P2 takes priority over the GPIO out function.
 	 */
-	val =  AD4130_IO_CONTROL_GPIO_CTRL_MASK;
+	val = 0;
+	for (i = 0; i < AD4130_MAX_GPIOS; i++) {
+		if (st->pins_fn[i + AD4130_AIN2_P1] != AD4130_PIN_FN_NONE)
+			continue;
+		val |= FIELD_PREP(AD4130_IO_CONTROL_GPIO_CTRL_MASK, BIT);
+	}
 	val |= FIELD_PREP(AD4130_IO_CONTROL_INT_PIN_SEL_MASK, st->int_pin_sel);
 
 	ret = regmap_write(st->regmap, AD4130_IO_CONTROL_REG, val);


### PR DESCRIPTION

## PR Description
There is an error while probing the AD4130. The clk_init_data has to be initialized as an empty struct otherwise the probe will fail.

There is an error assigning the functions of GPIO pins. Before setting the GPIO as an output, the GPIO has to be verified if it does not already has a function.

## PR Type
- [X] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [X] I have conducted a self-review of my own code changes
- [X] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
