### PR TITLE
arm: dts: remove "mclk" from AD7124 overlays

### DIFF
--- a/arch/arm/boot/dts/overlays/rpi-ad7124-8-all-diff-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ad7124-8-all-diff-overlay.dts
@@ -19,34 +19,19 @@
 	};
 
 	fragment@1 {
-		target-path = "/";
-		__overlay__ {
-			clocks {
-				ad7124_mclk: clock@0 {
-					#clock-cells = <0>;
-					compatible = "fixed-clock";
-					clock-frequency = <614400>;
-				};
-			};
-		};
-	};
-
-	fragment@2 {
 		target = <&spi0>;
 		__overlay__ {
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "okay";
 
-			ad7124: ad7124@0 {
+			ad7124: adc@0 {
 				compatible = "adi,ad7124-8";
 				reg = <0>; //CS0 default
 				spi-max-frequency = <5000000>;
 				interrupts = <19 2>; // interrupt, Default to PMD-RPI-INTZ P1
 				interrupt-parent = <&gpio>;
 				refin1-supply = <&vref>;
-				clocks = <&ad7124_mclk>;
-				clock-names = "mclk";
 
 				#address-cells = <1>;
 				#size-cells = <0>;
@@ -94,14 +79,14 @@
 		};
 	};
 
-	fragment@3 {
+	fragment@2 {
 		target = <&spidev0>;
 		__overlay__ {
 			status = "disabled";
 		};
 	};
 
-	fragment@4 {
+	fragment@3 {
 		target = <&spidev1>;
 		__overlay__ {
 			status = "disabled";

--- a/arch/arm/boot/dts/overlays/rpi-ad7124-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ad7124-overlay.dts
@@ -19,34 +19,19 @@
 	};
 
 	fragment@1 {
-		target-path = "/";
-		__overlay__ {
-			clocks {
-				ad7124_mclk: clock@0 {
-					#clock-cells = <0>;
-					compatible = "fixed-clock";
-					clock-frequency = <614400>;
-				};
-			};
-		};
-	};
-
-	fragment@2 {
 		target = <&spi0>;
 		__overlay__ {
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "okay";
 
-			ad7124@0 {
+			adc@0 {
 				compatible = "adi,ad7124-4";
 				reg = <0>;
 				spi-max-frequency = <5000000>;
 				interrupts = <25 2>;
 				interrupt-parent = <&gpio>;
 				refin1-supply = <&vref>;
-				clocks = <&ad7124_mclk>;
-				clock-names = "mclk";
 
 				#address-cells = <1>;
 				#size-cells = <0>;
@@ -102,14 +87,14 @@
 		};
 	};
 
-	fragment@3 {
+	fragment@2 {
 		target = <&spidev0>;
 		__overlay__ {
 			status = "disabled";
 		};
 	};
 
-	fragment@4 {
+	fragment@3 {
 		target = <&spidev1>;
 		__overlay__ {
 			status = "disabled";

--- a/arch/arm/boot/dts/overlays/rpi-cn0508-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-cn0508-overlay.dts
@@ -52,19 +52,6 @@
 	};
 
 	fragment@3 {
-		target-path = "/";
-		__overlay__ {
-			clocks {
-				ad7124_mclk: clock@0 {
-					#clock-cells = <0>;
-					compatible = "fixed-clock";
-					clock-frequency = <614400>;
-				};
-			};
-		};
-	};
-
-	fragment@4 {
 		target = <&spi0>;
 		__overlay__ {
 			#address-cells = <1>;
@@ -81,22 +68,20 @@
 		};
 	};
 
-	fragment@5 {
+	fragment@4 {
 		target = <&spi0>;
 		__overlay__ {
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "okay";
 
-			ad7124@1 {
+			adc@1 {
 				compatible = "adi,ad7124-4";
 				reg = <1>;
 				spi-max-frequency = <5000000>;
 				interrupts = <23 2>;
 				interrupt-parent = <&gpio>;
 				refin1-supply = <&vref>;
-				clocks = <&ad7124_mclk>;
-				clock-names = "mclk";
 
 				#address-cells = <1>;
 				#size-cells = <0>;
@@ -152,21 +137,21 @@
 		};
 	};
 
-	fragment@6 {
+	fragment@5 {
 		target = <&spidev0>;
 		__overlay__ {
 			status = "disabled";
 		};
 	};
 
-	fragment@7 {
+	fragment@6 {
 		target = <&spidev1>;
 		__overlay__ {
 			status = "disabled";
 		};
 	};
 
-	fragment@8 {
+	fragment@7 {
 		target = <&gpio>;
 		__overlay__ {
 			pitft_pins: pitft_pins {
@@ -177,7 +162,7 @@
 		};
 	};
 
-	fragment@9 {
+	fragment@8 {
 		target = <&spi0>;
 		__overlay__ {
 			/* needed to avoid dtc warning */
@@ -235,7 +220,7 @@
 		};
 	};
 
-	fragment@10 {
+	fragment@9 {
 		target-path = "/soc";
 		__overlay__ {
 			backlight {

--- a/arch/arm/boot/dts/overlays/rpi-cn0554-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-cn0554-overlay.dts
@@ -31,12 +31,6 @@
 };
 
 &{/clocks} {
-	ad7124_mclk: clock@0 {
-		#clock-cells = <0>;
-		compatible = "fixed-clock";
-		clock-frequency = <614400>;
-	};
-
 	ltc2688_tgp1: clock@1 {
 		compatible = "fixed-clock";
 		#clock-cells = <0>;
@@ -72,9 +66,6 @@
 
 		#address-cells = <1>;
 		#size-cells = <0>;
-
-		clocks = <&ad7124_mclk>;
-		clock-names = "mclk";
 
 		interrupts = <25 2>;
 		interrupt-parent = <&gpio>;

--- a/arch/arm/boot/dts/overlays/rpi-cn0556-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-cn0556-overlay.dts
@@ -59,12 +59,6 @@
 };
 
 &{/clocks} {
-	ad7124_mclk: clock@0 {
-		#clock-cells = <0>;
-		compatible = "fixed-clock";
-		clock-frequency = <614400>;
-	};
-
 	ltc2688_tgp1: clock@1 {
 		compatible = "fixed-clock";
 		#clock-cells = <0>;
@@ -93,16 +87,13 @@
 	#size-cells = <0>;
 	status = "okay";
 
-	ad7124: ad7124@0 {
+	ad7124: adc@0 {
 		compatible = "adi,ad7124-8";
 		reg = <0>;
 		spi-max-frequency = <5000000>;
 
 		#address-cells = <1>;
 		#size-cells = <0>;
-
-		clocks = <&ad7124_mclk>;
-		clock-names = "mclk";
 
 		interrupts = <25 2>;
 		interrupt-parent = <&gpio>;


### PR DESCRIPTION
We recently did some backports from upstream for the ad7124 driver. These got automatically copied to the rpi-6.12.y branch. However, there are some devicetree overlays that only exist in the rpi branch. So we need one more patch to fix those up.

## PR Description

The upstream devicetree binding deprecated using `clock-names = "mclk";` as this is an internal clock, not an external one. Remove this from the AD7124 overlays since the ad7124 driver no longer requires it.

Also use generic node names for the adc nodes while we are cleaning things up.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
