### PR TITLE
Fix some invalid DT property types

### DIFF
--- a/Documentation/devicetree/bindings/clock/clk-ad9545.yaml
+++ b/Documentation/devicetree/bindings/clock/clk-ad9545.yaml
@@ -74,6 +74,7 @@ properties:
     maxItems: 14
 
   assigned-clock-phases:
+    $ref: /schemas/types.yaml#/definitions/uint32-array
     minItems: 1
     maxItems: 14
 

--- a/Documentation/devicetree/bindings/iio/adc/adi,ad9083.yaml
+++ b/Documentation/devicetree/bindings/iio/adc/adi,ad9083.yaml
@@ -40,7 +40,7 @@ properties:
 
   jesd204-inputs:
     description: JESD204-fsm devices phandles and specifiers (used to build the link topology)
-    $ref: "/schemas/types.yaml#/definitions/phandle"
+    $ref: /schemas/types.yaml#/definitions/phandle
 
   spi-max-frequency:
     const: 1000000
@@ -49,7 +49,7 @@ properties:
     maxItems: 1
 
   clock-names:
-    const: "adc_ref_clk"
+    const: adc_ref_clk
     description: AD9083 reference clock name
 
   adi,adc-frequency-hz:

--- a/Documentation/devicetree/bindings/iio/adc/adi,ad9083.yaml
+++ b/Documentation/devicetree/bindings/iio/adc/adi,ad9083.yaml
@@ -31,9 +31,11 @@ properties:
     const: 2
 
   jesd204-top-device:
+    $ref: /schemas/types.yaml#/definitions/uint32
     const: 0
 
   jesd204-link-ids:
+    $ref: /schemas/types.yaml#/definitions/uint32
     const: 0
 
   jesd204-inputs:

--- a/Documentation/devicetree/bindings/iio/adc/adi,ad9083.yaml
+++ b/Documentation/devicetree/bindings/iio/adc/adi,ad9083.yaml
@@ -40,7 +40,8 @@ properties:
 
   jesd204-inputs:
     description: JESD204-fsm devices phandles and specifiers (used to build the link topology)
-    $ref: /schemas/types.yaml#/definitions/phandle
+    $ref: /schemas/types.yaml#/definitions/phandle-array
+    maxItems: 1
 
   spi-max-frequency:
     const: 1000000
@@ -143,41 +144,41 @@ properties:
 
   adi,octets-per-frame:
     description: Number of octets per frame (F)
-    $ref: /schemas/types.yaml#/definitions/uint8
+    $ref: /schemas/types.yaml#/definitions/uint32
 
   adi,frames-per-multiframe:
     description: Number of frames per multi-frame (K)
-    $ref: /schemas/types.yaml#/definitions/uint16
+    $ref: /schemas/types.yaml#/definitions/uint32
 
   adi,converter-resolution:
     description: Converter resolution (N)
