### PR TITLE
arm64: dts: zynqmp: Add missing fclk nodes for PL clock initialization

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-clk-ccf.dtsi
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-clk-ccf.dtsi
@@ -10,6 +10,30 @@
 
 #include <dt-bindings/clock/xlnx-zynqmp-clk.h>
 / {
+	fclk0: fclk0 {
+		status = "okay";
+		compatible = "xlnx,fclk";
+		clocks = <&zynqmp_clk PL0_REF>;
+	};
+
+	fclk1: fclk1 {
+		status = "okay";
+		compatible = "xlnx,fclk";
+		clocks = <&zynqmp_clk PL1_REF>;
+	};
+
+	fclk2: fclk2 {
+		status = "okay";
+		compatible = "xlnx,fclk";
+		clocks = <&zynqmp_clk PL2_REF>;
+	};
+
+	fclk3: fclk3 {
+		status = "okay";
+		compatible = "xlnx,fclk";
+		clocks = <&zynqmp_clk PL3_REF>;
+	};
+
 	pss_ref_clk: pss-ref-clk {
 		bootph-all;
 		compatible = "fixed-clock";


### PR DESCRIPTION
## PR Description
Add fclk0-3 nodes to properly initialize the PL reference clocks (pl0_ref through pl3_ref) before they are used by fabric peripherals.

The issue appeared when using the zynqmp-adrv9009-zu11eg-revb-adrv2crr-fmc-revb-sync-fmcomms8.dts
The AXI GPIO driver at axi_fmcomms8_gpio: gpio@86000000 references clock pl0_ref which is not correctly prepared or enabled by the clock framework. When runtime PM suspends the GPIO device, xgpio_runtime_suspend calls clk_disable() on an unprepared clock, causing a kernel panic.

The issue occurs because the clock is being disabled by the GPIO driver, and somehow enters in a race condition when multiple drivers attempt to manage the same clock resource.

## PR Type
- [ x ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ x ] I have conducted a self-review of my own code changes
- [ x ] I have compiled my changes, including the documentation
- [ x ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
