### PR TITLE
arm64: dts: xilinx: fix whitespace

### DIFF
--- a/arch/arm64/boot/dts/xilinx/adi-ad9467-fmc-250ebz.dtsi
+++ b/arch/arm64/boot/dts/xilinx/adi-ad9467-fmc-250ebz.dtsi
@@ -21,29 +21,29 @@
 
 		spi-max-frequency = <10000000>;
 		adi,spi-3wire-enable;
-	
+
 		clocks = <&ad9517_ref_clk>;
 		clock-names = "adc_clk";
-	
+
 		#address-cells = <1>;
 		#size-cells = <0>;
 	};
-	
+
 	clk_ad9517: ad9517@1 {
 		compatible = "adi,ad9517-4";
 		reg = <1>;
-	
+
 		spi-max-frequency = <10000000>;
 		adi,spi-3wire-enable;
-	
+
 		clocks = <&ad9517_ref_clk>, <&ad9517_ref_clk>;
 		clock-names = "refclk", "clkin";
-	
+
 		clock-output-names = "out0", "out1", "out2", "out3", "out4", "out5", "out6", "out7";
 		#clock-cells = <1>;
-	
+
 		firmware = "ad9467_intbypass_ad9517.stp";
-	
+
 		#address-cells = <1>;
 		#size-cells = <0>;
 	};

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9467-fmc-250ebz.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9467-fmc-250ebz.dts
@@ -22,33 +22,33 @@
 		#address-cells = <0x1>;
 		#size-cells = <0x1>;
 		ranges = <0 0 0 0xffffffff>;
-		
-		rx_dma: dma-controller@84A30000 { 
+
+		rx_dma: dma-controller@84A30000 {
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x84A30000 0x10000>;
 			#dma-cells = <1>;
 			interrupts = <0 109 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&zynqmp_clk 71>;
 		};
-		
+
 		cf_ad9467_core_0: cf-ad9467-core-lpc@84A00000 {
 			compatible = "adi,axi-adc-10.0.a", "adi,axi-ad9467-1.0";
 			reg = <0x84A00000 0x10000>;
 			dmas = <&rx_dma 0>;
 			dma-names = "rx";
-			
+
 			spibus-connected = <&adc_ad9467>;
 		};
-		
+
 		axi_sysid_0: axi-sysid-0@85000000 {
-		   compatible = "adi,axi-sysid-1.00.a";
-		   reg = <0x85000000 0x10000>;
+			compatible = "adi,axi-sysid-1.00.a";
+			reg = <0x85000000 0x10000>;
 		};
 	};
 };
 
 &spi0 {
-   status = "okay";
+	status = "okay";
 };
 
 &i2c1 {
@@ -57,12 +57,11 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0>;
-			
+
 			eeprom@50 {
 				compatible = "at24,24c02";
 				reg = <0x50>;
 			};
-			
 		};
 	};
 };


### PR DESCRIPTION
Fixes: 3cb09be9d5 ("arm64: dts: xilinx: add AD9467 support for ZCU102")