### PR TITLE
kcu105_fmcomms4.dts: Update GPIO

### DIFF
--- a/arch/microblaze/boot/dts/kcu105_fmcomms4.dts
+++ b/arch/microblaze/boot/dts/kcu105_fmcomms4.dts
@@ -61,9 +61,9 @@
 #include "adi-fmcomms4.dtsi"
 
 &adc0_ad9364 {
-	en_agc-gpios = <&axi_gpio 12 8>;
-	sync-gpios = <&axi_gpio 13 8>;
-	reset-gpios = <&axi_gpio 14 8>;
-	enable-gpios = <&axi_gpio 15 8>;
-	txnrx-gpios = <&axi_gpio 16 8>;
+	en_agc-gpios = <&axi_gpio 44 8>;
+	sync-gpios = <&axi_gpio 45 8>;
+	reset-gpios = <&axi_gpio 46 8>;
+	enable-gpios = <&axi_gpio 47 8>;
+	txnrx-gpios = <&axi_gpio 48 8>;
 };


### PR DESCRIPTION
Set correct GPIOs for the FMCOMMS4 on the KCU105 carrier, matching the corresponding HDL.

Fixes: 75a2065 ("microblaze: dts: Add FMCOMMS4 support for KCU105")

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
