### PR TITLE
iio: adc: Add initial driver support for MAX22531

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -311,6 +311,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	rpi-ltc6952.dtbo \
 	rpi-max14830-i2c.dtbo \
 	rpi-max14830-spi.dtbo \
+	rpi-max22531.dtbo \
 	rpi-max31335.dtbo \
 	rpi-poe.dtbo \
 	rpi-poe-plus.dtbo \

--- a/arch/arm/boot/dts/overlays/rpi-max22531-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-max22531-overlay.dts
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: (GPL-2.0+)
+/*
+ * Device Tree Overlay for MAX22531 
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "bcrm,bcm2711";
+
+	reg_vdd: regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "vdd";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	max225341@0 {
+		compatible = "maxim,max22531";
+		reg = <0>;	/* Using CS0 on spi0 */
+		spi-max-frequency = <10000000>;
+		vref-supply = <&reg_vdd>;
+
+	};
+};

--- a/arch/arm/boot/dts/overlays/rpi-max22531-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-max22531-overlay.dts
@@ -7,7 +7,7 @@
 /plugin/;
 
 / {
-	compatible = "bcrm,bcm2711";
+	compatible = "brcm,bcm2835-spi", "brcm,bcm2711";
 
 	reg_vdd: regulator {
 		compatible = "regulator-fixed";
@@ -22,7 +22,7 @@
 &spi0 {
 	status = "okay";
 
-	max225341@0 {
+	max22531@0 {
 		compatible = "maxim,max22531";
 		reg = <0>;	/* Using CS0 on spi0 */
 		spi-max-frequency = <10000000>;

--- a/drivers/iio/adc/Kconfig
+++ b/drivers/iio/adc/Kconfig
@@ -1126,6 +1126,12 @@ config MAX1363
 	  To compile this driver as a module, choose M here: the module will be
 	  called max1363.
 
+config MAX22531
+        tristate "Analog Devices MAX22531 ADC Driver"
+        depends on SPI
+        help
+          Say yes here to build support for this driver.
+
 config MAX77541_ADC
 	tristate "Analog Devices MAX77541 ADC driver"
 	depends on MFD_MAX77541

--- a/drivers/iio/adc/Makefile
+++ b/drivers/iio/adc/Makefile
@@ -156,6 +156,7 @@ obj-$(CONFIG_MAX11205) += max11205.o
 obj-$(CONFIG_MAX11410) += max11410.o
 obj-$(CONFIG_MAX1241) += max1241.o
 obj-$(CONFIG_MAX1363) += max1363.o
+obj-$(CONFIG_MAX22531) += max22531.o
 obj-$(CONFIG_MAX77541_ADC) += max77541-adc.o
 obj-$(CONFIG_MAX9611) += max9611.o
 obj-$(CONFIG_MCP320X) += mcp320x.o

--- a/drivers/iio/adc/max22531.c
+++ b/drivers/iio/adc/max22531.c
@@ -1,14 +1,41 @@
 #include <linux/module.h>
 #include <linux/spi/spi.h>
 #include <linux/iio/iio.h>
+#include <linux/regmap.h>
+#include <linux/regulator/consumer.h>
+
+#define MAX22531_REG_PROD_ID		0x00
+#define MAX22531_REG_ADC1		0x01
+#define MAX22531_REG_ADC2		0x02
+#define MAX22531_REG_ADC3		0x03
+#define MAX22531_REG_ADC4		0x04
+#define MAX22531_REG_FADC1		0x05
+#define MAX22531_REG_FADC2		0x06
+#define MAX22531_REG_FADC3		0x07
+#define MAX22531_REG_FADC4		0x08
+#define MAX22531_REG_COUTHI1		0x09
+#define MAX22531_REG_COUTHI2		0x0a
+#define MAX22531_REG_COUTHI3		0x0b
+#define MAX22531_REG_COUTHI4		0x0c
+#define MAX22531_REG_COUTLO1		0x0d
+#define MAX22531_REG_COUTLO2		0x0e
+#define MAX22531_REG_COUTLO3		0x0f
+#define MAX22531_REG_COUTLO4		0x10
+#define MAX22531_REG_COUT_STATUS	0x11
+#define MAX22531_REG_INTERRUPT_STATUS	0x12
+#define MAX22531_REG_INTERRUPT_ENABLE	0x13
+#define MAX22531_REG_CONTROL		0x14
 
 enum max22531_id {
 	max22531,
 };
 
 struct max22531 {
-	struct spi_device *spi;
+	struct spi_device *spi_dev;
 	struct regulator *vref;
+	struct regulator *vddl;
+	struct regulator *vddf;
+	struct regmap *regmap;
 };
 
 #define MAX22531_CHANNEL(ch)						\
@@ -30,53 +57,111 @@ static const struct iio_chan_spec max22531_channels[] = {
 	IIO_CHAN_SOFT_TIMESTAMP(2),
 };
 
-static const struct iio_info max22531_info = {
+static const struct regmap_config regmap_config = {
+	.reg_bits = 16,
+	.val_bits = 16,
+	.max_register = 0x14,
 };
+
+static int max22531_read_raw(struct iio_dev *indio_dev,
+			 struct iio_chan_spec const *chan,
+			 int *val, int *val2, long mask)
+{
+	struct regmap **regmap = iio_priv(indio_dev);
+	int ret; 
+
+	/* mock for now */
+	switch(mask) {
+	case IIO_CHAN_INFO_RAW:
+		ret = regmap_read(*regmap, chan->address, val);
+		if (ret) 
+			return ret;
+		return IIO_VAL_INT;
+	case IIO_CHAN_INFO_SCALE:
+		return IIO_VAL_INT;
+	default:
+		return -EINVAL;
+	}
+}
+
+static const struct iio_info max22531_info = {
+	.read_raw = max22531_read_raw,
+};
+
+static void max22531_regulator_disable(void *reg)
+{
+	regulator_disable(reg);
+}
 
 static int max22531_probe(struct spi_device *spi)
 {
-	pr_err("max22531: probe on\n");
+	dev_info(&spi->dev, "MAX22531: probing ADC\n");
 
+	unsigned int ret, prod_id;
 	struct max22531 *adc;
 	struct iio_dev *indio_dev;
-	const struct spi_device_id *id = spi_get_device_id(spi);
 
 	indio_dev = devm_iio_device_alloc(&spi->dev, sizeof(*adc));
 	if (!indio_dev) {
-		pr_err("max22531: Failed to allocate memory for IIO device.\n");
+		dev_err(&spi->dev, "MAX22531: Failed to allocate memory"
+			       "for IIO device.\n");
 		return -ENOMEM;
 	}
 
 	adc = iio_priv(indio_dev);
-	adc->spi = spi;
+	adc->spi_dev = spi;
 	
-	indio_dev->name = spi_get_device_id(spi)->name;
+	indio_dev->name = "max22531";
 	indio_dev->info = &max22531_info;
 	indio_dev->channels = max22531_channels;
 	indio_dev->num_channels = ARRAY_SIZE(max22531_channels);
+
+	adc->regmap = devm_regmap_init_spi(spi, &regmap_config);
+	if (IS_ERR(adc->regmap))
+		dev_err(&spi->dev, "regmap init failure\n");
+
+	ret = regmap_read(adc->regmap, MAX22531_REG_PROD_ID, &prod_id);
+	if (ret)
+		dev_err(&spi->dev, "Failed to read PROD_ID\n");
+	else
+		dev_info(&spi->dev, "MAX22531: Successfully read PROD_ID"
+				": %d from the driver.\n", ret);
+
+	adc->vref = devm_regulator_get(&spi->dev, "vref");
+	if (IS_ERR(adc->vref))
+		dev_err(&spi->dev, "Failed to retrieve vref\n");
+
+	ret = regulator_enable(adc->vref);
+	if (ret)
+		return ret;
+
+	ret = devm_add_action_or_reset(&spi->dev, max22531_regulator_disable,
+					adc->vref);
+	if (ret)
+		return ret;
 
 	return devm_iio_device_register(&spi->dev, indio_dev);
 }
 
 static const struct spi_device_id max22531_id[] = {
-	{ "max22531", max22531 },
-	{}
+	{ "max22531" },
+	{ }
 };
 MODULE_DEVICE_TABLE(spi, max22531_id);
 
-static const struct of_device_id max22531_dt_ids[] = {
-	{ .compatible = "maxim,max22531" },
-	{},
+static const struct of_device_id max22531_spi_of_id[] = {
+	{ .compatible = "adi,max22531" },
+	{ }
 };
-MODULE_DEVICE_TABLE(of, max22531_dt_ids);
+MODULE_DEVICE_TABLE(of, max22531_spi_of_id);
 
 static struct spi_driver max22531_driver = {
 	.driver = {
 		.name = "max22531",
-		.of_match_table = max22531_dt_ids,
+		.of_match_table = max22531_spi_of_id,
 	},
-	.probe = max22531_probe,
-	.id_table = max22531_id,
+	.probe		= max22531_probe,
+	.id_table	= max22531_id,
 };
 module_spi_driver(max22531_driver);
 

--- a/drivers/iio/adc/max22531.c
+++ b/drivers/iio/adc/max22531.c
@@ -1,0 +1,85 @@
+#include <linux/module.h>
+#include <linux/spi/spi.h>
+#include <linux/iio/iio.h>
+
+enum max22531_id {
+	max22531,
+};
+
+struct max22531 {
+	struct spi_device *spi;
+	struct regulator *vref;
+};
+
+#define MAX22531_CHANNEL(ch)						\
+	{								\
+		.type = IIO_VOLTAGE,					\
+		.indexed = 1,						\
+		.channel = (ch),					\
+		.info_mask_separate = BIT(IIO_CHAN_INFO_RAW),		\
+		.info_mask_shared_by_type = BIT(IIO_CHAN_INFO_SCALE),	\
+		.scan_index = ch,					\
+		.output = 0,						\
+	}
+
+static const struct iio_chan_spec max22531_channels[] = {
+	MAX22531_CHANNEL(0),
+	MAX22531_CHANNEL(1),
+	MAX22531_CHANNEL(2),
+	MAX22531_CHANNEL(3),
+	IIO_CHAN_SOFT_TIMESTAMP(2),
+};
+
+static const struct iio_info max22531_info = {
+};
+
+static int max22531_probe(struct spi_device *spi)
+{
+	pr_err("max22531: probe on\n");
+
+	struct max22531 *adc;
+	struct iio_dev *indio_dev;
+	const struct spi_device_id *id = spi_get_device_id(spi);
+
+	indio_dev = devm_iio_device_alloc(&spi->dev, sizeof(*adc));
+	if (!indio_dev) {
+		pr_err("max22531: Failed to allocate memory for IIO device.\n");
+		return -ENOMEM;
+	}
+
+	adc = iio_priv(indio_dev);
+	adc->spi = spi;
+	
+	indio_dev->name = spi_get_device_id(spi)->name;
+	indio_dev->info = &max22531_info;
+	indio_dev->channels = max22531_channels;
+	indio_dev->num_channels = ARRAY_SIZE(max22531_channels);
+
+	return devm_iio_device_register(&spi->dev, indio_dev);
+}
+
+static const struct spi_device_id max22531_id[] = {
+	{ "max22531", max22531 },
+	{}
+};
+MODULE_DEVICE_TABLE(spi, max22531_id);
+
+static const struct of_device_id max22531_dt_ids[] = {
+	{ .compatible = "maxim,max22531" },
+	{},
+};
+MODULE_DEVICE_TABLE(of, max22531_dt_ids);
+
+static struct spi_driver max22531_driver = {
+	.driver = {
+		.name = "max22531",
+		.of_match_table = max22531_dt_ids,
+	},
+	.probe = max22531_probe,
+	.id_table = max22531_id,
+};
+module_spi_driver(max22531_driver);
+
+MODULE_AUTHOR("Abhinav Jain <jain.abhinav177@gmail.com>");
+MODULE_DESCRIPTION("MAX22531 ADC");
+MODULE_LICENSE("GPL v2");


### PR DESCRIPTION
MAX22531 is a galvanically isolated, field-side self-powered, 4-channel, multiplexed, 12-bit ADC.

## PR Description

Basic IIO ADC max22531 driver features:
- Definitions for register addresses and useful constants (if any).
- Definitions for the IIO channels.
- A device state struct.
- A read_raw function implementation (may be just a mock for now).
- An iio_info struct populated with a reference to the read_raw function.
- A probe function to initialize and setup the device.
- SPI and device tree MODULE_DEVICE_TABLEs

## PR Type
- New feature (a change that adds new functionality)

## PR Checklist
- I have conducted a self-review of my own code changes
- I could not test the DT overlay and/or the driver probing. However, I have compiled it on my machine and used static tools to ensure the code is okay.