### PR TITLE
serial: adi_uart4: fix NULL dereference and error path resource leaks…

### DIFF
--- a/drivers/tty/serial/adi_uart4.c
+++ b/drivers/tty/serial/adi_uart4.c
@@ -640,10 +640,6 @@ static int adi_uart4_serial_startup(struct uart_port *port)
 
 	uart->tx_done = 1;
 
-	ret = clk_prepare_enable(uart->clk);
-	if (ret)
-		return ret;
-
 	if (!IS_ERR(uart->tx_dma_channel)) {
 		/* RX channel:
 		 *	- src_addr is not configured because we're attached to
@@ -653,7 +649,7 @@ static int adi_uart4_serial_startup(struct uart_port *port)
 			&uart->rx_dma_phy, GFP_KERNEL);
 		if (!uart->rx_dma_buf.buf) {
 			ret = -ENOMEM;
-			goto err_disable_clk;
+			return ret;
 		}
 
 		uart->rx_dma_buf.head = 0;
@@ -731,13 +727,11 @@ err_unmap_tx_dma:
 	dma_unmap_single(uart->dev, uart->tx_dma_phy, UART_XMIT_SIZE,
 			DMA_TO_DEVICE);
 err_stop_rx_dma:
-	timer_delete(&uart->rx_dma_timer);
+	timer_delete_sync(&uart->rx_dma_timer);
 	dmaengine_terminate_sync(uart->rx_dma_channel);
 err_free_rx_dma_buf:
 	dmam_free_coherent(uart->dev, UART_XMIT_SIZE,
 			uart->rx_dma_buf.buf, uart->rx_dma_phy);
-err_disable_clk:
-	clk_disable_unprepare(uart->clk);
 	return ret;
 }
 
@@ -754,10 +748,8 @@ static void adi_uart4_serial_shutdown(struct uart_port *port)
 				DMA_TO_DEVICE);
 		dmam_free_coherent(uart->dev, UART_XMIT_SIZE,
 				uart->rx_dma_buf.buf, uart->rx_dma_phy);
-		timer_delete(&uart->rx_dma_timer);
+		timer_delete_sync(&uart->rx_dma_timer);
 	}
-
-	clk_disable_unprepare(uart->clk);
 }
 
 static void adi_uart4_serial_set_termios(struct uart_port *port,
@@ -1011,7 +1003,7 @@ static void adi_uart4_serial_console_putchar(struct uart_port *port,
 	UART_PUT_CHAR(uart, ch);
 }
 
-static void __init
+static void
 adi_uart4_serial_console_get_options(struct adi_uart4_serial_port *uart,
 		int *baud, int *parity, int *bits)
 {
@@ -1058,7 +1050,7 @@ adi_uart4_serial_console_write(struct console *co, const char *s,
 
 }
 
-static int __init
+static int
 adi_uart4_serial_console_setup(struct console *co, char *options)
 {
 	struct adi_uart4_serial_port *uart;
@@ -1275,6 +1267,10 @@ static int adi_uart4_serial_probe(struct platform_device *pdev)
 	uart = adi_uart4_serial_ports[uartid];
 	uart->port.dev = &pdev->dev;
 
+	ret = clk_prepare_enable(uart->clk);
+	if (ret)
+		goto out_error;
+
 	ret = uart_add_one_port(&adi_uart4_serial_reg, &uart->port);
 	if (!ret) {
 		dev_set_drvdata(&pdev->dev, uart);
@@ -1299,6 +1295,7 @@ static void adi_uart4_serial_remove(struct platform_device *pdev)
 	dev_set_drvdata(&pdev->dev, NULL);
 	if (uart) {
 		uart_remove_one_port(&adi_uart4_serial_reg, &uart->port);
+		clk_disable_unprepare(uart->clk);
 		adi_uart4_serial_ports[uart->port.line] = NULL;
 
 		if (!IS_ERR(uart->tx_dma_channel)) {

--- a/drivers/tty/serial/adi_uart4.c
+++ b/drivers/tty/serial/adi_uart4.c
@@ -651,8 +651,10 @@ static int adi_uart4_serial_startup(struct uart_port *port)
 		 */
 		uart->rx_dma_buf.buf = dmam_alloc_coherent(uart->dev, UART_XMIT_SIZE,
 			&uart->rx_dma_phy, GFP_KERNEL);
-		if (!uart->rx_dma_buf.buf)
-			return -ENOMEM;
+		if (!uart->rx_dma_buf.buf) {
+			ret = -ENOMEM;
+			goto err_disable_clk;
+		}
 
 		uart->rx_dma_buf.head = 0;
 		uart->rx_dma_buf.tail = 0;
@@ -666,12 +668,17 @@ static int adi_uart4_serial_startup(struct uart_port *port)
 		ret = dmaengine_slave_config(uart->rx_dma_channel, &dma_config);
 		if (ret) {
 			dev_err(uart->dev, "Error configuring RX DMA channel\n");
-			return -EINVAL;
+			goto err_free_rx_dma_buf;
 		}
 
 		desc = dmaengine_prep_dma_cyclic(uart->rx_dma_channel,
 				uart->rx_dma_phy, UART_XMIT_SIZE, DMA_RX_XCOUNT,
 				DMA_DEV_TO_MEM, DMA_PREP_INTERRUPT);
+		if (!desc) {
+			dev_err(uart->dev, "Error preparing RX DMA cyclic\n");
+			ret = -ENODEV;
+			goto err_free_rx_dma_buf;
+		}
 		desc->callback = adi_uart4_serial_dma_rx;
 		desc->callback_param = uart;
 
@@ -690,8 +697,10 @@ static int adi_uart4_serial_startup(struct uart_port *port)
 				tport->xmit_buf,
 				UART_XMIT_SIZE,
 				DMA_TO_DEVICE);
