### PR TITLE
ARM: dts: adi: add Rev E support to SC598-SOM

### DIFF
--- a/arch/arm64/boot/dts/adi/sc598-som-ezkit.dts
+++ b/arch/arm64/boot/dts/adi/sc598-som-ezkit.dts
@@ -5,7 +5,7 @@
 
 /dts-v1/;
 
-#include "sc598-som.dtsi"
+#include "sc598-som-revE.dtsi"
 
 / {
 	model = "ADI 64-bit SC598 SOM EZ Kit";

--- a/arch/arm64/boot/dts/adi/sc598-som-ezlite.dts
+++ b/arch/arm64/boot/dts/adi/sc598-som-ezlite.dts
@@ -5,7 +5,7 @@
 
 /dts-v1/;
 
-#include "sc598-som.dtsi"
+#include "sc598-som-revE.dtsi"
 
 / {
 	model = "ADI 64-bit SC598 SOM EZ Lite";

--- a/arch/arm64/boot/dts/adi/sc598-som-revD.dtsi
+++ b/arch/arm64/boot/dts/adi/sc598-som-revD.dtsi
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Copyright (c) 2025 Analog Devices Incorporated
+ */
+
+/dts-v1/;
+
+#include "sc598-som.dtsi"
+
+&i2c2 {
+	som_gpio_expander: mcp23018@20 {
+		compatible = "microchip,mcp23018";
+		reg = <0x20>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		drive-pullups;
+
+		led-ds1 {
+			gpio-hog;
+			gpios = <0 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "led1-en";
+		};
+
+		led-ds2 {
+			gpio-hog;
+			gpios = <1 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "led-ds2";
+		};
+
+		led-ds3 {
+			gpio-hog;
+			gpios = <2 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "led-ds3";
+		};
+
+		som-flash-d2d3 {
+			gpio-hog;
+			gpios = <3 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "som-flash-d2d3-en";
+		};
+
+		som-flash-cs {
+			gpio-hog;
+			gpios = <4 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "som-flash-cs-en";
+		};
+
+		uart0 {
+			gpio-hog;
+			gpios = <5 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "uart0-en";
+		};
+
+		uart0-flow-en {
+			gpio-hog;
+			gpios = <6 GPIO_ACTIVE_LOW>;
+			output-low;
+			line-name = "uart0-flow-en";
+		};
+
+		som-emmc {
+			gpio-hog;
+			gpios = <8 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "som-emmc-en";
+		};
+
+		crr-sdcard {
+			gpio-hog;
+			gpios = <9 GPIO_ACTIVE_LOW>;
+			output-low;
+			line-name = "crr-sdcard-en";
+		};
+	};
+};
+
+&spi2 {
+	som_flash: is25lp512@0 {
+		compatible = "jedec,spi-nor", "is25lp512";
+		reg = <0>;
+		spi-rx-bus-width = <4>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			qspi_0@0 {
+				label = "u-boot-spl";
+				reg = <0x00000000 0x00040000>;
+			};
+
+			qspi_1@40000 {
+				label = "u-boot";
+				reg = <0x00040000 0x000C0000>;
+			};
+
+			qspi_2@100000 {
+				label = "dtb";
+				reg = <0x00100000 0x00010000>;
+			};
+
+			qspi_3@110000 {
+				label = "kernel";
+				reg = <0x00110000 0x02000000>;
+			};
+
+			qspi_4@2110000 {
+				label = "rootfs";
+				reg = <0x02110000 0x01EF0000>;
+			};
+		};
+	};
+};

--- a/arch/arm64/boot/dts/adi/sc598-som-revE.dtsi
+++ b/arch/arm64/boot/dts/adi/sc598-som-revE.dtsi
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Copyright (c) 2025 Analog Devices Incorporated
+ */
+
+/dts-v1/;
+
+#include "sc598-som.dtsi"
+
+&i2c2 {
+	som_gpio_expander: adp5587@34 {
+		compatible = "adi,adp5587";
+		reg = <0x34>;
+		gpio-controller;
+		#gpio-cells = <2>;
+
+		uart0 {
+			gpio-hog;
+			gpios = <0 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "uart0-en";
+		};
+
+		uart0-flow {
+			gpio-hog;
+			gpios = <1 GPIO_ACTIVE_LOW>;
+			output-low;
+			line-name = "uart0-flow-en";
+		};
+
+		som-flash-d2d3 {
+			gpio-hog;
+			gpios = <2 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "som-flash-d2d3-en";
+		};
+
+		som-flash-cs {
+			gpio-hog;
+			gpios = <3 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "som-flash-cs-en";
+		};
+
+		som-emmc {
+			gpio-hog;
+			gpios = <8 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "som-emmc-en";
+		};
+
+		crr-sdcard {
+			gpio-hog;
+			gpios = <9 GPIO_ACTIVE_LOW>;
+			output-low;
+			line-name = "crr-sdcard-en";
+		};
+
+		led-ds3 {
+			gpio-hog;
+			gpios = <15 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "led-ds3";
+		};
+
+		led-ds2 {
+			gpio-hog;
+			gpios = <16 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "led-ds2";
+		};
+
+		led-ds1 {
+			gpio-hog;
+			gpios = <17 GPIO_ACTIVE_LOW>;
+			output-high;
+			line-name = "led-ds1";
+		};
+	};
+};
+
+&spi2 {
+	som_flash: is25lp01g@0 {
+		compatible = "jedec,spi-nor", "is25lp01g";
+		reg = <0>;
+		spi-rx-bus-width = <4>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			qspi_0@0 {
+				label = "u-boot-spl";
+				reg = <0x00000000 0x00040000>;
+			};
+
+			qspi_1@40000 {
+				label = "u-boot";
+				reg = <0x00040000 0x000C0000>;
+			};
+
+			qspi_2@100000 {
+				label = "dtb";
+				reg = <0x00100000 0x00010000>;
+			};
+
+			qspi_3@110000 {
+				label = "kernel";
+				reg = <0x00110000 0x02000000>;
+			};
+
+			qspi_4@2110000 {
+				label = "rootfs";
+				reg = <0x02110000 0x05EF0000>;
+			};
+		};
+	};
+};

