### PR TITLE
arm64: dts: versal-vpk180-reva-ad9081: Update ctle filter settings

### DIFF
--- a/arch/arm64/boot/dts/xilinx/versal-vpk180-reva-ad9081.dts
+++ b/arch/arm64/boot/dts/xilinx/versal-vpk180-reva-ad9081.dts
@@ -522,6 +522,8 @@
 				#size-cells = <0>;
 				#address-cells = <1>;
 
+				adi,ctle-filter-settings = /bits/ 8 <3 4 3 3 3 4 3 3>; /* ctle filter for config */
+
 				ad9081_tx_jesd_l0: link@0 {
 					#address-cells = <1>;
 					#size-cells = <0>;


### PR DESCRIPTION
## PR Description

Tested on hardware. With the default filters the RX calibration is failing.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
