### PR TITLE
ci: Containerfile: Bump base image version

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -19,9 +19,9 @@ jobs:
 
     - name: Install pip packages
       run: |
-        python3.11 -m venv ~/venv
+        python3.13 -m venv ~/venv
         source ~/venv/bin/activate
-        pip3.11 install -r docs/requirements.txt --upgrade
+        pip3.13 install -r docs/requirements.txt --upgrade
 
     - name: Build doc
       working-directory: docs

--- a/ci/Containerfile
+++ b/ci/Containerfile
@@ -1,13 +1,13 @@
-FROM opensuse/leap:15.6
+FROM opensuse/leap:16.0
 
-ENV runner_labels=v1
-ARG runner_version=2.323.0
-ARG runner_version_sha=f1533c606d724c6f157335b1921fdff17f52ff57f22907f0b77f82862e9900f0
+ENV runner_labels=v2
+ARG runner_version=2.328.0
+ARG runner_version_sha=01066fad3a2893e63e6ca880ae3a1fad5bf9329d60e77ee15f2b97c148c3cd4e
 ARG bashrc=https://raw.githubusercontent.com/analogdevicesinc/doctools/refs/heads/main/ci/bashrc
 ARG entrypoint_sh=https://raw.githubusercontent.com/analogdevicesinc/doctools/refs/heads/main/ci/entrypoint.sh
 
 RUN zypper install -y --no-recommends \
-    tar gzip curl jq libicu coreutils sha3sum
+    tar gzip curl jq libicu coreutils
 
 RUN useradd -m runner
 
@@ -16,7 +16,7 @@ RUN mkdir -p /home/runner/actions-runner
 WORKDIR /home/runner/actions-runner
 
 RUN curl -o actions-runner.tar.gz -L https://github.com/actions/runner/releases/download/v${runner_version}/actions-runner-linux-x64-${runner_version}.tar.gz && \
-    echo "${runner_version_sha} actions-runner.tar.gz" | sha3sum -a 256 -c && \
+    echo -n "${runner_version_sha} actions-runner.tar.gz" | sha256sum -c && \
     tar xzf actions-runner.tar.gz
 
 USER root

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -30,9 +30,9 @@ check_checkpatch() {
 
 	echo "$step_name on range $base_sha..$head_sha"
 
-	python3.11 -m venv ~/venv
+	python3.13 -m venv ~/venv
         source ~/venv/bin/activate
-        pip3.11 install ply GitPython --upgrade
+        pip3.13 install ply GitPython --upgrade
 
 	# The output is not properly captured with --git
 	for commit in $(git rev-list $base_sha..$head_sha --reverse); do
@@ -141,9 +141,9 @@ check_dt_binding_check() {
 
 	echo "$step_name on range $base_sha..$head_sha"
 
-	python3.11 -m venv ~/venv
+	python3.13 -m venv ~/venv
         source ~/venv/bin/activate
-        pip3.11 install dtschema yamllint --upgrade
+        pip3.13 install dtschema yamllint --upgrade
 
 	[[ -z "$files" ]] && return 0
 	while read file; do
@@ -563,7 +563,7 @@ compile_kernel() {
 	fi
 	rm $tmp_log_file
 
-	python3.11 scripts/clang-tools/gen_compile_commands.py
+	python3.13 scripts/clang-tools/gen_compile_commands.py
 
 	_set_step_warn $warn
 	return $fail
@@ -968,7 +968,7 @@ auto_set_kconfig() {
 	done <<< "$c_files"
 
 	local k_symbols=$(echo "$k_blocks" | awk -f ci/touched_kconfig.awk)
-	symbols=$(python3.11 ci/symbols_depend.py ${k_symbols[@]} "${o_files[@]}")
+	symbols=$(python3.13 ci/symbols_depend.py ${k_symbols[@]} "${o_files[@]}")
 	for sym in $symbols; do
 		scripts/config -e $sym
 	done

--- a/ci/install-compilers.sh
+++ b/ci/install-compilers.sh
@@ -2,18 +2,15 @@
 
 set -e
 
-zypper addrepo -c http://download.opensuse.org/distribution/leap/16.0/repo/oss leap-16.0-repo-oss
-zypper refresh
-
 #core, linux, linux gcc, linux clang, arm, aarch64, linux checks
 zypper install -y --no-recommends \
     git \
     libncurses6 swig bc u-boot-tools flex bison tar kmod xz gawk diffutils \
-    gcc14 libelf1 libelf-devel \
+    gcc15 libelf1 libelf-devel \
     clang19 llvm19 lld19 \
-    cross-arm-gcc14 \
-    cross-aarch64-gcc14-bootstrap \
-    sparse coccinelle ocaml ocaml-findlib cppcheck python311 python311-pip python311-devel
+    cross-arm-gcc15 \
+    cross-aarch64-gcc15 \
+    sparse coccinelle ocaml ocaml-findlib cppcheck python313 python313-pip python313-devel
 
-update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 50
-update-alternatives --install /usr/bin/cpp cpp /usr/bin/cpp-14 50
+update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-15 50
+update-alternatives --install /usr/bin/cpp cpp /usr/bin/cpp-15 50


### PR DESCRIPTION

## PR Description
opensuse/leap/16.0 is now in the container registry, and adding the repo is not necessary anymore. Bump gcc to 15 as well.
This may sit here for a while until there is an actual need to move to gcc 15 

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
