### PR TITLE
iio: dac: add ad5706r (part 2)

### DIFF
--- a/Documentation/ABI/testing/sysfs-bus-iio-dac-ad5706r
+++ b/Documentation/ABI/testing/sysfs-bus-iio-dac-ad5706r
@@ -1,0 +1,153 @@
+What:		/sys/bus/iio/devices/iio:deviceX/dev_addr
+KernelVersion:	6.10
+Contact:	linux-iio@vger.kernel.org
+Description:
+		Device address (0-3) used for SPI communication. This 2-bit
+		address is included in the SPI frame at bits [14:13] to select
+		the specific device when multiple AD5706R devices share the same
+		SPI bus. The address is stored in software and applied to SPI
+		transactions.
+
+What:		/sys/bus/iio/devices/iio:deviceX/addr_ascension
+KernelVersion:	6.10
+Contact:	linux-iio@vger.kernel.org
+Description:
+		Address ascension mode for streaming operations. Controls whether
+		the internal register address increments or decrements during
+		consecutive streaming writes. Valid values are:
+		- "increment": Address increments after each transfer
+		- "decrement": Address decrements after each transfer
+
+		Multibyte registers in "decrement" needs to be accessed from the
+		highest register address first.
+
+		This setting corresponds to bit 5 of the Interface Configuration A register (0x00).
+
+What:		/sys/bus/iio/devices/iio:deviceX/addr_ascension_available
+KernelVersion:	6.10
+Contact:	linux-iio@vger.kernel.org
+Description:
+		Returns the available address ascension modes: "decrement increment"
+
+What:		/sys/bus/iio/devices/iio:deviceX/single_instr
+KernelVersion:	6.10
+Contact:	linux-iio@vger.kernel.org
+Description:
+		Instruction mode for SPI communication. Controls how the device
+		interprets SPI frames. Valid values are:
+		- "streaming": Device expects continuous streaming data transfers
+		- "single_instruction": Each SPI frame is treated as a discrete
+		  instruction with address and data
+
+		This setting corresponds to bit 7 of the Interface Configuration B register (0x01).
+
+What:		/sys/bus/iio/devices/iio:deviceX/single_instr_available
+KernelVersion:	6.10
+Contact:	linux-iio@vger.kernel.org
+Description:
+		Returns the available instruction modes: "streaming single_instruction"
+
+What:		/sys/bus/iio/devices/iio:deviceX/hw_ldac_tg_state
+KernelVersion:	6.10
+Contact:	linux-iio@vger.kernel.org
+Description:
+		Hardware LDAC trigger GPIO state. Controls the logical state of the LDAC trigger pin when using GPIO control. Valid values are:
+		- "low": LDAC pin driven low
+		- "high": LDAC pin driven high
+
+		Setting this on any value overrides the status of hw_ldac_tg_pwm.
+
+		Requires optional PWM device tree configuration for LDAC control.
+
+What:		/sys/bus/iio/devices/iio:deviceX/hw_ldac_tg_state_available
+KernelVersion:	6.10
+Contact:	linux-iio@vger.kernel.org
+Description:
+		Returns the available LDAC GPIO states: "low high"
+
+What:		/sys/bus/iio/devices/iio:deviceX/sampling_frequency
+KernelVersion:	6.10
+Contact:	linux-iio@vger.kernel.org
+Description:
+		PWM frequency in Hz for hardware LDAC triggering. Sets the period
+		of the PWM output used to trigger DAC updates. Valid range depends on PWM hardware capabilities. Default is 1 MHz.
+
+		Requires optional PWM device tree configuration.
+
+What:		/sys/bus/iio/devices/iio:deviceX/hw_ldac_tg_pwm
+KernelVersion:	6.10
+Contact:	linux-iio@vger.kernel.org
+Description:
+		Enable or disable PWM output for hardware LDAC triggering. Valid
+		values are:
+		- "disable": PWM disabled (duty cycle = recent value of hw_ldac_tg_state)
+		- "enable": PWM enabled with 50% duty cycle
+
+		Requires optional PWM device tree configuration.
+
+What:		/sys/bus/iio/devices/iio:deviceX/hw_ldac_tg_pwm_available
+KernelVersion:	6.10
+Contact:	linux-iio@vger.kernel.org
+Description:
+		Returns the available PWM states: "disable enable"
+
+What:		/sys/bus/iio/devices/iio:deviceX/mux_out_sel
+KernelVersion:	6.10
+Contact:	linux-iio@vger.kernel.org
+Description:
+		Multiplexer output selection for diagnostic monitoring. Routes
+		internal analog signals to the MUX_OUT pin for measurement.
+		Valid values include:
+		- "disabled": MUX output disabled
+		- "agnd", "avdd", "vref": Supply and Reference voltages
+		- "iout0_vmon" through "iout3_vmon": load voltage monitors
+		- "iout0_imon" through "iout3_imon": output current monitors
+		- "pvdd0" through "pvdd3": supply voltage monitors
+		- "tdiode_ch0" through "tdiode_ch3": temperature sensor monitors
+		- "mux_in0" through "mux_in3": External MUX inputs
+
+		This setting corresponds to the MUX Output Select register (0x54).
+
+What:		/sys/bus/iio/devices/iio:deviceX/mux_out_sel_available
+KernelVersion:	6.10
+Contact:	linux-iio@vger.kernel.org
+Description:
+		Returns all 24 available multiplexer output options.
+
+What:		/sys/bus/iio/devices/iio:deviceX/multi_dac_input_a
+KernelVersion:	6.10
+Contact:	linux-iio@vger.kernel.org
+Description:
+		Multi-DAC Input A register value in a 16bit hexadecimal format.
+		When used with multi-DAC selection, this value is loaded into the
+		selected channels' input registers. Write operations update the
+		Multi-DAC Input A register (0x5C).
+
+What:		/sys/bus/iio/devices/iio:deviceX/multi_dac_sw_ldac_trigger
+KernelVersion:	6.10
+Contact:	linux-iio@vger.kernel.org
+Description:
+		Software trigger for multi-DAC LDAC update. Writing "trigger" triggers a software LDAC pulse that simultaneously updates all selected DAC channels. This corresponds to writing to the Multi-DAC SW LDAC register (0x5A).
+
+What:		/sys/bus/iio/devices/iio:deviceX/multi_dac_sw_ldac_trigger_available
+KernelVersion:	6.10
+Contact:	linux-iio@vger.kernel.org
+Description:
+		Returns the available trigger option: "low trigger"
+
+What:		/sys/bus/iio/devices/iio:deviceX/hw_shutdown_state
+KernelVersion:	6.10
+Contact:	linux-iio@vger.kernel.org
+Description:
+		Hardware shutdown GPIO state. Controls the logical state of the
+		shutdown pin. Valid values are:
+		- "low": Shutdown pin driven low (device in shutdown)
+		- "high": Shutdown pin driven high (device active)
+
+		Requires optional shutdown GPIO device tree configuration.
+
+What:		/sys/bus/iio/devices/iio:deviceX/hw_shutdown_state_available
+KernelVersion:	6.10
+Contact:	linux-iio@vger.kernel.org
+Description:
+		Returns the available shutdown states: "low high"

