### PR TITLE
ARM: dts: fix ad7124 overlay

### DIFF
--- a/arch/arm/boot/dts/overlays/rpi-ad7124-8-all-diff-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ad7124-8-all-diff-overlay.dts
@@ -30,7 +30,7 @@
 				compatible = "adi,ad7124-8";
 				reg = <0>; //CS0 default
 				spi-max-frequency = <5000000>;
-				interrupts = <19 2>; // interrupt, Default to PMD-RPI-INTZ P1
+				interrupts = <19 8>; // interrupt, Default to PMD-RPI-INTZ P1, active-low level
 				interrupt-parent = <&gpio>;
 				pinctrl-names = "default";
 				pinctrl-0 = <&ad7124_irq_pin>;

--- a/arch/arm/boot/dts/overlays/rpi-ad7124-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ad7124-overlay.dts
@@ -3,7 +3,7 @@
 /plugin/;
 
 / {
-	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709";
+	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709", "brcm,bcm2712";
 
 	fragment@0 {
 		target-path = "/";
@@ -25,12 +25,14 @@
 			#size-cells = <0>;
 			status = "okay";
 
-			adc@0 {
+			ad7124: adc@0 {
 				compatible = "adi,ad7124-4";
 				reg = <0>;
 				spi-max-frequency = <5000000>;
-				interrupts = <25 2>;
+				interrupts = <19 8>; // interrupt, Default to PMD-RPI-INTZ P1, active-low level
 				interrupt-parent = <&gpio>;
+				pinctrl-names = "default";
+				pinctrl-0 = <&ad7124_irq_pin>;
 				refin1-supply = <&vref>;
 
 				#address-cells = <1>;
@@ -99,5 +101,21 @@
 		__overlay__ {
 			status = "disabled";
 		};
+	};
+
+	fragment@4 {
+		target = <&gpio>;
+		__overlay__ {
+			ad7124_irq_pin: ad7124_irq_pin {
+				brcm,pins = <19>; /* default IRQ GPIO, matches interrupts */
+				brcm,function = <0>; /* input */
+				brcm,pull = <2>; /* pull-up */
+			};
+		};
+	};
+
+	__overrides__ {
+		irq_gpio = <&ad7124>,"interrupts:0",
+			   <&ad7124_irq_pin>,"brcm,pins:0";
 	};
 };

--- a/arch/arm/boot/dts/overlays/rpi-cn0508-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-cn0508-overlay.dts
@@ -3,7 +3,7 @@
 /plugin/;
 
 / {
-	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709";
+	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709", "brcm,bcm2712";
 
 	fragment@0 {
 		target = <&spi0_cs_pins>;
@@ -75,12 +75,14 @@
 			#size-cells = <0>;
 			status = "okay";
 
-			adc@1 {
+			ad7124: adc@1 {
 				compatible = "adi,ad7124-4";
 				reg = <1>;
 				spi-max-frequency = <5000000>;
-				interrupts = <23 2>;
+				interrupts = <23 8>; // active-low level
 				interrupt-parent = <&gpio>;
+				pinctrl-names = "default";
+				pinctrl-0 = <&cn0508_irq_pin>;
 				refin1-supply = <&vref>;
 
 				#address-cells = <1>;
@@ -227,6 +229,17 @@
 				compatible = "gpio-backlight";
 				gpios = <&stmpe_gpio 2 0>;
 				default-on;
+			};
+		};
+	};
+
+	fragment@10 {
+		target = <&gpio>;
+		__overlay__ {
+			cn0508_irq_pin: cn0508_irq_pin {
+				brcm,pins = <23>; /* IRQ GPIO */
+				brcm,function = <0>; /* input */
+				brcm,pull = <2>; /* pull-up */
 			};
 		};
 	};

--- a/arch/arm/boot/dts/overlays/rpi-cn0554-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-cn0554-overlay.dts
@@ -11,7 +11,7 @@
 #include <dt-bindings/gpio/gpio.h>
 
 / {
-	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709";
+	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709", "brcm,bcm2712";
 };
 
 &{/} {
@@ -54,6 +54,14 @@
 	status = "disabled";
 };
 
+&gpio {
+	cn0554_irq_pin: cn0554_irq_pin {
+		brcm,pins = <25>; /* IRQ GPIO */
+		brcm,function = <0>; /* input */
+		brcm,pull = <2>; /* pull-up */
+	};
+};
+
 &spi0 {
 	#address-cells = <1>;
 	#size-cells = <0>;
@@ -67,8 +75,10 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 
-		interrupts = <25 2>;
+		interrupts = <25 8>; // active-low level
 		interrupt-parent = <&gpio>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&cn0554_irq_pin>;
 
 		refin1-supply = <&vref>;
 

--- a/arch/arm/boot/dts/overlays/rpi-cn0556-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-cn0556-overlay.dts
@@ -12,7 +12,7 @@
 #include <dt-bindings/gpio/gpio.h>
 
 / {
-	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709";
+	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709", "brcm,bcm2712";
 };
 
 &{/} {
@@ -82,6 +82,14 @@
 	status = "disabled";
 };
 
+&gpio {
+	cn0556_irq_pin: cn0556_irq_pin {
+		brcm,pins = <25>; /* IRQ GPIO */
+		brcm,function = <0>; /* input */
+		brcm,pull = <2>; /* pull-up */
+	};
+};
+
 &spi0 {
 	#address-cells = <1>;
 	#size-cells = <0>;
@@ -95,8 +103,10 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 
-		interrupts = <25 2>;
+		interrupts = <25 8>; // active-low level
 		interrupt-parent = <&gpio>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&cn0556_irq_pin>;
 
 		refin1-supply = <&vref>;
 


### PR DESCRIPTION
## PR Description

This PR fixes AD7124 overlay for Pi5 for:
- the ad7124-8-all-diff overlay.
- the ad7124 overlay.
- the cn0554 overlay.
- the cn0556 overlay.
- the cn0508 overlay.

These overlays were tested with their respective boards, and interrupt pins were changed to the expected default where it wasn't. Override support was added where it was due.
For testing Pi4 was also used beside Pi5 to assure changes are working on both.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
