### PR TITLE
axi_cfd: Fix depends for regmap_spi

### DIFF
--- a/drivers/iio/frequency/Kconfig
+++ b/drivers/iio/frequency/Kconfig
@@ -147,6 +147,7 @@ config CF_AXI_DDS_AD9172
 config CF_AXI_DDS_AD9783
 	tristate "Analog Devices AD9783 DAC"
 	depends on CF_AXI_DDS
+	select REGMAP_SPI
 	help
 	  Say yes here to build support for Analog Devices AD9783 DAC family,
 	  provides direct access via sysfs.

--- a/drivers/iio/frequency/Kconfig
+++ b/drivers/iio/frequency/Kconfig
@@ -139,6 +139,7 @@ config CF_AXI_DDS_AD9162
 config CF_AXI_DDS_AD9172
 	tristate "Analog Devices AD917x DAC"
 	depends on CF_AXI_DDS
+	select REGMAP_SPI
 	help
 	  Say yes here to build support for Analog Devices AD917x DAC chip
 	  ad917x, provides direct access via sysfs.

--- a/drivers/iio/frequency/Kconfig
+++ b/drivers/iio/frequency/Kconfig
@@ -131,6 +131,7 @@ config CF_AXI_DDS_AD9144
 config CF_AXI_DDS_AD9162
 	tristate "Analog Devices AD9162 DAC"
 	depends on CF_AXI_DDS
+	select REGMAP_SPI
 	help
 	  Say yes here to build support for Analog Devices AD9162 DAC chip
 	  ad9162, provides direct access via sysfs.


### PR DESCRIPTION
## PR Description

Detected by [run](https://github.com/analogdevicesinc/linux/actions/runs/17153264626/job/49077185114?pr=2906) pr #2906 
Batch resolve for other drivers as well:
```
$grep -rnw devm_regmap_init_spi
ad9144.c:       st->map = devm_regmap_init_spi(spi, &ad9144_regmap_config); # OK
ad9162.c:       st->map = devm_regmap_init_spi(spi, &ad9162_regmap_config); # NOK
ad9172.c:       st->map = devm_regmap_init_spi(spi, &ad9172_regmap_config); # NOK
ad9783.c:       phy->regmap = devm_regmap_init_spi(spi, &ad9783_regmap_config); # NOK
adf4030.c:      st->regmap = devm_regmap_init_spi(spi, &adf4030_regmap_config); # OK
adf4371.c:      regmap = devm_regmap_init_spi(spi, &adf4371_regmap_config); # ÒK
adf4377.c:      regmap = devm_regmap_init_spi(spi, &adf4377_regmap_config); # OK
adl5960.c:      dev->regmap = devm_regmap_init_spi(spi, &adl5960_regmap_config); # OK
admv4420.c:     regmap = devm_regmap_init_spi(spi, &admv4420_regmap_config); # OK
```
Same as #2790

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
