### PR TITLE
.github/top-level.yml: Gate run condition

### DIFF
--- a/.github/workflows/top-level.yml
+++ b/.github/workflows/top-level.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   checks:
     uses: analogdevicesinc/linux/.github/workflows/checks.yml@ci
+    if: (github.event_name != 'push' || github.repository_owner == 'analogdevicesinc')
     secrets: inherit
     permissions:
       contents: read
@@ -49,6 +50,7 @@ jobs:
       defconfig: "adi_ci_defconfig"
   build_gcc_arm:
     uses: analogdevicesinc/linux/.github/workflows/build.yml@ci
+    if: (github.event_name != 'push' || github.repository_owner == 'analogdevicesinc')
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/top-level.yml
+++ b/.github/workflows/top-level.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - 'main'
-      - 'ci/*'
   pull_request:
 
 jobs:

--- a/.github/workflows/top-level.yml
+++ b/.github/workflows/top-level.yml
@@ -6,6 +6,10 @@ on:
       - 'main'
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   checks:
     uses: analogdevicesinc/linux/.github/workflows/checks.yml@ci


### PR DESCRIPTION
## PR Description

Since we mirror those branches across repositories, we end-up running
those branches at least twice. Add a minimal gate to stop earlier on
pushes to org != analogdevicesinc.

Also clean-up unused rules.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have compiled my changes, including the documentation
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
