### PR TITLE
drivers: tty: serial: adi_uart4: Fix non-dma mode crash

### DIFF
--- a/drivers/tty/serial/adi_uart4.c
+++ b/drivers/tty/serial/adi_uart4.c
@@ -1142,7 +1142,11 @@ static int adi_uart4_serial_probe(struct platform_device *pdev)
 
 	uartid = of_alias_get_id(np, "serial");
 	tx_dma_channel = dma_request_chan(dev, "tx");
+	if (IS_ERR(tx_dma_channel))
+		tx_dma_channel = NULL;
 	rx_dma_channel = dma_request_chan(dev, "rx");
+	if (IS_ERR(rx_dma_channel))
+		rx_dma_channel = NULL;
 
 	if (uartid < 0) {
 		dev_err(&pdev->dev, "failed to get alias/pdev id, errno %d\n",


### PR DESCRIPTION
    dma_request_chan() returns an ERRPTR on failure, not a null pointer.
    This will result in a crash when the driver operates without DMA.

## PR Description
this PR add's back missing changes from old repository https://github.com/analogdevicesinc/lnxdsp-linux/pull/15

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [x] I have provided links for the relevant upstream lore
