### PR TITLE
iio: trx-rf: ad9088: fix fft sniffer buffer length handling

### DIFF
--- a/drivers/iio/trx-rf/ad9088/ad9088_fft.c
+++ b/drivers/iio/trx-rf/ad9088/ad9088_fft.c
@@ -432,23 +432,24 @@ static const struct iio_info ad9088_fft_sniffer_info = {
 	.update_scan_mode = ad9088_fft_sniffer_update_scan_mode,
 };
 
+static int ad9088_fft_sniffer_buffer_preenable(struct iio_dev *indio_dev)
+{
+	struct ad9088_fft_sniffer_state *st = iio_priv(indio_dev);
+	u32 dlen;
+
+	dlen = st->sniffer_config_hw.init.real_mode ? (ADI_APOLLO_SNIFFER_FFT_LENGTH / 2) :
+								ADI_APOLLO_SNIFFER_FFT_LENGTH;
+	indio_dev->buffer->length = dlen;
+
+	return 0;
+}
+
 static int ad9088_fft_sniffer_buffer_postenable(struct iio_dev *indio_dev)
 {
 	struct ad9088_fft_sniffer_state *st = iio_priv(indio_dev);
 	int ret = 0;
-	u32 blen, dlen;
 
 	dev_dbg(st->dev, "%s:%d\n", __func__, __LINE__);
-
-	blen = indio_dev->buffer->length / indio_dev->num_channels;
-	dlen = st->sniffer_config_hw.init.real_mode ? (ADI_APOLLO_SNIFFER_FFT_LENGTH / 2) :
-								ADI_APOLLO_SNIFFER_FFT_LENGTH;
-
-	if (blen != dlen) {
-		dev_err(st->dev, "Buffer length %d incompatible with current sniffer mode (real/complex) set to %d\n",
-			blen, dlen);
-		return -EINVAL;
-	}
 
 	guard(mutex)(&st->phy->lock);
 
@@ -490,6 +491,7 @@ static int ad9088_fft_sniffer_buffer_predisable(struct iio_dev *indio_dev)
 }
 
 static const struct iio_buffer_setup_ops ad9088_fft_sniffer_buffer_ops = {
+	.preenable = ad9088_fft_sniffer_buffer_preenable,
 	.postenable = ad9088_fft_sniffer_buffer_postenable,
 	.predisable = ad9088_fft_sniffer_buffer_predisable,
 };


### PR DESCRIPTION
## PR Description

The buffer length check in ad9088_fft_sniffer_buffer_postenable()
incorrectly divided buffer->length by num_channels before comparing
against ADI_APOLLO_SNIFFER_FFT_LENGTH, causing EINVAL on every enable attempt. 

IIO Oscilloscope also hardcodes a buffer length of 400 up to 16384 
depending on the number of channels enabled which
does not match the required 512 (IQ) or 256 (magnitude) bins.

Fix by adding a preenable callback that forces buffer->length to the
correct value before the kfifo is allocated, overriding whatever the caller set.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have compiled my changes, including the documentation
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
