### PR TITLE
Ad9081 update ctle filter

### DIFF
--- a/Documentation/devicetree/bindings/iio/adc/adi,ad9081.yaml
+++ b/Documentation/devicetree/bindings/iio/adc/adi,ad9081.yaml
@@ -389,6 +389,13 @@ properties:
 
           '#size-cells':
             const: 0
+
+          adi,ctle-filter-settings:
+            $ref: /schemas/types.yaml#/definitions/uint8-array
+            minItems: 1
+            maxItems: 8
+            description: CTLE filter settings for JESD lanes.
+
         patternProperties:
           "^link@[0-1]$":
             type: object

--- a/arch/arm64/boot/dts/xilinx/versal-vck190-reva-ad9081-204c-txmode22-rxmode23.dts
+++ b/arch/arm64/boot/dts/xilinx/versal-vck190-reva-ad9081-204c-txmode22-rxmode23.dts
@@ -307,6 +307,8 @@
 				#size-cells = <0>;
 				#address-cells = <1>;
 
+				adi,ctle-filter-settings = /bits/ 8 <3 4 3 3 3 4 3 3>; /* ctle filter for config */
+
 				ad9081_rx_jesd_l0: link@0 {
 					reg = <0>;
 					adi,converter-select =

--- a/arch/arm64/boot/dts/xilinx/versal-vck190-reva-ad9081-204c-txmode23-rxmode25.dts
+++ b/arch/arm64/boot/dts/xilinx/versal-vck190-reva-ad9081-204c-txmode23-rxmode25.dts
@@ -134,6 +134,8 @@
 			adi,jesd-links {
 				#size-cells = <0>;
 				#address-cells = <1>;
+				
+				adi,ctle-filter-settings = /bits/ 8 <3 4 3 3 3 4 3 3>; /* ctle filter for config */
 
 				ad9081_tx_jesd_l0: link@0 {
 					#address-cells = <1>;

--- a/arch/arm64/boot/dts/xilinx/versal-vck190-reva-ad9081.dts
+++ b/arch/arm64/boot/dts/xilinx/versal-vck190-reva-ad9081.dts
@@ -522,6 +522,8 @@
 				#size-cells = <0>;
 				#address-cells = <1>;
 
+				adi,ctle-filter-settings = /bits/ 8 <3 4 3 3 3 4 3 3>; /* ctle filter for config */
+
 				ad9081_tx_jesd_l0: link@0 {
 					#address-cells = <1>;
 					#size-cells = <0>;

--- a/arch/arm64/boot/dts/xilinx/versal-vck190-reva-ad9082.dts
+++ b/arch/arm64/boot/dts/xilinx/versal-vck190-reva-ad9082.dts
@@ -74,6 +74,8 @@
 			#size-cells = <0>;
 			#address-cells = <1>;
 
+			adi,ctle-filter-settings = /bits/ 8 <3 4 3 3 3 4 3 3>; /* ctle filter for config */
+
 			ad9081_tx_jesd_l0: link@0 {
 				#address-cells = <1>;
 				#size-cells = <0>;


### PR DESCRIPTION
## PR Description

With the latest feature of running ad9081_jesd_rx_calibrate_204c, projects with higher lane rates were failing calibration on certain lanes. Added the corresponding device-trees ctle-filter-settings to avoid calibration fail.
ctle-filter-settings was missing from adi,ad9081.yaml file, added the new entry.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have compiled my changes, including the documentation
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
