### PR TITLE
ci: add Cloudsmith cleanup job on PR close

### DIFF
--- a/.github/workflows/pr-closed.yml
+++ b/.github/workflows/pr-closed.yml
@@ -1,0 +1,34 @@
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  clean-cloudsmith:
+    if: github.repository == 'analogdevicesinc/linux'
+    runs-on: [self-hosted, repo-only]
+    steps:
+    - uses: cloudsmith-io/cloudsmith-cli-action@v1.0.5
+      env:
+        CLOUDSMITH_SERVICE_SLUG: ${{ secrets.CLOUDSMITH_SERVICE_SLUG }}
+      if: ${{ env.CLOUDSMITH_SERVICE_SLUG != '' && env.CLOUDSMITH_SERVICE_SLUG != ' ' }}
+      with:
+        oidc-namespace: ${{ vars.CLOUDSMITH_NAMESPACE }}
+        oidc-service-slug: ${{ secrets.CLOUDSMITH_SERVICE_SLUG }}
+        oidc-auth-only: 'true'
+
+    - name: Get Cloudsmith API Key
+      env:
+        CLOUDSMITH_SERVICE_SLUG: ${{ secrets.CLOUDSMITH_SERVICE_SLUG }}
+      if: ${{ env.CLOUDSMITH_SERVICE_SLUG == '' || env.CLOUDSMITH_SERVICE_SLUG == ' ' }}
+      run: |
+        CLOUDSMITH_API_KEY=$(echo "${{ secrets.CLOUDSMITH_API_KEY }}" | xargs)
+        echo "CLOUDSMITH_API_KEY=$CLOUDSMITH_API_KEY" >> "$GITHUB_ENV"
+        
+    - name: Delete PR artifacts from Cloudsmith
+      run: |
+        curl -sO https://raw.githubusercontent.com/analogdevicesinc/wiki-scripts/main/utils/cloudsmith_utils/cloudsmith_helper.py
+        python cloudsmith_helper.py \
+          --repo sdg-linux \
+          --method remove_item_from_location \
+          --package_version "^linux/PRs/.*/pr_${{ github.event.number }}/" \
+          --package_name "*"


### PR DESCRIPTION
Add a clean-cloudsmith job to pr-closed.yml that removes PR artifacts from Cloudsmith when a PR is merged or closed.

Uses wiki-scripts/cloudsmith_helper.py remove_item_from_location method to delete all packages matching the PR version pattern.

## PR Description

- Please replace this comment with a summary of your changes, and add any context
necessary to understand them. List any dependencies required for this change.
- To check the checkboxes below, insert a 'x' between square brackets (without
any space), or simply check them after publishing the PR.
- If you changes include a breaking change, please specify dependent PRs in the
description and try to push all related PRs simultaneously.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have compiled my changes, including the documentation
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
