### PR TITLE
arm/arm64: dts: adi: sc59x: fix I2C and CRC nodes

### DIFF
--- a/arch/arm/boot/dts/adi/sc594-som.dtsi
+++ b/arch/arm/boot/dts/adi/sc594-som.dtsi
@@ -305,14 +305,6 @@
 	};
 };
 
-&crc0 {
-	status = "disabled";
-};
-
-&crc1 {
-	status = "disabled";
-};
-
 &usb0_phy {
 	reset-gpios = <&gpg 11 GPIO_ACTIVE_LOW>;
 	status = "okay";

--- a/arch/arm/boot/dts/adi/sc594-som.dtsi
+++ b/arch/arm/boot/dts/adi/sc594-som.dtsi
@@ -230,14 +230,6 @@
 	};
 };
 
-&i2c0 {
-	status = "disabled";
-};
-
-&i2c1 {
-	status = "disabled";
-};
-
 &i2c2 {
 	status = "okay";
 

--- a/arch/arm/boot/dts/adi/sc59x.dtsi
+++ b/arch/arm/boot/dts/adi/sc59x.dtsi
@@ -44,6 +44,9 @@
 		i2c0 = &i2c0;
 		i2c1 = &i2c1;
 		i2c2 = &i2c2;
+		i2c3 = &i2c3;
+		i2c4 = &i2c4;
+		i2c5 = &i2c5;
 		i2s4 = &i2s4;
 		mmc0 = &mmc0;
 		sru0 = &sru_ctrl_dai0;
@@ -354,7 +357,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			compatible = "adi,twi";
-			reg = <0x31001400 0xFF>;
+			reg = <0x31001400 0x100>;
 			interrupts = <GIC_SPI 150 IRQ_TYPE_LEVEL_HIGH>;
 			clock-khz = <100>;
 			clocks = <&clk ADSP_SC594_CLK_CGU0_SCLK0>;
@@ -366,7 +369,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			compatible = "adi,twi";
-			reg = <0x31001500 0xFF>;
+			reg = <0x31001500 0x100>;
 			interrupts = <GIC_SPI 151 IRQ_TYPE_LEVEL_HIGH>;
 			clock-khz = <100>;
 			clocks = <&clk ADSP_SC594_CLK_CGU0_SCLK0>;
@@ -378,8 +381,44 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			compatible = "adi,twi";
-			reg = <0x31001600 0xFF>;
+			reg = <0x31001600 0x100>;
 			interrupts = <GIC_SPI 152 IRQ_TYPE_LEVEL_HIGH>;
+			clock-khz = <100>;
+			clocks = <&clk ADSP_SC594_CLK_CGU0_SCLK0>;
+			clock-names = "sclk0";
+			status = "disabled";
+		};
+
+		i2c3: twi@31001000 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			compatible = "adi,twi";
+			reg = <0x31001000 0x100>;
+			interrupts = <GIC_SPI 153 IRQ_TYPE_LEVEL_HIGH>;
+			clock-khz = <100>;
+			clocks = <&clk ADSP_SC594_CLK_CGU0_SCLK0>;
+			clock-names = "sclk0";
+			status = "disabled";
+		};
+
+		i2c4: twi@31001100 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			compatible = "adi,twi";
+			reg = <0x31001100 0x100>;
+			interrupts = <GIC_SPI 154 IRQ_TYPE_LEVEL_HIGH>;
+			clock-khz = <100>;
+			clocks = <&clk ADSP_SC594_CLK_CGU0_SCLK0>;
+			clock-names = "sclk0";
+			status = "disabled";
+		};
+
+		i2c5: twi@31001200 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			compatible = "adi,twi";
+			reg = <0x31001200 0x100>;
+			interrupts = <GIC_SPI 155 IRQ_TYPE_LEVEL_HIGH>;
 			clock-khz = <100>;
 			clocks = <&clk ADSP_SC594_CLK_CGU0_SCLK0>;
 			clock-names = "sclk0";

--- a/arch/arm/boot/dts/adi/sc59x.dtsi
+++ b/arch/arm/boot/dts/adi/sc59x.dtsi
@@ -503,20 +503,38 @@
 			status = "disabled";
 		};
 
