### PR TITLE
dt-bindings: net: corundum,mqnic: Remove redundant quotes from $id field

### DIFF
--- a/Documentation/devicetree/bindings/net/corundum,mqnic.yaml
+++ b/Documentation/devicetree/bindings/net/corundum,mqnic.yaml
@@ -2,7 +2,7 @@
 # Copyright (c) 2019-2024 The Regents of the University of California
 %YAML 1.2
 ---
-$id: "http://devicetree.org/schemas/net/corundum,mqnic.yaml#"
+$id: http://devicetree.org/schemas/net/corundum,mqnic.yaml#
 $schema: http://devicetree.org/meta-schemas/core.yaml#
 
 title: Corundum mqnic Ethernet controller


### PR DESCRIPTION


## PR Description

Fix YAML linting error by removing  redundant quotes around the $id value, according to YAML style guidelines in corundum,mqnic device-tree binding

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
