### PR TITLE
serial: adi_uart4: remove redundant tx drain wait in set_termios

### DIFF
--- a/drivers/tty/serial/adi_uart4.c
+++ b/drivers/tty/serial/adi_uart4.c
@@ -821,24 +821,6 @@ static void adi_uart4_serial_set_termios(struct uart_port *port,
 		quot = uart_get_divisor(port, baud);
 	}
 
-	/* Wait till the transfer buffer is empty */
-	timeout = jiffies + msecs_to_jiffies(10);
-	while (UART_GET_GCTL(uart) & UCEN && !(UART_GET_LSR(uart) & TEMT))
-		if (time_after(jiffies, timeout)) {
-			dev_warn(port->dev,
-				"timeout waiting for TX buffer empty\n");
-			break;
-		}
-
-	/* Wait till the transfer buffer is empty */
-	timeout = jiffies + msecs_to_jiffies(10);
-	while (UART_GET_GCTL(uart) & UCEN && !(UART_GET_LSR(uart) & TEMT))
-		if (time_after(jiffies, timeout)) {
-			dev_warn(port->dev,
-				"timeout waiting for TX buffer empty\n");
-			break;
-		}
-
 	/* Disable UART */
 	ier = UART_GET_IER(uart);
 	UART_PUT_GCTL(uart, UART_GET_GCTL(uart) & ~UCEN);


### PR DESCRIPTION
Remove the while loop that polls for tx buffer drain inside set_termios.
This is unnecessary for two reasons:

When userspace calls tcsetattr(TCSADRAIN) or tcsetattr(TCSAFLUSH), the
kernel already handles draining via the call chain:
  tcsetattr -> tty_wait_until_sent -> uart_ops->tx_empty ->
  adi_uart4_serial_tx_empty
The driver can rely on the tty layer to have completed this before
set_termios is invoked.

When userspace calls tcsetattr(TCSANOW), the intent is to apply the
baudrate change immediately without waiting for the tx buffer to drain.
Blocking inside set_termios would violate that contract.

Additionally, the while loop is a potential hang on single-core SoCs.
The loop uses jiffies as a timeout, but spin_lock_irqsave disables
interrupts, preventing the timer interrupt from firing and advancing
jiffies. This causes an indefinite busy-wait.

## PR Type
- [x] Bug fix (a change that fixes an issue)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [] I have provided links for the relevant upstream lore