### PR TITLE
 iio: adc: adrv902x: Reformat Makefile

### DIFF
--- a/ci/travis/deadcode_exceptions
+++ b/ci/travis/deadcode_exceptions
@@ -1,0 +1,1 @@
+drivers/iio/adc/adrv902x/platforms/adi_platform.c

--- a/drivers/iio/adc/adrv902x/Makefile
+++ b/drivers/iio/adc/adrv902x/Makefile
@@ -1,58 +1,56 @@
-SRCS = 	devices/adrv9025/private/src/adrv9025_bf_analog_orx_mem_map.c \
-	devices/adrv9025/private/src/adrv9025_bf_analog_rx_mem_map.c \
-	devices/adrv9025/private/src/adrv9025_bf_analog_tx_mem_map.c \
-	devices/adrv9025/private/src/adrv9025_bf_core.c \
-	devices/adrv9025/private/src/adrv9025_bf_deser.c \
-	devices/adrv9025/private/src/adrv9025_bf_hal.c \
-	devices/adrv9025/private/src/adrv9025_bf_jesd_common.c \
-	devices/adrv9025/private/src/adrv9025_bf_jrx_link.c \
-	devices/adrv9025/private/src/adrv9025_bf_jtx_link.c \
-	devices/adrv9025/private/src/adrv9025_bf_orx.c \
-	devices/adrv9025/private/src/adrv9025_bf_pll_mem_map.c \
-	devices/adrv9025/private/src/adrv9025_bf_rx.c \
-	devices/adrv9025/private/src/adrv9025_bf_tx.c \
-	devices/adrv9025/private/src/adrv9025_bf_txdac_mem_map.c \
-	devices/adrv9025/private/src/adrv9025_cals.c \
-	devices/adrv9025/private/src/adrv9025_cpu.c \
-	devices/adrv9025/private/src/adrv9025_crc32.c \
-	devices/adrv9025/private/src/adrv9025_data_interface.c \
-	devices/adrv9025/private/src/adrv9025_dfe.c \
-	devices/adrv9025/private/src/adrv9025_dynamic_slicer.c \
-	devices/adrv9025/private/src/adrv9025_gpio.c \
-	devices/adrv9025/private/src/adrv9025_init.c \
-	devices/adrv9025/private/src/adrv9025_radioctrl.c \
-	devices/adrv9025/private/src/adrv9025_rx.c \
-	devices/adrv9025/private/src/adrv9025_shared_resource_manager.c \
-	devices/adrv9025/private/src/adrv9025_tx.c \
-	devices/adrv9025/private/src/adrv9025_utilities.c \
-	devices/adrv9025/public/src/adi_adrv9025_agc.c \
-	devices/adrv9025/public/src/adi_adrv9025_arm.c \
-	devices/adrv9025/public/src/adi_adrv9025.c \
-	devices/adrv9025/public/src/adi_adrv9025_cals.c \
-	devices/adrv9025/public/src/adi_adrv9025_cpu.c \
-	devices/adrv9025/public/src/adi_adrv9025_data_interface.c \
-	devices/adrv9025/public/src/adi_adrv9025_dfe.c \
-	devices/adrv9025/public/src/adi_adrv9025_dynamic_slicer.c \
-	devices/adrv9025/public/src/adi_adrv9025_gpio.c \
-	devices/adrv9025/public/src/adi_adrv9025_hal.c \
-	devices/adrv9025/public/src/adi_adrv9025_radioctrl.c \
-	devices/adrv9025/public/src/adi_adrv9025_rx.c \
-	devices/adrv9025/public/src/adi_adrv9025_tx.c \
-	devices/adrv9025/public/src/adi_adrv9025_utilities.c \
-	common/adi_logging/adi_common_log.c \
-	common/adi_error/adi_common_error.c  \
-	common/adi_hal/adi_common_hal.c \
-	platforms/linux_platform.c \
-	adrv9025.c \
-	adrv9025_conv.c
+adrv9025_drv-y := \
+	devices/adrv9025/private/src/adrv9025_bf_analog_orx_mem_map.o \
+	devices/adrv9025/private/src/adrv9025_bf_analog_rx_mem_map.o \
+	devices/adrv9025/private/src/adrv9025_bf_analog_tx_mem_map.o \
+	devices/adrv9025/private/src/adrv9025_bf_core.o \
+	devices/adrv9025/private/src/adrv9025_bf_deser.o \
+	devices/adrv9025/private/src/adrv9025_bf_hal.o \
+	devices/adrv9025/private/src/adrv9025_bf_jesd_common.o \
+	devices/adrv9025/private/src/adrv9025_bf_jrx_link.o \
+	devices/adrv9025/private/src/adrv9025_bf_jtx_link.o \
+	devices/adrv9025/private/src/adrv9025_bf_orx.o \
+	devices/adrv9025/private/src/adrv9025_bf_pll_mem_map.o \
+	devices/adrv9025/private/src/adrv9025_bf_rx.o \
+	devices/adrv9025/private/src/adrv9025_bf_tx.o \
+	devices/adrv9025/private/src/adrv9025_bf_txdac_mem_map.o \
+	devices/adrv9025/private/src/adrv9025_cals.o \
+	devices/adrv9025/private/src/adrv9025_cpu.o \
+	devices/adrv9025/private/src/adrv9025_crc32.o \
+	devices/adrv9025/private/src/adrv9025_data_interface.o \
+	devices/adrv9025/private/src/adrv9025_dfe.o \
+	devices/adrv9025/private/src/adrv9025_dynamic_slicer.o \
+	devices/adrv9025/private/src/adrv9025_gpio.o \
+	devices/adrv9025/private/src/adrv9025_init.o \
+	devices/adrv9025/private/src/adrv9025_radioctrl.o \
+	devices/adrv9025/private/src/adrv9025_rx.o \
+	devices/adrv9025/private/src/adrv9025_shared_resource_manager.o \
+	devices/adrv9025/private/src/adrv9025_tx.o \
+	devices/adrv9025/private/src/adrv9025_utilities.o \
+	devices/adrv9025/public/src/adi_adrv9025_agc.o \
+	devices/adrv9025/public/src/adi_adrv9025_arm.o \
+	devices/adrv9025/public/src/adi_adrv9025.o \
+	devices/adrv9025/public/src/adi_adrv9025_cals.o \
+	devices/adrv9025/public/src/adi_adrv9025_cpu.o \
+	devices/adrv9025/public/src/adi_adrv9025_data_interface.o \
+	devices/adrv9025/public/src/adi_adrv9025_dfe.o \
+	devices/adrv9025/public/src/adi_adrv9025_dynamic_slicer.o \
+	devices/adrv9025/public/src/adi_adrv9025_gpio.o \
+	devices/adrv9025/public/src/adi_adrv9025_hal.o \
+	devices/adrv9025/public/src/adi_adrv9025_radioctrl.o \
+	devices/adrv9025/public/src/adi_adrv9025_rx.o \
+	devices/adrv9025/public/src/adi_adrv9025_tx.o \
+	devices/adrv9025/public/src/adi_adrv9025_utilities.o \
+	common/adi_logging/adi_common_log.o \
+	common/adi_error/adi_common_error.o  \
+	common/adi_hal/adi_common_hal.o \
+	platforms/linux_platform.o \
+	adrv9025.o \
+	adrv9025_conv.o
 
 # For now just disable it in this one file
 ifdef CONFIG_CC_IS_GCC
 CFLAGS_devices/adrv9025/public/src/adi_adrv9025_data_interface.o = -Wno-error=old-style-declaration
 endif
-
-# Avoid FP operations and data sytpes - Remove DPD *_dfe.c files
-#SRCS := $(filter-out /devices/adrv9025/private/src/adrv9025_dfe.c /devices/adrv9025/public/src/adi_adrv9025_dfe.c, $(SRCS))
 
 ccflags-y += -I$(src)/devices/adrv9025/private/include/ \
 	-I$(src)/devices/adrv9025/public/include/  \
@@ -68,5 +66,4 @@ ccflags-y += -I$(src)/devices/adrv9025/private/include/ \
 	-DADI_ADRV9025_ARM_VERBOSE=0 \
 	-Wno-error=missing-prototypes
 
-adrv9025_drv-y := $(SRCS:.c=.o)
 obj-$(CONFIG_ADRV9025) += adrv9025_drv.o


### PR DESCRIPTION
## PR Description

Complementary PR to  #2909 solely to drop "complex" logic from the Makefile.
Complex from the point of view of statically analyzing the Makefile/Kconfig structure.
This allows symbol_depend to work with adrv902x .

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
