### PR TITLE
Staging/iio masklength cleanup

### DIFF
--- a/drivers/iio/adc/ad_adc.c
+++ b/drivers/iio/adc/ad_adc.c
@@ -362,7 +362,7 @@ static int axiadc_update_scan_mode(struct iio_dev *indio_dev,
 	struct axiadc_state *st = iio_priv(indio_dev);
 	unsigned int i, ctrl;
 
-	for (i = 0; i < indio_dev->masklength; i++) {
+	for (i = 0; i < iio_get_masklength(indio_dev); i++) {
 		ctrl = axiadc_read(st, ADI_REG_CHAN_CNTRL(i));
 
 		if (test_bit(i, scan_mask))

--- a/drivers/iio/adc/ad_pulsar.c
+++ b/drivers/iio/adc/ad_pulsar.c
@@ -622,20 +622,19 @@ static int ad_pulsar_buffer(struct iio_dev *indio_dev,
 				  adc->info->num_channels);
 
 	last = find_last_bit(indio_dev->active_scan_mask,
-			     indio_dev->masklength);
+			     iio_get_masklength(indio_dev));
 
 	first = find_first_bit(indio_dev->active_scan_mask,
-			       indio_dev->masklength);
+			       iio_get_masklength(indio_dev));
 	if (num_en_ch > 1) {
 		second = find_next_bit(indio_dev->active_scan_mask,
-				       indio_dev->masklength,
+				       iio_get_masklength(indio_dev),
 				       first + 1);
 	}
 
 	spi_message_init(msg);
 
-	for_each_set_bit(ch, indio_dev->active_scan_mask,
-			 indio_dev->masklength) {
+	iio_for_each_active_channel(indio_dev, ch) {
 		active_ch[i] = ch;
 		i++;
 	}

--- a/drivers/iio/adc/admc_adc.c
+++ b/drivers/iio/adc/admc_adc.c
@@ -104,7 +104,7 @@ static int axiadc_update_scan_mode(struct iio_dev *indio_dev,
 	struct axiadc_state *st = iio_priv(indio_dev);
 	unsigned i, ctrl;
 
-	for (i = 0; i < indio_dev->masklength; i++) {
+	for (i = 0; i < iio_get_masklength(indio_dev); i++) {
 		ctrl = axiadc_read(st, ADI_REG_CHAN_CNTRL(i));
 
 		if (test_bit(i, scan_mask))

--- a/drivers/iio/adc/admc_speed.c
+++ b/drivers/iio/adc/admc_speed.c
@@ -104,7 +104,7 @@ static int axiadc_update_scan_mode(struct iio_dev *indio_dev,
 	struct axiadc_state *st = iio_priv(indio_dev);
 	unsigned i, ctrl;
 
-	for (i = 0; i < indio_dev->masklength; i++) {
+	for (i = 0; i < iio_get_masklength(indio_dev); i++) {
 		ctrl = axiadc_read(st, ADI_REG_CHAN_CNTRL(i));
 
 		if (test_bit(i, scan_mask))

--- a/drivers/iio/adc/cf_axi_adc_core.c
+++ b/drivers/iio/adc/cf_axi_adc_core.c
@@ -721,7 +721,7 @@ static int axiadc_update_scan_mode(struct iio_dev *indio_dev,
 	struct axiadc_state *st = iio_priv(indio_dev);
 	unsigned i, ctrl;
 
-	for (i = 0; i < indio_dev->masklength; i++) {
+	for (i = 0; i < iio_get_masklength(indio_dev); i++) {
 		if (i > (st->have_slave_channels - 1))
 			ctrl = axiadc_slave_read(st,
 				ADI_REG_CHAN_CNTRL(i - st->have_slave_channels));

--- a/drivers/iio/dac/ad5686.c
+++ b/drivers/iio/dac/ad5686.c
@@ -522,7 +522,7 @@ static irqreturn_t ad5686_trigger_handler(int irq, void *p)
 		goto out;
 
 	mutex_lock(&st->lock);
-	for_each_set_bit(i, indio_dev->active_scan_mask, indio_dev->masklength) {
+	iio_for_each_active_channel(indio_dev, i) {
 		val = (sample[1] << 8) + sample[0];
 
 		chan = &indio_dev->channels[i];

--- a/drivers/iio/dac/ad7303.c
+++ b/drivers/iio/dac/ad7303.c
@@ -78,9 +78,7 @@ static irqreturn_t ad7303_trigger_handler(int irq, void *p)
 		goto out;
 
 	j = 0;
-	for_each_set_bit(i,
-		indio_dev->active_scan_mask,
-		indio_dev->masklength) {
+	iio_for_each_active_channel(indio_dev, i) {
 		st->dac_cache[i] = sample[j];
 		val = AD7303_CMD_UPDATE_INPUT |
 			(i << AD7303_CFG_ADDR_OFFSET) |
@@ -105,7 +103,7 @@ static int ad7303_update_scan_mode(struct iio_dev *indio_dev,
 	struct ad7303_state *st = iio_priv(indio_dev);
 	int i;
 
-	st->num_transfers = bitmap_weight(scan_mask, indio_dev->masklength);
+	st->num_transfers = bitmap_weight(scan_mask, iio_get_masklength(indio_dev));
 
 	spi_message_init(&st->msg);
 

--- a/drivers/iio/frequency/cf_axi_dds.c
+++ b/drivers/iio/frequency/cf_axi_dds.c
@@ -1041,7 +1041,7 @@ static int cf_axi_dds_update_scan_mode(struct iio_dev *indio_dev,
 	struct cf_axi_dds_state *st = iio_priv(indio_dev);
 	unsigned int i, sel;
 
-	for (i = 0; i < indio_dev->masklength; i++) {
+	for (i = 0; i < iio_get_masklength(indio_dev); i++) {
 
 		if (test_bit(i, scan_mask))
 			sel = DATA_SEL_DMA;


### PR DESCRIPTION
## PR Description

The upstream kernel has removed direct access to indio_dev->masklength. This patch series updates several drivers to use the modern helper functions iio_get_masklength() and iio_for_each_active_channel() instead.

This change aligns our out-of-tree drivers with the current upstream conventions, improves code readability, and prevents warnings from the sparse checker.

This series touches most of the out-of-tree drivers that were using the old masklength API, with the exception of the Xilinx  ina260 adc driver which is not maintained by us.


## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
