### PR TITLE
clk: adi: fix invalid IS_ERR() checks of of_iomap() in SC5xx clock drivers

### DIFF
--- a/drivers/clk/adi/clk-adi-sc57x.c
+++ b/drivers/clk/adi/clk-adi-sc57x.c
@@ -47,19 +47,19 @@ static void __init sc57x_clock_probe(struct device_node *np)
 	int i;
 
 	cgu0 = of_iomap(np, 0);
-	if (IS_ERR(cgu0)) {
+	if (!cgu0) {
 		pr_err("Unable to remap CGU0 address (resource 0)\n");
 		return;
 	}
 
 	cgu1 = of_iomap(np, 1);
-	if (IS_ERR(cgu1)) {
+	if (!cgu1) {
 		pr_err("Unable to remap CGU1 address (resource 1)\n");
 		return;
 	}
 
 	cdu = of_iomap(np, 2);
-	if (IS_ERR(cdu)) {
+	if (!cdu) {
 		pr_err("Unable to remap CDU address (resource 2)\n");
 		return;
 	}

--- a/drivers/clk/adi/clk-adi-sc58x.c
+++ b/drivers/clk/adi/clk-adi-sc58x.c
@@ -49,19 +49,19 @@ static void sc58x_clock_probe(struct device_node *np)
 	int i;
 
 	cgu0 = of_iomap(np, 0);
-	if (IS_ERR(cgu0)) {
+	if (!cgu0) {
 		pr_err("Unable to remap CGU0 address (resource 0)\n");
 		return;
 	}
 
 	cgu1 = of_iomap(np, 1);
-	if (IS_ERR(cgu1)) {
+	if (!cgu1) {
 		pr_err("Unable to remap CGU1 address (resource 1)\n");
 		return;
 	}
 
 	cdu = of_iomap(np, 2);
-	if (IS_ERR(cdu)) {
+	if (!cdu) {
 		pr_err("Unable to remap CDU address (resource 2)\n");
 		return;
 	}

--- a/drivers/clk/adi/clk-adi-sc594.c
+++ b/drivers/clk/adi/clk-adi-sc594.c
@@ -53,19 +53,19 @@ static void sc594_clock_probe(struct device_node *np)
 	int i;
 
 	cgu0 = of_iomap(np, 0);
-	if (IS_ERR(cgu0)) {
+	if (!cgu0) {
 		pr_err("Unable to remap CGU0 address (resource 0)\n");
 		return;
 	}
 
 	cgu1 = of_iomap(np, 1);
-	if (IS_ERR(cgu1)) {
+	if (!cgu1) {
 		pr_err("Unable to remap CGU1 address (resource 1)\n");
 		return;
 	}
 
 	cdu = of_iomap(np, 2);
-	if (IS_ERR(cdu)) {
+	if (!cdu) {
 		pr_err("Unable to remap CDU address (resource 2)\n");
 		return;
 	}

--- a/drivers/clk/adi/clk-adi-sc598.c
+++ b/drivers/clk/adi/clk-adi-sc598.c
@@ -59,25 +59,25 @@ static void sc598_clock_probe(struct device_node *np)
 	int i;
 
 	cgu0 = of_iomap(np, 0);
-	if (IS_ERR(cgu0)) {
+	if (!cgu0) {
 		pr_err("Unable to remap CGU0 address (resource 0)\n");
 		return;
 	}
 
 	cgu1 = of_iomap(np, 1);
-	if (IS_ERR(cgu1)) {
+	if (!cgu1) {
 		pr_err("Unable to remap CGU1 address (resource 1)\n");
 		return;
 	}
 
 	cdu = of_iomap(np, 2);
-	if (IS_ERR(cdu)) {
+	if (!cdu) {
 		pr_err("Unable to remap CDU address (resource 2)\n");
 		return;
 	}
 
 	pll3 = of_iomap(np, 3);
-	if (IS_ERR(pll3)) {
+	if (!pll3) {
 		pr_err
 		    ("Unable to remap PLL3 control register (resource 3)\n");
 		return;


### PR DESCRIPTION
of_iomap() returns NULL on failure, but the ADI SC5xx clock drivers
check its return value with IS_ERR(). As a result, failed mappings are
not detected correctly. Fix this by replacing the IS_ERR() checks with
NULL checks.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore