### PR TITLE
ARM: dts: adi: Fix gige-reset output

### DIFF
--- a/arch/arm64/boot/dts/adi/sc598-som-ezkit.dts
+++ b/arch/arm64/boot/dts/adi/sc598-som-ezkit.dts
@@ -185,7 +185,7 @@
 		gige-reset {
 			gpio-hog;
 			gpios = <15 GPIO_ACTIVE_LOW>;
-			output-high;
+			output-low;
 			line-name = "gige-reset";
 		};
 	};


### PR DESCRIPTION
The output for the gige-reset line was not changed when the polarity of the gpio was changed, resulting in the gige-reset line being active all the time and preventing the probe of the ethernet.

Fixes: 7eaf7e4 (ARM: dts: adi: fix polarity of GPIO signals)

## PR Description

- Please replace this comment with a summary of your changes, and add any context
necessary to understand them. List any dependencies required for this change.
- To check the checkboxes below, insert a 'x' between square brackets (without
any space), or simply check them after publishing the PR.
- If you changes include a breaking change, please specify dependent PRs in the
description and try to push all related PRs simultaneously.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
