### PR TITLE
reset: sc5xx: Fix device reference count leak on -EPROBE_DEFER

### DIFF
--- a/drivers/soc/adi/mach-sc5xx/rcu.c
+++ b/drivers/soc/adi/mach-sc5xx/rcu.c
@@ -84,8 +84,10 @@ struct adi_rcu *get_adi_rcu_from_node(struct device *dev)
 	}
 
 	ret = dev_get_drvdata(&rcu_pdev->dev);
-	if (!ret)
+	if (!ret) {
+		put_device(&rcu_pdev->dev);
 		ret = ERR_PTR(-EPROBE_DEFER);
+	}
 
 cleanup:
 	of_node_put(rcu_node);


### PR DESCRIPTION
get_adi_rcu_from_node() uses of_find_device_by_node() to locate the RCU platform device. of_find_device_by_node() returns the device with an extra reference held.

When dev_get_drvdata(&rcu_pdev->dev) is NULL, get_adi_rcu_from_node() returns -EPROBE_DEFER but forgets to drop that reference. Since no valid struct adi_rcu * is returned on this path, callers cannot release it and the reference could potentially leak on deferred probe attempts. The of_find_device_by_node kerneldoc also states that the reference on the embedded struct_device must be dropped (https://docs.kernel.org/devicetree/kernel-api.html).

To fix this issue drop the reference via put_device() on the -EPROBE_DEFER path.

Fixes: ca0a7f7055d8 ("soc: adi: Add initial support for SC5xx SoCs")
Signed-off-by: Qasim Ijaz <qasim.ijaz@analog.com>

(resent this PR because last one targeted wrong branch, original discussion: <https://github.com/analogdevicesinc/linux/pull/3090#discussion_r2728239409>)

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [x] I have provided links for the relevant upstream lore