### PR TITLE
ci: Run Publish_to_Cloudsmith on cloud-hosted ubuntu-latest agents

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -152,7 +152,7 @@ stages:
     # - PRs (non-fork) targeting: main, next_stable, or 202* release branches
     # - Direct pushes to: main, next_stable, or 202* release branches
     - job: Push_to_Artifactory
-      timeoutInMinutes: 90
+      timeoutInMinutes: 120
       pool:
         name: Default
         demands:
@@ -186,6 +186,15 @@ stages:
             ARTIFACTORY_TOKEN: $(ART_TOKEN)
           name: PushArtifacts
           displayName: "Push to Artifactory"
+        - bash: |
+            cd $(Build.SourcesDirectory)/bin
+            TIMESTAMP=$(PushArtifacts.TIMESTAMP)
+            if [ -d "$TIMESTAMP" ]; then
+              echo "Cleaning up artifact directory: $TIMESTAMP"
+              rm -rf "$TIMESTAMP"
+            fi
+          displayName: "Cleanup artifacts"
+          condition: always()
     - job: Publish_to_Cloudsmith
       timeoutInMinutes: 120
       condition: or(
@@ -223,6 +232,15 @@ stages:
             CLOUDSMITH_API_KEY: $(CLOUDSMITH_API_KEY)
           name: PushArtifacts
           displayName: "Push to Cloudsmith"
+        - bash: |
+            cd $(Build.SourcesDirectory)/bin
+            TIMESTAMP=$(PushArtifacts.TIMESTAMP)
+            if [ -d "$TIMESTAMP" ]; then
+              echo "Cleaning up artifact directory: $TIMESTAMP"
+              rm -rf "$TIMESTAMP"
+            fi
+          displayName: "Cleanup artifacts"
+          condition: always()
   - stage: TestHarness
     dependsOn: PushArtifacts
     condition: succeeded()


### PR DESCRIPTION
Move the Publish_to_Cloudsmith job from self-hosted agents to cloud-hosted infrastructure to avoid disk space issues on the self-hosted linux_default agent.

## PR Description

- Removed custom pool configuration from `Publish_to_Cloudsmith` job
- Job now inherits the global `pool: vmImage: 'ubuntu-latest'` setting
- Eliminates dependency on self-hosted `linux_default` agent for Cloudsmith publishing

## Benefits
- Avoids "not enough space" errors on self-hosted infrastructure
- Leverages cloud agent scalability and clean environment for each run
- Reduces maintenance burden on self-hosted agents

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have compiled my changes, including the documentation
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
