### PR TITLE
Adsp sc5xx spi2 flash cs from gpio to hardware slvsel

### DIFF
--- a/Documentation/devicetree/bindings/mtd/jedec,spi-nor.yaml
+++ b/Documentation/devicetree/bindings/mtd/jedec,spi-nor.yaml
@@ -34,10 +34,14 @@ properties:
       - items:
           - enum:
               - issi,is25lp016d
+              - issi,is25lp01g
+              - issi,is25lp512
+              - issi,is25lx256
               - micron,mt25qu02g
               - mxicy,mx25r1635f
               - mxicy,mx25u6435f
               - mxicy,mx25v8035f
+              - mxicy,mx66lm1g45
               - spansion,s25sl12801
               - spansion,s25fs512s
           - const: jedec,spi-nor

--- a/arch/arm/boot/dts/adi/sc573-ezlite.dts
+++ b/arch/arm/boot/dts/adi/sc573-ezlite.dts
@@ -139,14 +139,13 @@
 	pinctrl-names = "default";
 	pinctrl-0 = <&spi2_quad>;
 	status = "okay";
-	cs-gpios = <&gpb 15 GPIO_ACTIVE_LOW>;
 
-	flash: w25q128@0 {
+	flash: w25q128@1 {
 		#address-cells = <1>;
 		#size-cells = <1>;
 		compatible = "winbond,w25q128", "jedec,spi-nor";
 		spi-max-frequency = <50000000>;
-		reg = <0>;
+		reg = <1>;
 		spi-cpol;
 		spi-cpha;
 		spi-tx-bus-width = <4>;
@@ -519,7 +518,8 @@
 				 <ADI_ADSP_PINMUX('B', 10, ADI_ADSP_PINFUNC_ALT0)>,
 				 <ADI_ADSP_PINMUX('B', 11, ADI_ADSP_PINFUNC_ALT0)>,
 				 <ADI_ADSP_PINMUX('B', 12, ADI_ADSP_PINFUNC_ALT0)>,
-				 <ADI_ADSP_PINMUX('B', 13, ADI_ADSP_PINFUNC_ALT0)>;
+				 <ADI_ADSP_PINMUX('B', 13, ADI_ADSP_PINFUNC_ALT0)>,
+				 <ADI_ADSP_PINMUX('B', 15, ADI_ADSP_PINFUNC_ALT0)>;
 		};
 	};
 	can0_default: can0_default_pins {

--- a/arch/arm/boot/dts/adi/sc573-ezlite.dts
+++ b/arch/arm/boot/dts/adi/sc573-ezlite.dts
@@ -138,9 +138,10 @@
 &spi2 {
 	pinctrl-names = "default";
 	pinctrl-0 = <&spi2_quad>;
+
 	status = "okay";
 
-	flash: w25q128@1 {
+	flash@1 {
 		#address-cells = <1>;
 		#size-cells = <1>;
 		compatible = "winbond,w25q128", "jedec,spi-nor";

--- a/arch/arm/boot/dts/adi/sc573-ezlite.dts
+++ b/arch/arm/boot/dts/adi/sc573-ezlite.dts
@@ -144,7 +144,7 @@
 	flash: w25q128@0 {
 		#address-cells = <1>;
 		#size-cells = <1>;
-		compatible = "winbond,w25q128";
+		compatible = "winbond,w25q128", "jedec,spi-nor";
 		spi-max-frequency = <50000000>;
 		reg = <0>;
 		spi-cpol;

--- a/arch/arm/boot/dts/adi/sc589-mini.dts
+++ b/arch/arm/boot/dts/adi/sc589-mini.dts
@@ -126,9 +126,10 @@
 &spi2 {
 	pinctrl-names = "default";
 	pinctrl-0 = <&spi2_quad>;
+
 	status = "okay";
 
-	flash: mt25ql512@1 {
+	flash@1 {
 		#address-cells = <1>;
 		#size-cells = <1>;
 		compatible = "micron,mt25ql512", "jedec,spi-nor";

--- a/arch/arm/boot/dts/adi/sc589-mini.dts
+++ b/arch/arm/boot/dts/adi/sc589-mini.dts
@@ -128,14 +128,12 @@
 	pinctrl-0 = <&spi2_quad>;
 	status = "okay";
 
-	cs-gpios = <&gpc 6 GPIO_ACTIVE_LOW>;
-
-	flash: mt25ql512@0 {
+	flash: mt25ql512@1 {
 		#address-cells = <1>;
 		#size-cells = <1>;
 		compatible = "micron,mt25ql512", "jedec,spi-nor";
 		spi-max-frequency = <5000000>;
-		reg = <0>;
+		reg = <1>;
 
 		partition@0 {
 			label = "u-boot-spl";
@@ -327,7 +325,8 @@
 				 <ADI_ADSP_PINMUX('C', 2, ADI_ADSP_PINFUNC_ALT0)>,
 				 <ADI_ADSP_PINMUX('C', 3, ADI_ADSP_PINFUNC_ALT0)>,
 				 <ADI_ADSP_PINMUX('C', 4, ADI_ADSP_PINFUNC_ALT0)>,
-				 <ADI_ADSP_PINMUX('C', 5, ADI_ADSP_PINFUNC_ALT0)>;
+				 <ADI_ADSP_PINMUX('C', 5, ADI_ADSP_PINFUNC_ALT0)>,
+				 <ADI_ADSP_PINMUX('C', 6, ADI_ADSP_PINFUNC_ALT0)>;
 		};
 	};
 	eth0_default: eth0_default_pins {

--- a/arch/arm/boot/dts/adi/sc594-som.dtsi
+++ b/arch/arm/boot/dts/adi/sc594-som.dtsi
@@ -148,7 +148,7 @@
 	flash: is25lp512@0 {
 		#address-cells = <1>;
 		#size-cells = <1>;
-		compatible = "is25lp512", "jedec,spi-nor";
+		compatible = "issi,is25lp512", "jedec,spi-nor";
 		spi-max-frequency = <5000000>;
 		reg = <0>;
 		spi-cpol;
@@ -189,7 +189,7 @@
 	flash0: is25lx256@0 {
 		#address-cells = <1>;
 		#size-cells = <1>;
-		compatible = "is25lx256", "jedec,spi-nor";
+		compatible = "issi,is25lx256", "jedec,spi-nor";
 		reg = <0>;
 
 		spi-tx-bus-width = <8>;

--- a/arch/arm/boot/dts/adi/sc594-som.dtsi
+++ b/arch/arm/boot/dts/adi/sc594-som.dtsi
@@ -141,9 +141,10 @@
 &spi2 {
 	pinctrl-names = "default";
 	pinctrl-0 = <&spi2_quad>;
+
 	status = "okay";
 
-	flash: is25lp512@1 {
+	flash@1 {
 		#address-cells = <1>;
 		#size-cells = <1>;
 		compatible = "issi,is25lp512", "jedec,spi-nor";
@@ -184,7 +185,7 @@
 
 	status = "disabled";
 
-	flash0: is25lx256@0 {
+	flash@0 {
 		#address-cells = <1>;
 		#size-cells = <1>;
 		compatible = "issi,is25lx256", "jedec,spi-nor";

--- a/arch/arm/boot/dts/adi/sc594-som.dtsi
+++ b/arch/arm/boot/dts/adi/sc594-som.dtsi
@@ -143,14 +143,12 @@
 	pinctrl-0 = <&spi2_quad>;
 	status = "okay";
 
-	cs-gpios = <&gpa 5 GPIO_ACTIVE_LOW>;
-
-	flash: is25lp512@0 {
+	flash: is25lp512@1 {
 		#address-cells = <1>;
 		#size-cells = <1>;
 		compatible = "issi,is25lp512", "jedec,spi-nor";
 		spi-max-frequency = <5000000>;
-		reg = <0>;
+		reg = <1>;
 		spi-cpol;
 		spi-cpha;
 		spi-rx-bus-width = <4>;
@@ -373,7 +371,8 @@
 				 <ADI_ADSP_PINMUX('A', 1, ADI_ADSP_PINFUNC_ALT0)>,
 				 <ADI_ADSP_PINMUX('A', 2, ADI_ADSP_PINFUNC_ALT0)>,
 				 <ADI_ADSP_PINMUX('A', 3, ADI_ADSP_PINFUNC_ALT0)>,
-					 <ADI_ADSP_PINMUX('A', 4, ADI_ADSP_PINFUNC_ALT0)>;
+				 <ADI_ADSP_PINMUX('A', 4, ADI_ADSP_PINFUNC_ALT0)>,
+				 <ADI_ADSP_PINMUX('A', 5, ADI_ADSP_PINFUNC_ALT0)>;
 		};
 	};
 	ospi_default: ospi_default_pins {

--- a/arch/arm64/boot/dts/adi/sc598-htol.dts
+++ b/arch/arm64/boot/dts/adi/sc598-htol.dts
@@ -99,11 +99,11 @@
 };
 
 &spi2 {
-	som_flash: is25lp01g@0 {
+	som_flash: is25lp01g@1 {
 		#address-cells = <1>;
 		#size-cells = <1>;
 		compatible = "issi,is25lp01g", "jedec,spi-nor";
-		reg = <0>;
+		reg = <1>;
 		spi-tx-bus-width = <4>;
 		spi-rx-bus-width = <4>;
 		spi-max-frequency = <10000000>;

--- a/arch/arm64/boot/dts/adi/sc598-htol.dts
+++ b/arch/arm64/boot/dts/adi/sc598-htol.dts
@@ -99,7 +99,7 @@
 };
 
 &spi2 {
-	som_flash: is25lp01g@1 {
+	flash@1 {
 		#address-cells = <1>;
 		#size-cells = <1>;
 		compatible = "issi,is25lp01g", "jedec,spi-nor";

--- a/arch/arm64/boot/dts/adi/sc598-som-ezkit.dts
+++ b/arch/arm64/boot/dts/adi/sc598-som-ezkit.dts
@@ -29,7 +29,7 @@
 	flash0: mx66lm1g45@0 {
 		#address-cells = <1>;
 		#size-cells = <1>;
-		compatible = "mx66lm1g45", "jedec,spi-nor";
+		compatible = "mxicy,mx66lm1g45", "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <83333334>;
 		spi-tx-bus-width = <8>;

--- a/arch/arm64/boot/dts/adi/sc598-som-ezkit.dts
+++ b/arch/arm64/boot/dts/adi/sc598-som-ezkit.dts
@@ -26,7 +26,7 @@
 
 	status = "disabled";
 
-	flash0: mx66lm1g45@0 {
+	flash@0 {
 		#address-cells = <1>;
 		#size-cells = <1>;
 		compatible = "mxicy,mx66lm1g45", "jedec,spi-nor";

--- a/arch/arm64/boot/dts/adi/sc598-som-revD.dtsi
+++ b/arch/arm64/boot/dts/adi/sc598-som-revD.dtsi
@@ -81,9 +81,9 @@
 };
 
 &spi2 {
-	som_flash: is25lp512@0 {
+	som_flash: is25lp512@1 {
 		compatible = "issi,is25lp512", "jedec,spi-nor";
-		reg = <0>;
+		reg = <1>;
 		spi-rx-bus-width = <4>;
 		spi-max-frequency = <25000000>;
 

--- a/arch/arm64/boot/dts/adi/sc598-som-revD.dtsi
+++ b/arch/arm64/boot/dts/adi/sc598-som-revD.dtsi
@@ -81,7 +81,7 @@
 };
 
 &spi2 {
-	som_flash: is25lp512@1 {
+	flash@1 {
 		compatible = "issi,is25lp512", "jedec,spi-nor";
 		reg = <1>;
 		spi-rx-bus-width = <4>;

--- a/arch/arm64/boot/dts/adi/sc598-som-revD.dtsi
+++ b/arch/arm64/boot/dts/adi/sc598-som-revD.dtsi
@@ -82,7 +82,7 @@
 
 &spi2 {
 	som_flash: is25lp512@0 {
-		compatible = "jedec,spi-nor", "is25lp512";
+		compatible = "issi,is25lp512", "jedec,spi-nor";
 		reg = <0>;
 		spi-rx-bus-width = <4>;
 		spi-max-frequency = <25000000>;

--- a/arch/arm64/boot/dts/adi/sc598-som-revE.dtsi
+++ b/arch/arm64/boot/dts/adi/sc598-som-revE.dtsi
@@ -80,9 +80,9 @@
 };
 
 &spi2 {
-	som_flash: is25lp01g@0 {
+	som_flash: is25lp01g@1 {
 		compatible = "issi,is25lp01g", "jedec,spi-nor";
-		reg = <0>;
+		reg = <1>;
 		spi-rx-bus-width = <4>;
 		spi-max-frequency = <25000000>;
 

--- a/arch/arm64/boot/dts/adi/sc598-som-revE.dtsi
+++ b/arch/arm64/boot/dts/adi/sc598-som-revE.dtsi
@@ -80,7 +80,7 @@
 };
 
 &spi2 {
-	som_flash: is25lp01g@1 {
+	flash@1 {
 		compatible = "issi,is25lp01g", "jedec,spi-nor";
 		reg = <1>;
 		spi-rx-bus-width = <4>;

--- a/arch/arm64/boot/dts/adi/sc598-som-revE.dtsi
+++ b/arch/arm64/boot/dts/adi/sc598-som-revE.dtsi
@@ -81,7 +81,7 @@
 
 &spi2 {
 	som_flash: is25lp01g@0 {
-		compatible = "jedec,spi-nor", "is25lp01g";
+		compatible = "issi,is25lp01g", "jedec,spi-nor";
 		reg = <0>;
 		spi-rx-bus-width = <4>;
 		spi-max-frequency = <25000000>;

--- a/arch/arm64/boot/dts/adi/sc598-som.dtsi
+++ b/arch/arm64/boot/dts/adi/sc598-som.dtsi
@@ -203,7 +203,6 @@
 	pinctrl-names = "default";
 	pinctrl-0 = <&spi2_quad>;
 	status = "okay";
-	cs-gpios = <&gpa 5 GPIO_ACTIVE_LOW>;
 };
 
 &i2c0 {
@@ -276,7 +275,8 @@
 				 <ADI_ADSP_PINMUX('A', 1, ADI_ADSP_PINFUNC_ALT0)>,
 				 <ADI_ADSP_PINMUX('A', 2, ADI_ADSP_PINFUNC_ALT0)>,
 				 <ADI_ADSP_PINMUX('A', 3, ADI_ADSP_PINFUNC_ALT0)>,
-					 <ADI_ADSP_PINMUX('A', 4, ADI_ADSP_PINFUNC_ALT0)>;
+				 <ADI_ADSP_PINMUX('A', 4, ADI_ADSP_PINFUNC_ALT0)>,
+				 <ADI_ADSP_PINMUX('A', 5, ADI_ADSP_PINFUNC_ALT0)>;
 		};
 	};
 	spi3_default: spi3_default_pins {

--- a/drivers/spi/spi-adi.c
+++ b/drivers/spi/spi-adi.c
@@ -652,6 +652,23 @@ static int adi_spi_unprepare_message(struct spi_controller *controller, struct s
 	return 0;
 }
 
+static void adi_spi_set_cs(struct spi_device *spi, bool high)
+{
+	struct adi_spi_controller *drv = spi_controller_get_devdata(spi->controller);
+	u8 cs = spi_get_chipselect(spi, 0);
+	u32 ssel;
+
+	ssel = ioread32(&drv->regs->ssel);
+	/* Set SSEL value bit */
+	if (high)
+		ssel |= BIT(cs + 8);
+	else
+		ssel &= ~BIT(cs + 8);
+	/* Set SSE enable bit */
+	ssel |= BIT(cs);
+	iowrite32(ssel, &drv->regs->ssel);
+}
+
 static int adi_spi_setup(struct spi_device *spi)
 {
 	struct adi_spi_device *chip;
@@ -751,8 +768,9 @@ static int adi_spi_probe(struct platform_device *pdev)
 
 	controller->dev.of_node = dev->of_node;
 	controller->bus_num = -1;
-	controller->num_chipselect = 4;
+	controller->num_chipselect = 8;
 	controller->use_gpio_descriptors = true;
+	controller->set_cs = adi_spi_set_cs;
 	controller->cleanup = adi_spi_cleanup;
 	controller->setup = adi_spi_setup;
 	controller->prepare_message = adi_spi_prepare_message;


### PR DESCRIPTION
Currently Linux kernel uses GPIO for SPI2 flash CS, but u-boot uses hardware SLVSEL. To make them same so u-boot can use Linux device tree files, I chose to change Linux kernel to be as same as u-boot.

The 2nd commit depends on the 1st commit. So I put both in the same PR. The 1st commit should be straight forward.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] I have tested the changes only on SC598 SOM EZKIT board
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
