### PR TITLE
ci: symbols_depend: Extract symbols from kconfig, only touched lines

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,24 +82,24 @@ jobs:
     - name: Imply driver config
       if: ${{ env.AUTO_FROM_RANGE == 'true' }}
       run: |
-        source ci/build.sh
+        source ./ci/build.sh
         auto_set_kconfig
 
     - name: Apply cocci/bash and save defconfig
       run: |
-        source ci/build.sh
+        source ./ci/build.sh
         apply_prerun
         make savedefconfig
 
     - name: Compile devicetrees
       if: ${{ env.AUTO_FROM_RANGE == 'true' }}
       run: |
-        source ci/build.sh
+        source ./ci/build.sh
         compile_devicetree
 
     - name: Compile kernel
       run: |
-        source ci/build.sh
+        source ./ci/build.sh
         compile_kernel
 
     - name: Prepare dist
@@ -116,38 +116,38 @@ jobs:
     - name: Assert state
       if: ${{ failure() }}
       run: |
-        source ci/build.sh
+        source ./ci/build.sh
         set_step_fail "assert_state"
         echo "fatal=true" >> "$GITHUB_ENV"
 
     - name: Assert compiled
       if: ${{ !cancelled() && env.fatal != 'true' && env.AUTO_FROM_RANGE == 'true' }}
       run: |
-        source ci/build.sh
+        source ./ci/build.sh
         assert_compiled
 
     - name: Sparse
       if: ${{ !cancelled() && env.fatal != 'true' && env.CHECKS_SPARCE == 'true' }}
       run: |
-        source ci/build.sh
+        source ./ci/build.sh
         compile_kernel_sparse
 
     - name: GCC fanalyzer
       if: ${{ !cancelled() && env.fatal != 'true' && env.CHECKS_GCC_FANALYZER == 'true' }}
       run: |
-        source ci/build.sh
+        source ./ci/build.sh
         compile_gcc_fanalyzer
 
     - name: Clang analyzer
       if: ${{ !cancelled() && env.fatal != 'true' && env.CHECKS_CLANG_ANALYZER == 'true' }}
       run: |
-        source ci/build.sh
+        source ./ci/build.sh
         compile_clang_analyzer
 
     - name: Smatch
       if: ${{ !cancelled() && env.fatal != 'true' && env.CHECKS_SMATCH == 'true' }}
       run: |
-        source ci/build.sh
+        source ./ci/build.sh
         compile_kernel_smatch
 
     - name: Store the distribution packages
@@ -161,5 +161,5 @@ jobs:
       if: ${{ !cancelled() }}
       id: assert
       run: |
-        source ci/runner_env.sh
+        source ./ci/runner_env.sh
         export_labels

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -30,40 +30,40 @@ jobs:
 
     - name: Apply cocci
       run: |
-        source ci/build.sh
+        source ./ci/build.sh
         apply_prerun
 
     - name: Assert state
       if: ${{ failure() }}
       run: |
-        source ci/build.sh
+        source ./ci/build.sh
         set_step_fail "assert_state"
         echo "fatal=true" >> "$GITHUB_ENV"
 
     - name: License
       if: ${{ !cancelled() && env.fatal != 'true' }}
       run: |
-        source ci/build.sh
+        source ./ci/build.sh
         check_license
 
     - name: Check patch
       if: ${{ !cancelled() && env.fatal != 'true' }}
       run: |
-        status=0; timeout 1d bash -c "source ci/build.sh ; check_checkpatch" || status=$?
+        status=0; timeout 1d bash -c "source ./ci/build.sh ; check_checkpatch" || status=$?
         [ $status -eq 124 ] && echo "step_fail_checkpatch_timeout=true" >> "$GITHUB_ENV"
         exit $status
 
     - name: Coccicheck
       if: ${{ !cancelled() && env.fatal != 'true' }}
       run: |
