### PR TITLE
spi: adi: Fix error handling for dma_request_chan return value

### DIFF
--- a/drivers/spi/spi-adi.c
+++ b/drivers/spi/spi-adi.c
@@ -792,15 +792,15 @@ static int adi_spi_probe(struct platform_device *pdev)
 	iowrite32(SPI_IMSK_SET_ROM, &drv_data->regs->emaskst);
 
 	controller->dma_tx = dma_request_chan(dev, "tx");
-	if (!controller->dma_tx) {
+	if (IS_ERR(controller->dma_tx)) {
 		dev_err(dev, "Could not get TX DMA channel\n");
-		return -ENOENT;
+		return PTR_ERR(controller->dma_tx);
 	}
 
 	controller->dma_rx = dma_request_chan(dev, "rx");
-	if (!controller->dma_rx) {
+	if (IS_ERR(controller->dma_rx)) {
 		dev_err(dev, "Could not get RX DMA channel\n");
-		ret = -ENOENT;
+		ret = PTR_ERR(controller->dma_rx);
 		goto err_free_tx_dma;
 	}
 


### PR DESCRIPTION
  dma_request_chan() returns ERR_PTR on failure, never NULL. The existing
  NULL checks allowed error pointers to be stored as valid DMA channels,
  leading to a kernel panic in adi_spi_prepare_message when the pointer
  was later dereferenced.

  Use IS_ERR() and PTR_ERR() instead.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
