### PR TITLE
devicetree: arm: SC594-EZKIT remove tx dma configs

### DIFF
--- a/arch/arm/boot/dts/adi/sc594-som-ezkit.dts
+++ b/arch/arm/boot/dts/adi/sc594-som-ezkit.dts
@@ -172,27 +172,9 @@
 	pinctrl-names = "default";
 	pinctrl-0 = <&eth0_default>;
 	status = "okay";
-	snps,mtl-rx-config = <&emac0rxconfig>;
-	snps,mtl-tx-config = <&emac0txconfig>;
 
 	emac0txconfig: tx-config {
 		snps,tx-queues-to-use = <3>;
-
-		queue0 {
-			snps,dcb-algorithm;
-		};
-
-		queue1 {
-			snps,dcb-algorithm;
-		};
-
-		queue2 {
-			snps,dcb-algorithm;
-		};
-	};
-
-	emac0rxconfig: rx-config {
-		snps,rx-queues-to-use = <1>;
 
 		queue0 {
 			snps,dcb-algorithm;

--- a/arch/arm/boot/dts/adi/sc59x.dtsi
+++ b/arch/arm/boot/dts/adi/sc59x.dtsi
@@ -477,9 +477,7 @@
 			interrupt-parent = <&gic>;
 			interrupts = <GIC_SPI 221 IRQ_TYPE_LEVEL_HIGH>;
 			interrupt-names = "macirq";
-			snps,mixed-burst;
 			snps,pbl = <8>;
-			snps,force_sf_dma_mode;
 			snps,perfect-filter-entries = <32>;
 			clocks = <&clk ADSP_SC594_CLK_GIGE>;
 			clock-names = "stmmaceth";


### PR DESCRIPTION
## PR Description

Regression between ADSP Linux Yocto releases 3.1.2 -> 5.0.0 
SC594 boards isn't stable when running for more then few minutes, this changes makes its stable.
Max bandwidth benchmark after change stayed at same level >500MBit/s

## PR Type
- [x] Bug fix (a change that fixes an issue)


## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have tested the changes on the relevant hardware
