### PR TITLE
iio: adc: adrv9002: Fix selecting port B on RX2

### DIFF
--- a/drivers/iio/adc/navassa/adrv9002.c
+++ b/drivers/iio/adc/navassa/adrv9002.c
@@ -3566,11 +3566,14 @@ static int adrv9002_radio_init(struct adrv9002_rf_phy *phy)
 	if (ret)
 		return ret;
 
-	if (phy->port_switch.enable) {
-		ret = api_call(phy, adi_adrv9001_Rx_PortSwitch_Configure, &phy->port_switch);
-		if (ret)
-			return ret;
-	}
+	/*
+	 * This needs to be done otherwise selecting port B on RX2 and port A on RX1 would
+	 * not properly work. Likely a bug in the device FW but for now, let`s just
+	 * workaround it here.
+	 */
+	ret = api_call(phy, adi_adrv9001_Rx_PortSwitch_Configure, &phy->port_switch);
+	if (ret)
+		return ret;
 
 	for (chan = 0; chan < ARRAY_SIZE(phy->channels); chan++) {
 		struct adrv9002_chan *c = phy->channels[chan];

--- a/drivers/iio/adc/navassa/adrv9002_of.c
+++ b/drivers/iio/adc/navassa/adrv9002_of.c
@@ -1078,6 +1078,18 @@ static int adrv9002_parse_port_switch(struct adrv9002_rf_phy *phy, struct device
 	const char *mode;
 	int ret;
 
+	/*
+	 * Put some defaults even if disabled as we will have to still call
+	 * adi_adrv9001_Rx_PortSwitch_Configure() during setup() and API validations would
+	 * fail. This needas to be done otherwise selecting port B on RX2 and port A on RX1 would
+	 * not properly work. Likely a bug in the device FW but for now, let`s just
+	 * workaround it here.
+	 */
+	phy->port_switch.minFreqPortA_Hz = 890000000;
+	phy->port_switch.maxFreqPortA_Hz = 910000000;
+	phy->port_switch.minFreqPortB_Hz = 1890000000;
+	phy->port_switch.maxFreqPortB_Hz = 1910000000;
+
 	ret = of_property_read_string(node, "adi,rx-port-switch", &mode);
 	if (ret)
 		/* not a mandatory property... Ignoring errors...*/


### PR DESCRIPTION
## PR Description

When using a profile with RX1 on port A and RX2 on port B, RX2 would still receive data on port A. As it turns out, we do have to call adi_adrv9001_Rx_PortSwitch_Configure() even if port switch is disabled. Annoyingly, we also need to put some valid values on the carrier intervals for making the API happy (even if the feature is disabled).

Likely this is a bug in the device FW but for now, let's just workaround it like this. And being this a workaround, I'm not giving a Fixes tag.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
