### PR TITLE
serial: adi_uart4: fix xmit_fifo wakeup check in DMA TX completion ca…

### DIFF
--- a/drivers/tty/serial/adi_uart4.c
+++ b/drivers/tty/serial/adi_uart4.c
@@ -560,15 +560,13 @@ static void adi_uart4_serial_dma_tx(void *data)
 	UART_CLEAR_IER(uart, ETBEI);
 	uart->port.icount.tx += uart->tx_count;
 
-	if (!kfifo_is_empty(&tport->xmit_fifo)) {
-		if (kfifo_len(&tport->xmit_fifo) < WAKEUP_CHARS)
-			uart_write_wakeup(&uart->port);
-	}
-
 	/*
-	 * Advance fifo to match the dma write
+	 * Advance fifo to match the DMA write
 	 */
 	uart_xmit_advance(&uart->port, uart->tx_count);
+	if (kfifo_len(&tport->xmit_fifo) < WAKEUP_CHARS)
+		uart_write_wakeup(&uart->port);
+
 	adi_uart4_serial_dma_tx_chars(uart);
 	spin_unlock_irqrestore(&uart->port.lock, flags);
 }


### PR DESCRIPTION
During the DMA TX completion callback adi_uart4_serial_dma_tx(), the
driver checks whether to call uart_write_wakeup() before advancing the
xmit_fifo TX queue with uart_xmit_advance().

uart_write_wakeup() notifies the tty layer that the driver can accept
more output and wakes tasks blocked in the tty write path. For ttySC0,
that allows a blocked writer to resume and eventually queue more bytes
into the TX buffer (xmit_fifo).

Because this check is done before xmit_fifo is advanced, the wakeup
decision uses stale xmit_fifo state. This becomes problematic when a
completed DMA transfer reduces the pending TX queue below
WAKEUP_CHARS, because blocked writers can miss their wakeup and remain
stalled. This includes the case where the DMA completion drains the
queue completely.

Missing this wakeup can stop further output from being queued and make
the serial console appear to hang or freeze.

I was able to reproduce the issue on both the ADSP-SC594 and ADSP-SC598
by running 'top' on the serial console and repeatedly refreshing the
display. When the issue triggers, the userspace writer ('top') ends up
blocked in the tty write path, for example:

    wait_woken
    n_tty_write
    file_tty_write
    tty_write
    vfs_write
    ksys_write

To fix this issue, the driver should first advance xmit_fifo via
uart_xmit_advance() and only then evaluate whether uart_write_wakeup()
is needed based on the post completion FIFO state. Furthermore 
drop the "if (!kfifo_is_empty(&tport->xmit_fifo)" check, since an empty 
xmit_fifo after uart_xmit_advance() means the pending TX queue 
has dropped to 0, which is still below WAKEUP_CHARS and is a 
valid case for uart_write_wakeup().

Fixes: https://github.com/analogdevicesinc/linux/commit/eab94da9de287e8d4b3cee383e479a18363262fe ("serial: Add UART driver for SC5xx SoCs")
Signed-off-by: Qasim Ijaz <qasim.ijaz@analog.com>

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
