### PR TITLE
arch: arm: boot: overlays: fix adt7420 overlay

### DIFF
--- a/arch/arm/boot/dts/overlays/rpi-adt7420-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-adt7420-overlay.dts
@@ -13,7 +13,7 @@
 			status = "okay";
 
 			adt7420: adt7420@48 {
-				compatible = "adt7420";
+				compatible = "adi,adt7420";
 				reg = <0x48>;
 			};
 		};


### PR DESCRIPTION
## PR Description

Fix Raspberry PI overlay for adt7420 overlay to include vendor's name.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [x] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
