### PR TITLE
.github: pr-closed: Bump cloudsmith version

### DIFF
--- a/.github/workflows/pr-closed.yml
+++ b/.github/workflows/pr-closed.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.repository == 'analogdevicesinc/linux'
     runs-on: [self-hosted, repo-only]
     steps:
-    - uses: cloudsmith-io/cloudsmith-cli-action@v1.0.5
+    - uses: cloudsmith-io/cloudsmith-cli-action@v2.0.3
       env:
         CLOUDSMITH_SERVICE_SLUG: ${{ secrets.CLOUDSMITH_SERVICE_SLUG }}
       if: ${{ env.CLOUDSMITH_SERVICE_SLUG != '' && env.CLOUDSMITH_SERVICE_SLUG != ' ' }}


### PR DESCRIPTION
## PR Description

Bump version from v1.0.5 to v2.0.3 for node24 support.
Consider wrapping it at a `@ci` action in the future, or isolating just the oidc pipeline like in
https://github.com/analogdevicesinc/hw-test/blob/46fd42ced00c126131f2674b3baaa7bc3cac0a0f/hw_tests/cloudsmith.py
to not depend on specific node.js versions for no good reason.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have compiled my changes, including the documentation
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
