### PR TITLE
prepare_rpi_artifacts: add kernel headers layout for debian

### DIFF
--- a/ci/prepare_rpi_artifacts.sh
+++ b/ci/prepare_rpi_artifacts.sh
@@ -151,9 +151,86 @@ artifacts_structure() {
 	echo "=== Artifacts structure created ==="
 }
 
+# Prepare one architecture's *-devel artifacts into the headers layout
+create_headers_structure() {
+	local karch="$1"; shift
+	local bcms=( "$@" )
+
+	local stage="${OUTPUT_DIRECTORY}/headers-${karch}"
+	local root="${stage}/lib/modules"
+	local base_version="" shared_name=""
+
+	for bcm in "${bcms[@]}"; do
+		local src="${SOURCE_DIRECTORY}/adi_${bcm}_defconfig-gcc-${karch}-devel"
+		if [[ ! -d "$src" ]]; then
+			echo "  WARN: missing ${src}, skipping ${bcm}"
+			continue
+		fi
+
+		local release
+		release=$(cat "${src}/include/config/kernel.release")
+		if [[ -z "$base_version" ]]; then
+			base_version=$(echo "$release" | grep -oE '^[0-9]+\.[0-9]+\.[0-9]+')
+			shared_name="rpi-${karch}-shared-${base_version}"
+		fi
+
+		local shared_dir="${root}/${shared_name}"
+		local build_dir="${root}/${release}/build"
+
+		# Populate the shared area once (first present flavor wins).
+		if [[ ! -d "$shared_dir" ]]; then
+			mkdir -p "${shared_dir}/include" "${shared_dir}/arch"
+			cp -r "${src}/arch/${karch}" "${shared_dir}/arch/"
+			for sub in "${src}/include"/*/; do
+				local name=$(basename "$sub")
+				[[ "$name" == "generated" || "$name" == "config" ]] && continue
+				cp -r "$sub" "${shared_dir}/include/"
+			done
+			[[ -f "${src}/Makefile" ]] && cp "${src}/Makefile" "${shared_dir}/"
+		fi
+
+		echo "  ${bcm} -> lib/modules/${release}/build"
+		mkdir -p "${build_dir}/include" "${build_dir}/arch"
+
+		# Real per-flavor files.
+		cp -r "${src}/include/generated" "${build_dir}/include/"
+		cp -r "${src}/include/config"    "${build_dir}/include/"
+		cp -r "${src}/scripts"           "${build_dir}/"
+		[[ -f "${src}/Module.symvers" ]] && cp "${src}/Module.symvers" "${build_dir}/"
+		[[ -f "${src}/context.txt" ]]    && cp "${src}/context.txt"    "${build_dir}/"
+
+		# Relative symlinks into the shared dir (depths per layout).
+		ln -s "../../../${shared_name}/arch/${karch}" "${build_dir}/arch/${karch}"
+		ln -s "../../${shared_name}/Makefile"         "${build_dir}/Makefile"
+		for sub in "${shared_dir}/include"/*/; do
+			local name=$(basename "$sub")
+			ln -s "../../../${shared_name}/include/${name}" "${build_dir}/include/${name}"
+		done
+	done
+
+	if [[ -z "$base_version" ]]; then
+		echo "  No ${karch} devel artifacts found; skipping ${karch} headers archive."
+		return 0
+	fi
+
+	echo "Creating rpi_headers_${karch}.tar.gz..."
+	tar -C "${stage}" -czf "${OUTPUT_DIRECTORY}/rpi_headers_${karch}.tar.gz" . >/dev/null
+	rm -r "${stage}"
+}
+
+# Arrange both architectures' headers into the symlinked layout.
+headers_structure() {
+	echo ""
+	echo "=== Arranging kernel headers layout ==="
+	create_headers_structure "arm"   "bcmrpi" "bcm2709" "bcm2711"
+	create_headers_structure "arm64" "bcm2711" "bcm2712"
+	echo "=== Headers layout ready at ${OUTPUT_DIRECTORY}/headers ==="
+}
+
 #create final boot archives and properties file
 create_rpi_boot_archives() {
 	artifacts_structure
+	headers_structure
 
 	echo ""
 	echo "=== Creating boot archives ==="


### PR DESCRIPTION
## PR Description

Add create_headers_structure() and headers_structure() to assemble the *-devel artifacts into lib/modules/<release>/build, sharing arch/include/ Makefile via relative symlinks, then package per-arch rpi_headers_<arch>.tar.gz for arm (bcmrpi/bcm2709/bcm2711) and arm64 (bcm2711/bcm2712).

The output artifacts can be found in the linux-rpi cloudsmith repo
To test the implementation I managed to build the ad4000 on a rpi64 

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have compiled my changes, including the documentation
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
