### PR TITLE
arm/arm64: dts: adi: use ngpios DT property for port pin count

### DIFF
--- a/arch/arm/boot/dts/adi/sc57x.dtsi
+++ b/arch/arm/boot/dts/adi/sc57x.dtsi
@@ -560,6 +560,7 @@
 			#gpio-cells = <2>;
 			reg = <0x31004000 0x7F>;
 			gpio-ranges = <&pinctrl0 0 0 16>;
+			ngpios = <16>;
 			adi,pint = <&pint0 1>;
 			adi,gpio-base = <0>;
 		};
@@ -570,6 +571,7 @@
 			#gpio-cells = <2>;
 			reg = <0x31004080 0x7F>;
 			gpio-ranges = <&pinctrl0 0 16 16>;
+			ngpios = <16>;
 			adi,pint = <&pint0 0>;
 			adi,gpio-base = <16>;
 		};
@@ -580,6 +582,7 @@
 			#gpio-cells = <2>;
 			reg = <0x31004100 0x7F>;
 			gpio-ranges = <&pinctrl0 0 32 16>;
+			ngpios = <16>;
 			adi,pint = <&pint2 1>;
 			adi,gpio-base = <32>;
 		};
@@ -590,6 +593,7 @@
 			#gpio-cells = <2>;
 			reg = <0x31004180 0x7F>;
 			gpio-ranges = <&pinctrl0 0 48 16>;
+			ngpios = <16>;
 			adi,pint = <&pint2 0>;
 			adi,gpio-base = <48>;
 		};
@@ -600,6 +604,7 @@
 			#gpio-cells = <2>;
 			reg = <0x31004200 0x7F>;
 			gpio-ranges = <&pinctrl0 0 64 16>;
+			ngpios = <16>;
 			adi,pint = <&pint4 1>;
 			adi,gpio-base = <64>;
 		};
@@ -610,6 +615,7 @@
 			#gpio-cells = <2>;
 			reg = <0x31004280 0x7F>;
 			gpio-ranges = <&pinctrl0 0 80 12>;
+			ngpios = <12>;
 			adi,pint = <&pint4 0>;
 			adi,gpio-base = <80>;
 		};

--- a/arch/arm/boot/dts/adi/sc58x.dtsi
+++ b/arch/arm/boot/dts/adi/sc58x.dtsi
@@ -603,6 +603,7 @@
 			#gpio-cells = <2>;
 			reg = <0x31004000 0x7F>;
 			gpio-ranges = <&pinctrl0 0 0 16>;
+			ngpios = <16>;
 			adi,pint = <&pint0 1>;
 			adi,gpio-base = <0>;
 		};
@@ -613,6 +614,7 @@
 			#gpio-cells = <2>;
 			reg = <0x31004080 0x7F>;
 			gpio-ranges = <&pinctrl0 0 16 16>;
+			ngpios = <16>;
 			adi,pint = <&pint0 0>;
 			adi,gpio-base = <16>;
 		};
@@ -623,6 +625,7 @@
 			#gpio-cells = <2>;
 			reg = <0x31004100 0x7F>;
 			gpio-ranges = <&pinctrl0 0 32 16>;
+			ngpios = <16>;
 			adi,pint = <&pint2 1>;
 			adi,gpio-base = <32>;
 		};
@@ -633,6 +636,7 @@
 			#gpio-cells = <2>;
 			reg = <0x31004180 0x7F>;
 			gpio-ranges = <&pinctrl0 0 48 16>;
+			ngpios = <16>;
 			adi,pint = <&pint2 0>;
 			adi,gpio-base = <48>;
 		};
@@ -643,6 +647,7 @@
 			#gpio-cells = <2>;
 			reg = <0x31004200 0x7F>;
 			gpio-ranges = <&pinctrl0 0 64 16>;
+			ngpios = <16>;
 			adi,pint = <&pint4 1>;
 			adi,gpio-base = <64>;
 		};
