### PR TITLE
arm64: dts: xilinx: ad9084: remove qspi props

### DIFF
--- a/arch/arm64/boot/dts/xilinx/versal-vpk180-reva-ad9084.dts
+++ b/arch/arm64/boot/dts/xilinx/versal-vpk180-reva-ad9084.dts
@@ -103,10 +103,6 @@
 
 &qspi {
 	is-dual = <1>;
-	num-cs = <1>;
-	spi-rx-bus-width = <4>;
-	spi-tx-bus-width = <4>;
-	status = "okay";
 };
 
 &sdhci1 {


### PR DESCRIPTION


## PR Description

The qpsi node would set num-cs, spi-[rx|tx]-bus-width and status, already set by versal-vpk180-revA.dts. The value of num-cs set to 1 would overwrite value 2 fixed by:
8da5692126c8 ("arm64: versal: Add new parallel/stacked DT bindings") Causing the spi.c to fail with error:
"has number of CS > ctlr->num_chipselect (2)"
The check itself was duplicated and removed upstream: 83c522fb6423 ("spi: don't check spi_controller::num_chipselect when parsing a dt device") On > 6.18, the failure occurs at __spi_add_device() instead.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have compiled my changes, including the documentation
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
