### PR TITLE
arm: dts: xilinx: Add dts for AD3530R on CoraZ7

### DIFF
--- a/arch/arm/boot/dts/xilinx/zynq-coraz7s-ad3530r.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-coraz7s-ad3530r.dts
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD3530R
+ *
+ * hdl_project: <ad353xr/coraz7s>
+ * board_revision: <A>
+ *
+ * Copyright (C) 2026 Analog Devices Inc.
+ */
+/dts-v1/;
+#include "zynq-coraz7s.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	vdd: regulator-vref {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-supply";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		regulator-always-on;
+	};
+
+	iovdd: regulator-iovdd {
+		compatible = "regulator-fixed";
+		regulator-name = "iovdd-supply";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-always-on;
+	};
+};
+
+&spi0 {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	ad3530r: dac@0 {
+		compatible = "adi,ad3530r";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+		reset-gpios = <&gpio0 87 GPIO_ACTIVE_LOW>;
+		ldac-gpios = <&gpio0 88 GPIO_ACTIVE_LOW>;
+		vdd-supply = <&vdd>;
+		iovdd-supply = <&iovdd>;
+	};
+};


### PR DESCRIPTION
Add device tree for using AD3530R on CoraZ7.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [X] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [X] I have conducted a self-review of my own code changes
- [X] I have compiled my changes, including the documentation
- [X] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
