### PR TITLE
arch: arm64: boot: dts: xilinx: fixed incorrect device tree parameter…

### DIFF
--- a/arch/arm64/boot/dts/xilinx/vu11p-ad9084-vpx-reva-204C_M4_L8_NP16_8p0_4x2.dtso
+++ b/arch/arm64/boot/dts/xilinx/vu11p-ad9084-vpx-reva-204C_M4_L8_NP16_8p0_4x2.dtso
@@ -481,7 +481,7 @@
 				<&axi_ad9084_core_tx 0 DEFRAMER_LINK_A0_TX>,
 				<&axi_ad9084_core_tx_b 0 DEFRAMER_LINK_B0_TX>;
 
-			adi,side-b-use-seperate-tpl-en;
+			adi,side-b-use-separate-tpl-en;
 #else
 			jesd204-link-ids = <DEFRAMER_LINK_A0_TX FRAMER_LINK_A0_RX>;
 

--- a/arch/arm64/boot/dts/xilinx/vu11p-ad9084-vpx-reva.dtso
+++ b/arch/arm64/boot/dts/xilinx/vu11p-ad9084-vpx-reva.dtso
@@ -482,7 +482,7 @@
 				<&axi_ad9084_core_tx 0 DEFRAMER_LINK_A0_TX>,
 				<&axi_ad9084_core_tx_b 0 DEFRAMER_LINK_B0_TX>;
 
-			adi,side-b-use-seperate-tpl-en;
+			adi,side-b-use-separate-tpl-en;
 #else
 			jesd204-link-ids = <DEFRAMER_LINK_A0_TX FRAMER_LINK_A0_RX>;
 

--- a/arch/arm64/boot/dts/xilinx/vu11p-ad9084-vpx-revb-204C_M4_L4_NP16_8p0_2x2.dtso
+++ b/arch/arm64/boot/dts/xilinx/vu11p-ad9084-vpx-revb-204C_M4_L4_NP16_8p0_2x2.dtso
@@ -518,7 +518,7 @@
 				<&axi_ad9084_core_tx 0 DEFRAMER_LINK_A0_TX>,
 				<&axi_ad9084_core_tx_b 0 DEFRAMER_LINK_B0_TX>;
 
-			adi,side-b-use-seperate-tpl-en;
+			adi,side-b-use-separate-tpl-en;
 #else
 			jesd204-link-ids = <DEFRAMER_LINK_A0_TX FRAMER_LINK_A0_RX>;
 

--- a/arch/arm64/boot/dts/xilinx/vu11p-ad9084-vpx-revb-204C_M4_L8_NP16_8p0_4x2.dtso
+++ b/arch/arm64/boot/dts/xilinx/vu11p-ad9084-vpx-revb-204C_M4_L8_NP16_8p0_4x2.dtso
@@ -597,7 +597,7 @@
 				<&axi_ad9084_core_tx 0 DEFRAMER_LINK_A0_TX>,
 				<&axi_ad9084_core_tx_b 0 DEFRAMER_LINK_B0_TX>;
 
-			adi,side-b-use-seperate-tpl-en;
+			adi,side-b-use-separate-tpl-en;
 #else
 			jesd204-link-ids = <DEFRAMER_LINK_A0_TX FRAMER_LINK_A0_RX>;
 

--- a/arch/arm64/boot/dts/xilinx/vu11p-ad9084-vpx-revb.dtso
+++ b/arch/arm64/boot/dts/xilinx/vu11p-ad9084-vpx-revb.dtso
@@ -561,7 +561,7 @@
 				<&axi_ad9084_core_tx 0 DEFRAMER_LINK_A0_TX>,
 				<&axi_ad9084_core_tx_b 0 DEFRAMER_LINK_B0_TX>;
 
-			adi,side-b-use-seperate-tpl-en;
+			adi,side-b-use-separate-tpl-en;
 #else
 			jesd204-link-ids = <DEFRAMER_LINK_A0_TX FRAMER_LINK_A0_RX>;
 


### PR DESCRIPTION
## PR Description

Commit cb63d55675de ("Add comprehensive calibration save/restore system") fixed a typo in the device tree property name in the driver, changing it from "adi,side-b-use-seperate-tpl-en" to "adi,side-b-use-separate-tpl-en". However, the device tree files modified in this commit continued to uses the old misspelled name adi,side-b-use-seperate-tpl-en. This commit changes the name from adi,side-b-use-seperate-tpl-en to adi,side-b-use-separate-tpl-en.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [x] I have updated the documentation outside this repo accordingly
- [x] I have provided links for the relevant upstream lore


<img width="1097" height="785" alt="image" src="https://github.com/user-attachments/assets/5442cc82-577b-4c2e-acc4-fe7e8583693f" />
