### PR TITLE
iio: frequency: ad917x: Fix incorrect register address in SERDES init table

### DIFF
--- a/drivers/iio/frequency/ad917x/ad917x_jesd_api.c
+++ b/drivers/iio/frequency/ad917x/ad917x_jesd_api.c
@@ -83,7 +83,7 @@ static struct adi_reg_data ADI_REC_ES_SERDES_INIT_TBL_2[] = {
 	{0x213, 0x01}, /*ADI INTERNAL Init Serdes PLL Settings*/
 	{0x213, 0x00}, /*ADI INTERNAL Init Serdes PLL Settings*/
 	{0x210, 0x86}, /*ADI INTERNAL Init Serdes PLL Settings*/
-	{0x210, 0x00}, /*ADI INTERNAL Init Serdes PLL Settings*/
+	{0x216, 0x00}, /*ADI INTERNAL Init Serdes PLL Settings*/
 	{0x213, 0x01}, /*ADI INTERNAL Init Serdes PLL Settings*/
 	{0x213, 0x00}, /*ADI INTERNAL Init Serdes PLL Settings*/
 	{0x210, 0x87}, /*ADI INTERNAL Init Serdes PLL Settings*/


### PR DESCRIPTION
## PR Description

Fix the register address from 0x210 to 0x216 in the ADI_REC_ES_SERDES_INIT_TBL_2 initialization sequence. The previous value was incorrect and would overwrite the wrong register during SERDES PLL initialization.

Fixes: 76a7e071081e ("iio: frequency: ad917x: Add AD936x API driver source")

## PR Type
- [X] Bug fix (a change that fixes an issue)

