### PR TITLE
rpmsg: fix stale src address causing rebind to fail depending on order

### DIFF
--- a/drivers/rpmsg/rpmsg_core.c
+++ b/drivers/rpmsg/rpmsg_core.c
@@ -527,8 +527,19 @@ static void rpmsg_dev_remove(struct device *dev)
 	if (rpdrv->remove)
 		rpdrv->remove(rpdev);
 
-	if (rpdev->ept)
+	if (rpdev->ept) {
 		rpmsg_destroy_ept(rpdev->ept);
+		rpdev->ept = NULL;
+		/*
+		 * If the source address was dynamically allocated during probe
+		 * (i.e. the channel was not a pre-announced server channel),
+		 * reset it so a subsequent re-bind allocates a fresh address
+		 * instead of requesting the now-stale one, which may have been
+		 * claimed by another endpoint in the meantime.
+		 */
+		if (!rpdev->announce)
+			rpdev->src = RPMSG_ADDR_ANY;
+	}
 }
 
 static const struct bus_type rpmsg_bus = {


### PR DESCRIPTION
### Opening PR to track upstream contribution - to be merged when upstreamed

When a channel gets unbound, rpmsg_dev_remove() destroys the endpoint and frees the IDR slot, but forgets to reset rpdev->src back to RPMSG_ADDR_ANY. So the next time the channel gets bound, rpmsg_dev_probe() passes the old stale address as a specific IDR request. If another channel snached that address in the meantime, idr_alloc() fails with -ENOSPC (-28) and probe blows up with:

  rpmsg_chrdev: idr_alloc failed: -28
  rpmsg_chrdev: failed to create endpoint
  rpmsg_chrdev: probe with driver rpmsg_chrdev failed with error -12

This makes the sucess of bind/unbind sequences order-dependent when it really shouldn't be.

Fix: reset rpdev->src to RPMSG_ADDR_ANY after tearing down the endpoint, but only for channels with dynamically-assigned addresses (!rpdev->announce). Channels with a predefined local address need to keep their src so they re-announce the same address on rebind.

Since the rpmsg_device now outlives the unbind and is re-probed on the next bind, also clear rpdev->ept after destroying the endpoint so the stale pointer isn't left dangling for the next probe to trip over.

Fixes: bbd188092e3b ("rpmsg: Support drivers without primary endpoint")

## PR Description

- Please replace this comment with a summary of your changes, and add any context
necessary to understand them. List any dependencies required for this change.
- To check the checkboxes below, insert a 'x' between square brackets (without
any space), or simply check them after publishing the PR.
- If you changes include a breaking change, please specify dependent PRs in the
description and try to push all related PRs simultaneously.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have compiled my changes, including the documentation
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