-        status=0; timeout 1d bash -c "source ci/build.sh ; check_coccicheck" || status=$?
+        status=0; timeout 1d bash -c "source ./ci/build.sh ; check_coccicheck" || status=$?
         [ $status -eq 124 ] && echo "step_fail_coccicheck_timeout=true" >> "$GITHUB_ENV"
         exit $status
 
     - name: CPP Check
       if: ${{ !cancelled() && env.fatal != 'true' }}
       run: |
-        source ci/build.sh
+        source ./ci/build.sh
         check_cppcheck
 
     - name: Checkout and patch reference branch
@@ -118,7 +118,7 @@ jobs:
     - name: Check dt-bindings
       if: ${{ !cancelled() && env.fatal != 'true' }}
       run: |
-        source ci/build.sh
+        source ./ci/build.sh
         check_dt_binding_check
 
     - name: Revert patch reference branch
@@ -131,6 +131,6 @@ jobs:
       id: assert
       run: |
         echo "fatal=$fatal" >> "$GITHUB_OUTPUT"
-        source ci/runner_env.sh
+        source ./ci/runner_env.sh
         export_labels
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,13 +20,13 @@ jobs:
 
     - name: update-mirror
       run: |
-        source ci/maintenance.sh
+        source ./ci/maintenance.sh
         sync_branches "adi-6.12.0 rpi-6.12.y"
 
     - name: Export labels
       id: assert
       run: |
-        source ci/runner_env.sh
+        source ./ci/runner_env.sh
         export_labels
 
   assert:

--- a/.github/workflows/many_devicetrees.yml
+++ b/.github/workflows/many_devicetrees.yml
@@ -46,7 +46,7 @@ jobs:
 
     - name: Compile many devicetrees
       run: |
-        source ci/build.sh
+        source ./ci/build.sh
         compile_many_devicetrees
 
     - name: Prepare dist
@@ -67,5 +67,5 @@ jobs:
     - name: Assert
       id: assert
       run: |
-        source ci/runner_env.sh
+        source ./ci/runner_env.sh
         export_labels

--- a/.github/workflows/top-level.yml
+++ b/.github/workflows/top-level.yml
@@ -89,7 +89,7 @@ jobs:
         run: |
           curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -L -o runner_env.sh \
             https://raw.githubusercontent.com/${{ github.repository }}/$GITHUB_SHA/ci/runner_env.sh
-          source runner_env.sh
+          source ./runner_env.sh
           assert_labels
   conditional_xlnx:
     if: |
@@ -203,7 +203,7 @@ jobs:
         run: |
           curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -L -o runner_env.sh \
             https://raw.githubusercontent.com/${{ github.repository }}/$GITHUB_SHA/ci/runner_env.sh
-          source runner_env.sh
+          source ./runner_env.sh
           assert_labels
   conditional_rpi:
     if: |
@@ -287,7 +287,7 @@ jobs:
         run: |
           curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -L -o runner_env.sh \
             https://raw.githubusercontent.com/${{ github.repository }}/$GITHUB_SHA/ci/runner_env.sh
-          source runner_env.sh
+          source ./runner_env.sh
           assert_labels
   conditional_adsp:
     if: |
@@ -384,7 +384,7 @@ jobs:
         run: |
           curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -L -o runner_env.sh \
             https://raw.githubusercontent.com/${{ github.repository }}/$GITHUB_SHA/ci/runner_env.sh
-          source runner_env.sh
+          source ./runner_env.sh
           assert_labels
   conditional_oran:
     if: |
@@ -416,5 +416,5 @@ jobs:
         run: |
           curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -L -o runner_env.sh \
             https://raw.githubusercontent.com/${{ github.repository }}/$GITHUB_SHA/ci/runner_env.sh
-          source runner_env.sh
+          source ./runner_env.sh
           assert_labels