--- a/Documentation/devicetree/bindings/iio/dac/adi,ad5706r.yaml
+++ b/Documentation/devicetree/bindings/iio/dac/adi,ad5706r.yaml
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/iio/dac/adi,ad5706r.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
+
+title: Analog Devices AD5706R 4-Channel Current Output DAC
+
+maintainers:
+  - Alexis Czezar Torreno <alexisczezar.torreno@analog.com>
+
+description: |
+  The AD5706R is a 4-channel, 16-bit resolution, current output
+  digital-to-analog converter (DAC) with programmable output current
+  ranges (50mA, 150mA, 200mA, 300mA), an integrated 2.5V voltage
+  reference, and load DAC, A/B toggle, and dither functions.
+
+  Datasheet:
+    https://www.analog.com/en/products/ad5706r.html
+
+properties:
+  compatible:
+    enum:
+      - adi,ad5706r
+
+  reg:
+    maxItems: 1
+
+  avdd-supply:
+    description: Analog power supply (2.9V to 3.6V).
+
+  iovdd-supply:
+    description: Logic power supply (1.14V to 1.89V).
+
+  pvdd0-supply:
+    description: Power supply for IDAC0 channel (1.65V to AVDD).
+
+  pvdd1-supply:
+    description: Power supply for IDAC1 channel (1.65V to AVDD).
+
+  pvdd2-supply:
+    description: Power supply for IDAC2 channel (1.65V to AVDD).
+
+  pvdd3-supply:
+    description: Power supply for IDAC3 channel (1.65V to AVDD).
+
+  vref-supply:
+    description:
+      Optional external 2.5V voltage reference. If not provided, the
+      internal 2.5V reference is used.
+
+  pwms:
+    maxItems: 1
+    description:
+      Optional PWM connected to the LDAC/TGP/DCK pin for hardware
+      triggered DAC updates, toggle, or dither clock generation.
+
+  reset-gpios:
+    maxItems: 1
+    description:
+      GPIO connected to the active low RESET pin. If not provided,
+      software reset is used.
+
+  enable-gpios:
+    maxItems: 1
+    description:
+      GPIO connected to the active low OUT_EN pin. Controls whether
+      the current outputs are enabled or in high-Z/ground state.
+
+required:
+  - compatible
+  - reg
+  - avdd-supply
+  - iovdd-supply
+
+allOf:
+  - $ref: /schemas/spi/spi-peripheral-props.yaml#
+
+unevaluatedProperties: false
+
+examples:
+  - |
+    #include <dt-bindings/gpio/gpio.h>
+
+    spi {
+        #address-cells = <1>;
+        #size-cells = <0>;
+
+        dac@0 {
+            compatible = "adi,ad5706r";
+            reg = <0>;
+            avdd-supply = <&avdd>;
+            iovdd-supply = <&iovdd>;
+            pvdd0-supply = <&pvdd>;
+            pvdd1-supply = <&pvdd>;
+            pvdd2-supply = <&pvdd>;
+            pvdd3-supply = <&pvdd>;
+            vref-supply = <&vref>;
+            spi-max-frequency = <50000000>;
+            pwms = <&pwm0 0 1000000 0>;
+            reset-gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
+            enable-gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
+        };
+    };
+...

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1367,6 +1367,7 @@ L:	linux-iio@vger.kernel.org
 S:	Supported
 W:	https://ez.analog.com/linux-software-drivers
 F:	Documentation/devicetree/bindings/iio/dac/adi,ad5706r.yaml
+F:	drivers/iio/dac/ad5706r.c
 
 ANALOG DEVICES INC AD7091R DRIVER
 M:	Marcelo Schmitt <marcelo.schmitt@analog.com>

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1361,6 +1361,13 @@ F:	Documentation/iio/ad4695.rst
 F:	drivers/iio/adc/ad4695.c
 F:	include/dt-bindings/iio/adc/adc/adi,ad4695.h
 
+ANALOG DEVICES INC AD5706R DRIVER
+M:	Alexis Czezar Torreno <alexisczezar.torreno@analog.com>
+L:	linux-iio@vger.kernel.org
+S:	Supported
+W:	https://ez.analog.com/linux-software-drivers
+F:	Documentation/devicetree/bindings/iio/dac/adi,ad5706r.yaml
+
 ANALOG DEVICES INC AD7091R DRIVER
 M:	Marcelo Schmitt <marcelo.schmitt@analog.com>
 L:	linux-iio@vger.kernel.org

--- a/drivers/iio/Kconfig.adi
+++ b/drivers/iio/Kconfig.adi
@@ -110,6 +110,7 @@ config IIO_ALL_ADI_DRIVERS
 	imply AD5592R_BASE
 	imply AD5592R
 	imply AD5593R
+	imply AD5706R
 	imply AD5755
 	imply AD5758
 	imply AD5761

--- a/drivers/iio/dac/Kconfig
+++ b/drivers/iio/dac/Kconfig
@@ -173,6 +173,17 @@ config AD5624R_SPI
 	  Say yes here to build support for Analog Devices AD5624R, AD5644R and
 	  AD5664R converters (DAC). This driver uses the common SPI interface.
 
+config AD5706R
+	tristate "Analog Devices AD5706R DAC driver"
+	depends on SPI
+	select REGMAP
+	help
+	  Say yes here to build support for Analog Devices AD5706R 4-channel,
+	  16-bit current output DAC.
+
+	  To compile this driver as a module, choose M here: the
+	  module will be called ad5706r.
+
 config AD9739A
 	tristate "Analog Devices AD9739A RF DAC spi driver"
 	depends on SPI

--- a/drivers/iio/dac/Makefile
+++ b/drivers/iio/dac/Makefile
@@ -20,6 +20,7 @@ obj-$(CONFIG_AD5449) += ad5449.o
 obj-$(CONFIG_AD5592R_BASE) += ad5592r-base.o
 obj-$(CONFIG_AD5592R) += ad5592r.o
 obj-$(CONFIG_AD5593R) += ad5593r.o
+obj-$(CONFIG_AD5706R) += ad5706r.o
 obj-$(CONFIG_AD5755) += ad5755.o
 obj-$(CONFIG_AD5758) += ad5758.o
 obj-$(CONFIG_AD5761) += ad5761.o

