### PR TITLE
arm: dts: overlays: adis16475: Add reset_pin override

### DIFF
--- a/arch/arm/boot/dts/overlays/adis16475-overlay.dts
+++ b/arch/arm/boot/dts/overlays/adis16475-overlay.dts
@@ -83,6 +83,8 @@
 		 */
 		drdy_gpio25 = <&adis16475_pins>,"brcm,pins:0=25",
 				<&adis16475>,"interrupts:0=25";
+		reset_pin = <&adis16475_pins>,"brcm,pins:4",
+				<&adis16475>,"reset-gpios:4";
 		device = <&adis16475>,"compatible";
 		sync_mode = <&adis16475>,"adi,sync-mode:0";
 		ext_sync_freq = <&adis16475_ref_clk>, "clock-frequency:0",


### PR DESCRIPTION
Include https://github.com/analogdevicesinc/linux/pull/3219 in this release. My intention is to get this change in the Kuiper rc, and I previously mistakenly thought `rpi-6.12.y` was the branch for that. Hoping I'm not too late 🙃

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
