### PR TITLE
ci: build: Fix invoke touch

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -927,7 +927,7 @@ apply_prerun() {
 touch_files () {
 	local files=$(git diff --diff-filter=ACM --no-renames --name-only $base_sha..$head_sha)
 
-	touch $files
+	[[ ! -z "$files" ]] && touch $files
 }
 
 auto_set_kconfig() {


### PR DESCRIPTION
## PR Description

Only invoke touch if the list of lines is not empty, resolving it returning error on this condition.

Aims to solve https://github.com/analogdevicesinc/linux/actions/runs/17738233538/job/50405386618?pr=2938

```
touch: missing file operand
Try 'touch --help' for more information.
```

#2938

@pamolloy  easy review
## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