--- a/drivers/iio/dac/ad5706r.c
+++ b/drivers/iio/dac/ad5706r.c
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * AD5706R 16-bit Current Output Digital to Analog Converter
+ *
+ * Copyright 2026 Analog Devices Inc.
+ */
+
+#include <linux/array_size.h>
+#include <linux/bits.h>
+#include <linux/dev_printk.h>
+#include <linux/err.h>
+#include <linux/iio/iio.h>
+#include <linux/mod_devicetable.h>
+#include <linux/module.h>
+#include <linux/regmap.h>
+#include <linux/spi/spi.h>
+#include <linux/types.h>
+#include <linux/unaligned.h>
+
+/* SPI frame layout */
+#define AD5706R_RD_MASK			BIT(15)
+#define AD5706R_ADDR_MASK		GENMASK(11, 0)
+
+/* Registers */
+#define AD5706R_REG_DAC_INPUT_A_CH(x)		(0x60 + ((x) * 2))
+#define AD5706R_REG_DAC_DATA_READBACK_CH(x)	(0x68 + ((x) * 2))
+
+#define AD5706R_DAC_RESOLUTION		16
+#define AD5706R_DAC_MAX_CODE		GENMASK(15, 0)
+#define AD5706R_MULTIBYTE_REG_START	0x14
+#define AD5706R_MULTIBYTE_REG_END	0x71
+#define AD5706R_MAX_REG			0x77
+
+struct ad5706r_state {
+	struct spi_device *spi;
+	struct regmap *regmap;
+
+	u8 tx_buf[4] __aligned(IIO_DMA_MINALIGN);
+	u8 rx_buf[4];
+};
+
+static int ad5706r_reg_len(unsigned int reg)
+{
+	if (reg >= AD5706R_MULTIBYTE_REG_START && reg <= AD5706R_MULTIBYTE_REG_END)
+		return 2;
+
+	return 1;
+}
+
+static int ad5706r_regmap_write(void *context, const void *data, size_t count)
+{
+	struct ad5706r_state *st = context;
+	unsigned int num_bytes;
+	u16 reg, val;
+
+	if (count != 4)
+		return -EINVAL;
+
+	reg = get_unaligned_be16(data);
+	val = get_unaligned_be16(data + 2);
+	num_bytes = ad5706r_reg_len(reg);
+
+	struct spi_transfer xfer = {
+		.tx_buf = st->tx_buf,
+		.len = num_bytes + 2,
+	};
+
+	put_unaligned_be16(reg, &st->tx_buf[0]);
+
+	if (num_bytes == 1)
+		st->tx_buf[2] = (u8)val;
+	else if (num_bytes == 2)
+		put_unaligned_be16(val, &st->tx_buf[2]);
+	else
+		return -EINVAL;
+
+	return spi_sync_transfer(st->spi, &xfer, 1);
+}
+
+static int ad5706r_regmap_read(void *context, const void *reg_buf,
+			       size_t reg_size, void *val_buf, size_t val_size)
+{
+	struct ad5706r_state *st = context;
+	unsigned int num_bytes;
+	u16 reg, cmd, val;
+	int ret;
+
+	if (reg_size != 2 || val_size != 2)
+		return -EINVAL;
+
+	reg = get_unaligned_be16(reg_buf);
+	num_bytes = ad5706r_reg_len(reg);
+
+	/* Full duplex, device responds immediately after command */
+	struct spi_transfer xfer = {
+		.tx_buf = st->tx_buf,
+		.rx_buf = st->rx_buf,
+		.len = 2 + num_bytes,
+	};
+
+	cmd = AD5706R_RD_MASK | (reg & AD5706R_ADDR_MASK);
+	put_unaligned_be16(cmd, &st->tx_buf[0]);
+	put_unaligned_be16(0, &st->tx_buf[2]);
+
+	ret = spi_sync_transfer(st->spi, &xfer, 1);
+	if (ret)
+		return ret;
+
+	/* Extract value from response (skip 2-byte command echo) */
+	if (num_bytes == 1)
+		val = st->rx_buf[2];
+	else if (num_bytes == 2)
+		val = get_unaligned_be16(&st->rx_buf[2]);
+	else
+		return -EINVAL;
+
+	put_unaligned_be16(val, val_buf);
+
+	return 0;
+}
+
+static int ad5706r_read_raw(struct iio_dev *indio_dev,
+			    struct iio_chan_spec const *chan,
+			    int *val, int *val2, long mask)
+{
+	struct ad5706r_state *st = iio_priv(indio_dev);
+	unsigned int reg, reg_val;
+	int ret;
+
+	switch (mask) {
+	case IIO_CHAN_INFO_RAW:
+		reg = AD5706R_REG_DAC_DATA_READBACK_CH(chan->channel);
+		ret = regmap_read(st->regmap, reg, &reg_val);
+		if (ret)
+			return ret;
+
+		*val = reg_val;
+		return IIO_VAL_INT;
+	case IIO_CHAN_INFO_SCALE:
+		*val = 50;
+		*val2 = AD5706R_DAC_RESOLUTION;
+		return IIO_VAL_FRACTIONAL_LOG2;
+	default:
+		return -EINVAL;
+	}
+}
+
+static int ad5706r_write_raw(struct iio_dev *indio_dev,
+			     struct iio_chan_spec const *chan,
+			     int val, int val2, long mask)
+{
+	struct ad5706r_state *st = iio_priv(indio_dev);
+	unsigned int reg;
+
+	switch (mask) {
+	case IIO_CHAN_INFO_RAW:
+		if (val < 0 || val > AD5706R_DAC_MAX_CODE)
+			return -EINVAL;
+
+		reg = AD5706R_REG_DAC_INPUT_A_CH(chan->channel);
+		return regmap_write(st->regmap, reg, val);
+	default:
+		return -EINVAL;
+	}
+}
+
+static const struct regmap_bus ad5706r_regmap_bus = {
+	.write = ad5706r_regmap_write,
+	.read = ad5706r_regmap_read,
+	.reg_format_endian_default = REGMAP_ENDIAN_BIG,
+	.val_format_endian_default = REGMAP_ENDIAN_BIG,
+};
+
+static const struct regmap_config ad5706r_regmap_config = {
+	.reg_bits = 16,
+	.val_bits = 16,
+	.max_register = AD5706R_MAX_REG,
+};
+
+static const struct iio_info ad5706r_info = {
+	.read_raw = ad5706r_read_raw,
+	.write_raw = ad5706r_write_raw,
+};
+
+#define AD5706R_CHAN(_channel) {				\
+	.type = IIO_CURRENT,					\
+	.info_mask_separate = BIT(IIO_CHAN_INFO_RAW) |		\
+			      BIT(IIO_CHAN_INFO_SCALE),		\
+	.output = 1,						\
+	.indexed = 1,						\
+	.channel = _channel,					\
+}
+
+static const struct iio_chan_spec ad5706r_channels[] = {
+	AD5706R_CHAN(0),
+	AD5706R_CHAN(1),
+	AD5706R_CHAN(2),
+	AD5706R_CHAN(3),
+};
+
+static int ad5706r_probe(struct spi_device *spi)
+{
+	struct device *dev = &spi->dev;
+	struct iio_dev *indio_dev;
+	struct ad5706r_state *st;
+
+	indio_dev = devm_iio_device_alloc(dev, sizeof(*st));
+	if (!indio_dev)
+		return -ENOMEM;
+
+	st = iio_priv(indio_dev);
+	st->spi = spi;
+
+	st->regmap = devm_regmap_init(dev, &ad5706r_regmap_bus,
+				      st, &ad5706r_regmap_config);
+	if (IS_ERR(st->regmap))
+		return dev_err_probe(dev, PTR_ERR(st->regmap),
+				     "Failed to init regmap\n");
+
+	indio_dev->name = "ad5706r";
+	indio_dev->info = &ad5706r_info;
+	indio_dev->modes = INDIO_DIRECT_MODE;
+	indio_dev->channels = ad5706r_channels;
+	indio_dev->num_channels = ARRAY_SIZE(ad5706r_channels);
+
+	return devm_iio_device_register(dev, indio_dev);
+}
+
+static const struct of_device_id ad5706r_of_match[] = {
+	{ .compatible = "adi,ad5706r" },
+	{ }
+};
+MODULE_DEVICE_TABLE(of, ad5706r_of_match);
+
+static const struct spi_device_id ad5706r_id[] = {
+	{ "ad5706r" },
+	{ }
+};
+MODULE_DEVICE_TABLE(spi, ad5706r_id);
+
+static struct spi_driver ad5706r_driver = {
+	.driver = {
+		.name = "ad5706r",
+		.of_match_table = ad5706r_of_match,
+	},
+	.probe = ad5706r_probe,
+	.id_table = ad5706r_id,
+};
+module_spi_driver(ad5706r_driver);
+
+MODULE_AUTHOR("Alexis Czezar Torreno <alexisczezar.torreno@analog.com>");
+MODULE_DESCRIPTION("AD5706R 16-bit Current Output DAC driver");
+MODULE_LICENSE("GPL");

--- a/drivers/iio/dac/ad5706r.c
+++ b/drivers/iio/dac/ad5706r.c
@@ -6,34 +6,210 @@
  */
 
 #include <linux/array_size.h>
+#include <linux/bitfield.h>
 #include <linux/bits.h>
 #include <linux/dev_printk.h>
 #include <linux/err.h>
+#include <linux/gpio/consumer.h>
 #include <linux/iio/iio.h>
 #include <linux/mod_devicetable.h>
 #include <linux/module.h>
+#include <linux/pwm.h>
 #include <linux/regmap.h>
+#include <linux/regulator/consumer.h>
 #include <linux/spi/spi.h>
 #include <linux/types.h>
 #include <linux/unaligned.h>
+#include <linux/units.h>
 
 /* SPI frame layout */
 #define AD5706R_RD_MASK			BIT(15)
+#define AD5706R_ADDR_PIN_MASK		GENMASK(14, 13)
 #define AD5706R_ADDR_MASK		GENMASK(11, 0)
 
 /* Registers */
