### PR TITLE
iio: frequency: ad917x: Fix incorrect register address in SERDES init table

### DIFF
--- a/drivers/iio/frequency/ad917x/ad917x_jesd_api.c
+++ b/drivers/iio/frequency/ad917x/ad917x_jesd_api.c
@@ -430,7 +430,7 @@ int ad917x_jesd_enable_datapath(ad917x_handle_t *h,
 		err = ad917x_register_write(h,
 					    AD917X_MASTER_PD_REG, AD917X_SERDES_PDN(0));
 		if (err != API_ERROR_OK)
-			return err;;
+			return err;
 
 		/*Config SERDES PLL with ADI RECOMMENDED Settings*/
 		err = ad917x_register_write_tbl(h, &ADI_REC_ES_SERDES_INIT_TBL_2[0],
@@ -462,7 +462,7 @@ int ad917x_jesd_enable_datapath(ad917x_handle_t *h,
 		err = ad917x_register_write(h,
 					    AD917X_MASTER_PD_REG, AD917X_SERDES_PDN(1));
 		if (err != API_ERROR_OK)
-			return err;;
+			return err;
 		/*Power Down ALL Lanes*/
 		err = ad917x_register_write(h, AD917X_PHY_PD_REG, 0xFF);
 		if (err != API_ERROR_OK)

--- a/drivers/iio/frequency/ad917x/ad917x_jesd_api.c
+++ b/drivers/iio/frequency/ad917x/ad917x_jesd_api.c
@@ -83,7 +83,7 @@ static struct adi_reg_data ADI_REC_ES_SERDES_INIT_TBL_2[] = {
 	{0x213, 0x01}, /*ADI INTERNAL Init Serdes PLL Settings*/
 	{0x213, 0x00}, /*ADI INTERNAL Init Serdes PLL Settings*/
 	{0x210, 0x86}, /*ADI INTERNAL Init Serdes PLL Settings*/
-	{0x210, 0x00}, /*ADI INTERNAL Init Serdes PLL Settings*/
+	{0x216, 0x00}, /*ADI INTERNAL Init Serdes PLL Settings*/
 	{0x213, 0x01}, /*ADI INTERNAL Init Serdes PLL Settings*/
 	{0x213, 0x00}, /*ADI INTERNAL Init Serdes PLL Settings*/
 	{0x210, 0x87}, /*ADI INTERNAL Init Serdes PLL Settings*/


### PR DESCRIPTION
## PR Description

Fix the register address from 0x210 to 0x216 in the ADI_REC_ES_SERDES_INIT_TBL_2 initialization sequence. The previous value was incorrect and would overwrite the wrong register during SERDES PLL initialization.

Fixes: 76a7e071081e ("iio: frequency: ad917x: Add AD936x API driver source")

## PR Type
- [X] Bug fix (a change that fixes an issue)
