### PR TITLE
serial: adi_uart4: avoid double increment of icount.tx in DMA TX path

### DIFF
--- a/drivers/tty/serial/Kconfig
+++ b/drivers/tty/serial/Kconfig
@@ -473,7 +473,7 @@ config SERIAL_SA1100_CONSOLE
 
 config SERIAL_ADI_UART4
 	tristate "ADI uart4 serial port support"
-	depends on ARCH_SC59X = y || ARCH_SC58X = y || ARCH_SC57X = y || ARCH_SC59X_64 = y
+	depends on ARCH_SC59X = y || ARCH_SC58X = y || ARCH_SC57X = y || ARCH_SC59X_64 = y || COMPILE_TEST
 	select SERIAL_CORE
 	select SERIAL_CORE_CONSOLE
 	help

--- a/drivers/tty/serial/adi_uart4.c
+++ b/drivers/tty/serial/adi_uart4.c
@@ -559,15 +559,13 @@ static void adi_uart4_serial_dma_tx(void *data)
 	 */
 	UART_CLEAR_IER(uart, ETBEI);
 
-	if (!kfifo_is_empty(&tport->xmit_fifo)) {
-		if (kfifo_len(&tport->xmit_fifo) < WAKEUP_CHARS)
-			uart_write_wakeup(&uart->port);
-	}
-
 	/*
-	 * Advance fifo to match the dma write
+	 * Advance fifo to match the DMA write
 	 */
 	uart_xmit_advance(&uart->port, uart->tx_count);
+	if (kfifo_len(&tport->xmit_fifo) < WAKEUP_CHARS)
+		uart_write_wakeup(&uart->port);
+
 	adi_uart4_serial_dma_tx_chars(uart);
 	spin_unlock_irqrestore(&uart->port.lock, flags);
 }

--- a/drivers/tty/serial/adi_uart4.c
+++ b/drivers/tty/serial/adi_uart4.c
@@ -1377,3 +1377,6 @@ static int __init adi_uart_early_console_setup(struct earlycon_device *device,
 }
 
 EARLYCON_DECLARE(adi_uart, adi_uart_early_console_setup);
+
+MODULE_DESCRIPTION("ADI UART4 serial driver");
+MODULE_LICENSE("GPL");

--- a/drivers/tty/serial/adi_uart4.c
+++ b/drivers/tty/serial/adi_uart4.c
@@ -1273,12 +1273,12 @@ static void adi_uart4_serial_remove(struct platform_device *pdev)
 	if (uart) {
 		uart_remove_one_port(&adi_uart4_serial_reg, &uart->port);
 		adi_uart4_serial_ports[uart->port.line] = NULL;
-		kfree(uart);
-		if (IS_ERR(uart->tx_dma_channel))
-			return;
 
-		dma_release_channel(uart->tx_dma_channel);
-		dma_release_channel(uart->rx_dma_channel);
+		if (!IS_ERR(uart->tx_dma_channel)) {
+			dma_release_channel(uart->tx_dma_channel);
+			dma_release_channel(uart->rx_dma_channel);
+		}
+		kfree(uart);
 	}
 }
 

--- a/drivers/tty/serial/adi_uart4.c
+++ b/drivers/tty/serial/adi_uart4.c
@@ -1295,7 +1295,6 @@ static struct platform_driver adi_uart4_serial_driver = {
 	.resume		= adi_uart4_serial_resume,
 	.driver		= {
 		.name	= DRIVER_NAME,
-		.owner	= THIS_MODULE,
 		.of_match_table	= adi_uart_dt_match,
 	},
 };

--- a/drivers/tty/serial/adi_uart4.c
+++ b/drivers/tty/serial/adi_uart4.c
@@ -558,7 +558,6 @@ static void adi_uart4_serial_dma_tx(void *data)
 	 *		when start a new tx.
 	 */
 	UART_CLEAR_IER(uart, ETBEI);
-	uart->port.icount.tx += uart->tx_count;
 
 	if (!kfifo_is_empty(&tport->xmit_fifo)) {
 		if (kfifo_len(&tport->xmit_fifo) < WAKEUP_CHARS)


### PR DESCRIPTION
In adi_uart4_serial_dma_tx(), the driver updates uart->port.icount.tx
manually and then calls uart_xmit_advance(&uart->port, uart->tx_count).

However, uart_xmit_advance() already advances the xmit_fifo TX queue and
accounts transmitted bytes into icount.tx, so the function counts each
completed DMA transfer twice.

Fix this by dropping the explicit icount.tx update and rely on uart_xmit_advance() 
for TX accounting.

Fixes: https://github.com/analogdevicesinc/linux/commit/eab94da9de287e8d4b3cee383e479a18363262fe ("serial: Add UART driver for SC5xx SoCs")
Signed-off-by: Qasim Ijaz <qasim.ijaz@analog.com>

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