--- a/ci/Containerfile
+++ b/ci/Containerfile
@@ -3,9 +3,8 @@ FROM opensuse/leap:15.6
 ENV runner_labels=v1
 ARG runner_version=2.323.0
 ARG runner_version_sha=f1533c606d724c6f157335b1921fdff17f52ff57f22907f0b77f82862e9900f0
-ARG bashrc=https://raw.githubusercontent.com/analogdevicesinc/doctools/refs/heads/v1/bashrc
-ARG github_api_sh=https://raw.githubusercontent.com/analogdevicesinc/doctools/refs/heads/v1/github-api.sh
-ARG entrypoint_sh=https://raw.githubusercontent.com/analogdevicesinc/doctools/refs/heads/v1/entrypoint.sh
+ARG bashrc=https://raw.githubusercontent.com/analogdevicesinc/doctools/refs/heads/main/ci/bashrc
+ARG entrypoint_sh=https://raw.githubusercontent.com/analogdevicesinc/doctools/refs/heads/main/ci/entrypoint.sh
 
 RUN zypper install -y --no-recommends \
     tar gzip curl jq libicu coreutils sha3sum
@@ -30,9 +29,7 @@ RUN chmod +x install-extra.sh ; ./install-extra.sh
 
 RUN mkdir -p /usr/local/bin
 WORKDIR /usr/local/bin
-ADD ${github_api_sh} .
 ADD ${entrypoint_sh} .
-RUN chmod +rx github-api.sh
 RUN chmod +rx entrypoint.sh
 
 RUN git config --add --system user.name "CSE CI" ; \

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -4,8 +4,10 @@ fi
 
 if [[ "$GITHUB_ACTIONS" == "true" ]]; then
 	export _n='%0A'
+	export _c='%2C'
 else
 	export _n=$'\n'
