### PR TITLE
iio: frequency: ad916x: namespace utility functions to avoid symbol c…

### DIFF
--- a/drivers/iio/frequency/ad916x/ad916x_nco_api.c
+++ b/drivers/iio/frequency/ad916x/ad916x_nco_api.c
@@ -74,12 +74,12 @@ static int ad916x_nco_set_configure_main(ad916x_handle_t *h,
 		uint64_t tmp_ah, tmp_al, tmp_bh, tmp_bl, tmp_fh, tmp_fl;
 		/* Modulus NCO mode */
 
-		gcd = adi_api_utils_gcd(carrier_freq_hz, h->dac_freq_hz);
+		gcd = ad916x_api_utils_gcd(carrier_freq_hz, h->dac_freq_hz);
 		M = DIV64_U64(carrier_freq_hz, gcd);
 		N = DIV64_U64(h->dac_freq_hz, gcd);
 
 		if (M > INT16_MAX) {
-			uint64_t mask = U64MSB;
+			uint64_t mask = AD916X_U64MSB;
 			int i = 0;
 			while (((mask & M) == 0) && (mask != 1)) {
 				mask >>= 1;
@@ -91,13 +91,13 @@ static int ad916x_nco_set_configure_main(ad916x_handle_t *h,
 			int_part = DIV64_U64(M*(ADI_POW2_48), N);
 		}
 
-		adi_api_utils_mult_128(M, ADI_POW2_48, &tmp_ah, &tmp_al);
-		adi_api_utils_mult_128(N, int_part, &tmp_bh, &tmp_bl);
-		adi_api_utils_subt_128(tmp_ah, tmp_al, tmp_bh, tmp_bl, &tmp_fh, &tmp_fl);
+		ad916x_api_utils_mult_128(M, ADI_POW2_48, &tmp_ah, &tmp_al);
+		ad916x_api_utils_mult_128(N, int_part, &tmp_bh, &tmp_bl);
+		ad916x_api_utils_subt_128(tmp_ah, tmp_al, tmp_bh, tmp_bl, &tmp_fh, &tmp_fl);
 		frac_part_a = tmp_fl;
 		frac_part_b = N;
 
-		gcd = adi_api_utils_gcd(frac_part_a, frac_part_b);
+		gcd = ad916x_api_utils_gcd(frac_part_a, frac_part_b);
 		frac_part_a = DIV64_U64(frac_part_a, gcd);
 		frac_part_b = DIV64_U64(frac_part_b, gcd);
 
@@ -144,8 +144,8 @@ static int ad916x_nco_calc_freq_int_main(ad916x_handle_t *h, uint64_t int_part,
 										int64_t *carrier_freq_hz)
 {
 	uint64_t tmpa_lo, tmpa_hi;
-	adi_api_utils_mult_128(int_part, h->dac_freq_hz, &tmpa_hi, &tmpa_lo);
-	adi_api_utils_div_128(tmpa_hi, tmpa_lo, 0, ADI_POW2_48, &tmpa_hi, &tmpa_lo);
+	ad916x_api_utils_mult_128(int_part, h->dac_freq_hz, &tmpa_hi, &tmpa_lo);
+	ad916x_api_utils_div_128(tmpa_hi, tmpa_lo, 0, ADI_POW2_48, &tmpa_hi, &tmpa_lo);
 	*carrier_freq_hz = tmpa_lo;
 	return API_ERROR_OK;
 }
@@ -156,11 +156,11 @@ static int ad916x_nco_calc_freq_fract_main(ad916x_handle_t *h,
 {
 	uint64_t tmpa_lo, tmpa_hi;
 	uint64_t tmpb_lo, tmpb_hi;
-	adi_api_utils_mult_128(int_part, h->dac_freq_hz, &tmpa_hi, &tmpa_lo);
-	adi_api_utils_mult_128(frac_part_a, h->dac_freq_hz, &tmpb_hi, &tmpb_lo);
-	adi_api_utils_div_128(tmpb_hi, tmpb_lo, 0, frac_part_b, &tmpb_hi, &tmpb_lo);
-	adi_api_utils_add_128(tmpa_hi, tmpa_lo, tmpb_hi, tmpb_lo, &tmpa_hi, &tmpa_lo);
-	adi_api_utils_div_128(tmpa_hi, tmpa_lo, 0, ADI_POW2_48, &tmpa_hi, &tmpa_lo);
+	ad916x_api_utils_mult_128(int_part, h->dac_freq_hz, &tmpa_hi, &tmpa_lo);
+	ad916x_api_utils_mult_128(frac_part_a, h->dac_freq_hz, &tmpb_hi, &tmpb_lo);
+	ad916x_api_utils_div_128(tmpb_hi, tmpb_lo, 0, frac_part_b, &tmpb_hi, &tmpb_lo);
+	ad916x_api_utils_add_128(tmpa_hi, tmpa_lo, tmpb_hi, tmpb_lo, &tmpa_hi, &tmpa_lo);
+	ad916x_api_utils_div_128(tmpa_hi, tmpa_lo, 0, ADI_POW2_48, &tmpa_hi, &tmpa_lo);
 	*carrier_freq_hz = tmpa_lo;
 	return API_ERROR_OK;
 }

--- a/drivers/iio/frequency/ad916x/utils.c
+++ b/drivers/iio/frequency/ad916x/utils.c
@@ -7,7 +7,7 @@
 #define UPPER_16(A) (((A) >> 16) & 0xFFFF)
 #define LOWER_32(A) ((A) & (uint32_t) 0xFFFFFFFF)
 
-int64_t adi_api_utils_gcd(int64_t u, int64_t v)
+int64_t ad916x_api_utils_gcd(int64_t u, int64_t v)
 {
 	int64_t t;
 	while (v != 0) {
@@ -18,7 +18,7 @@ int64_t adi_api_utils_gcd(int64_t u, int64_t v)
 	return u < 0 ? -u : u; /* abs(u) */
 }
 
-void adi_api_utils_mult_64(uint32_t a, uint32_t b, uint32_t *hi, uint32_t *lo)
+void ad916x_api_utils_mult_64(uint32_t a, uint32_t b, uint32_t *hi, uint32_t *lo)
 {
 	uint32_t    ah = (a >> 16), al = a & 0xffff,
 				bh = (b >> 16), bl = b & 0xffff,
@@ -35,26 +35,26 @@ void adi_api_utils_mult_64(uint32_t a, uint32_t b, uint32_t *hi, uint32_t *lo)
 	*hi = rh;
 }
 
-void adi_api_utils_lshift_128(uint64_t *hi, uint64_t *lo)
+void ad916x_api_utils_lshift_128(uint64_t *hi, uint64_t *lo)
 {
 	*hi <<= 1;
-	if (*lo & U64MSB)
+	if (*lo & AD916X_U64MSB)
 	{
 		*hi |= 1ul;
 	}
 	*lo <<= 1;
 }
 
-void adi_api_utils_rshift_128(uint64_t *hi, uint64_t *lo)
+void ad916x_api_utils_rshift_128(uint64_t *hi, uint64_t *lo)
 {
 	*lo >>= 1;
 	if (*hi & 1u) {
-		*lo |= U64MSB;
+		*lo |= AD916X_U64MSB;
 	}
 	*hi >>= 1;
 }
 
-void adi_api_utils_mult_128(uint64_t a, uint64_t b, uint64_t *hi, uint64_t *lo)
+void ad916x_api_utils_mult_128(uint64_t a, uint64_t b, uint64_t *hi, uint64_t *lo)
 {
 	uint64_t    ah = (a >> 32), al = a & 0xffffffff,
 				bh = (b >> 32), bl = b & 0xffffffff,
@@ -71,7 +71,7 @@ void adi_api_utils_mult_128(uint64_t a, uint64_t b, uint64_t *hi, uint64_t *lo)
 	*hi = rh;
 }
 
-void adi_api_utils_div_128(uint64_t a_hi, uint64_t a_lo,
+void ad916x_api_utils_div_128(uint64_t a_hi, uint64_t a_lo,
 							uint64_t b_hi, uint64_t b_lo,
 							uint64_t *hi, uint64_t *lo)
 {
@@ -83,7 +83,7 @@ void adi_api_utils_div_128(uint64_t a_hi, uint64_t a_lo,
 	uint64_t result_hi  = 0;
 	uint64_t mask_lo    = 1;
 	uint64_t mask_hi    = 0;
-	
+
 	if ((part1_lo == 0) && (part1_hi == 0)) {
 		/* Do whatever should happen when dividing by zero. */
 		return;
@@ -92,31 +92,31 @@ void adi_api_utils_div_128(uint64_t a_hi, uint64_t a_lo,
 	/* while(part1_lo < remain_lo)
 	 * Alternative: while(!(part1 & 0x8000)) - For 16-bit, test highest order bit.
 	 * Alternative: while(not_signed(part1)) - Same as above: As long as sign bit is not set in part1. */
-	while (!(part1_hi & U64MSB)) {
-		adi_api_utils_lshift_128(&part1_hi, &part1_lo);
-		adi_api_utils_lshift_128(&mask_hi, &mask_lo);
+	while (!(part1_hi & AD916X_U64MSB)) {
+		ad916x_api_utils_lshift_128(&part1_hi, &part1_lo);
+		ad916x_api_utils_lshift_128(&mask_hi, &mask_lo);
 	}
 
 	do {
 		if ((remain_hi > part1_hi) || ((remain_hi == part1_hi) && (remain_lo >= part1_lo))) {
 			/* remain_lo = remain_lo - part1_lo; */
-			adi_api_utils_subt_128(remain_hi, remain_lo, part1_hi, part1_lo, &remain_hi, &remain_lo);
+			ad916x_api_utils_subt_128(remain_hi, remain_lo, part1_hi, part1_lo, &remain_hi, &remain_lo);
 			/* result = result + mask; */
-			adi_api_utils_add_128(result_hi, result_lo, mask_hi, mask_lo, &result_hi, &result_lo);
+			ad916x_api_utils_add_128(result_hi, result_lo, mask_hi, mask_lo, &result_hi, &result_lo);
 		}
 		/* part1 = part1 >> 1; */
-		adi_api_utils_rshift_128(&part1_hi, &part1_lo);
+		ad916x_api_utils_rshift_128(&part1_hi, &part1_lo);
 		/* mask  = mask  >> 1; */
-		adi_api_utils_rshift_128(&mask_hi, &mask_lo);
+		ad916x_api_utils_rshift_128(&mask_hi, &mask_lo);
 	} while ((mask_hi != 0) || (mask_lo != 0));
-	
+
 	/* Now: result = division result (quotient)
 	 *      remain_lo = division remain_loder (modulo) */
 	*lo = result_lo;
 	*hi = result_hi;
 }
 
-void adi_api_utils_add_128(uint64_t ah, uint64_t al,
+void ad916x_api_utils_add_128(uint64_t ah, uint64_t al,
 							uint64_t bh, uint64_t bl,
 							uint64_t *hi, uint64_t *lo)
 {
@@ -134,8 +134,8 @@ void adi_api_utils_add_128(uint64_t ah, uint64_t al,
 	*hi = rh;
 }
 
-void adi_api_utils_subt_128(uint64_t ah, uint64_t al, 
-							uint64_t bh, uint64_t bl, 
+void ad916x_api_utils_subt_128(uint64_t ah, uint64_t al,
+							uint64_t bh, uint64_t bl,
 							uint64_t *hi, uint64_t *lo)
 {
 	/* r = a - b*/
@@ -154,7 +154,7 @@ void adi_api_utils_subt_128(uint64_t ah, uint64_t al,
 	*hi = rh;
 }
 
-int is_power_of_two(uint64_t x)
+int ad916x_is_power_of_two(uint64_t x)
 {
 	return ((x != 0) && !(x & (x - 1)));
 }

--- a/drivers/iio/frequency/ad916x/utils.h
+++ b/drivers/iio/frequency/ad916x/utils.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
-#ifndef __AD_UTILS_H__
-#define __AD_UTILS_H__
+#ifndef __AD916X_UTILS_H__
+#define __AD916X_UTILS_H__
 
 #include <linux/kernel.h>
 
@@ -8,21 +8,21 @@
 #define MS_TO_US(x) ((x)*1000)
 
 
-#define U64MSB 0x8000000000000000ull
+#define AD916X_U64MSB 0x8000000000000000ull
 
-int64_t adi_api_utils_gcd(int64_t u, int64_t v);
-void adi_api_utils_mult_64(uint32_t a, uint32_t b, uint32_t *hi, uint32_t *lo);
-void adi_api_utils_lshift_128(uint64_t *hi, uint64_t *lo);
-void adi_api_utils_rshift_128(uint64_t *hi, uint64_t *lo);
-void adi_api_utils_mult_128(uint64_t a, uint64_t b, uint64_t *hi, uint64_t *lo);
-void adi_api_utils_div_128(uint64_t a_hi, uint64_t a_lo,
+int64_t ad916x_api_utils_gcd(int64_t u, int64_t v);
+void ad916x_api_utils_mult_64(uint32_t a, uint32_t b, uint32_t *hi, uint32_t *lo);
+void ad916x_api_utils_lshift_128(uint64_t *hi, uint64_t *lo);
+void ad916x_api_utils_rshift_128(uint64_t *hi, uint64_t *lo);
+void ad916x_api_utils_mult_128(uint64_t a, uint64_t b, uint64_t *hi, uint64_t *lo);
+void ad916x_api_utils_div_128(uint64_t a_hi, uint64_t a_lo,
 							uint64_t b_hi, uint64_t b_lo,
 							uint64_t *hi, uint64_t *lo);
-void adi_api_utils_add_128(uint64_t ah, uint64_t al,
+void ad916x_api_utils_add_128(uint64_t ah, uint64_t al,
 							uint64_t bh, uint64_t bl,
 							uint64_t *hi, uint64_t *lo);
-void adi_api_utils_subt_128(uint64_t ah, uint64_t al, 
-							uint64_t bh,uint64_t bl, 
-							uint64_t *hi,uint64_t *lo);
-int is_power_of_two(uint64_t x);
-#endif /*__AD_UTILS_H__*/
+void ad916x_api_utils_subt_128(uint64_t ah, uint64_t al,
+							uint64_t bh, uint64_t bl,
+							uint64_t *hi, uint64_t *lo);
+int ad916x_is_power_of_two(uint64_t x);
+#endif /*__AD916X_UTILS_H__*/


### PR DESCRIPTION
## PR Description

Namespace utility functions to avoid symbol conflicts

Rename the adi_api_utils_* functions to ad916x_api_utils_* to avoid symbol conflicts with the apollo driver which defines the same function names.

The following symbols are renamed:
  - adi_api_utils_gcd -> ad916x_api_utils_gcd
  - adi_api_utils_mult_64 -> ad916x_api_utils_mult_64
  - adi_api_utils_lshift_128 -> ad916x_api_utils_lshift_128
  - adi_api_utils_rshift_128 -> ad916x_api_utils_rshift_128
  - adi_api_utils_mult_128 -> ad916x_api_utils_mult_128
  - adi_api_utils_div_128 -> ad916x_api_utils_div_128
  - adi_api_utils_add_128 -> ad916x_api_utils_add_128
  - adi_api_utils_subt_128 -> ad916x_api_utils_subt_128
  - is_power_of_two -> ad916x_is_power_of_two
  - U64MSB -> AD916X_U64MSB

This fixes linker errors when both ad916x and apollo drivers are built into the kernel:

  multiple definition of `adi_api_utils_gcd'
  multiple definition of `adi_api_utils_mult_64'
  ...

Fixes: e592f1ce47d1 ("drivers/iio/frequency/cf_axi_dds: Add support for AD9162")


