### PR TITLE
Add device tree for ADAQ23875. Add one lane support for CN0577

### DIFF
--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq23875.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq23875.dts
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0
 /*
- * Analog Devices LTC2387-18/ADAQ23878
+ * Analog Devices LTC2387-16/ADAQ23875
  *
- * hdl_project: <cn0577/zed>
+ * hdl_project: <cn0577/zed with make parameter ADC_RES=16>
  * for all config modes, please check the README of the HDL project
  * board_revision: <A>
  *
@@ -39,11 +39,11 @@
 			    <&gpio0 87 GPIO_ACTIVE_HIGH>;
 		channel@0 {
 			reg = <0>;
-			label = "ltc2387_testpat";
+			label = "adaq23875_testpat";
 		};
 		channel@1 {
 			reg = <1>;
-			label = "ltc2387_pd";
+			label = "adaq23875_pd";
 		};
 	};
 };
@@ -62,7 +62,7 @@
 
 			dma-channel@0 {
 				reg = <0>;
-				adi,source-bus-width = <32>;
+				adi,source-bus-width = <16>;
 				adi,source-bus-type = <2>;
 				adi,destination-bus-width = <64>;
 				adi,destination-bus-type = <0>;
@@ -73,14 +73,14 @@
 	axi_pwm_gen: pwm@44a60000 {
 		compatible = "adi,axi-pwmgen-2.00.a";
 		reg = <0x44a60000 0x1000>;
-		label = "ltc2387_if";
+		label = "adaq23875_if";
 		#pwm-cells = <2>;
 		clocks = <&clkc 15>, <&ext_clk>;
 		clock-names = "axi", "ext";
 	};
 
-	ltc2387@0{
-		compatible = "ltc2387-18";
+	adaq23875@0{
+		compatible = "adaq23875";
 		clocks = <&ext_clk>;
 		dmas = <&rx_dma 0>;
 		dma-names = "rx";

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-cn0577.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-cn0577.dts
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: GPL-2.0
 /*
- * Analog Devices LTC2387
+ * Analog Devices LTC2387-18/ADAQ23878
  *
  * hdl_project: <cn0577/zed>
  * board_revision: <A>
  *
- * Copyright (C) 2022 Analog Devices Inc.
+ * Copyright (C) 2022 - 2025 Analog Devices Inc.
  */
 /dts-v1/;
 
@@ -54,6 +54,19 @@
 		#dma-cells = <1>;
 		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 15>;
+
+		adi,channels {
+			#size-cells = <0>;
+			#address-cells = <1>;
+
+			dma-channel@0 {
+				reg = <0>;
+				adi,source-bus-width = <32>;
+				adi,source-bus-type = <2>;
+				adi,destination-bus-width = <64>;
+				adi,destination-bus-type = <0>;
+			};
+		};
 	};
 
 	axi_pwm_gen: pwm@44a60000 {
@@ -75,6 +88,7 @@
 		pwm-names = "cnv", "clk_en";
 		vref-supply = <&vref>;
 
-		adi,use-two-lanes;
+		// uncomment the below command to use in one lane mode
+		// adi,use-one-lane;
 	};
 };

--- a/drivers/iio/adc/ltc2387.c
+++ b/drivers/iio/adc/ltc2387.c
@@ -222,10 +222,13 @@ static int ltc2387_setup(struct iio_dev *indio_dev)
 	struct ltc2387_dev *ltc = iio_priv(indio_dev);
 	struct device *dev = indio_dev->dev.parent;
 
-	if (device_property_present(dev, "adi,use-two-lanes"))
+	if (device_property_present(dev, "adi,use-one-lane")) {
+		ltc->lane_mode = ONE_LANE;
+		return ltc2387_set_sampling_freq(ltc, 7.5 * MHz);
+	} else {
 		ltc->lane_mode = TWO_LANES;
-
-	return ltc2387_set_sampling_freq(ltc, 15 * MHz);
+		return ltc2387_set_sampling_freq(ltc, 15 * MHz);
+	}
 }
 
 static int ltc2387_read_raw(struct iio_dev *indio_dev,


### PR DESCRIPTION
## PR Description

- Added the device tree for ADAQ23875. It supports the ADAQ23876 as well, if the compatible is changed to "adaq23876"
- The CN0577 device tree supports the ADAQ23878 if the compatible is changed to "adaq23878"
- Added one lane and two lanes (default) support to both the device trees. To change to one lane mode, an attribute needs to be specified "adi,use-one-lane;"
- Tested in hardware with all combinations of one lane and two lanes, on all ADAQ devices, with the HDL changes from this PR https://github.com/analogdevicesinc/hdl/pull/1850

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
