### PR TITLE
drivers/misc/mathworks: Use wrapper mathods for devm

### DIFF
--- a/drivers/misc/mathworks/mathworks_generic_of.c
+++ b/drivers/misc/mathworks/mathworks_generic_of.c
@@ -19,6 +19,7 @@
 
 #define DRIVER_NAME "mathworks_generic_of"
 
+#if defined(CONFIG_I2C)
 static inline void mwgen_of_node_put(void *data)
 {
 	struct device_node *node = data;
@@ -100,6 +101,7 @@ static int mathworks_generic_of_i2c_init(struct mathworks_ip_info *thisIpcore){
 
 	return 0;
 }
+#endif
 
 static int	mathworks_generic_of_get_param(struct mathworks_ip_info *thisIpcore, void *arg)
 {

--- a/drivers/misc/mathworks/mw_mm_iio_channel.c
+++ b/drivers/misc/mathworks/mw_mm_iio_channel.c
@@ -192,6 +192,13 @@ static void mw_mm_iio_channel_release(struct device *dev)
 {
 }
 
+static inline void mw_device_unregister(void *data)
+{
+	struct device *dev = data;
+
+	device_unregister(dev);
+}
+
 static struct iio_dev *devm_mw_mm_iio_alloc(
 		struct mathworks_ipcore_dev *mwdev,
 		struct device_node *node,
@@ -253,7 +260,7 @@ static struct iio_dev *devm_mw_mm_iio_alloc(
 	if (status)
 		return ERR_PTR(status);
 
-	status = devm_add_action(IP2DEVP(mwdev), (devm_action_fn)device_unregister, &mwchan->dev);
+	status = devm_add_action(IP2DEVP(mwdev), mw_device_unregister, &mwchan->dev);
 	if (status) {
 		device_unregister(&mwchan->dev);
 		return ERR_PTR(status);

--- a/drivers/misc/mathworks/mw_stream_iio_channel.c
+++ b/drivers/misc/mathworks/mw_stream_iio_channel.c
@@ -490,6 +490,13 @@ static void mw_stream_iio_channel_release(struct device *dev)
 {
 }
 
+static inline void mw_device_unregister(void *data)
+{
+	struct device *dev = data;
+
+	device_unregister(dev);
+}
+
 static struct iio_dev *devm_mw_stream_iio_alloc(
 		struct mathworks_ipcore_dev *mwdev,
 		struct device_node *node,
@@ -565,7 +572,7 @@ static struct iio_dev *devm_mw_stream_iio_alloc(
 	if (status)
 		return ERR_PTR(status);
 
-	status = devm_add_action(IP2DEVP(mwdev), (devm_action_fn)device_unregister, &mwchan->dev);
+	status = devm_add_action(IP2DEVP(mwdev), mw_device_unregister, &mwchan->dev);
 	if (status) {
 		device_unregister(&mwchan->dev);
 		return ERR_PTR(status);

--- a/include/linux/mathworks/mathworks_ip.h
+++ b/include/linux/mathworks/mathworks_ip.h
@@ -34,7 +34,6 @@
 /*********************************************************
 * Devm Helpers
 *********************************************************/
-typedef void (*devm_action_fn)(void *);
 
 static inline int devm_add_action_helper(struct device *dev, void (*action)(void *), void *data){
 	int status;


### PR DESCRIPTION
## PR Description

To solve
```
cast from 'void (*)(struct device *)' to 'devm_action_fn' (aka 'void (*)(void *)') converts to incompatible function type [-Werror,-Wcast-function-type-strict] 48 | status = devm_add_action_helper(thisIpcore->dev, (devm_action_fn)put_device, &thisIpcore->i2c->dev); | 
```
on strict compile

Not sure the upstream for this driver.

Note: changed base to test #2877 

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
