### PR TITLE
soc: adi: Only build system drivers for ADSP architecture

### DIFF
--- a/drivers/soc/adi/Makefile
+++ b/drivers/soc/adi/Makefile
@@ -2,9 +2,9 @@
 
 # todo modularize; already depends on CONFIG_ARCH_SC59X_64 though
 
-obj-y += pads_system.o system.o
-
+obj-$(CONFIG_ARCH_SC59X_64)	+= pads_system.o system.o
 obj-$(CONFIG_ARCH_SC59X_64)	+= mach-sc59x/
 obj-$(CONFIG_ARCH_SC59X_64)	+= mach-sc5xx/
 
+obj-$(CONFIG_ARCH_SC5XX)	+= pads_system.o system.o
 obj-$(CONFIG_ARCH_SC5XX)	+= mach-sc5xx/


### PR DESCRIPTION
SoC specific code should not be built for all platforms. Therefore only build it for ADSP-SC5xx based architectures.

In the future system.c and system.c and pads_system.c should be replaced with the corresponding mainline frameworks.