### PR TITLE
arm/arm64: dts: adi: fix gpio-hog polarity on sc5xx boards

### DIFF
--- a/arch/arm/boot/dts/adi/sc573-ezlite.dts
+++ b/arch/arm/boot/dts/adi/sc573-ezlite.dts
@@ -199,8 +199,8 @@
 
 		mlb3-en {
 			gpio-hog;
-			gpios = <5 GPIO_ACTIVE_HIGH>;
-			output-high;
+			gpios = <5 GPIO_ACTIVE_LOW>;
+			output-low;
 			line-name = "mlb3-en";
 		};
 
@@ -230,6 +230,13 @@
 			gpios = <9 GPIO_ACTIVE_LOW>;
 			output-high;
 			line-name = "adau1979-en";
+		};
+
+		audio-jack {
+			gpio-hog;
+			gpios = <10 GPIO_ACTIVE_HIGH>;
+			output-high;
+			line-name = "audio-jack-sel";
 		};
 
 		sd-wp-en {
@@ -277,85 +284,85 @@
 
 		pushbutton3-en {
 			gpio-hog;
-			gpios = <0 GPIO_ACTIVE_HIGH>;
-			output-low;
+			gpios = <0 GPIO_ACTIVE_LOW>;
+			output-high;
 			line-name = "pushbutton3-en";
 		};
 
 		pushbutton2-en {
 			gpio-hog;
-			gpios = <1 GPIO_ACTIVE_HIGH>;
-			output-low;
+			gpios = <1 GPIO_ACTIVE_LOW>;
+			output-high;
 			line-name = "pushbutton2-en";
 		};
 
 		pushbutton1-en {
 			gpio-hog;
-			gpios = <2 GPIO_ACTIVE_HIGH>;
-			output-low;
+			gpios = <2 GPIO_ACTIVE_LOW>;
+			output-high;
 			line-name = "pushbutton1-en";
 		};
 
 		leds-en {
 			gpio-hog;
-			gpios = <3 GPIO_ACTIVE_HIGH>;
-			output-high;
+			gpios = <3 GPIO_ACTIVE_LOW>;
+			output-low;
 			line-name = "leds-en";
 		};
 
 		flag0-loop {
 			gpio-hog;
-			gpios = <4 GPIO_ACTIVE_HIGH>;
-			output-high;
+			gpios = <4 GPIO_ACTIVE_LOW>;
+			output-low;
 			line-name = "flag0-loop";
 		};
 
 		flag1-loop {
 			gpio-hog;
-			gpios = <5 GPIO_ACTIVE_HIGH>;
-			output-high;
+			gpios = <5 GPIO_ACTIVE_LOW>;
+			output-low;
 			line-name = "flag1-loop";
 		};
 
 		flag2-loop {
 			gpio-hog;
-			gpios = <6 GPIO_ACTIVE_HIGH>;
-			output-high;
+			gpios = <6 GPIO_ACTIVE_LOW>;
+			output-low;
 			line-name = "flag2-loop";
 		};
 
 		flag3-loop {
 			gpio-hog;
-			gpios = <7 GPIO_ACTIVE_HIGH>;
-			output-high;
+			gpios = <7 GPIO_ACTIVE_LOW>;
+			output-low;
 			line-name = "flag3-loop";
 		};
 
 		adau1977-en {
 			gpio-hog;
-			gpios = <8 GPIO_ACTIVE_HIGH>;
-			output-high;
+			gpios = <8 GPIO_ACTIVE_LOW>;
+			output-low;
 			line-name = "adau1977-en";
 		};
 
 		adau1977-fault-rst-en {
 			gpio-hog;
-			gpios = <9 GPIO_ACTIVE_HIGH>;
-			output-high;
+			gpios = <9 GPIO_ACTIVE_LOW>;
+			output-low;
 			line-name = "adau1977-fault-rst-en";
 		};
 
 		thumbwheel-oe {
 			gpio-hog;
-			gpios = <10 GPIO_ACTIVE_HIGH>;
-			output-high;
+			gpios = <10 GPIO_ACTIVE_LOW>;
+			output-low;
 			line-name = "thumbwheel-oe";
 		};
 
 		engine-rpm-oe {
 			gpio-hog;
-			gpios = <11 GPIO_ACTIVE_HIGH>;
-			output-high;
+			gpios = <11 GPIO_ACTIVE_LOW>;
+			output-low;
 			line-name = "engine-rpm-oe";
 		};
 

--- a/arch/arm/boot/dts/adi/sc594-som-ezkit.dts
+++ b/arch/arm/boot/dts/adi/sc594-som-ezkit.dts
@@ -94,18 +94,11 @@
 			line-name = "spdif-optical-en";
 		};
 
-		audio-jack {
-			gpio-hog;
-			gpios = <11 GPIO_ACTIVE_HIGH>;
-			output-high;
-			line-name = "audio-jack-sel";
-		};
-
 		mlb {
 			gpio-hog;
-			gpios = <12 0x0>;
-			output-high;
-			line-name = "~mlb-en";
+			gpios = <12 GPIO_ACTIVE_LOW>;
+			output-low;
+			line-name = "mlb-en";
 		};
 
 		eth1 {

--- a/arch/arm64/boot/dts/adi/sc598-som-ezkit.dts
+++ b/arch/arm64/boot/dts/adi/sc598-som-ezkit.dts
@@ -147,17 +147,10 @@
 			line-name = "spdif-optical-en";
 		};
 
-		audio-jack {
-			gpio-hog;
-			gpios = <11 GPIO_ACTIVE_HIGH>;
-			output-high;
-			line-name = "audio-jack-sel";
-		};
-
 		mlb {
 			gpio-hog;
-			gpios = <12 GPIO_ACTIVE_HIGH>;
-			output-high;
+			gpios = <12 GPIO_ACTIVE_LOW>;
+			output-low;
 			line-name = "mlb-en";
 		};
 


### PR DESCRIPTION
On SC573 EZLITE board, all MCP23017 expander enable signals are active-low. Replace GPIO_ACTIVE_HIGH with GPIO_ACTIVE_LOW throughout and change output-low/output-high accordingly to keep the previous default behavior.

Also add missing audio-jack-sel hog for SC573 EZLITE board.

For SC594/SC598 SOM EZKIT boards, remove audio-jack-sel hog, which is not on schematics, and fix mlb-en polarity.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] I have tested the changes only on the SC598 SOM EZKIT board
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