-		if (dma_mapping_error(uart->dev, uart->tx_dma_phy))
-			return -ENOMEM;
+		if (dma_mapping_error(uart->dev, uart->tx_dma_phy)) {
+			ret = -ENOMEM;
+			goto err_stop_rx_dma;
+		}
 
 		uart->port.fifosize = UART_XMIT_SIZE;
 
@@ -705,7 +714,7 @@ static int adi_uart4_serial_startup(struct uart_port *port)
 		ret = dmaengine_slave_config(uart->tx_dma_channel, &dma_config);
 		if (ret) {
 			dev_err(uart->dev, "Error configuring TX DMA channel\n");
-			return -EINVAL;
+			goto err_unmap_tx_dma;
 		}
 	}
 
@@ -717,6 +726,19 @@ static int adi_uart4_serial_startup(struct uart_port *port)
 
 	UART_SET_IER(uart, ERBFI);
 	return 0;
+
+err_unmap_tx_dma:
+	dma_unmap_single(uart->dev, uart->tx_dma_phy, UART_XMIT_SIZE,
+			DMA_TO_DEVICE);
+err_stop_rx_dma:
+	timer_delete(&uart->rx_dma_timer);
+	dmaengine_terminate_sync(uart->rx_dma_channel);
+err_free_rx_dma_buf:
+	dmam_free_coherent(uart->dev, UART_XMIT_SIZE,
+			uart->rx_dma_buf.buf, uart->rx_dma_phy);
+err_disable_clk:
+	clk_disable_unprepare(uart->clk);
+	return ret;
 }
 
 static void adi_uart4_serial_shutdown(struct uart_port *port)


### PR DESCRIPTION
## PR Description

gcc-fanalyzer flagged a NULL dereference on desc — dmaengine_prep_dma_cyclic() can return NULL and we just blindly assign desc->callback without checking.

While fixing that I noticed all the error paths in adi_uart4_serial_startup() are broken too. Every early return after clk_prepare_enable() leaks the clock, and later failures dont clean up DMA buffers or mappings.

Fixed by adding goto-based cleanup like upstream does (same pattern as atmel_serial.c). Each failure point now unwinds exactly what was allocated before it. Also added a dev_err so we actually get a log message if cyclic prep fails.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
