### PR TITLE
ARM: dts: overlays: rpi-adxrs290: Fix GPIO IRQ on RPi5

### DIFF
--- a/arch/arm/boot/dts/overlays/rpi-adxrs290-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-adxrs290-overlay.dts
@@ -3,9 +3,19 @@
 /plugin/;
 
 / {
-	compatible = "brcm,bcm2836", "brcm,bcm2835";
+	compatible = "brcm,bcm2712", "brcm,bcm2836", "brcm,bcm2835";
 
 	fragment@0 {
+		target = <&gpio>;
+		__overlay__ {
+			adxrs290_pins: adxrs290_pins {
+				brcm,pins = <19>;
+				brcm,function = <0>; /* GPIO input */
+			};
+		};
+	};
+
+	fragment@1 {
 		target = <&spi0>;
 		__overlay__ {
 			#address-cells = <1>;
@@ -18,13 +28,15 @@
 				spi-max-frequency = <1000000>;
 				spi-cpha;
 				spi-cpol;
+				pinctrl-names = "default";
+				pinctrl-0 = <&adxrs290_pins>;
 				interrupts = <19 1>;
 				interrupt-parent = <&gpio>;
 			};
 		};
 	};
 
-	fragment@1 {
+	fragment@2 {
 		target = <&spidev0>;
 		__overlay__ {
 			status = "disabled";


### PR DESCRIPTION
## PR Description

The RP1 I/O chip on RPi5 only detects GPIO interrupts on pins configured in GPIO function mode, unlike BCM2835 which monitors pins at the pad level regardless of ALT function.

GPIO19 was left in its boot-default ALT function on RPi5, causing the data-ready IRQ to never fire in software despite the hardware signal being correct. Add a pinctrl fragment to explicitly configure GPIO19 as a GPIO input so the RP1 interrupt block can monitor it.

Also add brcm,bcm2712 to the compatible string to explicitly support RPi5.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
