### PR TITLE
drivers: misc: ad525x_dpot: Remove kfree calls for a device managed memory

### DIFF
--- a/drivers/misc/ad525x_dpot.c
+++ b/drivers/misc/ad525x_dpot.c
@@ -803,7 +803,6 @@ exit_remove_files:
 			ad_dpot_remove_files(dev, data->feat, i);
 
 exit_free:
-	kfree(data);
 	dev_set_drvdata(dev, NULL);
 exit:
 	dev_err(dev, "failed to create client for %s ID 0x%lX\n",
@@ -820,8 +819,6 @@ int ad_dpot_remove(struct device *dev)
 	for (i = DPOT_RDAC0; i < MAX_RDACS; i++)
 		if (data->wipers & (1 << i))
 			ad_dpot_remove_files(dev, data->feat, i);
-
-	kfree(data);
 
 	return 0;
 }


### PR DESCRIPTION

## PR Description

- This PR fixes kernel crash when the AD525x driver unloaded. 

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ x ] I have conducted a self-review of my own code changes
- [ x ] I have compiled my changes, including the documentation
- [ x ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
