### PR TITLE
arm64: Adding new node for UARTLITE

### DIFF
--- a/arch/arm64/boot/dts/xilinx/vu11p-ad9084-vpx-reva-204C_M4_L8_NP16_8p0_4x2.dtso
+++ b/arch/arm64/boot/dts/xilinx/vu11p-ad9084-vpx-reva-204C_M4_L8_NP16_8p0_4x2.dtso
@@ -290,6 +290,20 @@
 		xlnx,tri-default-2 = <0xFFFFFFFF>;
 	};
 
+	axi_uart: serial@88180000 {
+		compatible = "xlnx,axi-uartlite-2.0", "xlnx,xps-uartlite-1.00.a";
+		reg = <0x0 0x88180000 0x0 0x1000>;
+		clock-names = "s_axi_aclk";
+		clocks = <&mig_clkout1>;
+		clock-frequency = <100000000>;
+		current-speed = <115200>;
+		status = "okay";
+		device_type = "serial";
+		interrupt-parent = <&axi_intc_0>;
+		interrupts = <0 1>;
+		interrupt-names = "interrupt";
+	};
+
 	axi_iic_main: i2c@88150000 {
 		clock-frequency = <100000000>;
 		clocks = <&mig_clkout1>;

--- a/arch/arm64/boot/dts/xilinx/vu11p-ad9084-vpx-reva.dtso
+++ b/arch/arm64/boot/dts/xilinx/vu11p-ad9084-vpx-reva.dtso
@@ -291,6 +291,20 @@
 		xlnx,tri-default-2 = <0xFFFFFFFF>;
 	};
 
+	axi_uart: serial@88180000 {
+		compatible = "xlnx,axi-uartlite-2.0", "xlnx,xps-uartlite-1.00.a";
+		reg = <0x0 0x88180000 0x0 0x1000>;
+		clock-names = "s_axi_aclk";
+		clocks = <&mig_clkout1>;
+		clock-frequency = <100000000>;
+		current-speed = <115200>;
+		status = "okay";
+		device_type = "serial";
+		interrupt-parent = <&axi_intc_0>;
+		interrupts = <0 1>;
+		interrupt-names = "interrupt";
+	};
+
 	axi_iic_main: i2c@88150000 {
 		clock-frequency = <100000000>;
 		clocks = <&mig_clkout1>;

--- a/arch/arm64/boot/dts/xilinx/vu11p-ad9084-vpx-revb-204C_M4_L4_NP16_8p0_2x2.dtso
+++ b/arch/arm64/boot/dts/xilinx/vu11p-ad9084-vpx-revb-204C_M4_L4_NP16_8p0_2x2.dtso
@@ -331,6 +331,20 @@
 		xlnx,tri-default-2 = <0xFFFFFFFF>;
 	};
 
+	axi_uart: serial@88180000 {
+		compatible = "xlnx,axi-uartlite-2.0", "xlnx,xps-uartlite-1.00.a";
+		reg = <0x0 0x88180000 0x0 0x1000>;
+		clock-names = "s_axi_aclk";
+		clocks = <&mig_clkout1>;
+		clock-frequency = <100000000>;
+		current-speed = <115200>;
+		status = "okay";
+		device_type = "serial";
+		interrupt-parent = <&axi_intc_0>;
+		interrupts = <0 1>;
+		interrupt-names = "interrupt";
+	};
+
 	axi_iic_main: i2c@88150000 {
 		clock-frequency = <100000000>;
 		clocks = <&mig_clkout1>;

--- a/arch/arm64/boot/dts/xilinx/vu11p-ad9084-vpx-revb-204C_M4_L8_NP16_8p0_4x2.dtso
+++ b/arch/arm64/boot/dts/xilinx/vu11p-ad9084-vpx-revb-204C_M4_L8_NP16_8p0_4x2.dtso
@@ -406,6 +406,20 @@
 		xlnx,tri-default-2 = <0xFFFFFFFF>;
 	};
 
+	axi_uart: serial@88180000 {
+		compatible = "xlnx,axi-uartlite-2.0", "xlnx,xps-uartlite-1.00.a";
+		reg = <0x0 0x88180000 0x0 0x1000>;
+		clock-names = "s_axi_aclk";
+		clocks = <&mig_clkout1>;
+		clock-frequency = <100000000>;
+		current-speed = <115200>;
+		status = "okay";
+		device_type = "serial";
+		interrupt-parent = <&axi_intc_0>;
+		interrupts = <0 1>;
+		interrupt-names = "interrupt";
+	};
+
 	axi_iic_main: i2c@88150000 {
 		clock-frequency = <100000000>;
 		clocks = <&mig_clkout1>;

--- a/arch/arm64/boot/dts/xilinx/vu11p-ad9084-vpx-revb.dtso
+++ b/arch/arm64/boot/dts/xilinx/vu11p-ad9084-vpx-revb.dtso
@@ -374,6 +374,20 @@
 		xlnx,tri-default-2 = <0xFFFFFFFF>;
 	};
 
+	axi_uart: serial@88180000 {
+		compatible = "xlnx,axi-uartlite-2.0", "xlnx,xps-uartlite-1.00.a";
+		reg = <0x0 0x88180000 0x0 0x1000>;
+		clock-names = "s_axi_aclk";
+		clocks = <&mig_clkout1>;
+		clock-frequency = <100000000>;
+		current-speed = <115200>;
+		status = "okay";
+		device_type = "serial";
+		interrupt-parent = <&axi_intc_0>;
+		interrupts = <0 1>;
+		interrupt-names = "interrupt";
+	};
+
 	axi_iic_main: i2c@88150000 {
 		clock-frequency = <100000000>;
 		clocks = <&mig_clkout1>;


### PR DESCRIPTION
## PR Description
Changes: all device trees for vu11p-ad9084-vpx now have a new node for the uartlite.


## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [x] I have updated the documentation outside this repo accordingly
- [x] I have provided links for the relevant upstream lore
