### PR TITLE
main-xlnx: Add self-service llm reviews

### DIFF
--- a/.github/workflows/llm.yml
+++ b/.github/workflows/llm.yml
@@ -1,0 +1,55 @@
+name: LLM Agent
+
+on:
+  workflow_dispatch:
+    inputs:
+      base-sha:
+        required: false
+        type: string
+      head-sha:
+        required: false
+        type: string
+      run-id:
+        required: false
+        type: string
+      prompt:
+        required: false
+        type: string
+        default: ""
+      prompt-repository:
+        required: false
+        type: string
+        default: ""
+      model-small:
+        required: false
+        type: string
+        default: "@vertexai-global/anthropic.claude-haiku-4-5@20251001"
+      model-medium:
+        required: false
+        type: string
+        default: "@vertexai-global/anthropic.claude-sonnet-4-5@20250929"
+      model-large:
+        required: false
+        type: string
+        default: "@vertexai-global/anthropic.claude-opus-4-5@20251101"
+
+jobs:
+  llm:
+    uses: analogdevicesinc/linux/.github/workflows/llm.yml@ci
+    permissions:
+      contents: read
+      checks: read
+    secrets:
+      ANTHROPIC_CUSTOM_HEADERS: ${{ secrets.ANTHROPIC_CUSTOM_HEADERS }}
+      ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
+      ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
+    with:
+      base-sha: ${{ inputs.base-sha }}
+      head-sha: ${{ inputs.head-sha }}
+      run-id: ${{ inputs.run-id }}
+      prompt: ${{ inputs.prompt }}
+      prompt-repository: ${{ inputs.prompt-repository }}
+      model-small: ${{ inputs.model-small }}
+      model-medium: ${{ inputs.model-medium }}
+      model-large: ${{ inputs.model-large }}
+


### PR DESCRIPTION
## PR Description

- Don't run by default on every top-level.yml run
- Let users self-service, by providing the base-sha..head-sha range

Wrapper for main branch because is the current default nad dispatch only works on the default branch


Testing is straight forward, you can prompt a quick run with

<details>
<summary>

```
Write 2 jokes to $patches_path and a poem markdown formatted to $summary_file
```

</summary>

```
The Code Within

Lines of logic, clean and bright,
Dancing through the endless night,
Variables that hold their state,
Functions that collaborate.

Loops that spin with purpose true,
Algorithms breaking through,
Debugging till the dawn appears,
Building systems through the years.

From simple scripts to grand design,
Each semicolon marks a line,
In this world of ones and zeros,
Every coder plays the hero.

-------
Why do programmers prefer dark mode?
Because light attracts bugs!

Why did the developer go broke?
Because they used up all their cache!
```

<details/>

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have compiled my changes, including the documentation
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
