### PR TITLE
AD9083-EVB: Add VCU118 support

### DIFF
--- a/arch/microblaze/boot/dts/adi-ad9083-fmc-ebz.dtsi
+++ b/arch/microblaze/boot/dts/adi-ad9083-fmc-ebz.dtsi
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices ADRV9083-EVB
+ *
+ * hdl_project: <ad9083_evb>
+ * board_revision: <>
+ *
+ * Copyright (C) 2026 Analog Devices Inc.
+ */
+
+#include <dt-bindings/iio/frequency/ad9528.h>
+#include <dt-bindings/iio/adc/adi,ad9083.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+
+&fmc_spi {
+	status = "okay";
+
+	ad9528: ad9528@1 {
+		compatible = "adi,ad9528";
+		reg = <1>;
+
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		jesd204-device;
+		#jesd204-cells = <2>;
+		jesd204-sysref-provider;
+
+		spi-max-frequency = <1000000>;
+		adi,spi-3wire-enable;
+
+		clock-output-names = "ad9528-1_out0", "ad9528-1_out1", "ad9528-1_out2",
+			"ad9528-1_out3", "ad9528-1_out4", "ad9528-1_out5", "ad9528-1_out6",
+			"ad9528-1_out7", "ad9528-1_out8", "ad9528-1_out9", "ad9528-1_out10",
+			"ad9528-1_out11", "ad9528-1_out12", "ad9528-1_out13";
+		#clock-cells = <1>;
+
+		adi,vcxo-freq = <100000000>;
+
+		adi,refa-enable;
+		adi,refa-diff-rcv-enable;
+		adi,refa-r-div = <1>;
+		adi,osc-in-cmos-neg-inp-enable;
+
+		/* SYSREF config */
+		adi,sysref-src = <SYSREF_SRC_INTERNAL>;
+		adi,sysref-pattern-mode = <SYSREF_PATTERN_NSHOT>;
+		adi,sysref-k-div = <256>;
+		adi,sysref-nshot-mode = <SYSREF_NSHOT_4_PULSES>;
+		adi,sysref-request-trigger-mode = <SYSREF_LEVEL_HIGH>;
+		adi,jesd204-max-sysref-frequency-hz = <400000>;
+
+		/* PLL1 config */
+		adi,pll1-feedback-src-vcxo;
+		adi,pll1-feedback-div = <4>;
+		adi,pll1-charge-pump-current-nA = <5000>;
+		adi,osc-in-diff-enable;
+
+		/* PLL2 config */
+		/*
+		 * Valid ranges based on VCO locking range:
+		 *   1150.000 MHz - 1341.666 MHz
+		 *    862.500 MHz - 1006.250 MHz
+		 *    690.000 MHz -  805.000 MHz
+		 */
+
+		/* PLL2 config */
+		adi,pll2-m1-frequency = <750000000>;
+		adi,pll2-charge-pump-current-nA = <805000>;
+
+		adi,rpole2 = <RPOLE2_900_OHM>;
+		adi,rzero = <RZERO_1850_OHM>;
+		adi,cpole1 = <CPOLE1_16_PF>;
+
+		adi,status-mon-pin0-function-select = <0xFF>; /* No function */
+		adi,status-mon-pin1-function-select = <0xFF>; /* No function */
+
+		ad9528_0_c1: channel@1 {
+			reg = <1>;
+			adi,extended-name = "FPGA_GLBL_CLK";
+			adi,driver-mode = <DRIVER_MODE_LVDS>;
+			adi,divider-phase = <0>;
+			adi,channel-divider = <3>; /* 250 MHz */
+			adi,signal-source = <SOURCE_VCO>;
+		};
+
+		ad9528_0_c3: channel@3 {
+			reg = <3>;
+			adi,extended-name = "FPGA_REF_CLK";
+			adi,driver-mode = <DRIVER_MODE_LVDS>;
+			adi,divider-phase = <0>;
+			adi,channel-divider = <1>; /* 750 MHz */
+			adi,signal-source = <SOURCE_VCO>;
+		};
+
+		ad9528_0_c13: channel@13 {
+			reg = <13>;
+			adi,extended-name = "ADC_REF_CLK";
+			adi,driver-mode = <DRIVER_MODE_LVDS>;
+			adi,divider-phase = <0>;
+			adi,channel-divider = <3>; /* 250 MHz */
+			adi,signal-source = <SOURCE_VCO>;
+		};
+
+		ad9528_0_c12: channel@12 {
+			reg = <12>;
+			adi,extended-name = "DEV_SYSREF";
+			adi,driver-mode = <DRIVER_MODE_LVDS>;
+			adi,divider-phase = <0>;
+			adi,channel-divider = <5>;
+			adi,signal-source = <SOURCE_SYSREF_VCO>;
+		};
+
+		ad9528_0_c0: channel@0 {
+			reg = <0>;
+			adi,extended-name = "FMC_SYSREF";
+			adi,driver-mode = <DRIVER_MODE_LVDS>;
+			adi,divider-phase = <0>;
+			adi,channel-divider = <5>;
+			adi,signal-source = <SOURCE_SYSREF_VCO>;
+		};
+	};
+
+	adc0_ad9083: ad9083@0 {
+		compatible = "adi,ad9083";
+		reg = <0>;
+
+		jesd204-device;
+		#jesd204-cells = <2>;
+		jesd204-top-device = <0>;
+		jesd204-link-ids = <0>;
+		jesd204-inputs = <&axi_ad9083_core_rx 0 0>;
+
+		spi-max-frequency = <1000000>;
+		clocks = <&ad9528 13>;
+		clock-names = "adc_ref_clk";
+		adi,adc-frequency-hz= /bits/ 64 <2000000000>; /* 2 GHz */
+
+		/* software reset, resistor is not mounted */
+		/* reset-gpios = <&axi_gpio 33 0>; */
+		pwdn-gpios = <&axi_gpio 32 0>;
+
+		/* adi_ad9083 config */
+
+		adi,vmax-microvolt = <2000>;
+		adi,fc-hz =  /bits/ 64 <800000000>;
+		adi,rterm-ohms = <100>;
+		adi,backoff = <0>;
+		adi,finmax-hz = /bits/ 64 <100000000>;
+		adi,nco0_freq-hz = /bits/ 64 <0>;
+		adi,nco1_freq-hz = /bits/ 64 <0>;
+		adi,nco2_freq-hz = /bits/ 64 <0>;
+		adi,cic_decimation = /bits/ 8 <0>;
+		adi,j_decimation = /bits/ 8 <AD9083_J_DEC_8>;
+		adi,g_decimation = /bits/ 8 <0>;
+		adi,h_decimation = /bits/ 8 <0>;
+		adi,nco0_datapath_mode = /bits/ 8 <AD9083_DATAPATH_ADC_J>;
+
+		/* JESD204 parameters */
+
+		adi,octets-per-frame = <6>;
+		adi,frames-per-multiframe = <32>;
+		adi,converter-resolution = <12>;
+		adi,bits-per-sample = <12>;
+		adi,converters-per-device = <16>;
+		adi,control-bits-per-sample = <0>;
+		adi,lanes-per-device = <4>;
+		adi,subclass = <0>;
+	};
+};

