### PR TITLE
ADF4030 TDC improvements

### DIFF
--- a/drivers/iio/frequency/adf4030.c
+++ b/drivers/iio/frequency/adf4030.c
@@ -407,7 +407,9 @@ static int adf4030_tdc_measure(struct adf4030_state *st, u32 channel,
 				       ADF4030_MATH_BUSY_MSK)),
 				       2000, 10000);
 	if (ret) {
-		dev_err(&st->spi->dev, "TDC measurement failed TDC_BUSY\n");
+		dev_err(&st->spi->dev,
+			"TDC measurement channel %d to channel %d failed TDC_BUSY\n",
+			channel, source_channel);
 		return ret;
 	}
 
@@ -480,7 +482,9 @@ static int adf4030_duty_cycle_measure(struct adf4030_state *st, u32 channel,
 				       ADF4030_MATH_BUSY_MSK)),
 				       2000, 10000);
 	if (ret) {
-		dev_err(&st->spi->dev, "TDC measurement failed TDC_BUSY\n");
+		dev_err(&st->spi->dev,
+			"TDC measurement channel %d failed TDC_BUSY\n",
+			channel);
 		return ret;
 	}
 
@@ -585,7 +589,9 @@ static int adf4030_auto_align_single_channel(const struct adf4030_state *st,
 					       regval, !(regval & ADF4030_FSM_BUSY_MSK),
 					       4000, 3000000);
 		if (ret) {
-			dev_err(&st->spi->dev, "Autoalign failed FSM_BUSY\n");
+			dev_err(&st->spi->dev,
+				"Autoalign channel %d to channel %d failed FSM_BUSY\n",
+				channel, source_channel);
 			return ret;
 		}
 		ret = regmap_read(st->regmap, ADF4030_REG(0x90), &regval);


### PR DESCRIPTION
## PR Description

 Migrate frequency storage from u32 Hz to u64 µHz for sub-Hz precision control. This enables more accurate frequency configuration for JESD204 applications requiring precise rates. Additionally, enhance error messages in TDC measurement and autoalignment functions.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
