### PR TITLE
ci: azure-pipelines-rpi: Increase upload timeout

### DIFF
--- a/azure-pipelines-rpi.yml
+++ b/azure-pipelines-rpi.yml
@@ -101,6 +101,7 @@ stages:
           DEST_SERVER: $(SERVER_ADDRESS)
         displayName: "Push to SWDownloads"
   - job: Push_to_Artifactory
+    timeoutInMinutes: 90
     condition: and(
        succeeded(),
        or(eq(variables['Build.SourceBranch'], 'refs/heads/rpi-6.12.y'),


### PR DESCRIPTION
## PR Description

The upload to Artifactory stage started to take longer than 1h. Increase timeout to 90 minutes.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
