### PR TITLE
spi: legacy-spi-engine: no offload support as a module

### DIFF
--- a/include/linux/spi/legacy-spi-engine.h
+++ b/include/linux/spi/legacy-spi-engine.h
@@ -9,7 +9,7 @@
 #ifndef _INCLUDE_LINUX_SPI_SPI_ENGINE_H_
 #define _INCLUDE_LINUX_SPI_SPI_ENGINE_H_
 
-#ifdef CONFIG_SPI_AXI_SPI_ENGINE
+#if IS_REACHABLE(CONFIG_SPI_AXI_SPI_ENGINE)
 
 bool legacy_spi_engine_offload_supported(struct spi_device *spi);
 void legacy_spi_engine_offload_enable(struct spi_device *spi, bool enable);


### PR DESCRIPTION

## PR Description

No offload support for builtin users when using the legacy driver as a module.

Solves redefinition and, for other fix options, modpost failure.

In other terms "the legacy does not have the assertions required for optional handling during execution"

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
