### PR TITLE
Xlnx/fix/jupiter usb gadget

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-jupiter-sdr.dtsi
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-jupiter-sdr.dtsi
@@ -8,8 +8,6 @@
 #include <dt-bindings/pinctrl/pinctrl-zynqmp.h>
 #include <dt-bindings/phy/phy.h>
 
-#undef JUPITER_SDR_USB_ROLE_SW
-
 / {
 	model = "Analog Devices, Inc. Jupiter SDR";
 	compatible = "xlnx,zynqmp";
@@ -315,7 +313,6 @@
 		interrupts = <31 IRQ_TYPE_LEVEL_LOW>;
 		interrupt-names = "irq";
 
-#ifdef JUPITER_SDR_USB_ROLE_SW
 		typec_con: connector {
 			compatible = "usb-c-connector";
 			label = "USB-C";
@@ -325,7 +322,6 @@
 				};
 			};
 		};
-#endif
 	};
 
 	typec_pd1: usb-pd@3f {
@@ -382,18 +378,15 @@
 	status = "okay";
 	dr_mode = "otg";
 	maximum-speed = "super-speed";
-#ifdef JUPITER_SDR_USB_ROLE_SW
+
 	usb-role-switch;
 	role-switch-default-mode = "device";
 
-	port@0 {
-		reg = <0>;
-
+	port {
 		otg_ep: endpoint {
-			remote-endpoint = <&typec_con>;
+			remote-endpoint = <&typec_ep>;
 		};
 	};
-#endif
 };
 
 &gpio {

--- a/arch/arm64/boot/dts/xilinx/zynqmp-jupiter-sdr.dtsi
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-jupiter-sdr.dtsi
@@ -374,13 +374,13 @@
 	status = "okay";
 	pinctrl-names = "default";
 	pinctrl-0 = <&pinctrl_usb0_default>;
+	phy-names = "usb3-phy";
+	phys = <&psgtr 0 PHY_TYPE_USB3 0 0>;
 };
 
 &dwc3_0 {
 	status = "okay";
 	dr_mode = "otg";
-	phy-names = "usb3-phy";
-	phys = <&psgtr 0 PHY_TYPE_USB3 0 0>;
 	maximum-speed = "super-speed";
 #ifdef JUPITER_SDR_USB_ROLE_SW
 	usb-role-switch;


### PR DESCRIPTION
## PR Description

Fix USB gadget for Jupiter and properly enable type-C role switch. More details on the commit message.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
