### PR TITLE
iio: trx-rf: ad9088: Fix uninitialized dev_clk local variable in probe

### DIFF
--- a/drivers/iio/trx-rf/ad9088/ad9088.c
+++ b/drivers/iio/trx-rf/ad9088/ad9088.c
@@ -5491,9 +5491,9 @@ static int ad9088_probe(struct spi_device *spi)
 	priv = jesd204_dev_priv(jdev);
 	priv->phy = phy;
 
-	phy->dev_clk = devm_clk_get(&conv->spi->dev, "dev_clk");
-	if (IS_ERR(phy->dev_clk))
-		return PTR_ERR(phy->dev_clk);
+	dev_clk = devm_clk_get(&conv->spi->dev, "dev_clk");
+	if (IS_ERR(dev_clk))
+		return PTR_ERR(dev_clk);
 
 	conv->reset_gpio = devm_gpiod_get_optional(&spi->dev, "reset", GPIOD_OUT_HIGH);
 	if (IS_ERR(conv->reset_gpio))
@@ -5546,11 +5546,9 @@ static int ad9088_probe(struct spi_device *spi)
 
 	of_clk_get_scale(spi->dev.of_node, "dev_clk", &devclk_clkscale);
 
-	clk_set_rate_scaled(phy->dev_clk,
-			    phy->profile.clk_cfg.dev_clk_freq_Hz,
-			    &devclk_clkscale);
+	clk_set_rate_scaled(dev_clk, phy->profile.clk_cfg.dev_clk_freq_Hz, &devclk_clkscale);
 
-	ret = clk_prepare_enable(phy->dev_clk);
+	ret = clk_prepare_enable(dev_clk);
 	if (ret)
 		return ret;
 

--- a/drivers/iio/trx-rf/ad9088/ad9088.h
+++ b/drivers/iio/trx-rf/ad9088/ad9088.h
@@ -220,7 +220,7 @@ struct ad9088_phy {
 	adi_apollo_top_t profile;
 	adi_cms_chip_id_t chip_id;
 	struct axiadc_chip_info chip_info;
-	struct clk *dev_clk;
+
 	struct bin_attribute pfilt;
 	struct bin_attribute cfir;
 	struct bin_attribute cal_data;


### PR DESCRIPTION
Commit 92e2dcab5218 ("iio: trx-rf: ad9088: Update API v2.0.10, FW v2.0.6, device-profile v10.1.3") stored the dev_clk pointer in struct ad9088_phy and used phy->dev_clk for get/configure/enable, but probe() already had a local `dev_clk` variable that is passed to __clk_get_name() later. This left the local variable uninitialized, triggering a -Wuninitialized warning and potential undefined behavior.

Fix this by using the local variable consistently and dropping the now-unused struct member.

Fixes: 92e2dcab5218 ("iio: trx-rf: ad9088: Update API v2.0.10, FW v2.0.6, device-profile v10.1.3")

## PR Description

- Please replace this comment with a summary of your changes, and add any context
necessary to understand them. List any dependencies required for this change.
- To check the checkboxes below, insert a 'x' between square brackets (without
any space), or simply check them after publishing the PR.
- If you changes include a breaking change, please specify dependent PRs in the
description and try to push all related PRs simultaneously.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have compiled my changes, including the documentation
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