+	export _c=$','
 fi
 
 _fmt() {
@@ -14,6 +16,10 @@ _fmt() {
 		msg=$(printf "$msg" | sed ':a;N;$!ba;s/\n/'"$_n"'/g')
 	fi
 	printf "%s\n" "$msg"
+}
+
+_file () {
+	$(echo "$1" | sed 's/,/'"$_c"'/g')
 }
 
 check_checkpatch() {
@@ -84,9 +90,9 @@ check_checkpatch() {
 						if [[ -z $file ]]; then
 							# If no file, add to file 0 of first file on list.
 							file=$(git show --name-only --pretty=format: $commit | head -n 1)
-							echo "::$type file=$file,line=0::$step_name: $msg"
+							echo "::$type file=$(_file "$file"),line=0::$step_name: $msg"
 						else
-							echo "::$type file=$file,line=$line::$step_name: $msg"
+							echo "::$type file=$(_file "$file"),line=$line::$step_name: $msg"
 						fi
 						found=0
 						file=
@@ -161,7 +167,7 @@ check_dt_binding_check() {
 		# file name or realpath of example appears in output if it contains errors
 		if echo "$error_txt" | grep -qF -e "$file" -e "$file_ex"; then
 			fail=1
-			echo "::error file=$file,line=0::$step_name contain errors"
+			echo "::error file=$(_file "$file"),line=0::$step_name contain errors"
 		fi
 	done <<< "$files"
 
@@ -215,13 +221,12 @@ check_coccicheck() {
 				elif [[ "$row" =~ ^$file: ]]; then
 					# drivers/iio/.../adi_adrv9001_fh.c:645:67-70: duplicated argument to & or |
 					IFS=':' read -r -a list <<< "$row"
-					file_=$(echo ${list[0]} | xargs)
 					line=${list[1]}
 					msg=
 					for ((i=2; i<${#list[@]}; i++)); do
 						msg="$msg${list[$i]} "
 					done
-					echo "::$type file=$file,line=$line::$step_name: $msg"
+					echo "::$type file=$(_file "$file"),line=$line::$step_name: $msg"
 				else
 					if [[ "$row" ]]; then
 						echo $row

--- a/ci/symbols_depend.py
+++ b/ci/symbols_depend.py
@@ -343,11 +343,20 @@ def _get_symbols_from_mk(mk, obj, l_obj):
     return _get_symbols_from_mk(mk, f"{obj}.o", l_obj_)
 
 
-def get_symbols_from_o(files):
+def get_symbols(files):
     """
     Resolve the base symbols for .o targets.
+    If it is a symbol already, just add it.
     """
+    global symbols_
+
     for f in files:
+        if f == "":
+            continue
+        if not f.endswith(".o"):
+            symbols_.add(f)
+            continue
+
         found = False
         base = path.basename(f)
         ldir = path.dirname(f)
@@ -367,14 +376,14 @@ def get_symbols_from_o(files):
 
 def main():
     """
-    Resolve dependencies of a symbol based on the .o target.
+    Resolve dependencies of a symbol based on symbols and .o target.
     usage:
 
-        symbols=$(ci/symbols_depend.py [O_FILES])
+        symbols=$(ci/symbols_depend.py [SYMBOLS] [O_FILES])
 
     """
     argv.pop(0)
-    get_symbols_from_o(set(argv))
+    get_symbols(set(argv))
     print("Symbols of touched files:", file=stderr)
     print(symbols_, file=stderr)
     generate_map()

--- a/ci/touched_kconfig.awk
+++ b/ci/touched_kconfig.awk
@@ -1,0 +1,61 @@
+function push(sym){
+    if(!(sym in seen)){
+        seen[sym]=1
+        order[++n]=sym
+    }
+}
+
+BEGIN{
+    inK=0
+    curr=""
+}
+
+/^diff --git /{
+    inK=0
+    curr=""
+    next
+}
+
+/^\+\+\+ b\//{
+    path=substr($0,7)
+    inK=1
+    curr=""
+    next
+}
+
+!inK { next }
+
+/^@@ /{
+    curr=""
+    if (match($0, /config[ \t]+([A-Za-z0-9_]+)/, m)) {
+        curr=m[1]
+    }
+    next
+}
+
+{
+    line=$0
+    prefix=substr(line,1,1)
+    text=substr(line,2)
+
+    if (prefix==" " || prefix=="+" || prefix=="-") {
+	# (menu)?config <symbol>
+        if (match(text, /^[ \t]*(menu)?config[ \t]+([A-Za-z0-9_]+)/, m)) {
+            curr=m[2]
+            if (prefix=="+") { push(curr) }
+            next
+        }
+	# internal to config block
+        if ((prefix=="+" || prefix=="-") && curr!="") {
+            push(curr)
+            next
+        }
+    }
+}
+
+END{
+    for (i=1; i<=n; i++) {
+        printf "%s%s", order[i], (i<n?OFS:ORS)
+    }
+}
+


### PR DESCRIPTION
## PR Description
Combine git internal treesitter and awk good block syntax to extract symbols of touched (menu)?config blocks.

Captures internal addition/deletions, and whole block addition, for example:
```
  @@ -147,6 +147,7 @@ config CONFIG_MOCK
  +config CONFIG_MOCK
  + tristate
  + select IIO_BUFFER
  + select IIO_TRIGGERED_BUFFER

  @@ -147,6 +147,7 @@ config CONFIG_MOCK
          depends on CF_AXI_DDS
  +       select REGMAP_SPI
          help
            Say y

  @@ -147,6 +147,7 @@ config CONFIG_MOCK
   config CF_AXI_DDS_AD9783
          tristate "Analog Devices AD9783 DAC"
          depends on CF_AXI_DDS
  -       select REGMAP_SPI
          help
            Say y
```
This is a new method for our CI, previously we would just look at touched files and not individually files, 
and before this, we would just build everything based on kconfig

Commit @~ is better looked with `-w` to ignore the whitespace, since it drops 2 levels of indentation

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