--- a/arch/microblaze/boot/dts/vcu118_ad9083.dts
+++ b/arch/microblaze/boot/dts/vcu118_ad9083.dts
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices AD9083-EVB
+ * Link: https://wiki.analog.com/resources/eval/ad9083
+ *
+ * Copyright (C) 2018-2026 Analog Devices Inc.
+ */
+
+/dts-v1/;
+
+#include "vcu118.dtsi"
+#include <dt-bindings/interrupt-controller/irq.h>
+#include <dt-bindings/iio/adc/adi,ad9083.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/jesd204/adxcvr.h>
+
+#define fmc_spi axi_spi
+
+&axi_intc {
+	xlnx,kind-of-intr = <0xffff05f0>;
+};
+
+&axi_ethernet {
+	local-mac-address = [00 0a 35 00 90 81];
+};
+
+&amba_pl {
+
+	rx_dma: dma-controller@7c400000 {
+		compatible = "adi,axi-dmac-1.00.a";
+		reg = <0x7c400000 0x10000>;
+		#dma-cells = <1>;
+		#clock-cells = <0>;
+		interrupt-parent = <&axi_intc>;
+		interrupts = <12 2>;
+		clocks = <&clk_bus_0>;
+	};
+
+	axi_ad9083_core_rx: axi-ad9083-rx-hpc@44a00000 {
+		compatible = "adi,axi-ad9083-rx-1.0";
+		reg = <0x44a00000 0x8000>;
+		dmas = <&rx_dma 0>;
+		dma-names = "rx";
+		spibus-connected = <&adc0_ad9083>;
+
+		jesd204-device;
+		#jesd204-cells = <2>;
+		jesd204-inputs = <&axi_ad9083_rx_jesd 0 0>;
+	};
+
+	axi_ad9083_rx_jesd: axi-jesd204-rx@44AA0000 {
+		compatible = "adi,axi-jesd204-rx-1.0";
+		reg = <0x44AA0000 0x1000>;
+
+		interrupt-parent = <&axi_intc>;
+		interrupts = <13 2>;
+
+		clocks = <&clk_bus_0>, <&ad9528 1>, <&axi_ad9083_adxcvr_rx 0>, <&axi_ad9083_adxcvr_rx 1>;
+		clock-names = "s_axi_aclk", "device_clk", "lane_clk", "link_clk";
+
+		#clock-cells = <0>;
+		clock-output-names = "jesd_rx_lane_clk";
+
+		jesd204-device;
+		#jesd204-cells = <2>;
+		jesd204-inputs = <&axi_ad9083_adxcvr_rx 0 0>;
+	};
+
+	axi_ad9083_adxcvr_rx: axi-adxcvr-rx@44a60000 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "adi,axi-adxcvr-1.0";
+		reg = <0x44a60000 0x1000>;
+
+		clocks = <&ad9528 3>;
+		clock-names = "conv";
+
+		#clock-cells = <1>;
+		clock-output-names = "rx_gt_clk", "rx_out_clk";
+
+		adi,sys-clk-select = <XCVR_QPLL>;
+		adi,out-clk-select = <XCVR_REFCLK_DIV2>;
+		adi,use-lpm-enable;
+
+		jesd204-device;
+		#jesd204-cells = <2>;
+		jesd204-inputs = <&ad9528 0 0>;
+	};
+
+	axi_sysid_0: axi-sysid-0@45000000 {
+		compatible = "adi,axi-sysid-1.00.a";
+		reg = <0x45000000 0x10000>;
+	};
+};
+
+#include "adi-ad9083-fmc-ebz.dtsi"