--- a/arch/arm64/boot/dts/adi/sc598-som.dtsi
+++ b/arch/arm64/boot/dts/adi/sc598-som.dtsi
@@ -203,43 +203,6 @@
 	pinctrl-0 = <&spi2_quad>;
 	status = "okay";
 	cs-gpios = <&gpa 5 GPIO_ACTIVE_LOW>;
-
-	flash: is25lp512@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
-		compatible = "is25lp512", "jedec,spi-nor";
-		reg = <0>;
-		spi-cpha;
-		spi-cpol;
-		spi-max-frequency = <25000000>;
-		spi-rx-bus-width = <4>;
-
-		qspi_0: partition@0 {
-			label = "U-Boot SPL";
-			reg = <0x0 0x40000>;
-		};
-
-		qspi_1: partition@1 {
-			label = "U-Boot Proper";
-			reg = <0x40000 0xC0000>;
-		};
-
-		qspi_2: partition@2 {
-			label = "U-Boot Environment";
-			reg = <0x100000 0x20000>;
-		};
-
-		qspi_3: partition@3 {
-			label = "FIT Image";
-			reg = <0x120000 0xF00000>;
-		};
-
-		qspi_4: partition@4 {
-			label = "JFFS2 Formatted RFS";
-			reg = <0x1020000 0x2FE0000>;
-		};
-
-	};
 };
 
 &i2c0 {
@@ -254,86 +217,6 @@
 	status = "okay";
 	pinctrl-names = "default";
 	pinctrl-0 = <&i2c2_pins>;
-
-	som_gpio_expander: gpio@20 {
-		compatible = "microchip,mcp23018";
-		gpio-controller;
-		#gpio-cells = <2>;
-		reg = <0x20>;
-		status = "okay";
-
-		pinctrl-names = "default";
-		pinctrl-0 = <&som_gpio_expanderpullups>;
-
-		som_gpio_expanderpullups: pinmux {
-			bias-pull-up;
-			pins = "gpio0", "gpio1", "gpio2", "gpio3",
-				"gpio4", "gpio5", "gpio6", "gpio8", "gpio9";
-		};
-
-		led1 {
-			gpio-hog;
-			gpios = <0 GPIO_ACTIVE_LOW>;
-			output-high;
-			line-name = "led1-en";
-		};
-
-		led2 {
-			gpio-hog;
-			gpios = <1 GPIO_ACTIVE_LOW>;
-			output-high;
-			line-name = "led2-en";
-		};
-
-		led3 {
-			gpio-hog;
-			gpios = <2 GPIO_ACTIVE_LOW>;
-			output-high;
-			line-name = "led3-en";
-		};
-
-		spi2d2-d3 {
-			gpio-hog;
-			gpios = <3 GPIO_ACTIVE_LOW>;
-			output-high;
-			line-name = "spi2d2-d3-en";
-		};
-
-		spi2flash-cs {
-			gpio-hog;
-			gpios = <4 GPIO_ACTIVE_LOW>;
-			output-high;
-			line-name = "spi2flash-cs";
-		};
-
-		uart0 {
-			gpio-hog;
-			gpios = <5 GPIO_ACTIVE_LOW>;
-			output-high;
-			line-name = "uart0-en";
-		};
-
-		uart0-flow-en {
-			gpio-hog;
-			gpios = <6 GPIO_ACTIVE_LOW>;
-			output-low;
-			line-name = "uart0-flow-en";
-		};
-
-		emmc {
-			gpio-hog;
-			gpios = <8 GPIO_ACTIVE_LOW>;
-			output-high;
-			line-name = "emmc-en";
-		};
-
-		emmc-som-en {
-			gpio-hog;
-			gpios = <9 GPIO_ACTIVE_LOW>;
-			output-low;
-			line-name = "emmc-som-en";
-		};
-	};
 };
 
 &mmc0{


### PR DESCRIPTION
## PR Description

Add revision-specific DTS files layered on top of sc598-som.dtsi
to support Rev D and E.

Fix errors in the existing GPIO expanders by correcting
GPIO definitions and polarities so they match the hardware.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