+#define AD5706R_REG_INTERFACE_CONFIG_A		0x00
+#define AD5706R_MASK_ADDR_ASCENSION		BIT(5)
+#define AD5706R_REG_INTERFACE_CONFIG_B		0x01
+#define AD5706R_MASK_SINGLE_INSTR		BIT(7)
+#define AD5706R_REG_MUX_OUT_SEL			0x54
+#define AD5706R_REG_MUX_OUT_CONTROL		0x56
+#define AD5706R_REG_MULTI_DAC_SW_LDAC		0x5A
+#define AD5706R_REG_MULTI_DAC_INPUT_A		0x5C
+#define AD5706R_MASK_MULTI_DAC_INPUT_A		GENMASK(15, 0)
 #define AD5706R_REG_DAC_INPUT_A_CH(x)		(0x60 + ((x) * 2))
 #define AD5706R_REG_DAC_DATA_READBACK_CH(x)	(0x68 + ((x) * 2))
+#define AD5706R_REG_BANDGAP_CONTROL		0x73
 
 #define AD5706R_DAC_RESOLUTION		16
 #define AD5706R_DAC_MAX_CODE		GENMASK(15, 0)
 #define AD5706R_MULTIBYTE_REG_START	0x14
 #define AD5706R_MULTIBYTE_REG_END	0x71
 #define AD5706R_MAX_REG			0x77
+#define AD5706R_DEV_ADDR_MAX		3
+
+#define AD5706R_SAMPLING_FREQ_MIN_HZ	1
+#define AD5706R_SAMPLING_FREQ_MAX_HZ	(10 * HZ_PER_MHZ)
+
+/* Device attribute enums */
+enum addr_ascension_iio_dev_attr {
+	ADDR_ASCENSION_DECREMENT,
+	ADDR_ASCENSION_INCREMENT,
+};
+
+static const char * const addr_ascension_iio_dev_attr_vals[] = {
+	[ADDR_ASCENSION_DECREMENT] = "decrement",
+	[ADDR_ASCENSION_INCREMENT] = "increment",
+};
+
+enum single_instr_iio_dev_attr {
+	SINGLE_INSTR_STREAMING,
+	SINGLE_INSTR_SINGLE_INSTRUCTION,
+};
+
+static const char * const single_instr_iio_dev_attr_vals[] = {
+	[SINGLE_INSTR_STREAMING] = "streaming",
+	[SINGLE_INSTR_SINGLE_INSTRUCTION] = "single_instruction",
+};
+
+enum hw_ldac_tg_state_iio_dev_attr {
+	HW_LDAC_TG_STATE_LOW,
+	HW_LDAC_TG_STATE_HIGH,
+};
+
+static const char * const hw_ldac_tg_state_iio_dev_attr_vals[] = {
+	[HW_LDAC_TG_STATE_LOW] = "low",
+	[HW_LDAC_TG_STATE_HIGH] = "high",
+};
+
+enum hw_ldac_tg_pwm_iio_dev_attr {
+	HW_LDAC_TG_PWM_DISABLED,
+	HW_LDAC_TG_PWM_ENABLED,
+};
+
+static const char * const hw_ldac_tg_pwm_iio_dev_attr_vals[] = {
+	[HW_LDAC_TG_PWM_DISABLED] = "disable",
+	[HW_LDAC_TG_PWM_ENABLED] = "enable",
+};
+
+enum mux_out_sel_iio_dev_attr {
+	MUX_OUT_SEL_DISABLED,
+	MUX_OUT_SEL_AGND,
+	MUX_OUT_SEL_AVDD,
+	MUX_OUT_SEL_VREF,
+	MUX_OUT_SEL_IOUT0_VMON,
+	MUX_OUT_SEL_IOUT1_VMON,
+	MUX_OUT_SEL_IOUT2_VMON,
+	MUX_OUT_SEL_IOUT3_VMON,
+	MUX_OUT_SEL_IOUT0_IMON,
+	MUX_OUT_SEL_IOUT1_IMON,
+	MUX_OUT_SEL_IOUT2_IMON,
+	MUX_OUT_SEL_IOUT3_IMON,
+	MUX_OUT_SEL_PVDD0,
+	MUX_OUT_SEL_PVDD1,
+	MUX_OUT_SEL_PVDD2,
+	MUX_OUT_SEL_PVDD3,
+	MUX_OUT_SEL_TEMP_SENSOR0,
+	MUX_OUT_SEL_TEMP_SENSOR1,
+	MUX_OUT_SEL_TEMP_SENSOR2,
+	MUX_OUT_SEL_TEMP_SENSOR3,
+	MUX_OUT_SEL_MUX_IN0,
+	MUX_OUT_SEL_MUX_IN1,
+	MUX_OUT_SEL_MUX_IN2,
+	MUX_OUT_SEL_MUX_IN3,
+};
+
+static const char * const mux_out_sel_iio_dev_attr_vals[] = {
+	[MUX_OUT_SEL_DISABLED]		= "disabled",
+	[MUX_OUT_SEL_AGND]		= "agnd",
+	[MUX_OUT_SEL_AVDD]		= "avdd",
+	[MUX_OUT_SEL_VREF]		= "vref",
+	[MUX_OUT_SEL_IOUT0_VMON]	= "iout0_vmon",
+	[MUX_OUT_SEL_IOUT1_VMON]	= "iout1_vmon",
+	[MUX_OUT_SEL_IOUT2_VMON]	= "iout2_vmon",
+	[MUX_OUT_SEL_IOUT3_VMON]	= "iout3_vmon",
+	[MUX_OUT_SEL_IOUT0_IMON]	= "iout0_imon",
+	[MUX_OUT_SEL_IOUT1_IMON]	= "iout1_imon",
+	[MUX_OUT_SEL_IOUT2_IMON]	= "iout2_imon",
+	[MUX_OUT_SEL_IOUT3_IMON]	= "iout3_imon",
+	[MUX_OUT_SEL_PVDD0]		= "pvdd0",
+	[MUX_OUT_SEL_PVDD1]		= "pvdd1",
+	[MUX_OUT_SEL_PVDD2]		= "pvdd2",
+	[MUX_OUT_SEL_PVDD3]		= "pvdd3",
+	[MUX_OUT_SEL_TEMP_SENSOR0]	= "tdiode_ch0",
+	[MUX_OUT_SEL_TEMP_SENSOR1]	= "tdiode_ch1",
+	[MUX_OUT_SEL_TEMP_SENSOR2]	= "tdiode_ch2",
+	[MUX_OUT_SEL_TEMP_SENSOR3]	= "tdiode_ch3",
+	[MUX_OUT_SEL_MUX_IN0]		= "mux_in0",
+	[MUX_OUT_SEL_MUX_IN1]		= "mux_in1",
+	[MUX_OUT_SEL_MUX_IN2]		= "mux_in2",
+	[MUX_OUT_SEL_MUX_IN3]		= "mux_in3",
+};
+
+static const u8 mux_out_sel_reg_vals[] = {
+	[MUX_OUT_SEL_DISABLED]		= 0x00,
+	[MUX_OUT_SEL_AGND]		= 0x80,
+	[MUX_OUT_SEL_AVDD]		= 0x81,
+	[MUX_OUT_SEL_VREF]		= 0x82,
+	[MUX_OUT_SEL_IOUT0_VMON]	= 0x84,
+	[MUX_OUT_SEL_IOUT1_VMON]	= 0x85,
+	[MUX_OUT_SEL_IOUT2_VMON]	= 0x86,
+	[MUX_OUT_SEL_IOUT3_VMON]	= 0x87,
+	[MUX_OUT_SEL_IOUT0_IMON]	= 0x88,
+	[MUX_OUT_SEL_IOUT1_IMON]	= 0x89,
+	[MUX_OUT_SEL_IOUT2_IMON]	= 0x8A,
+	[MUX_OUT_SEL_IOUT3_IMON]	= 0x8B,
+	[MUX_OUT_SEL_PVDD0]		= 0x8C,
+	[MUX_OUT_SEL_PVDD1]		= 0x8D,
+	[MUX_OUT_SEL_PVDD2]		= 0x8E,
+	[MUX_OUT_SEL_PVDD3]		= 0x8F,
+	[MUX_OUT_SEL_TEMP_SENSOR0]	= 0x90,
+	[MUX_OUT_SEL_TEMP_SENSOR1]	= 0x91,
+	[MUX_OUT_SEL_TEMP_SENSOR2]	= 0x92,
+	[MUX_OUT_SEL_TEMP_SENSOR3]	= 0x93,
+	[MUX_OUT_SEL_MUX_IN0]		= 0x94,
+	[MUX_OUT_SEL_MUX_IN1]		= 0x95,
+	[MUX_OUT_SEL_MUX_IN2]		= 0x96,
+	[MUX_OUT_SEL_MUX_IN3]		= 0x97,
+};
+
+enum multi_dac_sw_ldac_trigger_iio_dev_attr {
+	MULTI_DAC_SW_LDAC_TRIGGER_LOW = 0,
+	MULTI_DAC_SW_LDAC_TRIGGER_TRIGGER,
+};
+
+static const char * const multi_dac_sw_ldac_trigger_iio_dev_attr_vals[] = {
+	[MULTI_DAC_SW_LDAC_TRIGGER_LOW] = "low",
+	[MULTI_DAC_SW_LDAC_TRIGGER_TRIGGER] = "trigger",
+};
+
+enum hw_shutdown_state_iio_dev_attr {
+	HW_SHUTDOWN_STATE_LOW,
+	HW_SHUTDOWN_STATE_HIGH,
+};
+
+static const char * const hw_shutdown_state_iio_dev_attr_vals[] = {
+	[HW_SHUTDOWN_STATE_LOW] = "low",
+	[HW_SHUTDOWN_STATE_HIGH] = "high",
+};
 
 struct ad5706r_state {
 	struct spi_device *spi;
 	struct regmap *regmap;
+
+	struct pwm_device *ldac_pwm;
+	struct gpio_desc *reset_gpio;
+	struct gpio_desc *shdn_gpio;
+	struct regulator *vref;
+
+	u8 shift_val;
+
+	u8 dev_addr;
+	enum addr_ascension_iio_dev_attr addr_ascension;
+	enum single_instr_iio_dev_attr single_instr;
+	enum hw_ldac_tg_state_iio_dev_attr hw_ldac_tg_state;
+	u64 sampling_frequency;
+	enum mux_out_sel_iio_dev_attr mux_out_sel;
 
 	u8 tx_buf[4] __aligned(IIO_DMA_MINALIGN);
 	u8 rx_buf[4];
@@ -51,7 +227,7 @@ static int ad5706r_regmap_write(void *context, const void *data, size_t count)
 {
 	struct ad5706r_state *st = context;
 	unsigned int num_bytes;
-	u16 reg, val;
+	u16 reg, val, cmd;
 
 	if (count != 4)
 		return -EINVAL;
@@ -65,14 +241,27 @@ static int ad5706r_regmap_write(void *context, const void *data, size_t count)
 		.len = num_bytes + 2,
 	};
 
-	put_unaligned_be16(reg, &st->tx_buf[0]);
-
-	if (num_bytes == 1)
+	if (num_bytes == 1) {
 		st->tx_buf[2] = (u8)val;
-	else if (num_bytes == 2)
+	} else if (num_bytes == 2) {
 		put_unaligned_be16(val, &st->tx_buf[2]);
-	else
+		
+		/*
+		 * In addr ascension DECREMENT, write starts on next register for
+		 * multibyte registers. For INCREMENT, write values are swapped
+		 * as per device expectation
+		 */
+		if (st->addr_ascension == ADDR_ASCENSION_DECREMENT)
+			reg = reg + 1;
+		else
+			swap(st->tx_buf[2], st->tx_buf[3]);
+	} else {
 		return -EINVAL;
+	}
+
+	/* Construct command word: [dev_addr(14:13)] [reg_addr(11:0)] */
+	cmd = ((st->dev_addr << 13) & AD5706R_ADDR_PIN_MASK) | (reg & AD5706R_ADDR_MASK);
+	put_unaligned_be16(cmd, &st->tx_buf[0]);
 
 	return spi_sync_transfer(st->spi, &xfer, 1);
 }
