### PR TITLE
ARM: dts: overlays: Add cs_pin and irq_gpio overrides to AD7124 overlays

### DIFF
--- a/arch/arm/boot/dts/overlays/rpi-ad7124-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-ad7124-overlay.dts
@@ -115,6 +115,7 @@
 	};
 
 	__overrides__ {
+		cs_pin   = <&ad7124>,"reg:0";
 		irq_gpio = <&ad7124>,"interrupts:0",
 			   <&ad7124_irq_pin>,"brcm,pins:0";
 	};

--- a/arch/arm/boot/dts/overlays/rpi-cn0508-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-cn0508-overlay.dts
@@ -36,6 +36,10 @@
 		rotate =  <&pitft>,"rotate:0";
 		fps =     <&pitft>,"fps:0";
 		debug =   <&pitft>,"debug:0";
+
+		cs_pin   = <&ad7124>,"reg:0";
+		irq_gpio = <&ad7124>,"interrupts:0",
+			   <&cn0508_irq_pin>,"brcm,pins:0";
 	};
 
 	fragment@2 {

--- a/arch/arm/boot/dts/overlays/rpi-cn0554-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-cn0554-overlay.dts
@@ -12,6 +12,12 @@
 
 / {
 	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709", "brcm,bcm2712";
+
+	__overrides__ {
+		cs_pin   = <&adc7214>,"reg:0";
+		irq_gpio = <&adc7214>,"interrupts:0",
+			   <&cn0554_irq_pin>,"brcm,pins:0";
+	};
 };
 
 &{/} {

--- a/arch/arm/boot/dts/overlays/rpi-cn0556-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-cn0556-overlay.dts
@@ -13,6 +13,12 @@
 
 / {
 	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709", "brcm,bcm2712";
+
+	__overrides__ {
+		cs_pin   = <&ad7124>,"reg:0";
+		irq_gpio = <&ad7124>,"interrupts:0",
+			   <&cn0556_irq_pin>,"brcm,pins:0";
+	};
 };
 
 &{/} {


### PR DESCRIPTION
## PR Description

Ensure all AD7124-related overlays expose consistent __overrides__ for both the SPI chip-select and IRQ GPIO pins:

- rpi-ad7124: add cs_pin (irq_gpio was already present)
- rpi-cn0554: add __overrides__ with cs_pin and irq_gpio
- rpi-cn0556: add __overrides__ with cs_pin and irq_gpio
- rpi-cn0508: add cs_pin and irq_gpio to existing __overrides__

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
