### PR TITLE
ci: add staging-rpi/rpi-6.12.y to cron.yml and use /dev/shm

### DIFF
--- a/.github/workflows.mirror/cron.yml
+++ b/.github/workflows.mirror/cron.yml
@@ -15,6 +15,17 @@ jobs:
       branch: "main"
       patch_ci: "false"
 
+  adi-staging-rpi-rpi-6.12.y:
+    uses: ./.github/workflows/mirror.yml
+    secrets: inherit
+    permissions:
+      contents: write
+    with:
+      remote_name: "analogdevicesinc/linux"
+      fetch_url: "https://github.com/analogdevicesinc/linux.git"
+      branch: "staging-rpi/rpi-6.12.y"
+      patch_ci: "false"
+
   next-linux-next-master:
     uses: ./.github/workflows/mirror.yml
     needs: [adi-main]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,9 @@ on:
       warn:
         value: ${{ jobs.build.outputs.warn }}
 
+env:
+  run_id: ${{ github.run_id }}
+
 jobs:
   build:
     runs-on: [self-hosted, v1]

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,3 +1,7 @@
+if [[ -z "$run_id" ]]; then
+	export run_id=$(uuidgen)
+fi
+
 check_checkpatch() {
 	local mail=
 	local fail=0
@@ -322,7 +326,7 @@ check_cppcheck () {
 }
 
 compile_devicetree() {
-	local tmp_log_file=.ci_compile_devicetree_log
+	local tmp_log_file=/dev/shm/$run_id.ci_compile_devicetree.log
 	local err=0
 	local dtb_file=
 	local dts_files=""
@@ -417,7 +421,7 @@ compile_devicetree() {
 }
 
 compile_kernel() {
-	local tmp_log_file=.ci_compile_kernel_log
+	local tmp_log_file=/dev/shm/$run_id.ci_compile_kernel.log
 	local err=0
 	local regex='^[[:alnum:]/._-]+:[[:digit:]]+:[[:digit:]]+: .*$'
 	local fail=0


### PR DESCRIPTION
## PR Description

on /dev/shm commit, run_id will have a single value for all jobs in the same workflow file, but since there is a single job it doesn't matter.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
