### PR TITLE
arm: dts: zynq-zed-adv7511-ad7383-4: new devicetree

### DIFF
--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad7383-4.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad7383-4.dts
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD7383
+ * https://www.analog.com/media/en/technical-documentation/data-sheets/AD7383-7384.pdf
+ * https://www.analog.com/media/en/technical-documentation/user-guides/eval-ad7383fmcz-ug-1770.pdf
+ * https://wiki.analog.com/resources/tools-software/linux-drivers/iio-adc/ad738x
+ * https://wiki.analog.com/resources/eval/user-guides/ad738x
+ * http://analogdevicesinc.github.io/hdl/projects/ad738x_fmc/index.html
+ *
+ * hdl_project: <ad738x_fmc/zed>
+ * board_revision: <>
+ *
+ * Copyright (C) 2025 Analog Devices Inc.
+ */
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+
+#include "zynq-zed.dtsi"
+#include "zynq-zed-adv7511.dtsi"
+
+/ {
+	eval_u2: eval-board-u2-regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "EVAL +3.3V supply (U2)";
+		regulator-always-on;
+	};
+
+	eval_u3: eval-board-u3-regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "EVAL +3.3V supply (U3)";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-always-on;
+	};
+
+	eval_u6: eval-board-u6-regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "EVAL +2.3V supply (U6)";
+		regulator-always-on;
+	};
+
+	trigger_pwm: adc-pwm-trigger {
+		compatible = "pwm-trigger";
+		#trigger-source-cells = <0>;
+		pwms = <&adc_trigger 0 10000 0>;
+	};
+
+	vcm: vcm-regulator {
+		/*
+		 * External source that supplies common mode voltage for
+		 * negative inputs of the ADC. Assumed to be V_REF / 2.
+		 */
+		compatible = "regulator-fixed";
+		regulator-name = "External VCM supply";
+		regulator-min-microvolt = <1650000>;
+		regulator-max-microvolt = <1650000>;
+		regulator-always-on;
+	};
+};
+
+&fpga_axi {
+	adc_trigger: pwm@44b00000 {
+		compatible = "adi,axi-pwmgen-2.00.a";
+		reg = <0x44b00000 0x1000>;
+		label = "adc_conversion_trigger";
+		#pwm-cells = <3>;
+		clocks = <&clkc 15>, <&spi_clk>;
+		clock-names = "axi", "ext";
+	};
+
+	spi_clk: clock-controller@44a70000 {
+		compatible = "adi,axi-clkgen-2.00.a";
+		reg = <0x44a70000 0x1000>;
+		#clock-cells = <0>;
+		clocks = <&clkc 15>, <&clkc 15>;
+		clock-names = "clkin1", "s_axi_aclk";
+		clock-output-names = "spi_clk";
+		assigned-clocks = <&spi_clk>;
+		assigned-clock-rates = <160000000>;
+	};
+
+	rx_dma: dma-controller@44a30000 {
+		compatible = "adi,axi-dmac-1.00.a";
+		reg = <0x44a30000 0x1000>;
+		#dma-cells = <1>;
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&clkc 15>;
+	};
+
+	axi_spi_engine_0: spi@44a00000 {
+		compatible = "adi,axi-spi-engine-1.00.a";
+		reg = <0x44a00000 0x1000>;
+		interrupt-parent = <&intc>;
+		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&clkc 15>, <&spi_clk>;
+		clock-names = "s_axi_aclk", "spi_clk";
+
+		dmas = <&rx_dma 0>;
+		dma-names = "offload0-rx";
+		trigger-sources = <&trigger_pwm>;
+
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		adc@0 {
+			compatible = "adi,ad7383-4";
+			reg = <0>;
+
+			spi-cpol;
+			spi-max-frequency = <80000000>;
+
+			/*
+			 * ADI tree extension (not mainline). Set this based on
+			 * HDL NUM_OF_SDI compile argument. Can omit if =1.
+			 */
+			adi,num-sdi = <4>;
+
+			/* Not currently used by the driver. */
+			// interrupts = <86 IRQ_TYPE_EDGE_FALLING>;
+			// interrupt-parent = <&gpio0>;
+
+			vcc-supply = <&eval_u2>;
+			vlogic-supply = <&eval_u6>;
+			refio-supply = <&eval_u3>;
+
+			aina-supply = <&vcm>;
+			ainb-supply = <&vcm>;
+			ainc-supply = <&vcm>;
+			aind-supply = <&vcm>;
+		};
+	};
+};


### PR DESCRIPTION
## PR Description

Add a new devicetree for the Zedboard with the EVAL-AD7383-4FMCZ evaluation board. This is one of the pseudo-differential chips in the family, so this is a useful example of how to set up the common mode voltage supply that is required only for pseudo-differential chips.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)

I don't have hardware handy to test this but hopefully simple enough I didn't mess it up.