### PR TITLE
MAINTAINERS: Add entry for ADI ADSP-SC5xx SoC support

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -2016,6 +2016,43 @@ F:	include/dt-bindings/reset/actions,*
 F:	include/linux/soc/actions/
 N:	owl
 
+ARM/ADI SoC Support
+M:	Arturs Artamonovs <arturs.artamonovs@analog.com>
+M:	Utsav Agarwal <utsav.agarwal@analog.com>
+M:	Vasileios Bimpikas <vasileios.bimpikas@analog.com>
+L:	linux@analog.com
+S:	Maintained
+F:	Documentation/devicetree/bindings/clock/adi,sc5xx-clocks.yaml
+F:	Documentation/devicetree/bindings/usb/adi,musb.yaml
+F:	arch/arm/boot/dts/adi/*
+F:	arch/arm/configs/sc5*_defconfig
+F:	arch/arm/mach-sc5xx/
+F:	arch/arm64/boot/dts/adi/*
+F:	arch/arm64/configs/sc5*_defconfig
+F:	drivers/clk/adi/*
+F:	drivers/clocksource/timer-adi-adsp-sc5xx.c
+F:	drivers/dma/adi-dma.c
+F:	drivers/dma/adi-dma.h
+F:	drivers/gpio/gpio-adi-adsp-port.c
+F:	drivers/i2c/busses/i2c-adi-twi.c
+F:	drivers/irqchip/irq-adi-adsp.c
+F:	drivers/misc/adi/
+F:	drivers/net/ethernet/stmicro/stmmac/dwmac-adi.c
+F:	drivers/pinctrl/adi/
+F:	drivers/rpmsg/adi_rpmsg.c
+F:	drivers/soc/adi/
+F:	drivers/spi/spi-adi.c
+F:	drivers/tty/serial/adi_uart4.c
+F:	drivers/usb/musb/adi.c
+F:	drivers/usb/musb/adi.h
+F:	drivers/watchdog/adi_wdt.c
+F:	include/dt-bindings/clock/adi-sc5xx-clock.h
+F:	include/dt-bindings/pinctrl/adi-adsp-sru.h
+F:	include/dt-bindings/pinctrl/adi-adsp.h
+F:	include/linux/soc/adi/
+F:	include/sound/sc5xx-dai.h
+F:	sound/soc/adi/sc5xx*
+
 ARM/AIROHA SOC SUPPORT
 M:	Matthias Brugger <matthias.bgg@gmail.com>
 M:	AngeloGioacchino Del Regno <angelogioacchino.delregno@collabora.com>


### PR DESCRIPTION
There is not entry in MAINTAINERS for ADSP-SC5xx drivers. Seems most bindings are missing. Only bindings are mentioned in MAINTAINERS that will addressed in different PR.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have compiled my changes, including the documentation
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
