### PR TITLE
dmaengine: adi-dma: fix use-after-free in cyclic transfers

### DIFF
--- a/drivers/dma/adi-dma.c
+++ b/drivers/dma/adi-dma.c
@@ -896,10 +896,12 @@ static irqreturn_t adi_dma_thread_handler(int irq, void *id)
 	spin_lock_irqsave(&channel->lock, flags);
 
 	if (channel->current_desc && channel->current_desc->cyclic) {
+		struct dmaengine_result result = channel->current_desc->result;
+
 		dmaengine_desc_get_callback(&channel->current_desc->tx, &cb);
 
 		spin_unlock_irqrestore(&channel->lock, flags);
-		dmaengine_desc_callback_invoke(&cb, &channel->current_desc->result);
+		dmaengine_desc_callback_invoke(&cb, &result);
 		return IRQ_HANDLED;
 	}
 


### PR DESCRIPTION
A customer reported a bug and proposed a fix for a kernel crash. The following stack trace is generated by simulating that crash.

I generated the patch in this PR based on the above. It will require more thorough review and testing. The comments are also fairly verbose and should likely get dropped before merging.

```
[  151.146581] Unable to handle kernel paging request at virtual address dead000000000108
[  151.154506] Mem abort info:
[  151.157169]   ESR = 0x96000044
[  151.160190]   EC = 0x25: DABT (current EL), IL = 32 bits
[  151.165497]   SET = 0, FnV = 0
[  151.168509]   EA = 0, S1PTW = 0
[  151.171639]   FSC = 0x04: level 0 translation fault
[  151.176498] Data abort info:
[  151.179357]   ISV = 0, ISS = 0x00000044
[  151.183185]   CM = 0, WnR = 1
[  151.186119] [dead000000000108] address between user and kernel address ranges
[  151.193281] Internal error: Oops: 96000044 [#1] PREEMPT SMP
[  151.198789] Modules linked in: mod(OE) crct10dif_ce(E) spi_cadence_quadspi(E) fuse(E) xl4ptpextts(OE) overlay(E) adi_rpmsg(E) alap_ipc(OE)
[  151.211206] CPU: 0 PID: 2059 Comm: sim_handler Tainted: G           OE     5.15.78-yocto-standard #1
[  151.220315] Hardware name: MARS L1 US (DT)
[  151.224392] pstate: 60400005 (nZCv daif +PAN -UAO -TCO -DIT -SSBS BTYPE=--)
[  151.231337] pc : handler_fn+0x9c/0xcc [mod]
[  151.235501] Physical pc : 0x000000007aa4116c
[  151.239755] lr : handler_fn+0x98/0xcc [mod]
[  151.243921] sp : ffff80000d39be20
[  151.247219] Physical sp : 0x000000008759be20
[  151.251481] pmr_save: 000000e0
[  151.254511] x29: ffff80000d39be20 x28: 0000000000000000 x27: 0000000000000000
[  151.261631] x26: ffff000017f4fec0 x25: ffff800008cd17d8 x24: dead000000000122
[  151.268748] x23: dead000000000100 x22: ffff800000842078 x21: ffff00001b522e00
[  151.275866] x20: ffff800000843000 x19: ffff8000008433c0 x18: fffffffffffed110
[  151.282984] x17: ffff800015544000 x16: ffff800008004000 x15: 0000000000000030
[  151.290101] x14: 00000000000002cd x13: ffff80000d39bae0 x12: ffff800008c10b88
[  151.297219] x11: fffffffffffed110 x10: ffff800008c10b88 x9 : ffff800008bb8b88
[  151.304337] x8 : 00000000ffffefff x7 : ffff800008c10b88 x6 : 0000000000000000
[  151.311454] x5 : ffff00001dfa1710 x4 : 0000000000000000 x3 : 0000000000000000
[  151.318571] x2 : 0000000000000000 x1 : dead000000000100 x0 : dead000000000122
[  151.325690] Call trace:
[  151.328118]  handler_fn+0x9c/0xcc [mod]
[  151.331937]  kthread+0x144/0x150
[  151.335148]  ret_from_fork+0x10/0x20
[  151.338713] Code: b0000000 9103c000 95fdd7b7 a94002a1 (f9000420) 
[  151.344790] ---[ end trace d1f7840f61b087da ]---
[  151.361967] Kernel panic - not syncing: Oops: Fatal exception
[  151.367575] Kernel Offset: disabled
[  151.371013] CPU features: 0xc0000101,23380e02
[  151.375353] Memory Limit: none
```

A more trivial fix would be as follows and more clearly identifies the problem:

```
  diff --git a/drivers/dma/adi-dma.c b/drivers/dma/adi-dma.c                                             
  index b631b5e0aaa2b..xxxxxxxxxxxxx 100644              
  --- a/drivers/dma/adi-dma.c                                                                            
  +++ b/drivers/dma/adi-dma.c                            
  @@ -896,10 +896,11 @@ static irqreturn_t adi_dma_thread_handler(int irq, void *id)

        spin_lock_irqsave(&channel->lock, flags);

        if (channel->current_desc && channel->current_desc->cyclic) {
  +             struct dmaengine_result result = channel->current_desc->result;
                dmaengine_desc_get_callback(&channel->current_desc->tx, &cb);

                spin_unlock_irqrestore(&channel->lock, flags);
  -             dmaengine_desc_callback_invoke(&cb, &channel->current_desc->result);
  +             dmaengine_desc_callback_invoke(&cb, &result);
                return IRQ_HANDLED;
        }
```