### PR TITLE
serial: adi_uart4: require built in driver for console

### DIFF
--- a/drivers/tty/serial/Kconfig
+++ b/drivers/tty/serial/Kconfig
@@ -481,7 +481,7 @@ config SERIAL_ADI_UART4
 
 config SERIAL_ADI_UART4_CONSOLE
 	bool "Console on ADI uart4 serial port"
-	depends on SERIAL_ADI_UART4
+	depends on SERIAL_ADI_UART4=y
 	default y
 	select SERIAL_CORE_CONSOLE
 	select SERIAL_EARLYCON


### PR DESCRIPTION
SERIAL_ADI_UART4_CONSOLE selects SERIAL_EARLYCON, but only
depended on SERIAL_ADI_UART4. This allowed the UART driver and
serial core to be built as modules while earlycon was built into
vmlinux, causing a link failure during CI checks.
    
earlycon.c:(.init.text+0x1e0): undefined reference to `uart_parse_earlycon'
    
Require SERIAL_ADI_UART4=y for console support so earlycon is only
enabled when the ADI UART4 driver and serial core are built into
the kernel.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore