### PR TITLE
iio: buffer-dma: Remove quotes from export symbols

### DIFF
--- a/drivers/iio/buffer/industrialio-buffer-dma.c
+++ b/drivers/iio/buffer/industrialio-buffer-dma.c
@@ -1145,7 +1145,7 @@ struct device *iio_dma_buffer_get_dma_dev(struct iio_buffer *buffer)
 {
 	return iio_buffer_to_queue(buffer)->dev;
 }
-EXPORT_SYMBOL_NS_GPL(iio_dma_buffer_get_dma_dev, "IIO_DMA_BUFFER");
+EXPORT_SYMBOL_NS_GPL(iio_dma_buffer_get_dma_dev, IIO_DMA_BUFFER);
 
 void iio_dma_buffer_lock_queue(struct iio_buffer *buffer)
 {


### PR DESCRIPTION


## PR Description

Unfortunately, our fork is behind cdd30ebb1b9f, so the cherry-pick introduced an unsupported syntax (export with quotes). "Temporally" remove quotes to be able to compile without MMAP_LEGACY enabled. Fixes: 7e43440d6865 ("iio: buffer-dma: support getting the DMA channel")

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have compiled my changes, including the documentation
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
