### PR TITLE
ci: Fix DTBs upload after version upgrade

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,8 +66,13 @@ stages:
         displayName: 'Device-Tree Build Test'
       - task: CopyFiles@2
         inputs:
-          sourceFolder: '$(Agent.BuildDirectory)/s/arch/arm/boot/dts'
-          contents: '$(Agent.BuildDirectory)/s/arch/arm/boot/dts/?(*.dtb)'
+          sourceFolder: '$(Agent.BuildDirectory)/s/arch/arm/boot/dts/intel/socfpga'
+          contents: '$(Agent.BuildDirectory)/s/arch/arm/boot/dts/intel/socfpga/?(*.dtb)'
+          targetFolder: '$(Build.ArtifactStagingDirectory)'
+      - task: CopyFiles@2
+        inputs:
+          sourceFolder: '$(Agent.BuildDirectory)/s/arch/arm/boot/dts/xilinx'
+          contents: '$(Agent.BuildDirectory)/s/arch/arm/boot/dts/xilinx/?(*.dtb)'
           targetFolder: '$(Build.ArtifactStagingDirectory)'
       - task: CopyFiles@2
         inputs:

--- a/ci/travis/prepare_artifacts.sh
+++ b/ci/travis/prepare_artifacts.sh
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #!/bin/bash -e
 
-TIMESTAMP=$(date +%Y_%m_%d-%H_%M)
+TIMESTAMP=$(date +%Y_%m_%d-%H_%M_%S)
 # For PRs, Azure makes a merge commit (HEAD) because of the shallow copy option
 # (which we want). So, GIT_SHA in this case is the actual correct commit inside
 # the PR, and MERGE_COMMIT is the commit made by Azure (which we extract the date
@@ -88,17 +88,17 @@ artifacts_structure() {
                 echo "IMAGE: ${image_to_copy[${platform}]}!"
                 cp ${image_to_copy[${platform}]} ${image_location}
             fi
-        done
 
-        if [ "${arch}" == "microblaze" ]; then
-            dtbs_to_copy=$(ls -d -1 Microblaze/*)
-        else
-            dtbs_to_copy=$(ls -d -1 DTBs/* | grep "${platform}")
-        fi
+            if [ "${arch}" == "microblaze" ]; then
+                dtbs_to_copy=$(ls -d -1 Microblaze/*)
+            else
+                dtbs_to_copy=$(ls -d -1 DTBs/* | grep "${platform}[-|_]")
+            fi
 
-        # Copy DTBs to the correct location
-        for dtb in ${dtbs_to_copy}; do
-            cp ${dtb} "${TIMESTAMP}/${arch}"
+            # Copy DTBs to the correct location
+            for dtb in ${dtbs_to_copy}; do
+                cp ${dtb} "${TIMESTAMP}/${arch}"
+            done
         done
     done
 }


### PR DESCRIPTION
## PR Description

Changes introduced in 3b1f15d moved some DTS files to a different location. Update CIs to reflect those changes:
- Update DTBs location in `azure_pipelines.yml`
- Fix pattern matching in `prepare_artifacts.sh` to upload each DTB to the correct destination (based on platform).

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
