### PR TITLE
arm64: boot: xilinx: add fixed-layout nvmem

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-jupiter-sdr.dtsi
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-jupiter-sdr.dtsi
@@ -296,11 +296,15 @@
 		compatible = "atmel,24c16";
 		pagesize = <16>;
 		reg = <0x50>;
-		#address-cells = <1>;
-		#size-cells = <1>;
 
-		eth0_addr: eth-mac-addr@B {
-			reg = <0xB 0x06>;
+		nvmem-layout {
+			compatible = "fixed-layout";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			eth0_addr: eth-mac-addr@B {
+				reg = <0xB 0x06>;
+			};
 		};
 	};
 


### PR DESCRIPTION


## PR Description

The support of adding nvmem cells directly to the memory node is being removed in the future and has to be explicitly specified in driver  nvmem configuration. By default, nvmem only adds cells from fixed-layout node. Added fixed layout node in the i2c eeprom to support loading MAC address from eeprom. https://github.com/analogdevicesinc/linux/blob/main/drivers/nvmem/core.c#L1024 

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