-		crc0: crc@31001200 {
+		crc0: crc@3100a500 {
 			compatible = "adi,hmac-crc";
-			reg = <0x31001200 0xFF>;
-			interrupts = <GIC_SPI 176 IRQ_TYPE_LEVEL_HIGH>;
+			reg = <0x3100a500 0x100>;
+			interrupts = <GIC_SPI 196 IRQ_TYPE_LEVEL_HIGH>;
 			dma_channel = <8>;
 			crypto_crc_poly = <0x5c5c5c5c>;
 			status = "disabled";
 		};
 
-		crc1: crc@31001300 {
+		crc1: crc@3100a600 {
 			compatible = "adi,hmac-crc";
-			reg = <0x31001300 0xFF>;
-			interrupts = <GIC_SPI 177 IRQ_TYPE_LEVEL_HIGH>;
+			reg = <0x3100a600 0x100>;
+			interrupts = <GIC_SPI 197 IRQ_TYPE_LEVEL_HIGH>;
 			dma_channel = <18>;
+			crypto_crc_poly = <0x5c5c5c5c>;
+			status = "disabled";
+		};
+
+		crc2: crc@3100aa00 {
+			compatible = "adi,hmac-crc";
+			reg = <0x3100aa00 0x100>;
+			interrupts = <GIC_SPI 204 IRQ_TYPE_LEVEL_HIGH>;
+			dma_channel = <45>;
+			crypto_crc_poly = <0x5c5c5c5c>;
+			status = "disabled";
+		};
+
+		crc3: crc@3100ab00 {
+			compatible = "adi,hmac-crc";
+			reg = <0x3100ab00 0x100>;
+			interrupts = <GIC_SPI 205 IRQ_TYPE_LEVEL_HIGH>;
+			dma_channel = <47>;
 			crypto_crc_poly = <0x5c5c5c5c>;
 			status = "disabled";
 		};

--- a/arch/arm64/boot/dts/adi/sc598-som.dtsi
+++ b/arch/arm64/boot/dts/adi/sc598-som.dtsi
@@ -206,14 +206,6 @@
 	cs-gpios = <&gpa 5 GPIO_ACTIVE_LOW>;
 };
 
-&i2c0 {
-	status = "okay";
-};
-
-&i2c1 {
-	status = "disabled";
-};
-
 &i2c2 {
 	status = "okay";
 	pinctrl-names = "default";

--- a/arch/arm64/boot/dts/adi/sc59x-64.dtsi
+++ b/arch/arm64/boot/dts/adi/sc59x-64.dtsi
@@ -577,21 +577,41 @@
 
 		crc0: crc@310a5000 {
 			compatible = "adi,hmac-crc";
-			reg = <0x310a5000 0xFF>;
+			reg = <0x310a5000 0x100>;
 			interrupts = <GIC_SPI 196 IRQ_TYPE_LEVEL_HIGH>;
 			dmas = <&crc_cluster 8>;
 			dma-names = "mdma_chan";
-			crypto_crc_poly = <0x04C11DB7>;
+			crypto_crc_poly = <0x04c11db7>;
 			status = "disabled";
 		};
 
 		crc1: crc@310a6000 {
 			compatible = "adi,hmac-crc";
-			reg = <0x310a6000 0xFF>;
+			reg = <0x310a6000 0x100>;
 			interrupts = <GIC_SPI 197 IRQ_TYPE_LEVEL_HIGH>;
 			dmas = <&crc_cluster 18>;
 			dma-names = "mdma_chan";
-			crypto_crc_poly = <0x04C11DB7>;
+			crypto_crc_poly = <0x04c11db7>;
+			status = "disabled";
+		};
+
+		crc2: crc@310aa000 {
+			compatible = "adi,hmac-crc";
+			reg = <0x310aa000 0x100>;
+			interrupts = <GIC_SPI 204 IRQ_TYPE_LEVEL_HIGH>;
+			dmas = <&crc_cluster 45>;
+			dma-names = "mdma_chan";
+			crypto_crc_poly = <0x04c11db7>;
+			status = "disabled";
+		};
+
+		crc3: crc@310ab000 {
+			compatible = "adi,hmac-crc";
+			reg = <0x310ab000 0x100>;
+			interrupts = <GIC_SPI 205 IRQ_TYPE_LEVEL_HIGH>;
+			dmas = <&crc_cluster 47>;
+			dma-names = "mdma_chan";
+			crypto_crc_poly = <0x04c11db7>;
 			status = "disabled";
 		};
 
@@ -1200,6 +1220,22 @@
 					<GIC_SPI 283 IRQ_TYPE_LEVEL_HIGH>;
 				interrupt-names = "complete", "error";
 				adi,src-offset = <0x100>;
+			};
+
+			crc2_dma: channel@45 { /* MDMA4_SRC */
+				adi,id = <45>;
+				interrupts = <GIC_SPI 200 IRQ_TYPE_LEVEL_HIGH>,
+					<GIC_SPI 289 IRQ_TYPE_LEVEL_HIGH>;
+				interrupt-names = "complete", "error";
+				adi,src-offset = <0x200>;
+			};
+
+			crc3_dma: channel@47 { /* MDMA5_SRC */
+				adi,id = <47>;
+				interrupts = <GIC_SPI 202 IRQ_TYPE_LEVEL_HIGH>,
+					<GIC_SPI 291 IRQ_TYPE_LEVEL_HIGH>;
+				interrupt-names = "complete", "error";
+				adi,src-offset = <0x300>;
 			};
 		};
 


### PR DESCRIPTION
This patch does the following:

  - sc594-som.dtsi and sc598-som.dtsi: remove useless code

  - sc59x.dtsi: add i2c3/4/5 nodes; fix register block length in i2c controller nodes; fix register block base address, register block length, interrupt number in crc0 and crc1 nodes; add crc2 and crc3.

  - sc59x-64.dtsi: fix register block length for crc0 and crc1; add crc2 and crc3; add crc2_dma and crc3_dma in crc_cluster.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have compiled my changes, including the documentation
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
