### PR TITLE
iio: adc: ad9081: add device tree support for PA protection features

### DIFF
--- a/drivers/iio/adc/ad9081.c
+++ b/drivers/iio/adc/ad9081.c
@@ -4245,7 +4245,7 @@ static int ad9081_parse_dt_rx(struct ad9081_phy *phy, struct device_node *np)
 			phy->rx_cddc_gain_6db_en[reg] = of_property_read_bool(
 				of_chan, "adi,digital-gain-6db-enable");
 			phy->rx_cddc_select |= BIT(reg);
-			ret = of_property_read_u32(of_trx_path,
+			ret = of_property_read_u32(of_chan,
 				"adi,nyquist-zone", &tmp);
 			if (!ret)
 				phy->rx_nyquist_zone[reg] = tmp;

--- a/include/dt-bindings/iio/adc/adi,ad9081.h
+++ b/include/dt-bindings/iio/adc/adi,ad9081.h
@@ -100,4 +100,45 @@
 #define FRAMER_LINK0_RX 2
 #define FRAMER_LINK1_RX 3
 
+/*
+ * PA Protection Soft-Off Trigger Bitmasks
+ * Used with adi,pa-protection-soft-off-triggers property
+ * Multiple triggers can be OR'd together
+ * Example:
+ *   adi,pa-protection-soft-off-triggers = <(AD9081_PA_SOFT_OFF_SPI |
+ *                                           AD9081_PA_SOFT_OFF_TXEN |
+ *                                           AD9081_PA_SOFT_OFF_JESD_ERR)>;
+ */
+#define AD9081_PA_SOFT_OFF_SPI              (1 << 0)  /*!< SPI soft-off */
+#define AD9081_PA_SOFT_OFF_TXEN             (1 << 1)  /*!< TxEN soft-off */
+#define AD9081_PA_SOFT_OFF_ROTATE           (1 << 2)  /*!< Rotate soft-off */
+#define AD9081_PA_SOFT_OFF_JESD_ERR         (1 << 3)  /*!< JESD error soft-off */
+#define AD9081_PA_SOFT_OFF_HWIP_ERR         (1 << 4)  /*!< Hardware IP error soft-off */
+#define AD9081_PA_SOFT_OFF_LONG_PAERR       (1 << 6)  /*!< Long PA error soft-off */
+#define AD9081_PA_SOFT_OFF_SHORT_PAERR      (1 << 7)  /*!< Short PA error soft-off */
+#define AD9081_PA_SOFT_OFF_DLL_UNLOCK       (1 << 8)  /*!< DLL unlock soft-off */
+#define AD9081_PA_SOFT_OFF_204C_CRC_ERR     (1 << 9)  /*!< 204C CRC error soft-off */
+#define AD9081_PA_SOFT_OFF_HI_LO_FAIL       (1 << 11) /*!< Hi-Lo fail soft-off */
+#define AD9081_PA_SOFT_OFF_SLEW_RATE_ERR    (1 << 12) /*!< Slew rate error soft-off */
+
+/*
+ * PA Protection Soft-On Trigger Bitmasks
+ * Used with adi,pa-protection-soft-on-triggers property
+ * Example:
+ *   adi,pa-protection-soft-on-triggers = <(AD9081_PA_SOFT_ON_HI_LO_RECV |
+ *                                          AD9081_PA_SOFT_ON_SPI_FORCE)>;
+ */
+#define AD9081_PA_SOFT_ON_HI_LO_RECV        (1 << 4)  /*!< Hi-Lo recover soft-on */
+#define AD9081_PA_SOFT_ON_LONG_LEVEL        (1 << 6)  /*!< Long level soft-on */
+#define AD9081_PA_SOFT_ON_SPI_FORCE         (1 << 7)  /*!< SPI force soft-on when gain is 0 */
+
+/*
+ * PA Protection Rotation Mode Values
+ * Used with adi,pa-protection-rotation-mode property
+ * Example:
+ *   adi,pa-protection-rotation-mode = <AD9081_PA_ROTATION_JESD_AUTO>;
+ */
+#define AD9081_PA_ROTATION_JESD_AUTO        (1 << 0)  /*!< Enable JESD auto off/on during rotation */
+#define AD9081_PA_ROTATION_DATAPATH_AUTO    (1 << 1)  /*!< Enable datapath auto soft off/on during rotation */
+
 #endif


### PR DESCRIPTION
## PR Description

Add comprehensive device tree support for AD9081 PA (Power Amplifier) protection features including:

- Soft-off/on gain control with configurable ramp rates and triggers
- Long and short averaging power monitoring with thresholds
- Digital Step Attenuator (DSA) configuration
- GPIO PA enable outputs (global setting)
- Rotation mode settings (global setting)

The implementation ensures hardware register defaults are preserved when properties are not specified in the device tree. All numeric properties use standard u32 device tree parsing with proper validation.

Properties are only applied to hardware when explicitly provided, preventing unintended register modifications. Complex features like averaging require all related parameters to be specified.

Global settings (GPIO PA enable and rotation mode) are correctly parsed at the parent level and applied once, while per-DAC settings are parsed and applied individually for each DAC channel.

Added comprehensive bitmask definitions in dt-bindings header for:
- PA protection soft-off triggers (12 different trigger sources)
- PA protection soft-on triggers (3 different trigger sources)
- Rotation mode flags (JESD and datapath auto control)

Example device tree usage:

```
      #include <dt-bindings/iio/adc/adi,ad9081.h>
    
      &ad9081_tx_dacs {
          /* Global settings */
    
      &ad9081_tx_dacs {
          /* Global settings */
          adi,pa-protection-gpio-as-pa-enable;
          adi,pa-protection-rotation-mode = <(AD9081_PA_ROTATION_JESD_AUTO |
                                              AD9081_PA_ROTATION_DATAPATH_AUTO)>;
          adi,main-data-paths {
              dac@0 {
                  reg = <0>;
                  adi,pa-protection-soft-off-enable;
                  adi,pa-protection-soft-off-ramp-rate = <3>;
                  adi,pa-protection-soft-off-triggers = <(AD9081_PA_SOFT_OFF_SPI |
                                                          AD9081_PA_SOFT_OFF_TXEN |
                                                          AD9081_PA_SOFT_OFF_JESD_ERR)>;
                  adi,pa-protection-long-avg-enable;
                  adi,pa-protection-long-avg-time = <10>;
                  adi,pa-protection-long-avg-threshold = <1000>;
              };
          };
      };
```



## PR Type
- [X] New feature (a change that adds new functionality)

## PR Checklist
- [X] I have conducted a self-review of my own code changes
- [X] I have tested the changes on the relevant hardware

