### PR TITLE
ARM: dts: adi: SC594-EZLITE/EZKIT remove tx/rx queue configs

### DIFF
--- a/arch/arm/boot/dts/adi/sc594-som-ezkit.dts
+++ b/arch/arm/boot/dts/adi/sc594-som-ezkit.dts
@@ -173,22 +173,6 @@
 	pinctrl-0 = <&eth0_default>;
 	status = "okay";
 
-	emac0txconfig: tx-config {
-		snps,tx-queues-to-use = <3>;
-
-		queue0 {
-			snps,dcb-algorithm;
-		};
-
-		queue1 {
-			snps,dcb-algorithm;
-		};
-
-		queue2 {
-			snps,dcb-algorithm;
-		};
-	};
-
 	mdio0 {
 		compatible = "snps,dwmac-mdio";
 		#address-cells = <1>;

--- a/arch/arm/boot/dts/adi/sc594-som-ezlite.dts
+++ b/arch/arm/boot/dts/adi/sc594-som-ezlite.dts
@@ -123,40 +123,6 @@
 	pinctrl-names = "default";
 	pinctrl-0 = <&eth0_default>;
 	status = "okay";
-	snps,mtl-rx-config = <&emac0rxconfig>;
-	snps,mtl-tx-config = <&emac0txconfig>;
-
-	emac0txconfig: tx-config {
-		snps,tx-queues-to-use = <3>;
-
-		queue0 {
-			snps,dcb-algorithm;
-		};
-
-		queue1 {
-			snps,dcb-algorithm;
-		};
-
-		queue2 {
-			snps,dcb-algorithm;
-		};
-	};
-
-	emac0rxconfig: rx-config {
-		snps,rx-queues-to-use = <1>;
-
-		queue0 {
-			snps,dcb-algorithm;
-		};
-
-		queue1 {
-			snps,dcb-algorithm;
-		};
-
-		queue2 {
-			snps,dcb-algorithm;
-		};
-	};
 
 	mdio0 {
 		compatible = "snps,dwmac-mdio";


### PR DESCRIPTION
## PR Description

This PR remove device-tree configs that causes issues with NFSBOOT for SC594 EZLITE and EZKIT:
SC594 EZKIT : missed to remove emac0txconfig: tx-config in #2966
SC594 EZLITE : removed snps,mtl-rx-config and snps,mtl-tx-config from emac0 config
tested network performance with iperf3 no issues observed

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
