### PR TITLE
.github: delete-stale-from-cloudsmith: Add job

### DIFF
--- a/.github/workflows/delete-stale-from-cloudsmith.yml
+++ b/.github/workflows/delete-stale-from-cloudsmith.yml
@@ -1,0 +1,27 @@
+name: Delete stale artifacts from cloudsmith
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Number of days for branch packages'
+        type: number
+        default: 0
+      pr:
+        description: 'Number of days for pull request packages'
+        type: number
+        default: 90
+
+jobs:
+  delete-stale:
+    uses: analogdevicesinc/linux/.github/workflows/delete-stale-from-cloudsmith.yml@ci
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: read
+    secrets:
+      CLOUDSMITH_SERVICE_SLUG: ${{ secrets.CLOUDSMITH_SERVICE_SLUG }}
+      CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
+    with:
+      branch: ${{ inputs.branch }}
+      pr: ${{ inputs.pr }}


### PR DESCRIPTION
## PR Description

Adds cron job to clean-up stale artifacts on cloudsmith. Is considered a stale artifact if is from a closed pull request older than X days, and from a branch older than Y days. For branches is set to 0 ("never").

The branch case is the reason for this being a draft: by date on branch is terrible.
I though about:
- having a min value for branch, e.g., 3 years.
- distributed removal: before X time, keep only 5 commit per month, Y 1 commit per month
- 
Still, be can consider these intermediary artifacts, were we only preserve on the 'used for' end, e.g. kuiper images, and let these be deleted.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have compiled my changes, including the documentation
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
