### PR TITLE
arm/arm64: dts: adi: replace adi,port-sizes with adi,npins

### DIFF
--- a/arch/arm/boot/dts/adi/sc57x.dtsi
+++ b/arch/arm/boot/dts/adi/sc57x.dtsi
@@ -466,7 +466,7 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			reg = <0x31004400 0x400>;
-			adi,port-sizes = <16 16 16 16 16 12>;
+			adi,npins = <92>;
 			adi,no-drive-strength;
 			/*
 			 * @todo fix pinctrl driver:

--- a/arch/arm/boot/dts/adi/sc58x.dtsi
+++ b/arch/arm/boot/dts/adi/sc58x.dtsi
@@ -507,7 +507,7 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			reg = <0x31004400 0x400>;
-			adi,port-sizes = <16 16 16 16 16 16 6>;
+			adi,npins = <102>;
 			adi,no-drive-strength;
 			adi,no-pull-up-down;
 		};

--- a/arch/arm/boot/dts/adi/sc59x.dtsi
+++ b/arch/arm/boot/dts/adi/sc59x.dtsi
@@ -526,7 +526,7 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			reg = <0x31004600 0x400>;
-			adi,port-sizes = <16 16 16 16 16 16 16 16 7>;
+			adi,npins = <135>;
 		};
 
 		sru_ctrl_dai0: sru-ctrl-dai0@310C9000 {

--- a/arch/arm64/boot/dts/adi/sc59x-64.dtsi
+++ b/arch/arm64/boot/dts/adi/sc59x-64.dtsi
@@ -600,7 +600,7 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			reg = <0x31004600 0x400>;
-			adi,port-sizes = <16 16 16 16 16 16 16 16 7>;
+			adi,npins = <135>;
 		};
 
 		sru_ctrl_dai0: sru-ctrl-dai0@310C9000 {

--- a/drivers/pinctrl/adi/pinctrl-adsp.c
+++ b/drivers/pinctrl/adi/pinctrl-adsp.c
@@ -730,20 +730,22 @@ static int adsp_pinctrl_init_groups(struct adsp_pinctrl *adsp_pinctrl,
 	struct device *dev = adsp_pinctrl->dev;
 	struct pinctrl_pin_desc *all_pins;
 	size_t port, pin;
-	unsigned int i, pin_total;
+	unsigned int i;
+	u32 pin_total;
 	int num_ports;
 	int ret;
 
-	num_ports = of_property_count_u32_elems(dev->of_node, "adi,port-sizes");
-
-	if (num_ports < 0)
-		return num_ports;
-
-	if (num_ports == 0) {
-		dev_err(dev, "pinctrl missing `adi,port-sizes` port size definition\n");
-		return -ENOENT;
+	ret = of_property_read_u32(dev->of_node, "adi,npins", &pin_total);
+	if (ret) {
+		dev_err(dev, "pinctrl missing `adi,npins` definition\n");
+		return ret;
+	}
+	if (pin_total == 0) {
+		dev_err(dev, "pinctrl `adi,npins` should be larger than 0\n");
+		return -EINVAL;
 	}
 
+	num_ports = DIV_ROUND_UP(pin_total, ADSP_PORT_NGPIO);
 	adsp_pinctrl->num_ports = num_ports;
 
 	adsp_pinctrl->pin_counts = devm_kcalloc(dev, sizeof(*adsp_pinctrl->pin_counts),
@@ -751,15 +753,9 @@ static int adsp_pinctrl_init_groups(struct adsp_pinctrl *adsp_pinctrl,
 	if (!adsp_pinctrl->pin_counts)
 		return -ENOMEM;
 
-	ret = of_property_read_u32_array(dev->of_node, "adi,port-sizes",
-		adsp_pinctrl->pin_counts, num_ports);
-	if (ret)
-		return ret;
-
-	pin_total = 0;
-
-	for (i = 0; i < num_ports; ++i)
-		pin_total += adsp_pinctrl->pin_counts[i];
+	for (i = 0; i < num_ports - 1; ++i)
+		adsp_pinctrl->pin_counts[i] = ADSP_PORT_NGPIO;
+	adsp_pinctrl->pin_counts[num_ports - 1] = pin_total - (num_ports - 1) * ADSP_PORT_NGPIO;
 
 	adsp_pinctrl->total_pins = pin_total;
 


### PR DESCRIPTION
Replace the per-port size array adi,port-sizes with a single total pin count adi,npins. Update the pinctrl driver accordingly.

This is mainly for aligning with u-boot.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] I have tested the changes only on SC598 SOM EZKIT board
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
