### PR TITLE
CI: Add permissions to pr_closed workflow

### DIFF
--- a/.github/workflows/pr-closed.yml
+++ b/.github/workflows/pr-closed.yml
@@ -2,6 +2,10 @@ on:
   pull_request:
     types: [closed]
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   clean-cloudsmith:
     if: github.repository == 'analogdevicesinc/linux'
@@ -26,7 +30,9 @@ jobs:
         
     - name: Delete PR artifacts from Cloudsmith
       run: |
-        curl -sO https://raw.githubusercontent.com/analogdevicesinc/wiki-scripts/main/utils/cloudsmith_utils/cloudsmith_helper.py
+        curl -sO -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+        https://raw.githubusercontent.com/analogdevicesinc/wiki-scripts/main/utils/cloudsmith_utils/cloudsmith_helper.py
+        
         python cloudsmith_helper.py \
           --repo sdg-linux \
           --method remove_item_from_location \


### PR DESCRIPTION
## PR Description

Add necessary permissions to pr_closed.yml to access Cloudsmith and clean up old artefacts 

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have compiled my changes, including the documentation
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
