### PR TITLE
misc: mathworks: fix some -Wint-to-pointer-cast

### DIFF
--- a/drivers/misc/mathworks/mathworks_ip_common.c
+++ b/drivers/misc/mathworks/mathworks_ip_common.c
@@ -231,7 +231,7 @@ static vm_fault_t mathworks_ip_mmap_fault(struct vm_fault *vmf)
     struct page *thisPage;
     unsigned long offset;
     offset = (vmf->pgoff - vma->vm_pgoff) << PAGE_SHIFT;
-    thisPage = virt_to_page((void *)(thisIpcore->mem->start + offset));
+    thisPage = virt_to_page((void *)(uintptr_t)(thisIpcore->mem->start + offset));
     get_page(thisPage);
     vmf->page = thisPage;
     return 0;

--- a/drivers/misc/mathworks/mw_stream_channel.c
+++ b/drivers/misc/mathworks/mw_stream_channel.c
@@ -773,7 +773,7 @@ static vm_fault_t mwadma_mmap_fault(struct vm_fault *vmf)
     struct page *thisPage;
     unsigned long offset;
     offset = (vmf->pgoff - vma->vm_pgoff) << PAGE_SHIFT;
-    thisPage = virt_to_page((void *)(MWDEV_TO_MWIP(mwdev)->mem->start + offset));
+    thisPage = virt_to_page((void *)(uintptr_t)(MWDEV_TO_MWIP(mwdev)->mem->start + offset));
     get_page(thisPage);
     vmf->page = thisPage;
     return 0;


### PR DESCRIPTION
## PR Description

Some 32bits architectures (like those in RPIs) support LPAE (Large Physical Address Extension) which means phys_addr_t will be of 'u64' type. Therefore we can have some int-to-pointer-cast warnings if not properly casting (in calls like virt_to_page()). Hence, first cast to uintptr_t before doing (void *).

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
