### PR TITLE
ci: fix: Check defconfig before running build

### DIFF
--- a/ci/travis/run-build.sh
+++ b/ci/travis/run-build.sh
@@ -180,6 +180,17 @@ build_default() {
 	[ -d /docker_build_dir ] && git config --global --add safe.directory /docker_build_dir
 
 	make ${DEFCONFIG}
+
+	# Verify defconfig is coherent before building. Saves some CI time.
+	make savedefconfig
+	mv defconfig arch/$ARCH/configs/$DEFCONFIG
+
+	git diff --exit-code || {
+		__echo_red "Defconfig file should be updated: 'arch/$ARCH/configs/$DEFCONFIG'"
+		__echo_red "Run 'make savedefconfig', overwrite it and commit it"
+		return 1
+	}
+
 	if [[ "${SYSTEM_PULLREQUEST_TARGETBRANCH}" =~ ^rpi-.* || "${BUILD_SOURCEBRANCH}" =~ ^refs/heads/rpi-.* \
 		|| "${BUILD_SOURCEBRANCH}" =~ ^refs/heads/staging/rpi/* || "${BUILD_SOURCEBRANCH}" =~ ^refs/heads/rpi/release/* ]]; then
 		echo "Rpi build"
@@ -194,14 +205,6 @@ build_default() {
 		check_all_adi_files_have_been_built
 	fi
 
-	make savedefconfig
-	mv defconfig arch/$ARCH/configs/$DEFCONFIG
-
-	git diff --exit-code || {
-		__echo_red "Defconfig file should be updated: 'arch/$ARCH/configs/$DEFCONFIG'"
-		__echo_red "Run 'make savedefconfig', overwrite it and commit it"
-		return 1
-	}
 }
 
 build_allmodconfig() {


### PR DESCRIPTION
## PR Description

With 'bad' defconfigs, the CI build script previously spent 1-2h building the kernel before failing on the very cheap defconfig check at the very end. Move that check before the expensive kernel build, so defconfig errors are reported much quicker in CI.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have compiled my changes, including the documentation
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
