### PR TITLE
.github: workflows: Add read permission

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   build-doc:
     runs-on: [self-hosted, repo-only]
+    permissions:
+      contents: read
 
     steps:
     - uses: analogdevicesinc/doctools/checkout@action

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,6 +34,8 @@ jobs:
 
   assert:
     runs-on: [self-hosted, repo-only]
+    permissions:
+      contents: read
     needs: [sync_branches]
 
     steps:

--- a/.github/workflows/top-level.yml
+++ b/.github/workflows/top-level.yml
@@ -20,6 +20,8 @@ jobs:
   checks:
     uses: analogdevicesinc/linux/.github/workflows/checks.yml@ci
     secrets: inherit
+    permissions:
+      contents: read
     with:
       ref_branch: "mirror/next/linux-next/master"
   build_gcc_x86_64:
@@ -27,6 +29,8 @@ jobs:
     needs: [checks]
     if: needs.checks.outputs.fatal != 'true'
     secrets: inherit
+    permissions:
+      contents: read
     with:
       compiler: "gcc"
       arch: "x86"
@@ -36,6 +40,8 @@ jobs:
     needs: [checks]
     if: needs.checks.outputs.fatal != 'true'
     secrets: inherit
+    permissions:
+      contents: read
     with:
       compiler: "llvm"
       arch: "x86"
@@ -46,6 +52,8 @@ jobs:
     needs: [checks]
     if: needs.checks.outputs.fatal != 'true'
     secrets: inherit
+    permissions:
+      contents: read
     with:
       compiler: "gcc"
       arch: "arm64"
@@ -53,6 +61,8 @@ jobs:
   build_gcc_arm:
     uses: analogdevicesinc/linux/.github/workflows/build.yml@ci
     secrets: inherit
+    permissions:
+      contents: read
     with:
       compiler: "gcc"
       arch: "arm"
@@ -102,6 +112,8 @@ jobs:
     needs: [assert_checks]
     uses: analogdevicesinc/linux/.github/workflows/build.yml@ci
     secrets: inherit
+    permissions:
+      contents: read
     with:
       compiler: "gcc"
       arch: "arm"
@@ -111,6 +123,8 @@ jobs:
     needs: [assert_checks]
     uses: analogdevicesinc/linux/.github/workflows/build.yml@ci
     secrets: inherit
+    permissions:
+      contents: read
     with:
       compiler: "gcc"
       arch: "arm"
@@ -120,6 +134,8 @@ jobs:
     needs: [assert_checks]
     uses: analogdevicesinc/linux/.github/workflows/build.yml@ci
     secrets: inherit
+    permissions:
+      contents: read
     with:
       compiler: "gcc"
       arch: "arm"
@@ -129,6 +145,8 @@ jobs:
     needs: [assert_checks]
     uses: analogdevicesinc/linux/.github/workflows/build.yml@ci
     secrets: inherit
+    permissions:
+      contents: read
     with:
       compiler: "gcc"
       arch: "arm"
@@ -138,6 +156,8 @@ jobs:
     needs: [assert_checks]
     uses: analogdevicesinc/linux/.github/workflows/build.yml@ci
     secrets: inherit
+    permissions:
+      contents: read
     with:
       compiler: "gcc"
       arch: "arm64"
@@ -147,6 +167,8 @@ jobs:
     needs: [assert_checks]
     uses: analogdevicesinc/linux/.github/workflows/build.yml@ci
     secrets: inherit
+    permissions:
+      contents: read
     with:
       compiler: "gcc"
       arch: "arm"
@@ -156,6 +178,8 @@ jobs:
     needs: [assert_checks]
     uses: analogdevicesinc/linux/.github/workflows/compile-devicetrees.yml@ci
     secrets: inherit
+    permissions:
+      contents: read
     with:
       compiler: "gcc"
       archs: "arm arm64 microblaze nios2"


### PR DESCRIPTION

## PR Description

Explicitly mark the jobs with contents read permission.
Even though the repository default is `contents: read`, this solely wouldn't the GitHub Security checks from raising a medium level warning per instance.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly (if there is the case)
