### PR TITLE
azure-pipelines-rpi: Use explicit regex

### DIFF
--- a/azure-pipelines-rpi.yml
+++ b/azure-pipelines-rpi.yml
@@ -56,7 +56,7 @@ stages:
     - task: CopyFiles@2
       inputs:
         sourceFolder: '$(Agent.BuildDirectory)/s/arch/$(ARCH)/boot/dts'
-        contents: '$(Agent.BuildDirectory)/s/arch/$(ARCH)/boot/dts/overlays/?(*.dtb*)'
+        contents: '$(Agent.BuildDirectory)/s/arch/$(ARCH)/boot/dts/overlays/?(*.dtb|*.dtbo)'
         targetFolder: '$(Build.ArtifactStagingDirectory)'
     - task: CopyFiles@2
       inputs:


### PR DESCRIPTION
The intention of the commit 35804449ede6209ae7ded93d41ac4619c95f4820 was to also upload the .dtb files present in overlays/ folder.

By using .dtb* regex, unnecessary files found their way into the artifacts. Use explicit regex in order to upload only files ending in .dtb or .dtbo.

## PR Type
- [x] Bug fix (a change that fixes an issue)

## PR Checklist
- [x] I have conducted a self-review of my own code changes