### PR TITLE
nvmem: Kconfig: Add COMPILE_TEST to NVMEM_AXI_SYSID

### DIFF
--- a/drivers/nvmem/Kconfig
+++ b/drivers/nvmem/Kconfig
@@ -42,7 +42,7 @@ config NVMEM_APPLE_EFUSES
 
 config NVMEM_AXI_SYSID
 	tristate "Analog Devices AXI System ID Support"
-	depends on ARCH_ZYNQMP || ARCH_ZYNQ || MICROBLAZE || ARCH_INTEL_SOCFPGA || NIOS2
+	depends on ARCH_ZYNQMP || ARCH_ZYNQ || MICROBLAZE || ARCH_INTEL_SOCFPGA || NIOS2 || COMPILE_TEST
 	depends on HAS_IOMEM
 	help
 	  Say Y here to include AXI System ID support.


### PR DESCRIPTION
## PR Description

Add symbol required to compile without a specific arch symbol.
ARCH_ symbols are useful to filter-out non-relevant code for other archs, for CI we always want to test all code, hence why this symbol exists

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