--- a/drivers/iio/adc/ad9083.c
+++ b/drivers/iio/adc/ad9083.c
@@ -944,6 +944,20 @@ static int ad9083_parse_dt(struct ad9083_phy *phy, struct device *dev)
 	return 0;
 }
 
+static int ad9083_post_setup(struct iio_dev *indio_dev)
+{
+	struct axiadc_state *st = iio_priv(indio_dev);
+	struct axiadc_converter *conv = iio_device_get_drvdata(indio_dev);
+	struct ad9083_phy *phy = conv->phy;
+	int i;
+
+	for (i = 0; i < phy->jesd_param.jesd_m; i++)
+		axiadc_write(st, ADI_REG_CHAN_CNTRL(i),
+			     ADI_FORMAT_SIGNEXT | ADI_FORMAT_ENABLE);
+
+	return 0;
+}
+
 static void ad9083_setup_chip_info_tbl(struct ad9083_phy *phy)
 {
 	bool complex;
@@ -1024,6 +1038,7 @@ static int ad9083_probe(struct spi_device *spi)
 	conv->reg_access = ad9083_reg_access;
 	conv->write_raw = ad9083_write_raw;
 	conv->read_raw = ad9083_read_raw;
+	conv->post_setup = ad9083_post_setup;
 	conv->attrs = &ad9083_phy_attribute_group;
 
 	if (jdev) {

--- a/drivers/iio/adc/ad9083/adi_ad9083_hal.c
+++ b/drivers/iio/adc/ad9083/adi_ad9083_hal.c
@@ -295,7 +295,8 @@ int32_t adi_ad9083_hal_div_nume_deno(adi_ad9083_device_t *device, uint64_t a,
     for (deno_index = 2; deno_index < 32; deno_index++)
       for (nume_index = 0; nume_index < deno_index; nume_index++) {
 #ifdef __KERNEL__
-        diff = div_u64((frac * 1000 - (b * 1000 * nume_index)), deno_index);
+        diff = (int64_t)(frac * 1000) -
+               (int64_t)div_u64(b * 1000 * (uint64_t)nume_index, deno_index);
 #else
         diff = frac * 1000 - (b * 1000 * nume_index) / deno_index;
 #endif

--- a/drivers/iio/adc/ad9083/adi_ad9083_rx.c
+++ b/drivers/iio/adc/ad9083/adi_ad9083_rx.c
@@ -831,7 +831,7 @@ int32_t adi_ad9083_rx_adc_vti_set(adi_ad9083_device_t *device, uint32_t fc,
   temp = 2 * 314 * 2 * temp;
   kcap_temp = (uint64_t)1000000000000000ul - temp * 700;
 #ifdef __KERNEL__
-  kcap_temp = div_u64(kcap_temp + (temp / 2) * 115, temp * 115);
+  kcap_temp = div64_u64(kcap_temp + (temp / 2) * 115, temp * 115);
 #else
   kcap_temp = (kcap_temp + (temp / 2) * 115) / (temp * 115);
 #endif
@@ -1110,6 +1110,7 @@ int32_t adi_ad9083_rx_datapath_config_set(adi_ad9083_device_t *device,
     break;
   case AD9083_DATAPATH_ADC_J:
     deci_adc_data = 1;
+    no_ddc_mode = 1;
     sample_order = 0;
     break;
   case AD9083_DATAPATH_ADC_CIC_NCO_G:


### PR DESCRIPTION
## PR Description

New device tree and driver fixes to suppot AD9083-EVB on VCU118 with maximum performance.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [x] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