@@ -653,6 +658,7 @@
 			#gpio-cells = <2>;
 			reg = <0x31004280 0x7F>;
 			gpio-ranges = <&pinctrl0 0 80 16>;
+			ngpios = <16>;
 			adi,pint = <&pint4 0>;
 			adi,gpio-base = <80>;
 		};
@@ -663,6 +669,7 @@
 			#gpio-cells = <2>;
 			reg = <0x31004300 0x7F>;
 			gpio-ranges = <&pinctrl0 0 96 6>;
+			ngpios = <6>;
 			adi,pint = <&pint5 0>;
 			adi,gpio-base = <96>;
 		};

--- a/arch/arm/boot/dts/adi/sc59x.dtsi
+++ b/arch/arm/boot/dts/adi/sc59x.dtsi
@@ -639,6 +639,7 @@
 			#gpio-cells = <2>;
 			reg = <0x31004000 0x7F>;
 			gpio-ranges = <&pinctrl0 0 0 16>;
+			ngpios = <16>;
 			adi,pint = <&pint0 1>;
 			adi,gpio-base = <0>;
 		};
@@ -649,6 +650,7 @@
 			#gpio-cells = <2>;
 			reg = <0x31004080 0x7F>;
 			gpio-ranges = <&pinctrl0 0 16 16>;
+			ngpios = <16>;
 			adi,pint = <&pint0 0>;
 			adi,gpio-base = <16>;
 		};
@@ -659,6 +661,7 @@
 			#gpio-cells = <2>;
 			reg = <0x31004100 0x7F>;
 			gpio-ranges = <&pinctrl0 0 32 16>;
+			ngpios = <16>;
 			adi,pint = <&pint2 1>;
 			adi,gpio-base = <32>;
 		};
@@ -669,6 +672,7 @@
 			#gpio-cells = <2>;
 			reg = <0x31004180 0x7F>;
 			gpio-ranges = <&pinctrl0 0 48 16>;
+			ngpios = <16>;
 			adi,pint = <&pint2 0>;
 			adi,gpio-base = <48>;
 		};
@@ -679,6 +683,7 @@
 			#gpio-cells = <2>;
 			reg = <0x31004200 0x7F>;
 			gpio-ranges = <&pinctrl0 0 64 16>;
+			ngpios = <16>;
 			adi,pint = <&pint4 1>;
 			adi,gpio-base = <64>;
 		};
@@ -689,6 +694,7 @@
 			#gpio-cells = <2>;
 			reg = <0x31004280 0x7F>;
 			gpio-ranges = <&pinctrl0 0 80 16>;
+			ngpios = <16>;
 			adi,pint = <&pint4 0>;
 			adi,gpio-base = <80>;
 		};
@@ -699,6 +705,7 @@
 			#gpio-cells = <2>;
 			reg = <0x31004300 0x7F>;
 			gpio-ranges = <&pinctrl0 0 96 16>;
+			ngpios = <16>;
 			adi,pint = <&pint6 1>;
 			adi,gpio-base = <96>;
 		};
@@ -709,6 +716,7 @@
 			#gpio-cells = <2>;
 			reg = <0x31004380 0x7F>;
 			gpio-ranges = <&pinctrl0 0 112 16>;
+			ngpios = <16>;
 			adi,pint = <&pint6 0>;
 			adi,gpio-base = <112>;
 		};
@@ -719,6 +727,7 @@
 			#gpio-cells = <2>;
 			reg = <0x31004400 0x7F>;
 			gpio-ranges = <&pinctrl0 0 128 7>;
+			ngpios = <7>;
 			adi,pint = <&pint7 1>;
 			adi,gpio-base = <128>;
 		};

--- a/arch/arm64/boot/dts/adi/sc59x-64.dtsi
+++ b/arch/arm64/boot/dts/adi/sc59x-64.dtsi
@@ -720,6 +720,7 @@
 			#gpio-cells = <2>;
 			reg = <0x31004000 0x7F>;
 			gpio-ranges = <&pinctrl0 0 0 16>;
