### PR TITLE
Enable mmc DT node

### DIFF
--- a/arch/arm64/boot/dts/adi/sc598-som.dtsi
+++ b/arch/arm64/boot/dts/adi/sc598-som.dtsi
@@ -336,14 +336,14 @@
 	};
 };
 
-//&mmc0{
-//	pinctrl-names = "default";
-//	pinctrl-0 = <&mmc0_8bgrp>;
-//	bus-width = <8>;
-//	max-frequency = <50000000>;
-//	non-removable;
-//	status = "okay";
-//};
+&mmc0{
+	pinctrl-names = "default";
+	pinctrl-0 = <&mmc0_8bgrp>;
+	bus-width = <8>;
+	max-frequency = <50000000>;
+	non-removable;
+	status = "okay";
+};
 
 &usb0_phy {
 	reset-gpios = <&gpg 11 GPIO_ACTIVE_LOW>;


### PR DESCRIPTION
## PR Description

Re-enabling mmc DT node that was originally commented out in the transition from 5.15 to 6.12.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have tested the changes on the relevant hardware
- [] I have updated the documentation outside this repo accordingly (if there is the case)
