### PR TITLE
ci: symbol_depend: Fix endif block detection

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,18 +113,18 @@ jobs:
         find . -type f -name *.ko | \
           xargs -I % cp --parents % dist/modules
 
-    - name: Assert compiled
-      if: ${{ env.AUTO_FROM_RANGE == 'true' }}
-      run: |
-        source ci/build.sh
-        assert_compiled
-
     - name: Assert state
       if: ${{ failure() }}
       run: |
         source ci/build.sh
         set_step_fail "assert_state"
         echo "fatal=true" >> "$GITHUB_ENV"
+
+    - name: Assert compiled
+      if: ${{ !cancelled() && env.fatal != 'true' && env.AUTO_FROM_RANGE == 'true' }}
+      run: |
+        source ci/build.sh
+        assert_compiled
 
     - name: Sparse
       if: ${{ !cancelled() && env.fatal != 'true' && env.CHECKS_SPARCE == 'true' }}

--- a/ci/symbols_depend.py
+++ b/ci/symbols_depend.py
@@ -64,7 +64,7 @@ def track_if_blocks(symbol, target_kconfig):
 
     for kconfig in get_all_parent_kconfigs(path.dirname(target_kconfig)):
         if debug:
-            print(f"{target_kconfig}: Tracking if blocks at '{kconfig}'",
+            print(f"{target_kconfig}: Tracking if blocks at '{kconfig}' for symbol '{symbol}'",
                   file=stderr)
         with open(kconfig, 'r') as f:
             lines = f.readlines()
@@ -74,7 +74,7 @@ def track_if_blocks(symbol, target_kconfig):
             line_ = line.strip()
             if line.startswith('if '):
                 stack.append(line[3:].strip())
-            elif line_ == 'endif':
+            elif line_.startswith('endif'):
                 if stack:
                     stack.pop()
             elif line_.startswith('source') and line_.endswith('Kconfig"'):


### PR DESCRIPTION
## PR Description

Consider lines that start with endif, since it may have comments.
Detected by run of #2913
https://github.com/analogdevicesinc/linux/actions/runs/17266053343/job/48998303938?pr=2913

Create deadcode_exceptions file, for API code mostly, to reduce noise from #2909

Demote assert_compiled step, for in case of API code not added yet to the deadcode_exceptions file, still run the next steps, also #2909


## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
