### PR TITLE
usb: dwc3: ep0: Add missing DWC3_EP_DELAY_STOP resolution loop

### DIFF
--- a/drivers/usb/dwc3/ep0.c
+++ b/drivers/usb/dwc3/ep0.c
@@ -281,6 +281,7 @@ void dwc3_ep0_out_start(struct dwc3 *dwc)
 {
 	struct dwc3_ep			*dep;
 	int				ret;
+	int				i;
 
 	complete(&dwc->ep0_in_setup);
 
@@ -291,6 +292,22 @@ void dwc3_ep0_out_start(struct dwc3 *dwc)
 	if (ret < 0)
 		dev_err(dwc->dev, "ep0 out start transfer failed: %d\n", ret);
 
+	for (i = 2; i < DWC3_ENDPOINTS_NUM; i++) {
+		struct dwc3_ep *dwc3_ep;
+
+		dwc3_ep = dwc->eps[i];
+		if (!dwc3_ep)
+			continue;
+
+		if (!(dwc3_ep->flags & DWC3_EP_DELAY_STOP))
+			continue;
+
+		dwc3_ep->flags &= ~DWC3_EP_DELAY_STOP;
+		if (dwc->connected)
+			dwc3_stop_active_transfer(dwc3_ep, true, true);
+		else
+			dwc3_remove_requests(dwc, dwc3_ep, -ESHUTDOWN);
+	}
 }
 
 static struct dwc3_ep *dwc3_wIndex_to_dep(struct dwc3 *dwc, __le16 wIndex_le)

--- a/drivers/usb/dwc3/gadget.c
+++ b/drivers/usb/dwc3/gadget.c
@@ -4047,7 +4047,6 @@ void dwc3_stop_active_transfer(struct dwc3_ep *dep, bool force,
 		return;
 
 	if (!(dep->flags & DWC3_EP_TRANSFER_STARTED) ||
-	    (dep->flags & DWC3_EP_DELAY_STOP) ||
 	    (dep->flags & DWC3_EP_END_TRANSFER_PENDING))
 		return;
 


### PR DESCRIPTION
The 6.12 stable merge re-introduced DWC3_EP_DELAY_STOP checks in gadget.c but more importantly failed to carry over the corresponding resolution loop in dwc3_ep0_out_start() from ep0.c. This loop is necessary and was previously present via commit 787dc7688196 ("Revert "usb: dwc3: fixed OTG feature failure for xilinx platform"") but was lost during the merge.

The DWC3_EP_DELAY_STOP mechanism has two parts:
 1. dwc3_stop_active_transfer() defers the END_TRANSFER command when ep0 is not in SETUP phase (a Setup packet being processed would block the command), setting DWC3_EP_DELAY_STOP on the endpoint.
 2. dwc3_ep0_out_start() iterates all endpoints when ep0 returns to SETUP phase, clears DWC3_EP_DELAY_STOP, and retries the stop.

Without part 2, any bulk endpoint that gets DELAY_STOP set during a vendor control transfer (e.g. FunctionFS setup requests) will never have its END_TRANSFER issued. The cancelled USB requests remain on the endpoint's cancelled_list permanently, dwc3_gadget_giveback() is never called, and the FunctionFS async I/O completion callback never fires.

While at it, remove the useless (dep->flags & DWC3_EP_DELAY_STOP) check in dwc3_stop_active_transfer().

Fixes: ad44626f834c ("Merge tag 'xlnx_rebase_v6.12_LTS_2025.1_update_merge_6.12.60' of https://github.com/Xilinx/linux-xlnx.git")

## PR Description

- Please replace this comment with a summary of your changes, and add any context
necessary to understand them. List any dependencies required for this change.
- To check the checkboxes below, insert a 'x' between square brackets (without
any space), or simply check them after publishing the PR.
- If you changes include a breaking change, please specify dependent PRs in the
description and try to push all related PRs simultaneously.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have compiled my changes, including the documentation
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
