### PR TITLE
docs: iio: apollo: Add stub page

### DIFF
--- a/docs/iio/apollo.rst
+++ b/docs/iio/apollo.rst
@@ -1,0 +1,4 @@
+:stub: staging/apollo
+
+AD9088 driver
+-------------

--- a/docs/iio/index.rst
+++ b/docs/iio/index.rst
@@ -15,3 +15,4 @@ Industrial I/O Kernel Drivers
    :glob:
 
    ad*
+   apollo


### PR DESCRIPTION

## PR Description

The stub page is used to reserve and populate the target location, while providing an alternative label for a staging driver.
this pr generated doc can be used to test the stub redirect:
https://analogdevicesinc.github.io/linux/pull/2941/iio/apollo.html
redirects to
https://analogdevicesinc.github.io/linux/staging/apollo/iio/apollo.html

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
