### PR TITLE
serial: adi-uart4: avoid jiffies timeout under spin_lock_irqsave()

### DIFF
--- a/drivers/tty/serial/adi_uart4.c
+++ b/drivers/tty/serial/adi_uart4.c
@@ -19,6 +19,7 @@
 #include <linux/err.h>
 #include <linux/gpio.h>
 #include <linux/io.h>
+#include <linux/iopoll.h>
 #include <linux/init.h>
 #include <linux/irq.h>
 #include <linux/module.h>
@@ -744,7 +745,8 @@ static void adi_uart4_serial_set_termios(struct uart_port *port,
 	unsigned long flags;
 	unsigned int baud, quot;
 	unsigned int ier, lcr = 0;
-	unsigned long timeout;
+	u32 val;
+	int ret;
 
 	if (uart->hwflow_mode == ADI_UART_HWFLOW_PERI)
 		termios->c_cflag |= CRTSCTS;
@@ -818,23 +820,13 @@ static void adi_uart4_serial_set_termios(struct uart_port *port,
 		quot = uart_get_divisor(port, baud);
 	}
 
-	/* Wait till the transfer buffer is empty */
-	timeout = jiffies + msecs_to_jiffies(10);
-	while (UART_GET_GCTL(uart) & UCEN && !(UART_GET_LSR(uart) & TEMT))
-		if (time_after(jiffies, timeout)) {
-			dev_warn(port->dev,
-				"timeout waiting for TX buffer empty\n");
-			break;
-		}
-
-	/* Wait till the transfer buffer is empty */
-	timeout = jiffies + msecs_to_jiffies(10);
-	while (UART_GET_GCTL(uart) & UCEN && !(UART_GET_LSR(uart) & TEMT))
-		if (time_after(jiffies, timeout)) {
-			dev_warn(port->dev,
-				"timeout waiting for TX buffer empty\n");
-			break;
-		}
+	/* Wait up to 10 ms for any active TX to complete. */
+	ret = readl_poll_timeout_atomic(uart->port.membase + OFFSET_CTL, val,
+					(!(val & UCEN) ||
+					(UART_GET_LSR(uart) & TEMT)),
+					1, 10000);
+	if (ret)
+		dev_warn(port->dev, "timeout waiting for TX buffer empty\n");
 
 	/* Disable UART */
 	ier = UART_GET_IER(uart);


### PR DESCRIPTION
adi_uart4_serial_set_termios() applies new termios settings such as baud rate, parity and stop bits. Before reprogramming the UART registers, it waits for any active TX to complete so the settings are not changed mid transfer.

That wait is done while holding a spin lock with interrupts disabled via spin_lock_irqsave(). The driver has a safety mechanism in the loop where it waits for a maximum of 10 ms:

        timeout = jiffies + msecs_to_jiffies(10);
        while (UART_GET_GCTL(uart) & UCEN && !(UART_GET_LSR(uart) & TEMT))
                if (time_after(jiffies, timeout)) {
                        dev_warn(port->dev,
                                "timeout waiting for TX buffer empty\n");
                        break;
                }

However this approach is problematic because on single core systems, jiffies may not advance while interrupts are disabled (jiffies is advanced through timer interrupts), making the timeout approach unreliable if TX does not drain for some reason.

To confirm this behaviour on single core systems I wrote a small program to validate if jiffies was being advanced on the ADSP-SC589-MINI and it did not while holding the spin lock.

Use readl_poll_timeout_atomic() instead, which is suitable for atomic contexts and is suitable when timekeeping is disabled.

This fix also removes the duplicated TX empty wait loop which seems to be an accidental copy+paste issue.


## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
