### PR TITLE
fix zc706/zedboard + cn0506 onboard phy

### DIFF
--- a/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-cn0506-mii.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-cn0506-mii.dts
@@ -13,3 +13,7 @@
 #include "zynq-zc706.dtsi"
 #include "zynq-zc706-adv7511.dtsi"
 #include "adi-cn0506-mii.dtsi"
+
+&gem0 {
+	/delete-node/ phy@7;
+};

--- a/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-cn0506-rgmii.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-cn0506-rgmii.dts
@@ -13,3 +13,7 @@
 #include "zynq-zc706.dtsi"
 #include "zynq-zc706-adv7511.dtsi"
 #include "adi-cn0506-rgmii.dtsi"
+
+&gem0 {
+	/delete-node/ phy@7;
+};

--- a/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-cn0506-rmii.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-cn0506-rmii.dts
@@ -14,6 +14,10 @@
 #include "zynq-zc706-adv7511.dtsi"
 #include "adi-cn0506-rmii.dtsi"
 
+&gem0 {
+	/delete-node/ phy@7;
+};
+
 &i2c_mux {
 	i2c@6 {
 		#address-cells = <1>;

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-cn0506-mii.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-cn0506-mii.dts
@@ -13,3 +13,7 @@
 #include "zynq-zed.dtsi"
 #include "zynq-zed-adv7511.dtsi"
 #include "adi-cn0506-mii.dtsi"
+
+&gem0 {
+	/delete-node/ phy@0;
+};

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-cn0506-rgmii.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-cn0506-rgmii.dts
@@ -13,3 +13,7 @@
 #include "zynq-zed.dtsi"
 #include "zynq-zed-adv7511.dtsi"
 #include "adi-cn0506-rgmii.dtsi"
+
+&gem0 {
+	/delete-node/ phy@0;
+};

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-cn0506-rmii.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-cn0506-rmii.dts
@@ -14,6 +14,10 @@
 #include "zynq-zed-adv7511.dtsi"
 #include "adi-cn0506-rmii.dtsi"
 
+&gem0 {
+	/delete-node/ phy@0;
+};
+
 &fpga_axi {
 	fmc_i2c: i2c@41620000 {
 		compatible = "xlnx,axi-iic-1.01.b", "xlnx,xps-iic-2.00.a";


### PR DESCRIPTION
## PR Description

### Fix missing MDIO address on zed/zc706-cn0506

On ZedBoard and ZC706, the on board PHY uses MDIO address 7(ZCU706) or 0(ZedBoard), but when the CN0506 board is used, it overwrites the two GEM instances of the Zynq processor to use the addresses on the expansion board, but the old on-board MDIO address remains and gives an error message. 
The device tree entries for the zed/zc706 + cn0506 now remove the old on-board MDIO address to fix the error message.

Old error message: 

<img width="1584" height="448" alt="Screenshot 2026-05-19 105204" src="https://github.com/user-attachments/assets/739bf650-6e3c-41c7-93ba-b452e6659bf7" />


## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [x] I have updated the documentation outside this repo accordingly
- [x] I have provided links for the relevant upstream lore
