### PR TITLE
 [2023_R2] iio: adc: adrv9002: fix frequency hopping table configuration

### DIFF
--- a/drivers/iio/adc/navassa/adrv9002.c
+++ b/drivers/iio/adc/navassa/adrv9002.c
@@ -3944,7 +3944,7 @@ static ssize_t adrv9002_fh_bin_table_write(struct adrv9002_rf_phy *phy, char *bu
 	}
 
 	memcpy(tbl->bin_table, buf, count);
-	/* The bellow is always safe as @bin_table is bigger (by 1 byte) than the bin attribute */
+	/* The below is always safe as @bin_table is bigger (by 1 byte) than the bin attribute */
 	tbl->bin_table[count] = '\0';
 
 	if (phy->fh.mode == ADI_ADRV9001_FHMODE_LO_RETUNE_REALTIME_PROCESS_DUAL_HOP)
@@ -3969,7 +3969,7 @@ static ssize_t adrv9002_fh_bin_table_write(struct adrv9002_rf_phy *phy, char *bu
 			return -EINVAL;
 		}
 
-		if (entry > max_sz) {
+		if (entry >= max_sz) {
 			dev_err(&phy->spi->dev, "Hop:%d table:%d too big:%d\n", hop, table, entry);
 			return -EINVAL;
 		}
@@ -3983,10 +3983,10 @@ static ssize_t adrv9002_fh_bin_table_write(struct adrv9002_rf_phy *phy, char *bu
 
 		tbl->hop_tbl[entry].hopFrequencyHz = lo;
 		tbl->hop_tbl[entry].rx1OffsetFrequencyHz = rx10_if;
-		tbl->hop_tbl[entry].rx2OffsetFrequencyHz = rx10_if;
+		tbl->hop_tbl[entry].rx2OffsetFrequencyHz = rx20_if;
 		tbl->hop_tbl[entry].rx1GainIndex = rx1_gain;
 		tbl->hop_tbl[entry].tx1Attenuation_fifthdB = tx1_atten;
-		tbl->hop_tbl[entry].rx2GainIndex = rx1_gain;
+		tbl->hop_tbl[entry].rx2GainIndex = rx2_gain;
 		tbl->hop_tbl[entry].tx2Attenuation_fifthdB = tx2_atten;
 		entry++;
 	}


### PR DESCRIPTION
## PR Description

Fix multiple issues in the frequency hopping bin table write function:
- Correct typo "bellow" to "below" in comment
- Fix off-by-one error in entry bounds check (should be >= not >)
- Use correct rx20_if variable for rx2OffsetFrequencyHz instead of rx10_if
- Use correct rx2_gain variable for rx2GainIndex instead of rx1_gain

These fixes ensure proper configuration of RX2 channel parameters and prevent potential buffer overflow when the entry index equals max_sz.

(cherry picked from commit f7a682beec638c73596be001d8067e21463f0d4d)

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
