### PR TITLE
iio: core: Don't free buffer0 blocks when it's still in use via buffer fd API

### DIFF
--- a/drivers/iio/industrialio-core.c
+++ b/drivers/iio/industrialio-core.c
@@ -1800,7 +1800,16 @@ static int iio_chrdev_release(struct inode *inode, struct file *filp)
 	kfree(ib);
 	clear_bit(IIO_BUSY_BIT_POS, &iio_dev_opaque->flags);
 #ifdef CONFIG_IIO_DMA_BUF_MMAP_LEGACY
-	if (indio_dev->buffer)
+	/*
+	 * Only free buffer0 blocks if it was being used through the legacy
+	 * chrdev API. If buffer0 was opened through the new per-buffer fd API
+	 * (IIO_BUFFER_GET_FD_IOCTL), its blocks are managed by the buffer's
+	 * own fd and will be freed in iio_buffer_chrdev_release() instead.
+	 * Without this check, opening any other buffer's fd (which requires
+	 * opening and closing /dev/iio:deviceN) would destroy buffer0's
+	 * blocks and kill an active stream.
+	 */
+	if (indio_dev->buffer && !test_bit(IIO_BUSY_BIT_POS, &indio_dev->buffer->flags))
 		iio_buffer_free_blocks(indio_dev->buffer);
 #endif
 	iio_device_put(indio_dev);


### PR DESCRIPTION
When a user opens /dev/iio:deviceN to issue IIO_BUFFER_GET_FD_IOCTL for any buffer (including buffer0), the chrdev must be opened and then closed. On close, iio_chrdev_release() unconditionally frees buffer0's mmap blocks via iio_buffer_free_blocks().

This is wrong when buffer0 is actively streaming through its own per-buffer fd — the chrdev close destroys the blocks and kills the stream.

Guard the iio_buffer_free_blocks() call by checking buffer0's IIO_BUSY_BIT_POS flag. If buffer0's fd is still open and active, its blocks are managed by the buffer's own fd and will be freed in iio_buffer_chrdev_release() instead.

This becomes a problem with multi buffer support when userspace (rightfully) opens the main chardev to get the buffer handle and then closes it again.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have compiled my changes, including the documentation
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
