### PR TITLE
Fix build issues for ADSP boards after kernel bump from 6.12 to 6.18

### DIFF
--- a/drivers/gpio/Kconfig
+++ b/drivers/gpio/Kconfig
@@ -159,7 +159,7 @@ config GPIO_74XX_MMIO
 
 config GPIO_ADI_ADSP_PORT
 	bool "ADI ADSP PORT GPIO driver"
-	depends on OF_GPIO
+	depends on OF_GPIO && (ARCH_SC59X_64 || ARCH_SC59X || ARCH_SC58X || ARCH_SC57X || COMPILE_TEST)
 	select GPIO_GENERIC
 	select ADI_ADSP_IRQ
 	help

--- a/drivers/gpio/gpio-adi-adsp-port.c
+++ b/drivers/gpio/gpio-adi-adsp-port.c
@@ -50,7 +50,7 @@ static int adsp_gpio_direction_output(struct gpio_chip *chip, unsigned int offse
 	return 0;
 }
 
-static void adsp_gpio_set_value(struct gpio_chip *chip, unsigned int offset, int value)
+static int adsp_gpio_set_value(struct gpio_chip *chip, unsigned int offset, int value)
 {
 	struct adsp_gpio_port *port = to_adsp_gpio_port(chip);
 
@@ -73,6 +73,8 @@ static void adsp_gpio_set_value(struct gpio_chip *chip, unsigned int offset, int
 		else
 			__adsp_gpio_writew(port, BIT(offset), ADSP_PORT_REG_DATA_CLEAR);
 	}
+
+	return 0;
 }
 
 static int adsp_gpio_get_value(struct gpio_chip *chip, unsigned int offset)

--- a/drivers/irqchip/Kconfig
+++ b/drivers/irqchip/Kconfig
@@ -105,7 +105,7 @@ config ALPINE_MSI
 config ADI_ADSP_IRQ
 	bool "ADI PORT PINT Driver"
 	depends on OF
-	depends on (ARCH_SC59X_64 || ARCH_SC59X || ARCH_SC58X || ARCH_SC57X)
+	depends on (ARCH_SC59X_64 || ARCH_SC59X || ARCH_SC58X || ARCH_SC57X || COMPILE_TEST)
 	select IRQ_DOMAIN
 	help
 	  Say Y to enable the PORT-based PINT interrupt controller for

--- a/drivers/usb/musb/Kconfig
+++ b/drivers/usb/musb/Kconfig
@@ -107,7 +107,7 @@ config USB_MUSB_JZ4740
 
 config USB_MUSB_ADI
 	tristate "ADI"
-	depends on ARCH_SC59X || ARCH_SC58X || ARCH_SC57X
+	depends on ARCH_SC59X || ARCH_SC58X || ARCH_SC57X || COMPILE_TEST
 	help
 	  Enable usb on ADI platforms.
 

--- a/drivers/usb/musb/adi.c
+++ b/drivers/usb/musb/adi.c
@@ -35,7 +35,7 @@ struct adi_musb_glue {
 
 static void musb_conn_timer_handler(struct timer_list *t)
 {
-	struct musb *musb = from_timer(musb, t, dev_timer);
+	struct musb *musb = timer_container_of(musb, t, dev_timer);
 	unsigned long flags;
 	u16 val;
 	static u8 toggle;

--- a/include/linux/soc/adi/cpu.h
+++ b/include/linux/soc/adi/cpu.h
@@ -118,7 +118,15 @@ void disable_gptimers(u16 mask);
 void map_gptimers(void);
 u16 get_gptimer_status(void);
 void set_gptimer_status(u16 value);
+#if defined(CONFIG_ARCH_SC57X) || defined(CONFIG_ARCH_SC58X) || \
+	defined(CONFIG_ARCH_SC59X) || defined(CONFIG_ARCH_SC59X_64)
 void set_spu_securep_msec(u16 n, bool msec);
+#elif defined(CONFIG_COMPILE_TEST)
+static inline void set_spu_securep_msec(u16 n, bool msec)
+{
+}
+#endif
+
 void platform_ipi_init(void);
 
 #endif				/* __MACH_CPU_H */


### PR DESCRIPTION
The changes address two API mismatches surfaced by the newer kernel:
- update the ADI ADSP GPIO driver to match the current gpio_chip.set callback signature
- replace legacy from_timer() usage in the ADI MUSB glue driver with timer_container_of()

These fixes restore successful builds for ADSP board configurations and unblock CI. No functional change is intended.