### PR TITLE
gpio: adi-adsp-port: update set callback to return int

### DIFF
--- a/drivers/gpio/gpio-adi-adsp-port.c
+++ b/drivers/gpio/gpio-adi-adsp-port.c
@@ -50,7 +50,7 @@ static int adsp_gpio_direction_output(struct gpio_chip *chip, unsigned int offse
 	return 0;
 }
 
-static void adsp_gpio_set_value(struct gpio_chip *chip, unsigned int offset, int value)
+static int adsp_gpio_set_value(struct gpio_chip *chip, unsigned int offset, int value)
 {
 	struct adsp_gpio_port *port = to_adsp_gpio_port(chip);
 
@@ -73,6 +73,8 @@ static void adsp_gpio_set_value(struct gpio_chip *chip, unsigned int offset, int
 		else
 			__adsp_gpio_writew(port, BIT(offset), ADSP_PORT_REG_DATA_CLEAR);
 	}
+
+	return 0;
 }
 
 static int adsp_gpio_get_value(struct gpio_chip *chip, unsigned int offset)


### PR DESCRIPTION
  Adapt to the upstream gpio_chip API change where the .set callback
  now returns int instead of void, allowing error propagation.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
