### PR TITLE
iio:adc:ada4355: Add ADA4356 compatible flag

### DIFF
--- a/drivers/iio/adc/ada4355.c
+++ b/drivers/iio/adc/ada4355.c
@@ -529,6 +529,7 @@ MODULE_DEVICE_TABLE(spi, ada4355_id);
 
 static const struct of_device_id ada4355_of_match[] = {
 	{ .compatible = "adi,ada4355" },
+	{ .compatible = "adi,ada4356" },
 	{},
 };
 MODULE_DEVICE_TABLE(of, ada4355_of_match);


### PR DESCRIPTION
## PR Description

- Just added a line for AD4356 to make driver probable with 'adi, ad4356' compatible flag.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ x ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ x ] I have conducted a self-review of my own code changes
- [ x ] I have compiled my changes, including the documentation
- [ x ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
