### PR TITLE
iio: adc: ad7380: fix SPI offload trigger rate

### DIFF
--- a/drivers/iio/adc/ad7380.c
+++ b/drivers/iio/adc/ad7380.c
@@ -1235,6 +1235,14 @@ static int ad7380_offload_buffer_postenable(struct iio_dev *indio_dev)
 	if (ret)
 		return ret;
 
+	/*
+	 * When the sequencer is required to read all channels, we need to
+	 * trigger twice per sample period in order to read one complete set
+	 * of samples.
+	 */
+	if (st->seq)
+		config.periodic.frequency_hz *= 2;
+
 	switch (st->num_sdi) {
 	case 2:
 		sdo = AD7380_CONFIG2_SDO_2_WIRE;


### PR DESCRIPTION
This is backporting a fix that was just accepted upstream.

## PR Description

Add a special case to double the SPI offload trigger rate when all channels of a single-ended chip are enabled in a buffered read.

The single-ended chips in the AD738x family can only do simultaneous sampling of half their channels and have a multiplexer to allow reading the other half. To comply with the IIO definition of sampling_frequency, we need to trigger twice as often when the sequencer is enabled to so that both banks can be read in a single sample period.

Fixes: bbeaec81a03e ("iio: ad7380: add support for SPI offload")

Cc: <Stable@vger.kernel.org>

(cherry picked from commit 632757312d7eb320b66ca60e0cfe098ec53cee08)

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x]  I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
