### PR TITLE
iio: frequency: adf4030: Fix bsync_out_freq_uhz scaling

### DIFF
--- a/drivers/iio/frequency/adf4030.c
+++ b/drivers/iio/frequency/adf4030.c
@@ -276,12 +276,12 @@ static int adf4030_compute_odiv(u32 vco_freq, u64 bsync_out_freq_uhz, u32 *odiv)
 
 static int adf4030_set_odiva_freq(struct adf4030_state *st, u64 bsync_out_freq_uhz)
 {
-	u32 odiv;
+	u32 odiv, fract;
 	int ret;
 
 	ret = adf4030_compute_odiv(st->vco_freq, bsync_out_freq_uhz, &odiv);
+	fract = do_div(bsync_out_freq_uhz, MICROHZ_PER_HZ);
 	if (ret) {
-		u32 fract = do_div(bsync_out_freq_uhz, MICROHZ_PER_HZ);
 
 		dev_err(&st->spi->dev,
 			"Failed to compute ODIVA for Fvco=%u Hz and Fbsync=%llu.%06u uHz\n",


### PR DESCRIPTION
## PR Description

do_div() also changes the first argument and that will in fact scale bsync_out_freq_uhz back to herz. Therefore move it to before the if() statement.

Note the mess was introduced by me when cherry-picking Michael's patch.

Fixes: 8ba4dae68f1a ("iio: frequency: adf4030: support sub-Hz precision for Bsync frequency")

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
