### PR TITLE
arm64: dts: adi: sc598: Add EZLITE to build entry

### DIFF
--- a/arch/arm64/boot/dts/adi/Makefile
+++ b/arch/arm64/boot/dts/adi/Makefile
@@ -1,2 +1,2 @@
 # SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
-dtb-$(CONFIG_ARCH_SC59X_64) += sc598-som-ezkit.dtb
+dtb-$(CONFIG_ARCH_SC59X_64) += sc598-som-ezkit.dtb sc598-som-ezlite.dtb


### PR DESCRIPTION
The SC598-SOM-EZLITE device tree source and defconfig exist in the tree, but the device tree blob was never built because it was missing from the Makefile. This resulted in the EZLITE board being unusable despite having support in place.

Add the sc598-som-ezlite.dtb build target to fix the missing compilation step and enable proper EZLITE board support.

Fixes: a5d4be9 ("arm64: dts: adi: sc598: add device tree")

## PR Description

- Please replace this comment with a summary of your changes, and add any context
necessary to understand them. List any dependencies required for this change.
- To check the checkboxes below, insert a 'x' between square brackets (without
any space), or simply check them after publishing the PR.
- If you changes include a breaking change, please specify dependent PRs in the
description and try to push all related PRs simultaneously.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
