### PR TITLE
Adsp main 6.12 sc594 revert spi2 gpio changes

### DIFF
--- a/arch/arm/boot/dts/adi/sc594-som.dtsi
+++ b/arch/arm/boot/dts/adi/sc594-som.dtsi
@@ -297,16 +297,16 @@
 
 		spi2flash-cs {
 			gpio-hog;
-			gpios = <3 GPIO_ACTIVE_LOW>;
-			output-high;
-			line-name = "spi2flash-cs";
+			gpios = <3 GPIO_ACTIVE_HIGH>;
+			output-low;
+			line-name = "~spi2flash-cs";
 		};
 
 		spi2d2-d3 {
 			gpio-hog;
-			gpios = <4 GPIO_ACTIVE_LOW>;
-			output-high;
-			line-name = "spi2d2-d3-en";
+			gpios = <4 GPIO_ACTIVE_HIGH>;
+			output-low;
+			line-name = "~spi2d2-d3-en";
 		};
 
 		uart0 {
@@ -325,9 +325,9 @@
 
 		ospiflash-cs {
 			gpio-hog;
-			gpios = <7 GPIO_ACTIVE_LOW>;
-			output-high;
-			line-name = "ospiflash-cs";
+			gpios = <7 GPIO_ACTIVE_HIGH>;
+			output-low;
+			line-name = "~ospiflash-cs";
 		};
 	};
 };


### PR DESCRIPTION
## PR Description

Introduced GPIO changes, when booting from SPI2 can't mount/find rootfs on SC594.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
