### PR TITLE
github/llm: Add pull-requests write permission

### DIFF
--- a/.github/workflows/llm.yml
+++ b/.github/workflows/llm.yml
@@ -32,7 +32,7 @@ jobs:
     permissions:
       contents: read
       checks: read
-      pull-requests: read
+      pull-requests: write
     secrets:
       PORTKEY_API_KEY: ${{ secrets.PORTKEY_API_KEY }}
     with:


### PR DESCRIPTION

## PR Description

To allow publishing pull request comments, write permission is required. The LLM job remains with permission pull requests read, a second job with only pull requests permission write takes the llm.outputs.pr (number) and llm.outputs.commend (markdown comment) and write the comment. If a comment already exists, it updates the existing one to not clutter the pr conversation.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have compiled my changes, including the documentation
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
