### PR TITLE
Add workflow to patch workflows in the same repository

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -28,3 +28,16 @@ jobs:
       fetch_url: "https://git.kernel.org/pub/scm/linux/kernel/git/jic23/iio.git"
       branch: "testing"
 
+  self-branches:
+    uses: ./.github/workflows/sync_ci.yml
+    secrets: inherit
+    permissions:
+      contents: write
+      actions: write
+    strategy:
+      matrix:
+        branch:
+          - "oran-6.12.38-y"
+          - "adsp-6.12.38-y"
+    with:
+      branch: ${{ matrix.branch }}

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -54,6 +54,7 @@ jobs:
           )
           for i in "${arr[@]}"
           do
+            git rm -rf "$i" || true
             git checkout origin/${{ inputs.ci_branch }} -- "$i"
           done
           commit=$(git rev-parse origin/${{ inputs.ci_branch }})

--- a/.github/workflows/sync_ci.yml
+++ b/.github/workflows/sync_ci.yml
@@ -1,0 +1,75 @@
+name: CI synchronization
+
+on:
+  workflow_call:
+    inputs:
+      branch:
+        required: true
+        type: string
+
+jobs:
+  mirror:
+    runs-on: [self-hosted, v1]
+
+    steps:
+    - uses: analogdevicesinc/doctools/checkout@v1
+
+    - name: increase-limits
+      run: |
+        git config http.postBuffer 157286400
+
+    - name: update-mirror
+      run: |
+        git switch -d
+        git remote prune origin
+        git fetch origin ${{ inputs.branch }}:${{ inputs.branch }} -f
+        git switch ${{ inputs.branch }}
+
+        git fetch origin main --depth=1
+        declare -a arr=(
+          "ci"
+          ".github"
+          "arch/arm/configs/adi_ci_defconfig"
+          "arch/arm64/configs/adi_ci_defconfig"
+          "arch/x86/configs/adi_ci_defconfig"
+        )
+        for i in "${arr[@]}"
+        do
+          git rm -rf "$i" || true
+          git checkout origin/main -- "$i"
+        done
+        commit=$(git rev-parse origin/main)
+        git commit -m "deploy: $commit" -m "patch ci" -s
+        echo "{{ inputs.branch }}=${{ inputs.branch }}" >> "$GITHUB_ENV"
+
+    - name: push-ci
+      env:
+          WORKFLOW_SECRET: ${{ secrets.WORKFLOW_SECRET}}
+      if: ${{ env.WORKFLOW_SECRET != '' }}
+      run: |
+        url_=$(git remote get-url origin)
+        url="https://x-access-token:${{ secrets.WORKFLOW_SECRET }}@github.com/${{ github.repository }}.git"
+        git remote set-url origin "$url"
+        git push origin ${{ inputs.branch }}:${{ inputs.branch }} -f || true
+        git remote set-url origin "$url_"
+
+    - name: push-ci
+      env:
+          WORKFLOW_SECRET: ${{ secrets.WORKFLOW_SECRET}}
+      if: ${{ env.WORKFLOW_SECRET == '' }}
+      run: |
+        git push origin ${{ inputs.branch }}:${{ inputs.branch }} -f
+
+    - name: unset-limits
+      run: |
+        git config --unset http.postBuffer
+
+    - name: clean-up
+      if: github.event_name == 'schedule'
+      run: |
+        git gc --prune=now
+
+    - name: log-cached-branches
+      run: |
+        git --no-pager branch | cut -c 3- | \
+          while IFS= read -r b; do printf "$b: " ; git rev-list --count $b; done


### PR DESCRIPTION
## PR Description

@pamolloy here is the ci to patch the workflow to arbitrary branches.
It is a copy of mirror.yml, but simplified since it is the same remote, so just using `origin` is enough.
It also allows to use the matrix to just pass an array of branches.
Please update 
https://github.com/analogdevicesinc/linux/compare/ci/update?expand=1#diff-69b9772a7fe51bd7c367926862d89ca7d8949cc9832b3645e610a1ec5bfa1ddfR39-R40
with all the branches that are currently relevant to update the ci.

One last note, on sync_ci.yml, the hardcoded main will be replaced by `ci` or similar name when we move the ci to a dedicated branch, and then `xlnx-main` will also be appended to the list of branches called for sync_ci.yml

Final note after last note: the cron.yml runs every 24h or dispatch (e.g. github gui). Now that it updating same remote branches, may be useful to add `on push main` 

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
