### PR TITLE
spi: spidev: Remove noisy type changes

### DIFF
--- a/drivers/spi/spidev.c
+++ b/drivers/spi/spidev.c
@@ -75,7 +75,7 @@ struct spidev_data {
 
 	/* TX/RX buffers are NULL unless this device is open (users > 0) */
 	struct mutex		buf_lock;
-	unsigned int		users;
+	unsigned		users;
 	u8			*tx_buffer;
 	u8			*rx_buffer;
 	u32			speed_hz;
@@ -84,7 +84,7 @@ struct spidev_data {
 static LIST_HEAD(device_list);
 static DEFINE_MUTEX(device_list_lock);
 
-static unsigned int bufsiz = 4096;
+static unsigned bufsiz = 4096;
 module_param(bufsiz, uint, S_IRUGO);
 MODULE_PARM_DESC(bufsiz, "data bytes in biggest supported SPI message");
 
@@ -208,13 +208,13 @@ spidev_write(struct file *filp, const char __user *buf,
 }
 
 static int spidev_message(struct spidev_data *spidev,
-		struct spi_ioc_transfer *u_xfers, unsigned int n_xfers)
+		struct spi_ioc_transfer *u_xfers, unsigned n_xfers)
 {
 	struct spi_message	msg;
 	struct spi_transfer	*k_xfers;
 	struct spi_transfer	*k_tmp;
 	struct spi_ioc_transfer *u_tmp;
-	unsigned int		n, total, tx_total, rx_total;
+	unsigned		n, total, tx_total, rx_total;
 	u8			*tx_buf, *rx_buf;
 	int			status = -EFAULT;
 
@@ -330,7 +330,7 @@ done:
 
 static struct spi_ioc_transfer *
 spidev_get_ioc_message(unsigned int cmd, struct spi_ioc_transfer __user *u_ioc,
-		unsigned int *n_ioc)
+		unsigned *n_ioc)
 {
 	u32	tmp;
 
@@ -359,7 +359,7 @@ spidev_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 	struct spi_device	*spi;
 	struct spi_controller	*ctlr;
 	u32			tmp;
-	unsigned int		n_ioc;
+	unsigned		n_ioc;
 	struct spi_ioc_transfer	*ioc;
 
 	/* Check type and command number */
@@ -525,7 +525,7 @@ spidev_compat_ioc_message(struct file *filp, unsigned int cmd,
 	int				retval = 0;
 	struct spidev_data		*spidev;
 	struct spi_device		*spi;
-	unsigned int			n_ioc, n;
+	unsigned			n_ioc, n;
 	struct spi_ioc_transfer		*ioc;
 
 	u_ioc = (struct spi_ioc_transfer __user *) compat_ptr(arg);


### PR DESCRIPTION
Although `unsigned int` should be used for new code, updating all instances of `unsigned` to `unsigned int` is unnecessarily noisy. The latest mainline spidev.c mixes both. Drop these changes to reduce conflicts when rebasing on new upstream releases.

Fixes: a47e92c0a11c ("spi: Add v3 SPI controller support for ADSP-SC5xx")