### PR TITLE
Really fix AD4630-20/AD4632-20 data capture

### DIFF
--- a/drivers/iio/adc/ad4630.c
+++ b/drivers/iio/adc/ad4630.c
@@ -854,7 +854,7 @@ static const struct ad4630_out_mode ad4630_20_modes[] = {
 			AD4630_CHAN(0, AD4630_CHAN_INFO_NONE, 32, 20, 0, AD4630_CHAN_INFO_NONE),
 			AD4630_CHAN(1, AD4630_CHAN_INFO_NONE, 32, 20, 0, AD4630_CHAN_INFO_NONE),
 		},
-		.data_width = 24,
+		.data_width = 20,
 	},
 	[AD4630_16_DIFF_8_COM] = {
 		.channels = {


### PR DESCRIPTION
## PR Description

It happens that https://github.com/analogdevicesinc/linux/pull/3241 missed updating the data width to 20-bit.
This time, I got confirmation from an application engineer that data capture runs as expected. Finally fix the data capture on main xD

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] An ADI product applications engineer tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
