### PR TITLE
arm/arm64: dts: adi: rename ospi compatible from sc5xx-qspi to sc59x-…

### DIFF
--- a/arch/arm/boot/dts/adi/sc59x.dtsi
+++ b/arch/arm/boot/dts/adi/sc59x.dtsi
@@ -459,7 +459,7 @@
 		};
 
 		ospi: spi@31027000 {
-			compatible = "adi,sc5xx-qspi";
+			compatible = "adi,sc59x-ospi";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x31027000 0x1000>,

--- a/arch/arm64/boot/dts/adi/sc59x-64.dtsi
+++ b/arch/arm64/boot/dts/adi/sc59x-64.dtsi
@@ -529,7 +529,7 @@
 		};
 
 		ospi: spi@31027000 {
-			compatible = "adi,sc5xx-qspi";
+			compatible = "adi,sc59x-ospi";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x31027000 0x1000>,


### PR DESCRIPTION
sc59x-ospi is a better compatible string for OSPI hardware in SC59x.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
