### PR TITLE
rpmsg: fix stale src address causing rebind to fail depending on order

### DIFF
--- a/drivers/rpmsg/rpmsg_core.c
+++ b/drivers/rpmsg/rpmsg_core.c
@@ -603,8 +603,19 @@ static void rpmsg_dev_remove(struct device *dev)
 
 	dev_pm_domain_detach(dev, true);
 
-	if (rpdev->ept)
+	if (rpdev->ept) {
 		rpmsg_destroy_ept(rpdev->ept);
+		rpdev->ept = NULL;
+		/*
+		 * If the source address was dynamically allocated during probe
+		 * (i.e. the channel was not a pre-announced server channel),
+		 * reset it so a subsequent re-bind allocates a fresh address
+		 * instead of requesting the now-stale one, which may have been
+		 * claimed by another endpoint in the meantime.
+		 */
+		if (!rpdev->announce)
+			rpdev->src = RPMSG_ADDR_ANY;
+	}
 }
 
 static const struct bus_type rpmsg_bus = {


### PR DESCRIPTION
## PR Description

Fixes a bug in `rpmsg_dev_remove()` where `rpdev->src` was left holding
a stale dynamically-allocated endpoint address after unbind. On the next
bind, `rpmsg_dev_probe()` would pass that address as a specific IDR request
instead of `RPMSG_ADDR_ANY`. If another channel snached that address in the
meantime, `idr_alloc()` would fail with -ENOSPC and the whole probe would
blow up. This made bind/unbind sucess order-dependent when it really
shouldn't be.

The fix is a one-liner in `rpmsg_dev_remove()`: reset `rpdev->src` to
`RPMSG_ADDR_ANY` after destroying the endpoint, but only for channels
with dynamically-assigned addresses (`!rpdev->announce`). Static server
channels keep their src.

Reproducer (run after starting the remote processor):
```sh
export X=virtio0.sharc-echo.-1.288
export Y=virtio0.sharc-echo-cap.-1.352

xbind() {
    echo rpmsg_chrdev > /sys/bus/rpmsg/devices/$1/driver_override
    echo $1 > /sys/bus/rpmsg/drivers/rpmsg_chrdev/$2
}
bind()   { xbind $1 bind; }
unbind() { xbind $1 unbind; }

# previously failed with "idr_alloc failed: -28 / probe failed with error -12"
bind $X; unbind $X; bind $Y; bind $X
echo $?  # should be 0
```
Expected output: all four operations succeed, no errors in dmesg.

No dependencies on other PRs.

## PR Type

- Bug fix (a change that fixes an issue)
- New feature (a change that adds new functionality)
- Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist

- I have conducted a self-review of my own code changes
- I have compiled my changes, including the documentation
- I have tested the changes on the relevant hardware
- I have updated the documentation outside this repo accordingly
- I have provided links for the relevant upstream lore