@@ -98,7 +287,16 @@ static int ad5706r_regmap_read(void *context, const void *reg_buf,
 		.len = 2 + num_bytes,
 	};
 
-	cmd = AD5706R_RD_MASK | (reg & AD5706R_ADDR_MASK);
+	/*
+	 * In addr ascension DECREMENT, read starts on next register for
+	 * multibyte registers
+	 */
+	if (num_bytes == 2 && st->addr_ascension == ADDR_ASCENSION_DECREMENT)
+		reg = reg + 1;
+
+	/* Construct command word: [RD(15)][dev_addr(14:13)] [reg_addr(11:0)] */
+	cmd = AD5706R_RD_MASK | ((st->dev_addr << 13) & AD5706R_ADDR_PIN_MASK) |
+	      (reg & AD5706R_ADDR_MASK);
 	put_unaligned_be16(cmd, &st->tx_buf[0]);
 	put_unaligned_be16(0, &st->tx_buf[2]);
 
@@ -106,13 +304,21 @@ static int ad5706r_regmap_read(void *context, const void *reg_buf,
 	if (ret)
 		return ret;
 
-	/* Extract value from response (skip 2-byte command echo) */
-	if (num_bytes == 1)
+	/*
+	 * Extract value from response (skip 2-byte command echo)
+	 * In addr ascension INCREMENT, multibyte values are swapped
+	 * as per device expectation
+	 */
+	if (num_bytes == 1) {
 		val = st->rx_buf[2];
-	else if (num_bytes == 2)
+	} else if (num_bytes == 2) {
 		val = get_unaligned_be16(&st->rx_buf[2]);
-	else
+
+		if (st->addr_ascension == ADDR_ASCENSION_INCREMENT)
+			val = swab16(val);
+	} else {
 		return -EINVAL;
+	}
 
 	put_unaligned_be16(val, val_buf);
 
@@ -140,6 +346,9 @@ static int ad5706r_read_raw(struct iio_dev *indio_dev,
 		*val = 50;
 		*val2 = AD5706R_DAC_RESOLUTION;
 		return IIO_VAL_FRACTIONAL_LOG2;
+	case IIO_CHAN_INFO_SAMP_FREQ:
+		*val = st->sampling_frequency;
+		return IIO_VAL_INT;
 	default:
 		return -EINVAL;
 	}
@@ -150,7 +359,9 @@ static int ad5706r_write_raw(struct iio_dev *indio_dev,
 			     int val, int val2, long mask)
 {
 	struct ad5706r_state *st = iio_priv(indio_dev);
+	struct pwm_state ldac_pwm_state;
 	unsigned int reg;
+	int ret;
 
 	switch (mask) {
 	case IIO_CHAN_INFO_RAW:
@@ -159,10 +370,413 @@ static int ad5706r_write_raw(struct iio_dev *indio_dev,
 
 		reg = AD5706R_REG_DAC_INPUT_A_CH(chan->channel);
 		return regmap_write(st->regmap, reg, val);
+	case IIO_CHAN_INFO_SAMP_FREQ:
+		/* Sets minimum and maximum frequency */
+		val = clamp_t(int, val, AD5706R_SAMPLING_FREQ_MIN_HZ, AD5706R_SAMPLING_FREQ_MAX_HZ);
+
+		pwm_get_state(st->ldac_pwm, &ldac_pwm_state);
+		ldac_pwm_state.period = DIV_ROUND_CLOSEST_ULL(NANO, val);
+		ldac_pwm_state.duty_cycle = DIV_ROUND_CLOSEST_ULL(ldac_pwm_state.period, 2);
+		ldac_pwm_state.enabled = true;
+
+		ret = pwm_apply_might_sleep(st->ldac_pwm, &ldac_pwm_state);
+		if (ret)
+			return ret;
+
+		st->sampling_frequency = val;
+
+		return 0;
 	default:
 		return -EINVAL;
 	}
 }
+
+static int _set_pwm_duty_cycle(struct ad5706r_state *st, int duty_cycle)
+{
+	struct pwm_state ldac_pwm_state;
+	int ret, val;
+
+	if (!st->ldac_pwm)
+		return -ENODEV;
+
+	pwm_get_state(st->ldac_pwm, &ldac_pwm_state);
+
+	val = DIV_ROUND_CLOSEST_ULL(ldac_pwm_state.period * duty_cycle, 100);
+	ldac_pwm_state.duty_cycle = val;
+
+	ret = pwm_apply_might_sleep(st->ldac_pwm, &ldac_pwm_state);
+	if (ret)
+		return ret;
+
+	return 0;
+}
+
+static ssize_t ad5706r_dev_addr_write(struct iio_dev *indio_dev,
+				      uintptr_t private,
+				      const struct iio_chan_spec *chan,
+				      const char *buf, size_t len)
+{
+	struct ad5706r_state *st = iio_priv(indio_dev);
+	u8 reg_val;
+	int ret;
+
+	ret = kstrtou8(buf, 10, &reg_val);
+	if (ret)
+		return ret;
+
+	if (reg_val > AD5706R_DEV_ADDR_MAX)
+		return -EINVAL;
+
+	st->dev_addr = reg_val;
+
+	return len;
+}
+
+static ssize_t ad5706r_dev_addr_read(struct iio_dev *indio_dev,
+				     uintptr_t private,
+				     const struct iio_chan_spec *chan,
+				     char *buf)
+{
+	struct ad5706r_state *st = iio_priv(indio_dev);
+
+	return sysfs_emit(buf, "%u\n", st->dev_addr);
+}
+
+static int ad5706r_addr_ascension_write(struct iio_dev *indio_dev,
+					const struct iio_chan_spec *chan,
+					unsigned int item)
+{
+	struct ad5706r_state *st = iio_priv(indio_dev);
+	int ret, val;
+
+	if (item >= ARRAY_SIZE(addr_ascension_iio_dev_attr_vals))
+		return -EINVAL;
+
+	if (item == ADDR_ASCENSION_DECREMENT)
+		val = 0;
+	else
+		val = 1;
+
+	val = FIELD_PREP(AD5706R_MASK_ADDR_ASCENSION, val);
+
+	ret = regmap_update_bits(st->regmap, AD5706R_REG_INTERFACE_CONFIG_A,
+				 AD5706R_MASK_ADDR_ASCENSION, val);
+	if (ret)
+		return ret;
+
+	st->addr_ascension = item;
+
+	return 0;
+}
+
+static int ad5706r_addr_ascension_read(struct iio_dev *indio_dev,
+				       const struct iio_chan_spec *chan)
+{
+	struct ad5706r_state *st = iio_priv(indio_dev);
+	unsigned int reg_val;
+	int ret;
+
+	ret = regmap_read(st->regmap, AD5706R_REG_INTERFACE_CONFIG_A, &reg_val);
+	if (ret)
+		return ret;
+
+	if (reg_val & AD5706R_MASK_ADDR_ASCENSION)
+		st->addr_ascension = ADDR_ASCENSION_INCREMENT;
+	else
+		st->addr_ascension = ADDR_ASCENSION_DECREMENT;
+
+	return st->addr_ascension;
+}
+
+static const struct iio_enum ad5706r_addr_ascension_enum = {
+	.items = addr_ascension_iio_dev_attr_vals,
+	.num_items = ARRAY_SIZE(addr_ascension_iio_dev_attr_vals),
+	.set = ad5706r_addr_ascension_write,
+	.get = ad5706r_addr_ascension_read,
+};
+
+static int ad5706r_single_instr_write(struct iio_dev *indio_dev,
+				      const struct iio_chan_spec *chan,
+				      unsigned int item)
+{
+	struct ad5706r_state *st = iio_priv(indio_dev);
+	int ret;
+	int val;
+
+	if (item >= ARRAY_SIZE(single_instr_iio_dev_attr_vals))
+		return -EINVAL;
+
+	if (item == SINGLE_INSTR_STREAMING)
+		val = 0;
+	else
+		val = 1;
+
+	val = FIELD_PREP(AD5706R_MASK_SINGLE_INSTR, val);
+
+	ret = regmap_update_bits(st->regmap, AD5706R_REG_INTERFACE_CONFIG_B,
+				 AD5706R_MASK_SINGLE_INSTR, val);
+	if (ret)
+		return ret;
+
+	st->single_instr = item;
+
+	return 0;
+}
+
+static int ad5706r_single_instr_read(struct iio_dev *indio_dev,
+				     const struct iio_chan_spec *chan)
+{
+	struct ad5706r_state *st = iio_priv(indio_dev);
+	unsigned int reg_val;
+	int ret;
+
+	ret = regmap_read(st->regmap, AD5706R_REG_INTERFACE_CONFIG_B, &reg_val);
+	if (ret)
+		return ret;
+
+	if (reg_val & AD5706R_MASK_SINGLE_INSTR)
+		st->single_instr = SINGLE_INSTR_SINGLE_INSTRUCTION;
+	else
+		st->single_instr = SINGLE_INSTR_STREAMING;
+
+	return st->single_instr;
+}
+
+static const struct iio_enum ad5706r_single_instr_enum = {
+	.items = single_instr_iio_dev_attr_vals,
+	.num_items = ARRAY_SIZE(single_instr_iio_dev_attr_vals),
+	.set = ad5706r_single_instr_write,
+	.get = ad5706r_single_instr_read,
+};
+
+static int ad5706r_hw_ldac_tg_state_write(struct iio_dev *indio_dev,
+					  const struct iio_chan_spec *chan,
+					  unsigned int item)
+{
+	struct ad5706r_state *st = iio_priv(indio_dev);
+	int ret;
+
+	if (item >= ARRAY_SIZE(hw_ldac_tg_state_iio_dev_attr_vals))
+		return -EINVAL;
+
+	/* Setting either high or low can override hw_ldac_tg_pwm */
+	if (item == HW_LDAC_TG_STATE_HIGH)
+		ret = _set_pwm_duty_cycle(st, 100);
+	else
+		ret = _set_pwm_duty_cycle(st, 0);
+
+	if (ret)
+		return ret;
+
+	st->hw_ldac_tg_state = item;
+
+	return 0;
+}
+
+static int ad5706r_hw_ldac_tg_state_read(struct iio_dev *indio_dev,
+					 const struct iio_chan_spec *chan)
+{
+	struct ad5706r_state *st = iio_priv(indio_dev);
+
+	/* Simply return previously set state, even if pwm is running */
+	return st->hw_ldac_tg_state;
+}
+
+static const struct iio_enum ad5706r_hw_ldac_tg_state_enum = {
+	.items = hw_ldac_tg_state_iio_dev_attr_vals,
+	.num_items = ARRAY_SIZE(hw_ldac_tg_state_iio_dev_attr_vals),
+	.set = ad5706r_hw_ldac_tg_state_write,
+	.get = ad5706r_hw_ldac_tg_state_read,
+};
+
+static int ad5706r_hw_ldac_tg_pwm_write(struct iio_dev *indio_dev,
+				       const struct iio_chan_spec *chan,
+				       unsigned int item)
+{
+	struct ad5706r_state *st = iio_priv(indio_dev);
+	int ret;
+
+	if (item >= ARRAY_SIZE(hw_ldac_tg_pwm_iio_dev_attr_vals))
+		return -EINVAL;
+
+	/* Enable = 50% duty, Disable notes present value of hw_ldac_tg_state */
+	if (item == HW_LDAC_TG_PWM_DISABLED)
+		if (st->hw_ldac_tg_state == HW_LDAC_TG_STATE_LOW)
+			ret = _set_pwm_duty_cycle(st, 0);
+		else
+			ret = _set_pwm_duty_cycle(st, 100);
+	else
+		ret = _set_pwm_duty_cycle(st, 50);
+
+	return ret;
+}
+
+static int ad5706r_hw_ldac_tg_pwm_read(struct iio_dev *indio_dev,
+				      const struct iio_chan_spec *chan)
+{
+	struct ad5706r_state *st = iio_priv(indio_dev);
+	struct pwm_state ldac_pwm_state;
+
+	pwm_get_state(st->ldac_pwm, &ldac_pwm_state);
+
+	if (ldac_pwm_state.duty_cycle == 0 ||
+	    ldac_pwm_state.duty_cycle == ldac_pwm_state.period)
+		return HW_LDAC_TG_PWM_DISABLED;
+	else
+		return HW_LDAC_TG_PWM_ENABLED;
+}
+
+static const struct iio_enum ad5706r_hw_ldac_tg_pwm_enum = {
+	.items = hw_ldac_tg_pwm_iio_dev_attr_vals,
+	.num_items = ARRAY_SIZE(hw_ldac_tg_pwm_iio_dev_attr_vals),
+	.set = ad5706r_hw_ldac_tg_pwm_write,
+	.get = ad5706r_hw_ldac_tg_pwm_read,
+};
+
+static int ad5706r_mux_out_sel_write(struct iio_dev *indio_dev,
+				     const struct iio_chan_spec *chan,
+				     unsigned int item)
+{
+	struct ad5706r_state *st = iio_priv(indio_dev);
+	int ret;
+
+	if (item >= ARRAY_SIZE(mux_out_sel_iio_dev_attr_vals))
+		return -EINVAL;
+
+	ret = regmap_write(st->regmap, AD5706R_REG_MUX_OUT_SEL,
+			   mux_out_sel_reg_vals[item]);
+	if (ret)
+		return ret;
+
+	st->mux_out_sel = item;
+
+	return 0;
+}
+
+static int ad5706r_mux_out_sel_read(struct iio_dev *indio_dev,
+				   const struct iio_chan_spec *chan)
+{
+	struct ad5706r_state *st = iio_priv(indio_dev);
+
+	return st->mux_out_sel;
+}
+
+static const struct iio_enum ad5706r_mux_out_sel_enum = {
+	.items = mux_out_sel_iio_dev_attr_vals,
+	.num_items = ARRAY_SIZE(mux_out_sel_iio_dev_attr_vals),
+	.set = ad5706r_mux_out_sel_write,
+	.get = ad5706r_mux_out_sel_read,
+};
+
+static ssize_t ad5706r_multi_dac_input_a_write(struct iio_dev *indio_dev,
+					       uintptr_t private,
+					       const struct iio_chan_spec *chan,
+					       const char *buf, size_t len)
+{
+	struct ad5706r_state *st = iio_priv(indio_dev);
+	unsigned int val;
+	int ret;
+
+	ret = kstrtou32(buf, 16, &val);
+	if (ret)
+		return ret;
+
+	if (val > 0xFFFF)
+		return -EINVAL;
+
+	ret = regmap_write(st->regmap, AD5706R_REG_MULTI_DAC_INPUT_A, val);
+	if (ret)
+		return ret;
+
+	return len;
+}
+
+static ssize_t ad5706r_multi_dac_input_a_read(struct iio_dev *indio_dev,
+					      uintptr_t private,
+					      const struct iio_chan_spec *chan,
+					      char *buf)
+{
+	struct ad5706r_state *st = iio_priv(indio_dev);
+	unsigned int reg_val;
+	int ret;
+
+	ret = regmap_read(st->regmap, AD5706R_REG_MULTI_DAC_INPUT_A, &reg_val);
+	if (ret)
+		return ret;
+
+	return sysfs_emit(buf, "0x%04x\n", reg_val);
+}
+
+static int ad5706r_multi_dac_sw_ldac_trigger_write(struct iio_dev *indio_dev,
+						   const struct iio_chan_spec *chan,
+						   unsigned int item)
+{
+	struct ad5706r_state *st = iio_priv(indio_dev);
+
+	if (item >= ARRAY_SIZE(multi_dac_sw_ldac_trigger_iio_dev_attr_vals))
+		return -EINVAL;
+
+	return regmap_write(st->regmap, AD5706R_REG_MULTI_DAC_SW_LDAC, item);
+}
+
+static int ad5706r_multi_dac_sw_ldac_trigger_read(struct iio_dev *indio_dev,
+						  const struct iio_chan_spec *chan)
+{
+	struct ad5706r_state *st = iio_priv(indio_dev);
+	unsigned int reg_val;
+	int ret;
+
+	ret = regmap_read(st->regmap, AD5706R_REG_MULTI_DAC_SW_LDAC, &reg_val);
+	if (ret)
+		return ret;
+
+	return reg_val;
+}
+
+static const struct iio_enum ad5706r_multi_dac_sw_ldac_trigger_enum = {
+	.items = multi_dac_sw_ldac_trigger_iio_dev_attr_vals,
+	.num_items = ARRAY_SIZE(multi_dac_sw_ldac_trigger_iio_dev_attr_vals),
+	.set = ad5706r_multi_dac_sw_ldac_trigger_write,
+	.get = ad5706r_multi_dac_sw_ldac_trigger_read,
+};
+
+static int ad5706r_hw_shutdown_state_write(struct iio_dev *indio_dev,
+					   const struct iio_chan_spec *chan,
+					   unsigned int item)
+{
+	struct ad5706r_state *st = iio_priv(indio_dev);
+
+	if (item >= ARRAY_SIZE(hw_shutdown_state_iio_dev_attr_vals))
+		return -EINVAL;
+
+	if (item == HW_SHUTDOWN_STATE_LOW)
+		gpiod_set_value_cansleep(st->shdn_gpio, 0);
+	else
+		gpiod_set_value_cansleep(st->shdn_gpio, 1);
+
+	return 0;
+}
+
+static int ad5706r_hw_shutdown_state_read(struct iio_dev *indio_dev,
+					  const struct iio_chan_spec *chan)
+{
+	struct ad5706r_state *st = iio_priv(indio_dev);
+	int val;
+
+	val = gpiod_get_value_cansleep(st->shdn_gpio);
+
+	if (val == 0)
+		return HW_SHUTDOWN_STATE_LOW;
+	else
+		return HW_SHUTDOWN_STATE_HIGH;
+}
+
+static const struct iio_enum ad5706r_hw_shutdown_state_enum = {
+	.items = hw_shutdown_state_iio_dev_attr_vals,
+	.num_items = ARRAY_SIZE(hw_shutdown_state_iio_dev_attr_vals),
+	.set = ad5706r_hw_shutdown_state_write,
+	.get = ad5706r_hw_shutdown_state_read,
+};
 
 static const struct regmap_bus ad5706r_regmap_bus = {
 	.write = ad5706r_regmap_write,
@@ -175,6 +789,7 @@ static const struct regmap_config ad5706r_regmap_config = {
 	.reg_bits = 16,
 	.val_bits = 16,
 	.max_register = AD5706R_MAX_REG,
+	.cache_type = REGCACHE_NONE,
 };
 
 static const struct iio_info ad5706r_info = {
@@ -182,13 +797,47 @@ static const struct iio_info ad5706r_info = {
 	.write_raw = ad5706r_write_raw,
 };
 
+#define AD5706R_CHAN_EXT_INFO(_name, _what, _shared, _read, _write) {	\
+	.name = _name,							\
+	.read = (_read),						\
+	.write = (_write),						\
+	.private = (_what),						\
+	.shared = (_shared),						\
+}
+
+static struct iio_chan_spec_ext_info ad5706r_ext_info[] = {
+	AD5706R_CHAN_EXT_INFO("dev_addr", 0, IIO_SHARED_BY_ALL,
+			      ad5706r_dev_addr_read, ad5706r_dev_addr_write),
+	IIO_ENUM("addr_ascension", IIO_SHARED_BY_ALL, &ad5706r_addr_ascension_enum),
+	IIO_ENUM_AVAILABLE("addr_ascension", IIO_SHARED_BY_ALL, &ad5706r_addr_ascension_enum),
+	IIO_ENUM("single_instr", IIO_SHARED_BY_ALL, &ad5706r_single_instr_enum),
+	IIO_ENUM_AVAILABLE("single_instr", IIO_SHARED_BY_ALL, &ad5706r_single_instr_enum),
+	IIO_ENUM("hw_ldac_tg_state", IIO_SHARED_BY_ALL, &ad5706r_hw_ldac_tg_state_enum),
+	IIO_ENUM_AVAILABLE("hw_ldac_tg_state", IIO_SHARED_BY_ALL, &ad5706r_hw_ldac_tg_state_enum),
+	IIO_ENUM("hw_ldac_tg_pwm", IIO_SHARED_BY_ALL, &ad5706r_hw_ldac_tg_pwm_enum),
+	IIO_ENUM_AVAILABLE("hw_ldac_tg_pwm", IIO_SHARED_BY_ALL, &ad5706r_hw_ldac_tg_pwm_enum),
+	IIO_ENUM("mux_out_sel", IIO_SHARED_BY_ALL, &ad5706r_mux_out_sel_enum),
+	IIO_ENUM_AVAILABLE("mux_out_sel", IIO_SHARED_BY_ALL, &ad5706r_mux_out_sel_enum),
+	AD5706R_CHAN_EXT_INFO("multi_dac_input_a", 0, IIO_SHARED_BY_ALL,
+			      ad5706r_multi_dac_input_a_read, ad5706r_multi_dac_input_a_write),
+	IIO_ENUM("multi_dac_sw_ldac_trigger", IIO_SHARED_BY_ALL,
+		 &ad5706r_multi_dac_sw_ldac_trigger_enum),
+	IIO_ENUM_AVAILABLE("multi_dac_sw_ldac_trigger", IIO_SHARED_BY_ALL,
+			   &ad5706r_multi_dac_sw_ldac_trigger_enum),
+	IIO_ENUM("hw_shutdown_state", IIO_SHARED_BY_ALL, &ad5706r_hw_shutdown_state_enum),
+	IIO_ENUM_AVAILABLE("hw_shutdown_state", IIO_SHARED_BY_ALL, &ad5706r_hw_shutdown_state_enum),
+	{ }
+};
+
 #define AD5706R_CHAN(_channel) {				\
 	.type = IIO_CURRENT,					\
 	.info_mask_separate = BIT(IIO_CHAN_INFO_RAW) |		\
 			      BIT(IIO_CHAN_INFO_SCALE),		\
+	.info_mask_shared_by_all = BIT(IIO_CHAN_INFO_SAMP_FREQ),\
 	.output = 1,						\
 	.indexed = 1,						\
 	.channel = _channel,					\
+	.ext_info = ad5706r_ext_info,				\
 }
 
 static const struct iio_chan_spec ad5706r_channels[] = {
@@ -203,6 +852,8 @@ static int ad5706r_probe(struct spi_device *spi)
 	struct device *dev = &spi->dev;
 	struct iio_dev *indio_dev;
 	struct ad5706r_state *st;
+	struct pwm_state ldac_pwm_state;
+	int ret;
 
 	indio_dev = devm_iio_device_alloc(dev, sizeof(*st));
 	if (!indio_dev)
@@ -211,11 +862,63 @@ static int ad5706r_probe(struct spi_device *spi)
 	st = iio_priv(indio_dev);
 	st->spi = spi;
 
+	/* Initialize default values for device attributes */
+	st->sampling_frequency = HZ_PER_MHZ;
+
+	/* Get optional PWM for LDAC triggering */
+	st->ldac_pwm = devm_pwm_get(dev, "ldac");
+	if (IS_ERR(st->ldac_pwm))
+		return dev_err_probe(dev, PTR_ERR(st->ldac_pwm),
+				     "Failed to get LDAC PWM\n");
+	pwm_get_state(st->ldac_pwm, &ldac_pwm_state);
+	ldac_pwm_state.duty_cycle = 0;
+	ldac_pwm_state.period = DIV_ROUND_CLOSEST_ULL(NANO, st->sampling_frequency);
+	ldac_pwm_state.enabled = true;
+	ret = pwm_apply_might_sleep(st->ldac_pwm, &ldac_pwm_state);
+	if (ret)
+		return dev_err_probe(dev, ret, "Failed to apply PWM state\n");
+
+	/* Get optional GPIOs */
+	st->reset_gpio = devm_gpiod_get_optional(dev, "reset", GPIOD_OUT_LOW);
+	if (IS_ERR(st->reset_gpio))
+		return dev_err_probe(dev, PTR_ERR(st->reset_gpio),
+				     "Failed to get reset GPIO\n");
+
+	st->shdn_gpio = devm_gpiod_get_optional(dev, "enable", GPIOD_OUT_HIGH);
+	if (IS_ERR(st->shdn_gpio))
+		return dev_err_probe(dev, PTR_ERR(st->shdn_gpio),
+				     "Failed to get enable GPIO\n");
+
+	/* Initialize regmap with custom read/write functions */
 	st->regmap = devm_regmap_init(dev, &ad5706r_regmap_bus,
 				      st, &ad5706r_regmap_config);
 	if (IS_ERR(st->regmap))
 		return dev_err_probe(dev, PTR_ERR(st->regmap),
 				     "Failed to init regmap\n");
+
+	/* Voltage reference - external or internal */
+	st->vref = devm_regulator_get_optional(dev, "vref");
+	if (IS_ERR(st->vref)) {
+		ret = PTR_ERR(st->vref);
+		if (ret != -ENODEV)
+			return dev_err_probe(dev, ret,
+					     "Failed to get vref regulator\n");
+		st->vref = NULL;
+	}
+
+	if (st->vref) {
+		/* External reference provided */
+		ret = regulator_enable(st->vref);
+		if (ret)
+			return dev_err_probe(dev, ret,
+					     "Failed to enable vref regulator\n");
+	} else {
+		/* Use internal reference */
+		ret = regmap_write(st->regmap, AD5706R_REG_BANDGAP_CONTROL, 1);
+		if (ret)
+			return dev_err_probe(dev, ret,
+					     "Failed to enable internal reference\n");
+	}
 
 	indio_dev->name = "ad5706r";
 	indio_dev->info = &ad5706r_info;


### PR DESCRIPTION
## PR Description

This is part 2 of series of patches to fully support ad5706r
refer to part 1 here: https://github.com/analogdevicesinc/linux/pull/3325

- Adding device attributes to AD5706R, a quad 16-bit current output digital-to-analog converter with integrated precision reference.
- Datasheet of [AD5706R](https://www.analog.com/en/products/ad5706r.html).
- Features Implemented:

  - dev_addr, spi cmd can change to communicate up to 4 devices on same bus
  - addr_ascension pertaining to how multibyte registers are accessed
  - single_instr to choose whether streaming or single transaction
  - sampling_frequency for PWM frequency
  - hw_ldac_tg_state for PWM control of low or high
  - hw_ldac_tg_pwm to make the ldac pin into a pwm
  - multi_dac_input_a content for multi select channel load
  - multi_dac_sw_ldac_trigger to trigger the multi channel load
  - mux_out_sel for internal monitoring
  - hw_shutdown_state controls device enable pin

This PR is related to https://github.com/analogdevicesinc/linux/pull/3096
The upstream asked this to be split. 
Part 1 - basic driver
Part 2 - device attributes (this)
Part 3 - Channel attributes
Part 4 - debugfs attributes

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
