### PR TITLE
arm64: dts: versa-vck190-reva-ad9081-204c-txmode22-rxmode23: Update R…

### DIFF
--- a/arch/arm64/boot/dts/xilinx/versal-vck190-reva-ad9081-204c-txmode22-rxmode23.dts
+++ b/arch/arm64/boot/dts/xilinx/versal-vck190-reva-ad9081-204c-txmode22-rxmode23.dts
@@ -127,7 +127,7 @@
 		hmc7044_c2: channel@2 {
 			reg = <2>;
 			adi,extended-name = "DEV_REFCLK";
-			adi,divider = <4>; /* 720 MHz */
+			adi,divider = <16>; /* 180 MHz */
 			adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
 		};
 
@@ -165,7 +165,7 @@
 		hmc7044_c12: channel@12 {
 			reg = <12>;
 			adi,extended-name = "FPGA_REFCLK2";
-			adi,divider = <8>;
+			adi,divider = <16>;
 			adi,driver-mode = <HMC7044_DRIVER_MODE_LVDS>;
 		};
 
@@ -320,14 +320,14 @@
 					adi,dual-link = <0>;			/* JESD Dual Link Mode */
 
 					adi,converters-per-device = <2>;	/* JESD M */
-					adi,octets-per-frame = <6>;		/* JESD F */
+					adi,octets-per-frame = <3>;		/* JESD F */
 
-					adi,frames-per-multiframe = <128>;	/* JESD K */
+					adi,frames-per-multiframe = <256>;	/* JESD K */
 					adi,converter-resolution = <12>;	/* JESD N */
 					adi,bits-per-sample = <12>;		/* JESD NP' */
 					adi,control-bits-per-sample = <0>;	/* JESD CS */
 					adi,lanes-per-device = <2>;		/* JESD L */
-					adi,samples-per-converter-per-frame = <4>; /* JESD S */
+					adi,samples-per-converter-per-frame = <2>; /* JESD S */
 					adi,high-density = <0>;			/* JESD HD */
 				};
 			};


### PR DESCRIPTION
…X mode and clocks

Update RX JESD204C parameters and reference clock
divider to match the HDL build parameters

## PR Description

The HDL built for the new release had the parameters for RX mode 23.00 while the DTS was set to 23.10 although the comment at the top said 23.00.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
