### PR TITLE
Add device tree for AD4630-20 on ZedBoard

### DIFF
--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4630-20.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4630-20.dts
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD4630-20
+ *
+ * hdl_project: <ad4630_fmc/zed>
+ * board_revision: <B>
+ *
+ * Copyright (C) 2026 Analog Devices Inc.
+ */
+/dts-v1/;
+
+#include "zynq-zed.dtsi"
+#include "zynq-zed-adv7511.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/pwm/pwm.h>
+
+/ {
+	vref: regulator-vref {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-supply";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		regulator-always-on;
+	};
+
+	vdd_1_8: regulator-vdd-1-8 {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-supply";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+		regulator-always-on;
+	};
+
+	vio: regulator-vio {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-supply";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+		regulator-always-on;
+	};
+
+	trigger_pwm: adc-pwm-trigger {
+		compatible = "pwm-trigger";
+		#trigger-source-cells = <0>;
+		pwms = <&adc_trigger 0 1000000 0>;
+	};
+
+	clocks {
+		cnv_ext_clk: ext-clk {
+			#clock-cells = <0x0>;
+			compatible = "fixed-clock";
+			clock-frequency = <100000000>;
+			clock-output-names = "cnv_ext_clk";
+		};
+	};
+};
+
+&fpga_axi {
+	adc_trigger: pwm@44b00000 {
+		compatible = "adi,axi-pwmgen-2.00.a";
+		reg = <0x44b00000 0x1000>;
+		#pwm-cells = <3>;
+		clocks = <&clkc 15>, <&cnv_ext_clk>;
+		clock-names = "axi", "ext";
+	};
+
+	rx_dma: dma-controller@44a30000 {
+		compatible = "adi,axi-dmac-1.00.a";
+		reg = <0x44a30000 0x1000>;
+		#dma-cells = <1>;
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&clkc 15>;
+	};
+
+	spi_clk: clock-controller@44a70000 {
+		compatible = "adi,axi-clkgen-2.00.a";
+		reg = <0x44a70000 0x10000>;
+		#clock-cells = <0>;
+		clocks = <&clkc 15>, <&clkc 15>;
+		clock-names = "clkin1", "s_axi_aclk";
+		clock-output-names = "spi_clk";
+	};
+
+	axi_spi_engine: spi@44a00000 {
+		compatible = "adi,axi-spi-engine-1.00.a";
+		reg = <0x44a00000 0x1FF>;
+		interrupt-parent = <&intc>;
+		interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&clkc 15>, <&spi_clk>;
+		clock-names = "s_axi_aclk", "spi_clk";
+
+		dmas = <&rx_dma 0>;
+		dma-names = "offload0-rx";
+		trigger-sources = <&trigger_pwm>;
+
+		#address-cells = <0x1>;
+		#size-cells = <0x0>;
+
+		ad4630_20: ad4630-20@0 {
+			compatible = "adi,ad4630-20";
+			reg = <0>;
+			spi-max-frequency = <80000000>;
+			vdd-supply = <&vref>;
+			vdd_1_8-supply = <&vdd_1_8>;
+			vio-supply = <&vio>;
+			vref-supply = <&vref>;
+			pwm-names = "cnv";
+			pwms = <&adc_trigger 1 1000000 0>;
+			reset-gpios = <&gpio0 86 GPIO_ACTIVE_LOW>;
+			adi,lane-mode = <1>;
+			adi,clock-mode = <0>;
+			adi,out-data-mode = <0>;
+		};
+	};
+};


### PR DESCRIPTION
Add device tree for using AD4630-20 on Digilent ZedBoard.

## PR Description

Essentially the same as AD4630-24.
```diff
$ diff arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4630-24.dts arch/arm/boot/dts/xilinx/zynq-zed-adv7511-ad4630-20.dts                                                                              
3c3
<  * Analog Devices AD4630-24
---
>  * Analog Devices AD4630-20
8c8
<  * Copyright (C) 2022 Analog Devices Inc.
---
>  * Copyright (C) 2026 Analog Devices Inc.
99,100c99,100
<               ad4630_24: ad4630-24@0 {
<                       compatible = "adi,ad4630-24";
---
>               ad4630_20: ad4630-20@0 {
>                       compatible = "adi,ad4630-20";
```

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have compiled my changes, including the documentation
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