-    $ref: /schemas/types.yaml#/definitions/uint8
+    $ref: /schemas/types.yaml#/definitions/uint32
 
   adi,bits-per-sample:
     description: Number of bits per sample (N')
-    $ref: /schemas/types.yaml#/definitions/uint8
+    $ref: /schemas/types.yaml#/definitions/uint32
 
   adi,converters-per-device:
     description: Number of converter per device (M)
-    $ref: /schemas/types.yaml#/definitions/uint8
+    $ref: /schemas/types.yaml#/definitions/uint32
 
   adi,control-bits-per-sample:
     description: Number of control bits per conversion sample (CS)
-    $ref: /schemas/types.yaml#/definitions/uint8
+    $ref: /schemas/types.yaml#/definitions/uint32
 
   adi,lanes-per-device:
     description: Number of lanes per link (L)
-    $ref: /schemas/types.yaml#/definitions/uint8
+    $ref: /schemas/types.yaml#/definitions/uint32
 
   adi,subclass:
     description: The JESD204B sublcass
-    $ref: /schemas/types.yaml#/definitions/uint8
+    $ref: /schemas/types.yaml#/definitions/uint32
 
 required:
   - compatible
   - reg
   - jesd204-device
-  - '#jesd-cells'
+  - '#jesd204-cells'
   - jesd204-top-device
   - jesd204-link-ids
   - jesd204-inputs
@@ -206,7 +207,6 @@ examples:
         spi-max-frequency = <1000000>;
         clocks = <&ad9528 13>;
         clock-names = "adc_ref_clk";
-        adi,sampling-frequency-hz = /bits/ 64 <125000000>;
 
         /* adi_ad9083 config */
 

--- a/Documentation/devicetree/bindings/iio/adc/adi,adar1000.yaml
+++ b/Documentation/devicetree/bindings/iio/adc/adi,adar1000.yaml
@@ -43,6 +43,7 @@ patternProperties:
           identify one device.
 
       adi,phasetable-name:
+        $ref: /schemas/types.yaml#/definitions/string
         description:
           The name specified here will be used by the device to load a custom
           phase table using the firmware load feature. The user can determine

--- a/Documentation/devicetree/bindings/iio/adc/lltc,ltc2387.yaml
+++ b/Documentation/devicetree/bindings/iio/adc/lltc,ltc2387.yaml
@@ -30,8 +30,8 @@ properties:
       - adaq23878
 
   clocks:
+    description: Sampling clock
     maxItems: 1
-      Sampling clock
 
   dmas:
     maxItems: 1

--- a/Documentation/devicetree/bindings/iio/adc/xlnx,versal-sysmon.yaml
+++ b/Documentation/devicetree/bindings/iio/adc/xlnx,versal-sysmon.yaml
@@ -70,7 +70,6 @@ patternProperties:
 
     properties:
       reg:
-        $ref: /schemas/types.yaml#/definitions/uint32
         minimum: 0
         maximum: 159
         description:

--- a/Documentation/devicetree/bindings/iio/addac/adi,one-bit-adc-dac.yaml
+++ b/Documentation/devicetree/bindings/iio/addac/adi,one-bit-adc-dac.yaml
@@ -25,12 +25,11 @@ properties:
     const: 0
 
   in-gpios:
-    description:
-      - Input GPIO numbers
+    description: Input GPIO numbers
 
   out-gpios:
-    description:
-      - Output GPIO numbers
+    description: Output GPIO numbers
+
 required:
   - compatible
   - in-gpios

--- a/Documentation/devicetree/bindings/iio/frequency/adf4371.yaml
+++ b/Documentation/devicetree/bindings/iio/frequency/adf4371.yaml
@@ -47,12 +47,14 @@ properties:
       - minimum: 1
 
   adi,spi-3wire-enable:
+    $ref: /schemas/types.yaml#/definitions/flag
     description:
       This attribute needs to be set in case the 4-wire SPI controller is
       used, and the 4 to 3 wire conversion is done with some external logic
       in between.
 
   adi,muxout-level-1v8-enable:
+    $ref: /schemas/types.yaml#/definitions/flag
     description:
       When set the output level of the mux out pin is set to 1.8V.
       (default is 3.3V)
@@ -121,6 +123,7 @@ patternProperties:
         maxItems: 1
 
       adi,output-enable:
+        $ref: /schemas/types.yaml#/definitions/flag
         description: |
           If this property is specified, the output channel will be enabled.
           If left empty, the driver will initialize the defaults (RF8x, channel 0

--- a/Documentation/devicetree/bindings/iio/frequency/adi,adf4360.yaml
+++ b/Documentation/devicetree/bindings/iio/frequency/adi,adf4360.yaml
@@ -27,6 +27,8 @@ description: |
   https://www.analog.com/media/en/technical-documentation/data-sheets/ADF4360-8.pdf
   https://www.analog.com/media/en/technical-documentation/data-sheets/ADF4360-9.pdf
 
+additionalProperties: false
+
 properties:
   compatible:
     enum:
@@ -44,6 +46,9 @@ properties:
   reg:
     maxItems: 1
 
+  spi-max-frequency:
+    maximum: 2000000
+
   clocks:
     description: phandle to external reference clock.
     maxItems: 1
@@ -59,34 +64,22 @@ properties:
     description: |
       The phase-frequency-detector frequency that the external loop filter was
       designed for.
-    allOf:
-      - $ref: /schemas/types.yaml#/definitions/uint32
-    maxItems: 1
 
   adi,loop-filter-charger-pump-current-microamp:
     description: |
       The charge pump current that the external loop filter was designed for.
       The provided value is clamped to the closest enumerated value.
-    allOf:
-      - $ref: /schemas/types.yaml#/definitions/uint32
-      - enum: [310, 620, 930, 1250, 1560, 1870, 2180, 2500]
-    maxItems: 1
+    enum: [310, 620, 930, 1250, 1560, 1870, 2180, 2500]
 
   adi,vco-minimum-frequency-hz:
     description: |
       Required for ADF4360-7, ADF4360-8 and ADF4360-9. Minimum VCO frequency
       that can be supported by the tuning range set by the external inductor.
-    allOf:
-      - $ref: /schemas/types.yaml#/definitions/uint32
-    maxItems: 1
 
   adi,vco-maximum-frequency-hz:
     description: |
       Required for ADF4360-7, ADF4360-8 and ADF4360-9. Maximum VCO frequency
       that can be supported by the tuning range set by the external inductor.
-    allOf:
-      - $ref: /schemas/types.yaml#/definitions/uint32
-    maxItems: 1
 
   adi,loop-filter-inverting:
     description: Indicates that the external loop filter is an inverting filter.
@@ -97,16 +90,12 @@ properties:
     description: |
       PLL tunes to the set frequency on probe or defaults to either the minimum
       for the part or value set using adi,vco-minimum-frequency-hz.
-    allOf:
-      - $ref: /schemas/types.yaml#/definitions/uint32
-    maxItems: 1
 
   adi,vdd-supply:
     description: |
       vdd supply is used to enable or disable chip when regulator power down
       mode is set. Other power down modes are used to mitigate the case of a
       shared regulator.
-    maxItems: 1
 
   adi,enable-gpios:
     description: |
@@ -124,8 +113,7 @@ properties:
     description: |
       Chip support setting of output power level. This property is optional.
       If it is not provided by default 11000 uA will be set.
-    allOf:
-      - enum: [3500, 5000, 7500, 11000]
+    enum: [3500, 5000, 7500, 11000]
 
 required:
   - compatible
@@ -146,8 +134,8 @@ examples:
         reg = <0>;
         spi-max-frequency = <2000000>;
         clocks = <&ref_clock>;
+        clock-names = "clkin";
         #clock-cells = <0>;
-        clock-output-names = "adf4360-7";
 
         adi,loop-filter-charge-pump-current = <5>;
         adi,loop-filter-pfd-frequency-hz = <2500000>;

--- a/Documentation/devicetree/bindings/media/adi,adi-axi-fb.yaml
+++ b/Documentation/devicetree/bindings/media/adi,adi-axi-fb.yaml
@@ -43,44 +43,44 @@ properties:
     maxItems: 2
 
   adi,flock-mode:
+    $ref: /schemas/types.yaml#/definitions/uint32
     description:
       Select operating mode of the framebuffer.
       0 -> Frame rate conversion mode
       1 -> Output delay mode
     enum: [ 0, 1 ]
-    maxItems: 1
 
   adi,flock-frm-buf-nr:
+    $ref: /schemas/types.yaml#/definitions/uint32
     description:
       The total number of video frame buffers.
       Related to NUM_BUF synthesys parameter.
     minimum: 3
-    maxItems: 1
 
   adi,flock-distance:
+    $ref: /schemas/types.yaml#/definitions/uint32
     description:
       Applicable only in output delay mode. Set the output delay in frames.
       Should be set in interval 0 to flock,frm-buf-nr - 2
     minimum: 0
-    maxItems: 1
 
   adi,flock-line-stride:
+    $ref: /schemas/types.yaml#/definitions/uint32
     description:
       The number of bytes between the start of one row and the next row.
       Needs to be aligned to the bus width.
-    maxItems: 1
 
   adi,flock-frm-stride:
+    $ref: /schemas/types.yaml#/definitions/uint32
     description:
       Stride of consecutive frames in memory in bytes. Should be at least the
       size of one frame.
-    maxItems: 1
 
   adi,flock-dwidth:
+    $ref: /schemas/types.yaml#/definitions/uint32
     description:
       Represent the number of bytes per pixel according to used color space.
     enum: [ 1, 2, 4 ]
-    maxItems: 1
 
 required:
   - compatible

--- a/Documentation/devicetree/bindings/media/adi,adi-axi-fb.yaml
+++ b/Documentation/devicetree/bindings/media/adi,adi-axi-fb.yaml
@@ -2,10 +2,10 @@
 # Copyright 2019 Analog Devices Inc.
 %YAML 1.2
 ---
-$id: http://devicetree.org/schemas/bindings/media/adi,adi-fb.yaml#
+$id: http://devicetree.org/schemas/media/adi,adi-axi-fb.yaml#
 $schema: http://devicetree.org/meta-schemas/core.yaml#
 
-title: Analog Devices AXI Frame Buffer Device Tree Bindings
+title: Analog Devices AXI Frame Buffer
 
 maintainers:
   - Bogdan Togorean <bogdan.togorean@analog.com>
@@ -16,29 +16,38 @@ description: |
   https://wiki.analog.com/resources/fpga/docs/axi_dmac
   First example is used when FB is stored in PS RAM and second for PL RAM.
 
+additionalProperties: false
+
 properties:
   compatible:
     enum:
-        - adi,axi-framebuffer-1.00.a
+      - adi,axi-framebuffer-1.00.a
 
   memory-region:
     description:
       Phandle to a node used to specify reserved memory for video frame buffers.
       If not used, frame buffer address and size should be specified using reg
       property.
-    allOf:
-      - $ref: /schemas/types.yaml#/definitions/phandle-array
 
   reg:
     minItems: 2
     maxItems: 3
 
+  reg-names:
+    oneOf:
+      - items:
+          - const: tx_dma
+          - const: rx_dma
+      - items:
+          - const: fb_mem
+          - const: tx_dma
+          - const: rx_dma
+
   adi,flock-resolution:
     description:
       (u32, u32) tuple setting resolution of input/output image in pixels.
       <horizontal> <vertical>
-    allOf:
-      - $ref: /schemas/types.yaml#/definitions/uint32-array
+    $ref: /schemas/types.yaml#/definitions/uint32-array
     minItems: 2
     maxItems: 2
 
@@ -85,10 +94,11 @@ properties:
 required:
   - compatible
   - reg
+  - reg-names
 
 examples:
   - |
-    adi-fb {
+    framebuffer@43000000 {
             compatible = "adi,axi-framebuffer-1.00.a";
             memory-region = <&reserved>;
             reg = <0x43000000 0x1000>, <0x43c20000 0x1000>;
@@ -112,7 +122,7 @@ examples:
     };
 
   - |
-    adi-fb {
+    framebuffer@1c000000 {
             compatible = "adi,axi-framebuffer-1.00.a";
             reg = <0x1C000000 0x2000>, <0x43000000 0x1000>, <0x43c20000 0x1000>;
             reg-names = "fb_mem", "tx_dma", "rx_dma";


### PR DESCRIPTION
## PR Description

I was trying to run `make dtbs_check` on the ADI tree but it was causing the dtschma tool to crash. This lead me to https://github.com/devicetree-org/dt-schema/issues/151 which lead me to running `dt-extract-props -d Documentation/devicetree/bindings/`. This revealed quite a few errors. I fixed some things where it told me the actual file name where the problem was for things that are only in the ADI tree.

The main one though is the last patch which fixes a problem likely from the upstream xilinx tree. I suppose we could submit that patch there, but I think it is important to fix it here ASAP so we can actually use `make dtbs_check` without crashing.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
