### PR TITLE
Add dts for AD4000 on cora

### DIFF
--- a/arch/arm/boot/dts/xilinx/zynq-coraz7s-ad4000.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-coraz7s-ad4000.dts
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD4000
+ *
+ * hdl_project: <pulsar_adc/coraz7s>
+ * Link: https://github.com/analogdevicesinc/hdl/tree/main/projects/pulsar_adc
+ * board_revision: <A>
+ *
+ * Copyright (C) 2025 Analog Devices Inc.
+ */
+/dts-v1/;
+#include "zynq-coraz7s.dtsi"
+#include "zynq-coraz7s-axi-sysid.dtsi"
+#include <dt-bindings/interrupt-controller/irq.h>
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	adc_vref: regulator-vref {
+		compatible = "regulator-fixed";
+		regulator-name = "EVAL 5V Vref";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		regulator-always-on;
+	};
+
+	adc_vdd: regulator-vdd {
+		compatible = "regulator-fixed";
+		regulator-name = "Eval VDD supply";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		regulator-always-on;
+	};
+
+	adc_vio: regulator-vio {
+		compatible = "regulator-fixed";
+		regulator-name = "Eval VIO supply";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-always-on;
+	};
+
+	trigger_pwm: adc-pwm-trigger {
+		compatible = "pwm-trigger";
+		#trigger-source-cells = <0>;
+		pwms = <&adc_trigger 0 1000000 0>;
+	};
+};
+
+&fpga_axi {
+	adc_trigger: pwm@0x44b00000 {
+		compatible = "adi,axi-pwmgen-2.00.a";
+		reg = <0x44b00000 0x1000>;
+		label = "adc_conversion_trigger";
+		#pwm-cells = <2>;
+		clocks = <&clkc 15>, <&spi_clk>;
+		clock-names = "axi", "ext";
+	};
+
+	spi_engine: spi@44a00000 {
+		compatible = "adi,axi-spi-engine-1.00.a";
+		reg = <0x44a00000 0x10000>;
+		interrupt-parent = <&intc>;
+		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&clkc 15 &spi_clk>;
+		clock-names = "s_axi_aclk", "spi_clk";
+
+		dmas = <&rx_dma 0>;
+		dma-names = "offload0-rx";
+		trigger-sources = <&trigger_pwm>;
+
+		#address-cells = <0x1>;
+		#size-cells = <0x0>;
+
+		adc@0 {
+			compatible = "adi,ad4000";
+			reg = <0>;
+			spi-max-frequency = <100000000>;
+			vdd-supply = <&adc_vdd>;
+			vio-supply = <&adc_vio>;
+			ref-supply = <&adc_vref>;
+			adi,high-z-input;
+		};
+	};
+
+	rx_dma: dma-controller@44a30000 {
+		compatible = "adi,axi-dmac-1.00.a";
+		reg = <0x44a30000 0x1000>;
+		#dma-cells = <1>;
+		interrupt-parent = <&intc>;
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&clkc 16>;
+	};
+
+	spi_clk: clock-controller@0x44a70000 {
+		compatible = "adi,axi-clkgen-2.00.a";
+		reg = <0x44a70000 0x10000>;
+		#clock-cells = <0>;
+		clocks = <&clkc 15>, <&clkc 15>;
+		clock-names = "clkin1", "s_axi_aclk";
+		clock-output-names = "spi_clk";
+
+		assigned-clocks = <&spi_clk>;
+		assigned-clock-rates = <200000000>;
+	};
+};


### PR DESCRIPTION
Add device tree for using AD4000 on CoraZ7.

## PR Description

Add a device tree for using AD4000 on CoraZ7. AD4000 eval boards interfaced the SPI host through an FMC connector. Though, there seem to be a new evaluation board for AD4000 that used a PMOD connector.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
