### PR TITLE
AD9081 release fixes

### DIFF
--- a/Documentation/devicetree/bindings/iio/adc/adi,ad9081.yaml
+++ b/Documentation/devicetree/bindings/iio/adc/adi,ad9081.yaml
@@ -389,6 +389,13 @@ properties:
 
           '#size-cells':
             const: 0
+
+          adi,ctle-filter-settings:
+            $ref: /schemas/types.yaml#/definitions/uint8-array
+            minItems: 1
+            maxItems: 8
+            description: CTLE filter settings for JESD lanes.
+
         patternProperties:
           "^link@[0-1]$":
             type: object

--- a/arch/arm64/boot/dts/xilinx/versal-vck190-reva-ad9081-204c-txmode22-rxmode23.dts
+++ b/arch/arm64/boot/dts/xilinx/versal-vck190-reva-ad9081-204c-txmode22-rxmode23.dts
@@ -307,6 +307,8 @@
 				#size-cells = <0>;
 				#address-cells = <1>;
 
+				adi,ctle-filter-settings = /bits/ 8 <3 4 3 3 3 4 3 3>; /* ctle filter for config */
+
 				ad9081_rx_jesd_l0: link@0 {
 					reg = <0>;
 					adi,converter-select =

--- a/arch/arm64/boot/dts/xilinx/versal-vck190-reva-ad9081-204c-txmode23-rxmode25.dts
+++ b/arch/arm64/boot/dts/xilinx/versal-vck190-reva-ad9081-204c-txmode23-rxmode25.dts
@@ -135,6 +135,8 @@
 				#size-cells = <0>;
 				#address-cells = <1>;
 
+				adi,ctle-filter-settings = /bits/ 8 <3 4 3 3 3 4 3 3>; /* ctle filter for config */
+
 				ad9081_tx_jesd_l0: link@0 {
 					#address-cells = <1>;
 					#size-cells = <0>;

--- a/arch/arm64/boot/dts/xilinx/versal-vck190-reva-ad9081.dts
+++ b/arch/arm64/boot/dts/xilinx/versal-vck190-reva-ad9081.dts
@@ -522,6 +522,8 @@
 				#size-cells = <0>;
 				#address-cells = <1>;
 
+				adi,ctle-filter-settings = /bits/ 8 <3 4 3 3 3 4 3 3>; /* ctle filter for config */
+
 				ad9081_tx_jesd_l0: link@0 {
 					#address-cells = <1>;
 					#size-cells = <0>;

--- a/arch/arm64/boot/dts/xilinx/versal-vck190-reva-ad9082.dts
+++ b/arch/arm64/boot/dts/xilinx/versal-vck190-reva-ad9082.dts
@@ -74,6 +74,8 @@
 			#size-cells = <0>;
 			#address-cells = <1>;
 
+			adi,ctle-filter-settings = /bits/ 8 <3 4 3 3 3 4 3 3>; /* ctle filter for config */
+
 			ad9081_tx_jesd_l0: link@0 {
 				#address-cells = <1>;
 				#size-cells = <0>;

--- a/arch/arm64/boot/dts/xilinx/versal-vpk180-reva-ad9081.dts
+++ b/arch/arm64/boot/dts/xilinx/versal-vpk180-reva-ad9081.dts
@@ -522,6 +522,8 @@
 				#size-cells = <0>;
 				#address-cells = <1>;
 
+				adi,ctle-filter-settings = /bits/ 8 <3 4 3 3 3 4 3 3>; /* ctle filter for config */
+
 				ad9081_tx_jesd_l0: link@0 {
 					#address-cells = <1>;
 					#size-cells = <0>;

--- a/drivers/iio/adc/ad9081.c
+++ b/drivers/iio/adc/ad9081.c
@@ -931,6 +931,9 @@ static const char *const ad9081_adc_testmodes[] = {
 	[AD9081_TMODE_PN15] = "pn15",
 	[AD9081_TMODE_PN31] = "pn31",
 	[AD9081_TMODE_RAMP] = "ramp",
+	[12] = "",
+	[13] = "",
+	[14] = ""
 };
 
 static const char *const ad9081_jesd_testmodes[] = {


### PR DESCRIPTION
## PR Description

Brings the changes from the following PRs to the release branch:

https://github.com/analogdevicesinc/linux/pull/3379
https://github.com/analogdevicesinc/linux/pull/3374
https://github.com/analogdevicesinc/linux/pull/3380

The filter updates are needed for the VCK190/VPK180 variants of the AD9081 project that are in the release, with the default filters the RX calibration doesn't pass and the JESD link is disabled.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
