### PR TITLE
arm64: dts: xilinx: zcu102: ad9467: fix hdl tag

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9467-fmc-250ebz.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9467-fmc-250ebz.dts
@@ -5,7 +5,7 @@
  * https://wiki.analog.com/resources/eval/ad9467-fmc-250ebz
  * https://wiki.analog.com/resources/fpga/xilinx/fmc/ad9467
  *
- * hdl_project: <ad9467_fmc/zed>
+ * hdl_project: <ad9467_fmc/zcu102>
  * board_revision: <>
  *
  * Copyright (C) 2025 Analog Devices Inc.


### PR DESCRIPTION
## PR Description

Fix hdl tag for  arm64: dts: xilinx: zcu102: ad946, which should point to zcu102 not zed

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have compiled my changes, including the documentation
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