+			ngpios = <16>;
 			adi,pint = <&pint0 1>;
 			status = "okay";
 		};
@@ -730,6 +731,7 @@
 			#gpio-cells = <2>;
 			reg = <0x31004080 0x7F>;
 			gpio-ranges = <&pinctrl0 0 16 16>;
+			ngpios = <16>;
 			adi,pint = <&pint0 0>;
 			status = "okay";
 		};
@@ -740,6 +742,7 @@
 			#gpio-cells = <2>;
 			reg = <0x31004100 0x7F>;
 			gpio-ranges = <&pinctrl0 0 32 16>;
+			ngpios = <16>;
 			adi,pint = <&pint2 1>;
 			status = "okay";
 		};
@@ -750,6 +753,7 @@
 			#gpio-cells = <2>;
 			reg = <0x31004180 0x7F>;
 			gpio-ranges = <&pinctrl0 0 48 16>;
+			ngpios = <16>;
 			adi,pint = <&pint2 0>;
 		};
 
@@ -759,6 +763,7 @@
 			#gpio-cells = <2>;
 			reg = <0x31004200 0x7F>;
 			gpio-ranges = <&pinctrl0 0 64 16>;
+			ngpios = <16>;
 			adi,pint = <&pint4 1>;
 		};
 
@@ -768,6 +773,7 @@
 			#gpio-cells = <2>;
 			reg = <0x31004280 0x7F>;
 			gpio-ranges = <&pinctrl0 0 80 16>;
+			ngpios = <16>;
 			adi,pint = <&pint4 0>;
 		};
 
@@ -777,6 +783,7 @@
 			#gpio-cells = <2>;
 			reg = <0x31004300 0x7F>;
 			gpio-ranges = <&pinctrl0 0 96 16>;
+			ngpios = <16>;
 			adi,pint = <&pint6 1>;
 		};
 
@@ -786,6 +793,7 @@
 			#gpio-cells = <2>;
 			reg = <0x31004380 0x7F>;
 			gpio-ranges = <&pinctrl0 0 112 16>;
+			ngpios = <16>;
 			adi,pint = <&pint6 0>;
 		};
 
@@ -795,6 +803,7 @@
 			#gpio-cells = <2>;
 			reg = <0x31004400 0x7F>;
 			gpio-ranges = <&pinctrl0 0 128 7>;
+			ngpios = <7>;
 			adi,pint = <&pint7 1>;
 		};
 

--- a/drivers/gpio/gpio-adi-adsp-port.c
+++ b/drivers/gpio/gpio-adi-adsp-port.c
@@ -133,7 +133,6 @@ static int adsp_gpio_probe(struct platform_device *pdev)
 	gpio->gpio.to_irq = adsp_gpio_to_irq;
 	gpio->gpio.request = gpiochip_generic_request;
 	gpio->gpio.free = gpiochip_generic_free;
-	gpio->gpio.ngpio = ADSP_PORT_NGPIO;
 	gpio->gpio.parent = dev;
 	gpio->gpio.base = -1;
 	ret = devm_gpiochip_add_data(dev, &gpio->gpio, gpio);

--- a/include/linux/soc/adi/adsp-gpio-port.h
+++ b/include/linux/soc/adi/adsp-gpio-port.h
@@ -14,8 +14,6 @@
 
 #include <linux/gpio/driver.h>
 
-/* Number of GPIOs per port instance */
-#define ADSP_PORT_NGPIO 16
 
 /* PORT memory layout */
 #define ADSP_PORT_REG_FER			0x00


### PR DESCRIPTION
Add ngpios to all GPIO port nodes in sc57x, sc58x, sc59x and sc59x-64 DTS files, correctly reflecting the actual hardware pin count for each port. Modify the ADI ADSP GPIO driver accordingly.


## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] I have tested the changes only on the SC598 SOM EZKIT board
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
