### PR TITLE
microblaze: dts: vcu118: Add console=ttyUL0,115200 to bootargs

### DIFF
--- a/arch/microblaze/boot/dts/vcu118.dtsi
+++ b/arch/microblaze/boot/dts/vcu118.dtsi
@@ -6,7 +6,7 @@
 	compatible = "xlnx,microblaze";
 	model = "Xilinx MicroBlaze";
 	chosen {
-		bootargs = "earlycon";
+		bootargs = "earlycon console=ttyUL0,115200";
 		stdout-path = "serial0:115200n8";
 	};
 	aliases {


### PR DESCRIPTION
## PR Description

The vcu118.dtsi base device tree only specified "earlycon" in the chosen bootargs. While earlycon provides output during early kernel init, it is disabled once the UartLite driver takes over. Without an explicit console= parameter, the kernel falls back to tty0 (virtual terminal) which has no physical backing on MicroBlaze, leaving the UART silent for the remainder of the boot.

Add console=ttyUL0,115200 to the bootargs so the kernel hands off from earlycon to the UartLite console driver seamlessly. This fixes the apparent "boot freeze" seen on all VCU118 MicroBlaze designs (ad9081, ad9082, ad9083, ad9084) where the board appears to stop responding on the serial terminal after the earlycon banner.

Fixes: all vcu118_*.dts targets that inherit from vcu118.dtsi

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ x I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
