### PR TITLE
serial: adi_uart4: use devm_kzalloc() and fix UART probe memory leaks

### DIFF
--- a/drivers/tty/serial/adi_uart4.c
+++ b/drivers/tty/serial/adi_uart4.c
@@ -1151,6 +1151,12 @@ static int adi_uart4_serial_probe(struct platform_device *pdev)
 		goto out_dma_release;
 	}
 
+	if (uartid >= ADI_UART_NR_PORTS) {
+		dev_err(dev, "serial id %d out of range\n", uartid);
+		ret = -EINVAL;
+		goto out_dma_release;
+	}
+
 	if (adi_uart4_serial_ports[uartid] == NULL) {
 		uart = devm_kzalloc(dev, sizeof(*uart), GFP_KERNEL);
 		if (!uart) {

--- a/drivers/tty/serial/adi_uart4.c
+++ b/drivers/tty/serial/adi_uart4.c
@@ -1152,7 +1152,7 @@ static int adi_uart4_serial_probe(struct platform_device *pdev)
 	}
 
 	if (adi_uart4_serial_ports[uartid] == NULL) {
-		uart = kzalloc(sizeof(*uart), GFP_KERNEL);
+		uart = devm_kzalloc(dev, sizeof(*uart), GFP_KERNEL);
 		if (!uart)
 			return -ENOMEM;
 
@@ -1160,8 +1160,10 @@ static int adi_uart4_serial_probe(struct platform_device *pdev)
 		uart->dev = &pdev->dev;
 
 		uart->clk = devm_clk_get(dev, "sclk0");
-		if (IS_ERR(uart->clk))
-			return -ENODEV;
+		if (IS_ERR(uart->clk)) {
+			ret = PTR_ERR(uart->clk);
+			goto out_error;
+		}
 
 		spin_lock_init(&uart->port.lock);
 		uart->port.uartclk   = clk_get_rate(uart->clk);
@@ -1175,14 +1177,15 @@ static int adi_uart4_serial_probe(struct platform_device *pdev)
 		if (res == NULL) {
 			dev_err(&pdev->dev, "Cannot get IORESOURCE_MEM\n");
 			ret = -ENOENT;
-			goto out_error_unmap;
+			goto out_error;
 		}
 
 		uart->port.membase = devm_ioremap(&pdev->dev, res->start,
 						resource_size(res));
 		if (!uart->port.membase) {
 			dev_err(&pdev->dev, "Cannot map uart IO\n");
-			return -ENXIO;
+			ret = -ENXIO;
+			goto out_error;
 		}
 
 		uart->tx_dma_channel = tx_dma_channel;
@@ -1203,7 +1206,7 @@ static int adi_uart4_serial_probe(struct platform_device *pdev)
 				uart);
 			if (ret) {
 				dev_err(dev, "Unable to attach UART RX int\n");
-				return ret;
+				goto out_error;
 			}
 
 			ret = devm_request_threaded_irq(dev, uart->tx_irq,
@@ -1211,7 +1214,7 @@ static int adi_uart4_serial_probe(struct platform_device *pdev)
 				uart);
 			if (ret) {
 				dev_err(dev, "Unable to attach UART TX int\n");
-				return ret;
+				goto out_error;
 			}
 		}
 
@@ -1241,24 +1244,23 @@ static int adi_uart4_serial_probe(struct platform_device *pdev)
 			if (IS_ERR(uart->hwflow_en_pin)) {
 				dev_err(dev,
 				"hwflow-en required in peripheral hwflow mode\n");
-				return PTR_ERR(uart->hwflow_en_pin);
+				ret = PTR_ERR(uart->hwflow_en_pin);
+				goto out_error;
 			}
 		}
 	}
 
 	uart = adi_uart4_serial_ports[uartid];
 	uart->port.dev = &pdev->dev;
-	dev_set_drvdata(&pdev->dev, uart);
 
 	ret = uart_add_one_port(&adi_uart4_serial_reg, &uart->port);
-	if (!ret)
+	if (!ret) {
+		dev_set_drvdata(&pdev->dev, uart);
 		return 0;
-
-	if (uart) {
-out_error_unmap:
-		adi_uart4_serial_ports[uartid] = NULL;
-		kfree(uart);
 	}
+
+out_error:
+	adi_uart4_serial_ports[uartid] = NULL;
 
 	return ret;
 }
@@ -1276,7 +1278,6 @@ static void adi_uart4_serial_remove(struct platform_device *pdev)
 			dma_release_channel(uart->tx_dma_channel);
 			dma_release_channel(uart->rx_dma_channel);
 		}
-		kfree(uart);
 	}
 }
 

--- a/drivers/tty/serial/adi_uart4.c
+++ b/drivers/tty/serial/adi_uart4.c
@@ -1148,13 +1148,15 @@ static int adi_uart4_serial_probe(struct platform_device *pdev)
 		dev_err(&pdev->dev, "failed to get alias/pdev id, errno %d\n",
 				uartid);
 		ret = -ENODEV;
-		return ret;
+		goto out_dma_release;
 	}
 
 	if (adi_uart4_serial_ports[uartid] == NULL) {
 		uart = devm_kzalloc(dev, sizeof(*uart), GFP_KERNEL);
-		if (!uart)
-			return -ENOMEM;
+		if (!uart) {
+			ret = -ENOMEM;
+			goto out_dma_release;
+		}
 
 		adi_uart4_serial_ports[uartid] = uart;
 		uart->dev = &pdev->dev;
@@ -1261,6 +1263,11 @@ static int adi_uart4_serial_probe(struct platform_device *pdev)
 
 out_error:
 	adi_uart4_serial_ports[uartid] = NULL;
+out_dma_release:
+	if (!IS_ERR(tx_dma_channel))
+		dma_release_channel(tx_dma_channel);
+	if (!IS_ERR(rx_dma_channel))
+		dma_release_channel(rx_dma_channel);
 
 	return ret;
 }


### PR DESCRIPTION
This PR introduces a few memory leak and bounds check fixes to the ADI UART driver 
as well as some general cleanups.

Currently `adi_uart4_serial_probe()` allocates `struct adi_uart4_serial_port` with
`kzalloc()`, but several failure paths ignore resource cleanup. The driver also 
requests DMA channels in probe without consistently releasing them on failure.
Another issue is that it gets the serial alias id to index `adi_uart4_serial_ports[]` without a
bounds check (this is a common check in upstream UART drivers).

To address these issues this PR does the following:

- converts port allocation from `kzalloc()` to `devm_kzalloc()`
- routes post allocation probe failures through a proper cleanup path
- clears port state on failed probe
- releases requested DMA channels on probe failure
- validates alias id range before indexing the port array
- delays the `dev_set_drvdata()` call until after successful `uart_add_one_port()`
- propagate the actual devm_clk_get() failure with PTR_ERR() instead of simply returning -ENODEV

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore