### PR TITLE
arch: arm64: boot: dts: gen_gmsl_dts: Updated README for Tegra234 platform

### DIFF
--- a/arch/arm64/boot/dts/gen_gmsl_dts/README.md
+++ b/arch/arm64/boot/dts/gen_gmsl_dts/README.md
@@ -4,62 +4,40 @@
 
 - [Overview](#overview)
 - [Prerequisites](#prerequisites)
-- [Usage](#usage)
 - [JSON Configuration Parameters](#json-configuration-parameters)
 - [Example Configuration](#example-configuration)
-- [Generating the DTS Overlay](#generating-the-dts-overlay)
-- [Applying the Overlay](#applying-the-overlay)
+- [Usage](#usage)
 - [Troubleshooting](#troubleshooting)
 - [References](#references)
 
 ## Overview
 
-The `gen_gmsl_dts` tool automates the generation of Device Tree Source (DTS) overlays tailored for Gigabit Multimedia Serial Link (GMSL) camera configurations on Raspberry Pi platforms. It simplifies the integration of GMSL serializers, deserializers, and camera modules by translating JSON configuration files into corresponding DTS overlays.
+The `gen_gmsl_dts` tool automates the generation of Device Tree Source (DTS) overlays tailored for Gigabit Multimedia Serial Link (GMSL) camera configurations on NVIDIA Jetson Orin (Tegra234) platforms. It simplifies the integration of GMSL serializers, deserializers, and camera modules by translating JSON configuration files into corresponding DTS overlays.
 
 ## Prerequisites
 
-- Raspberry Pi running a compatible Linux kernel (e.g., `gmsl/rpi-6.13.y` branch from Analog Devices).
+- NVIDIA Jetson Orin running a compatible Linux kernel (e.g., `gmsl/tegra-6.12.y` branch from Analog Devices).
 - Python 3.x installed on the system.
 - Access to the `gen_gmsl_dts` directory within the Analog Devices Linux kernel repository.
-
-## Usage
-
-1. **Navigate to the Tool Directory:**
-
-   ```bash
-   cd linux/arch/arm/boot/dts/overlays/gen_gmsl_dts
-   ```
-
-2. **Prepare Your JSON Configuration:**
-
-   In `gen_gmsl_dts` folder there are examples of pre defined configuration JSON files for a variety of serializers, deserializers and camera sensors. If none of these suit your usecase one can create a new JSON file (e.g., `gmsl_config.json`). Plsease refer to the [JSON Configuration Parameters](#json-configuration-parameters) section for details.
-
-3. **Generate the DTS Overlay:**
-
-   ```bash
-   python3 gen_gmsl_dts.py gmsl_config.json --dtbo --o ../gmsl-overlay.dts
-   ```
-
-   This command will generate a DTS overlay file named `gmsl-overlay.dts` based on your configuration.
 
 ## JSON Configuration Parameters
 
 The JSON configuration file defines the GMSL setup. Below are the primary parameters:
 
 - **`name`**: Specifies the deserializer model. Can be one of:
-  - `"max9296a"`, `"max96712"`, `"max96714"`, `"max96716"`, `"max96724"`, `"max96792a"`
+  - `"max96716a"`, `"max96724"`
 
-- **`i2c_bus`**: Configure the RPI I2C bus the deserializer is connected to. Can be:
-  - `"i2c_csi_dsi0"`: CAM0 on RPI5
-  - `"i2c_csi_dsi1"`: CAM1 on RPI5
-  - `"i2c_csi_dsi"`: CAM port on RPI4
+- **`i2c_bus`**: Configure the I2C bus the deserializer is connected to. For Tegra234:
+  - `"cam_mux"`: Camera I2C mux on Jetson Orin
 
-- **`platform_cfg`**: Platform (RPI) specific configurations:
-  - `name`: RPI model (e.g., `"rpi-5-b"`, `"rpi-4-b"`)
-  - `csi_idx`: CSI port (e.g., `1` for RPI4 | `0` or `1` for RPI5)
-  - `phy_idx`: Deserializer MIPI PHY the RPI is connected to
+- **`platform_cfg`**: Platform specific configurations:
+  - `name`: Platform name (e.g., `"tegra-234"`)
+  - `csi_idx`: CSI port index (e.g., `0` for CAM0 | `1` for CAM1)
+  - `phy_idx`: Deserializer MIPI PHY the platform is connected to
+  - `port_index`: CSI port index on the Tegra SoC (e.g., `1` for CAM0 | `2` for CAM1)
+  - `sensor_i2c_base`: Base I2C bus number for the camera sensors (e.g., `11`, `12`)
 
-- **`phys`**: List of MIPI PHY specificn configurations:
+- **`phys`**: List of MIPI PHY specific configurations:
   - `phy_idx`: Deserializer PHY configured in this block (e.g., `0`, `2`)
   - `num_lanes`: Number of MIPI lanes the PHY will use
   - `link_frequencies`: The MIPI PHY lane rate. Because of double data rate on MIPI
@@ -67,31 +45,34 @@ The JSON configuration file defines the GMSL setup. Below are the primary parame
   - `clock_lanes`: `[0]` for normal or `[5]` alternate clocking mode
   - `data_lanes`: `[1, 2]` for 2 lanes | `[1, 2, 3, 4]` for 4 lanes
 - **`links`**: List of GMSL links. One entry for every connected serializer
-  - `name`: Specifies the deserializer model. Can be one of:
-    - `"max96717"`, `"max9295a"`, `"max96793"`
+  - `name`: Specifies the serializer model. Can be:
+    - `"max96717"`
   - `cameras`: Camera connected to the serializer:
-    - `name`: camera model can be `"imx219"` or `"ov5640"`
-  - `"pool_addrs"`: is the range of addresses that the ATC and assign to the camera device
+    - `name`: Specifies the camera model. Can be:
+        - `"imx219-tegra"`
+  - `"pool_addrs"`: is the range of addresses that the ATC can assign to the camera device
 
 ## Example Configuration
 
 ```json
 [
     {
-        "name": "max96724",
-        "i2c_bus": "i2c_csi_dsi0",
+        "name": "max96716a",
+        "i2c_bus": "cam_mux",
         "platform_cfg": {
-            "name": "rpi-5-b",
+            "name": "tegra-234",
             "csi_idx": 0,
-            "phy_idx": 2
+            "phy_idx": 0,
+            "port_index": 1,
+            "sensor_i2c_base": 11
         },
         "phys": [
             {
-                "phy_idx": 2,
-                "num_lanes": 4,
+                "phy_idx": 0,
+                "num_lanes": 2,
                 "link_frequencies": [750000000],
                 "clock_lanes": [0],
-                "data_lanes": [1, 2, 3, 4]
+                "data_lanes": [1, 2]
             }
         ],
         "links": [
@@ -99,66 +80,83 @@ The JSON configuration file defines the GMSL setup. Below are the primary parame
                 "name": "max96717",
                 "cameras": [
                     {
-                        "name": "imx219"
+                        "name": "imx219-tegra"
                     }
                 ],
                 "pool_addrs": ["0x50", "0x51"]
-            },
-            {
-                "name": "max96717",
-                "cameras": [
-                    {
-                        "name": "imx219"
-                    }
-                ],
-                "pool_addrs": ["0x52", "0x53"]
-            },
-            {
-                "name": "max96717",
-                "cameras": [
-                    {
-                        "name": "imx219"
-                    }
-                ],
-                "pool_addrs": ["0x54", "0x55"]
-            },
-            {
-                "name": "max96717",
-                "cameras": [
-                    {
-                        "name": "imx219"
-                    }
-                ],
-                "pool_addrs": ["0x56", "0x57"]
             }
         ]
     }
 ]
 ```
 
-## Applying the Overlay
+## Usage
 
-1. **Compile the DTS Overlay:**
-
-   ```bash
-   make dtbs
-   ``` 
-
-2. **Copy the Overlay to the Boot Directory:**
+1. **Navigate to the Tool Directory:**
 
    ```bash
-   sudo cp gmsl.dtbo /boot/overlays/
+   cd linux/arch/arm64/boot/dts/gen_gmsl_dts
    ```
 
-3. **Edit the Boot Configuration:**
+2. **Prepare Your JSON Configuration:**
 
-   Add the overlay to your `/boot/config.txt` file:
+   In `gen_gmsl_dts` folder there are examples of pre defined configuration JSON files for a variety of serializers, deserializers and camera sensors. If none of these suit your usecase one can create a new JSON file (e.g., `gmsl_config.json`). Please refer to the [JSON Configuration Parameters](#json-configuration-parameters) section for details.
 
-   ```ini
-   dtoverlay=gmsl
+3. **Generate the DTS Overlay:**
+
+   ```bash
+   python3 gen_gmsl_dts.py gmsl_config.json --dtbo -o ../gmsl-overlay.dts
    ```
 
-4. **Reboot the System:**
+   This command will generate a DTS overlay file named `gmsl-overlay.dts` based on your configuration.
+
+4. **Compile the DTS Overlay:**
+
+   From the `linux/arch/arm64/boot/dts/gen_gmsl_dts` folder, compile the generated overlay using `dtc`:
+
+   ```bash
+   dtc -@ -I dts -O dtb -o gmsl.dtbo ../gmsl-overlay.dts
+   ```
+
+   **Note:** Warnings from `dtc` are expected and can be safely ignored.
+
+5. **(Optional) Copy the Overlay from the Host to the Target (Jetson Orin):**
+
+   If the overlay was compiled on a host machine, copy the `.dtbo` file to the Jetson Orin:
+
+   ```bash
+   scp gmsl.dtbo <target:path/to/gmsl_dtbo_dir>
+   ```
+
+   Example of `<target:path/to/gmsl_dtbo_dir>`: `analog@jetson-orin:/home/analog/`
+
+### **Note:** The following commands can only be run on the Jetson Orin
+
+6. **Apply the Overlay Over the Base DTB:**
+
+   Use `fdtoverlay` to merge the GMSL overlay into the base Tegra device tree:
+
+   ```bash
+   fdtoverlay -i /boot/tegra234-p3768-0000+p3767-0005-nv-super.dtb -o tegra234-p3768-0000+p3767-0005-nv-super-gmsl-cam.dtb gmsl.dtbo
+   ```
+
+   **Note:** The base DTB name may vary depending on your Jetson Orin module variant. Check `/boot/` for the correct DTB file name.
+
+7. **Copy the New Device Tree to the Boot Directory:**
+
+   ```bash
+   sudo cp tegra234-p3768-0000+p3767-0005-nv-super-gmsl-cam.dtb /boot/
+   ```
+
+8. **Update the Boot Configuration:**
+
+   Edit `/boot/extlinux/extlinux.conf` (for example, by using `nano` or `vim`) and update the `FDT` line to point to the new DTB:
+
+   ```
+   FDT /boot/tegra234-p3768-0000+p3767-0005-nv-super-gmsl-cam.dtb
+   ```
+
+9. **Reboot the System:**
 
    ```bash
    sudo reboot
@@ -166,15 +164,19 @@ The JSON configuration file defines the GMSL setup. Below are the primary parame
 
 ## Troubleshooting
 
-- **I2C Device Detection:**
+- **Driver Probe:**
 
-  Ensure that the I2C devices are detected:
+  Check that the deserializer and serializer drivers probed successfully:
 
   ```bash
-  sudo i2cdetect -y 10
+  sudo dmesg | grep max
   ```
 
-  You should see entries corresponding to your deserializer and serializers.
+  The output shows the I2C bus and address (e.g., `max96724 1-0027` means bus 1, address 0x27). Use these bus numbers to scan for devices:
+
+  ```bash
+  sudo i2cdetect -y -r 1
+  ```
 
 - **Video Device Verification:**
 
@@ -184,7 +186,7 @@ The JSON configuration file defines the GMSL setup. Below are the primary parame
   v4l2-ctl --list-devices
   ```
 
-  - **Media Device Verification:**
+- **Media Device Verification:**
 
   Check if the media devices are recognized:
 
@@ -192,10 +194,9 @@ The JSON configuration file defines the GMSL setup. Below are the primary parame
   media-ctl -p
   ```
 
-  Your GMSL parts should appear in the media devices tree. Take care there may be multiple devices created in /dev/media*. Select the correct one with -d flag.
+  Your GMSL parts should appear in the media devices tree. There may be multiple devices created in `/dev/media*`. Select the correct one with the `-d` flag.
 
 ## References
 
 - Analog Devices GMSL Linux Kernel Repository: [https://github.com/analogdevicesinc/linux](https://github.com/analogdevicesinc/linux)
 - GMSL support landing page: [Gigabit Multimedia Serial Link™ (GMSL) technology from Analog Devices Inc.](https://github.com/analogdevicesinc/gmsl)
-- Raspberry Pi User Guide for GMSL Cameras: [analogdevicesinc.github.io/documentation](https://analogdevicesinc.github.io/documentation/solutions/reference-designs/ad-gmslcamrpi-adp/raspberry-pi-user-guide/index.html)


### PR DESCRIPTION
## PR Description

Adapted the documentation for the gen_gmsl_dts tool from Raspberry Pi to Tegra234.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
