### PR TITLE
iio: frequency: hmc7044: accomodate LMFC rates

### DIFF
--- a/drivers/iio/frequency/hmc7044.c
+++ b/drivers/iio/frequency/hmc7044.c
@@ -2032,7 +2032,7 @@ static int hmc7044_lmfc_lemc_validate(struct hmc7044 *hmc, u64 dividend, u64 div
 	rem_u = hmc7044_get_rem(dividend, divisor + 1);
 
 
-	if ((rem_l > rem) && (rem_u > rem)) {
+	if ((rem_l >= rem) && (rem_u >= rem)) {
 		if (hmc->jdev_lmfc_lemc_gcd)
 			hmc->jdev_lmfc_lemc_gcd = min(hmc->jdev_lmfc_lemc_gcd, divisor);
 		else


### PR DESCRIPTION
This function was created to handle periodic LMFC rates but in some cases the calculated rem_l, rem_u end up being equal to the initial rem. Updated the if condition to accomodate this case.

## PR Description

- Please replace this comment with a summary of your changes, and add any context
necessary to understand them. List any dependencies required for this change.
- To check the checkboxes below, insert a 'x' between square brackets (without
any space), or simply check them after publishing the PR.
- If you changes include a breaking change, please specify dependent PRs in the
description and try to push all related PRs simultaneously.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
