### PR TITLE
drivers: tty: serial: Add missing CONFIG_SERIAL_EARLYCON for ADI UART4

### DIFF
--- a/drivers/tty/serial/Kconfig
+++ b/drivers/tty/serial/Kconfig
@@ -484,6 +484,7 @@ config SERIAL_ADI_UART4_CONSOLE
 	depends on SERIAL_ADI_UART4
 	default y
 	select SERIAL_CORE_CONSOLE
+	select SERIAL_EARLYCON
 	help
 	  If you have enabled the ADI UART4 serial port, you can
 	  make it the console by answering Y to this option.


### PR DESCRIPTION
## PR Description

Enable early console support for ADI UART4. Currently it is included in the kernel command line arguments for ADSP Linux but not enabled via Kconfig.

This makes it so the ADI UART4 driver selects and enables earlycon support by default and will be available as an early console option during boot.

With or without earlycon/earlyprintk, the current 5.0.1 build does not actually set up an early console. I tested with the following kernel command-line:
```
# Default + initcall_debug + ignore_loglevel (for debugging)
setenv mmcargs 'setenv bootargs root=/dev/mmcblk0p1 rw rootfstype=ext4 rootwait earlyprintk=serial,uart0,115200 console=ttySC0,115200 vmalloc=512M printk.time=1 printk.synchronous=1 initcall_debug ignore_loglevel'

# Without earlyprintk
setenv mmcargs 'setenv bootargs root=/dev/mmcblk0p1 rw rootfstype=ext4 rootwait console=ttySC0,115200 vmalloc=512M printk.time=1 printk.synchronous=1 initcall_debug ignore_loglevel'

# With earlycon
setenv mmcargs 'setenv bootargs root=/dev/mmcblk0p1 rw rootfstype=ext4 rootwait console=ttySC0,115200 vmalloc=512M printk.time=1 printk.synchronous=1 earlycon=adi_uart,0x31003000 initcall_debug ignore_loglevel'
```

In all cases, without the fix in this PR, same result (dropped messages) since the print buffer fills before the regular console is setup. 

```
Starting kernel ...

** 397 printk messages dropped **
[    0.157958] initcall iomem_init_inode+0x0/0x84 returned 0 after 0 usecs
[    0.158015] calling  clocksource_done_booting+0x0/0x44 @ 1
```

By adding CONFIG_SERIAL_EARLYCON, I can now get the early boot messages:
```
Starting kernel ...

[    0.000000] Booting Linux on physical CPU 0x0000000000 [0x410fd083]
[    0.000000] Linux version 6.6.16-j951c-standard.amd8e-guede09148cdb (on-username-host) (arm-m41_glibc-linux-gnueabihf-gcc (GCC) 13.4.0, GNU ld (GNU Binutil) 2.4
2.20240223) #1 Fri Oct 31 14:13:37 UTC 2025
[    0.000000] Machine model: raspberrypi 4-model-b          RPI4ADVFM2370040000
[    0.000000] CPU: PIPT / VIPT nonaliasing data cache, VIPT aliasing instruction cache
[    0.000000] OF: reserved mem: 0x5000:8031
[    0.000000] OF: reserved mem: rte-data1@30000000
[    0.000000] OF: reserved mem: 0x14800000..0x14ffffff (8 kib) nomap non-reusable rta-1@14b00000
[    0.000000] earlycon: set_uart0 at MMIO 0x10100000 (options '')
[    0.000000] printk: legacy bootconsole [sci_uart0] enabled
```

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [x] I have updated the documentation outside this repo accordingly
- [x] I have provided links for the relevant upstream lore
