### PR TITLE
[2026_r1] arm64: dts: zcu102-ad9467: Updated axi-adc compatible string

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9467-fmc-250ebz.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9467-fmc-250ebz.dts
@@ -32,7 +32,7 @@
 		};
 
 		cf_ad9467_core_0: cf-ad9467-core-lpc@84A00000 {
-			compatible = "adi,axi-adc-10.0.a", "adi,axi-ad9467-1.0";
+			compatible = "adi,axi-adc-legacy-10.0.a", "adi,axi-ad9467-1.0";
 			reg = <0x84A00000 0x10000>;
 			dmas = <&rx_dma 0>;
 			dma-names = "rx";


### PR DESCRIPTION
## PR Description

Changed driver from axi-adc-10.0.a to axi-adc-legacy-10.0.a


(cherry picked from commit ad8a6d81c9a67f333c5817bf4371b453069afe46)

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have compiled my changes, including the documentation
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
