### PR TITLE
docs: ci: Add hwmon to mirror_ci list, mirrors

### DIFF
--- a/docs/ci.rst
+++ b/docs/ci.rst
@@ -41,6 +41,11 @@ provided (``mirror_ci/<remote-name>/<branch>``):
   | https://git.kernel.org/pub/scm/linux/kernel/git/jic23/iio.git/log/?h=testing
 * | ``mirror_ci/lee/mfd/for-mfd-next``: MFD Subsystem Tree - Next and Fixes
   | https://git.kernel.org/pub/scm/linux/kernel/git/lee/mfd.git/log/?h=for-mfd-next
+* | ``mirror_ci/groeck/linux-staging/hwmon-next``: HWMON Subsystem - Staging
+  | https://git.kernel.org/pub/scm/linux/kernel/git/groeck/linux-staging.git/log/?h=hwmon-next
+
+To reduce the load on ``kernel.org``, clone from mirrors such as
+https://kernel.googlesource.com/pub/scm/linux/kernel/git/.
 
 When upstreaming a driver, target the pull-request against the mirror.
 


### PR DESCRIPTION

## PR Description

Follow-up to #3076
Add hwmon subsystem to mirror_ci, recommend using mirror to reduce load on kernel.org.
The rule was added to the cron-job, runs midnight

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have compiled my changes, including the documentation
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
