### PR TITLE
Add EVAL-ADT7604-AZ overlay

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -296,6 +296,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	rpi-ad5770r.dtbo \
 	rpi-ad5791.dtbo \
 	rpi-adt7420.dtbo \
+	rpi-adt7604.dtbo \
 	rpi-backlight.dtbo \
 	rpi-codeczero.dtbo \
 	rpi-cn0504.dtbo \

--- a/arch/arm/boot/dts/overlays/rpi-adt7604-overlay.dts
+++ b/arch/arm/boot/dts/overlays/rpi-adt7604-overlay.dts
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/interrupt-controller/irq.h>
+
+/ {
+	compatible = "brcm,bcm2711", "brcm,bcm2712";
+};
+
+&spi0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	adt7604: adt7604@0 {
+		compatible = "adi,adt7604";
+		reg = <0>;
+		spi-max-frequency = <1000000>;
+		vdd-supply = <&vdd_3v3_reg>;
+		interrupt-parent = <&gpio>;
+		/* GPIO25, 40-pin header pin 22, connect to board INTERRUPT pin */
+		interrupts = <25 IRQ_TYPE_EDGE_RISING>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&adt7604_pins>;
+
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		/* Channel 2: sense resistor R4 (100ohm, 0.01%), CH1-CH2 */
+		trace_rsense: rsense@2 {
+			reg = <2>;
+			adi,sensor-type = <29>;
+			adi,rsense-val-milli-ohms = <100000>;
+		};
+
+		/* Channels 4, 6, 8: copper trace sensors CH3-CH4 */
+		copper-trace@4 {
+			reg = <4>;
+			adi,sensor-type = <32>;
+			adi,rsense-handle = <&trace_rsense>;
+			adi,copper-trace-sub-ohm;
+		};
+
+		copper-trace@6 {
+			reg = <6>;
+			adi,sensor-type = <32>;
+			adi,rsense-handle = <&trace_rsense>;
+			adi,copper-trace-sub-ohm;
+		};
+
+		copper-trace@8 {
+			reg = <8>;
+			adi,sensor-type = <32>;
+			adi,rsense-handle = <&trace_rsense>;
+			adi,copper-trace-sub-ohm;
+		};
+
+		/* Channel 12: sense resistor R6 (1kohm, 0.01%), CH11-CH12 */
+		r_sense: rsense@12 {
+			reg = <12>;
+			adi,sensor-type = <29>;
+			adi,rsense-val-milli-ohms = <1000000>;
+		};
+
+		/* Channel 14: leak detector, CH13-CH14 */
+		leak-detector@14 {
+			reg = <14>;
+			adi,sensor-type = <33>;
+			adi,rsense-handle = <&r_sense>;
+			adi,excitation-current-nanoamp = <10000>;
+			/* Example custom table from ADT7604 datasheet Table 41 */
+			adi,custom-leak-detector =
+				/bits/ 64 <          0 100>,
+				/bits/ 64 <  202020000  99>,
+				/bits/ 64 <  285710000  70>,
+				/bits/ 64 <  333330000  60>,
+				/bits/ 64 <  400000000  50>,
+				/bits/ 64 <  500000000  40>,
+				/bits/ 64 <  666670000  30>,
+				/bits/ 64 < 1000000000  20>,
+				/bits/ 64 < 2000000000  10>,
+				/bits/ 64 <1000000000000 0>;
+		};
+
+		/* Channel 16: leak detector, CH15-CH16 */
+		leak-detector@16 {
+			reg = <16>;
+			adi,sensor-type = <33>;
+			adi,rsense-handle = <&r_sense>;
+			adi,excitation-current-nanoamp = <10000>;
+			adi,custom-leak-detector =
+				/bits/ 64 <          0 100>,
+				/bits/ 64 <  202020000  99>,
+				/bits/ 64 <  285710000  70>,
+				/bits/ 64 <  333330000  60>,
+				/bits/ 64 <  400000000  50>,
+				/bits/ 64 <  500000000  40>,
+				/bits/ 64 <  666670000  30>,
+				/bits/ 64 < 1000000000  20>,
+				/bits/ 64 < 2000000000  10>,
+				/bits/ 64 <1000000000000 0>;
+		};
+
+		/* Channel 18: PT100 onboard 100ohm (2-wire), CH17-CH18 */
+		rtd@18 {
+			reg = <18>;
+			adi,sensor-type = <12>;
+			adi,rsense-handle = <&r_sense>;
+			adi,number-of-wires = <2>;
+			adi,rsense-share;
+			adi,excitation-current-microamp = <500>;
+			adi,rtd-curve = <0>;
+		};
+	};
+};
+
+&gpio {
+	adt7604_pins: adt7604_pins {
+		brcm,pins = <25>;
+		brcm,function = <0>;
+		brcm,pull = <0>;
+	};
+};
+
+&spidev0 {
+	status = "disabled";
+};
+
+&spidev1 {
+	status = "disabled";
+};


### PR DESCRIPTION
## PR Description

Add a Raspberry Pi device tree overlay for the EVAL-ADT7604-AZ.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [X] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [X] I have conducted a self-review of my own code changes
- [X] I have compiled my changes, including the documentation
- [X] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
