### PR TITLE
drivers: iio: adc: ad9081: fix ramp test pattern

### DIFF
--- a/drivers/iio/adc/ad9081.c
+++ b/drivers/iio/adc/ad9081.c
@@ -931,6 +931,9 @@ static const char *const ad9081_adc_testmodes[] = {
 	[AD9081_TMODE_PN15] = "pn15",
 	[AD9081_TMODE_PN31] = "pn31",
 	[AD9081_TMODE_RAMP] = "ramp",
+	[12] = "",
+	[13] = "",
+	[14] = ""
 };
 
 static const char *const ad9081_jesd_testmodes[] = {


### PR DESCRIPTION
## PR Description

iio_sysfs_match_string_with_gaps() was replaced with __sysfs_match_string() which breaks on NULL values. The ad9081_adc_testmodes had gaps between "pn31" and "ramp" so selecting "ramp" was no longer possible.

I filled in the gaps with empty strings similar to the ad9088 driver: https://github.com/analogdevicesinc/linux/blob/main/drivers/iio/trx-rf/ad9088/ad9088.c#L1325

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
