### PR TITLE
hwmon: (pmbus/max20830) Add support for MAX20810/15, LTM4739/40

### DIFF
--- a/Documentation/devicetree/bindings/hwmon/pmbus/adi,max20830.yaml
+++ b/Documentation/devicetree/bindings/hwmon/pmbus/adi,max20830.yaml
@@ -44,15 +44,32 @@ properties:
       GPIO connected to the power-good status output pin.
     maxItems: 1
 
+  adi,vout-rfb1-ohms:
+    description:
+      Top feedback resistor (RFB1) value in ohms for VOUT sensing divider.
+      When the desired output voltage is higher than VREF, a resistor divider
+      is required. VOUT = VREF × (1 + RFB1/RFB2)
+
+  adi,vout-rfb2-ohms:
+    description:
+      Bottom feedback resistor (RFB2) value in ohms for VOUT sensing divider.
+      Datasheet recommends that RFB2 does not exceed 2.5kΩ.
+
 required:
   - compatible
   - reg
   - vddh-supply
 
+dependencies:
+  adi,vout-rfb1-ohms: ['adi,vout-rfb2-ohms']
+  adi,vout-rfb2-ohms: ['adi,vout-rfb1-ohms']
+
 unevaluatedProperties: false
 
 examples:
   - |
+    #include <dt-bindings/gpio/gpio.h>
+
     i2c {
         #address-cells = <1>;
         #size-cells = <0>;
@@ -61,6 +78,11 @@ examples:
             compatible = "adi,max20830";
             reg = <0x30>;
             vddh-supply = <&vddh>;
+            avdd-supply = <&avdd>;
+            ldoin-supply = <&ldoin>;
+            pwr-good-gpios = <&gpio 2 GPIO_ACTIVE_HIGH>;
+            adi,vout-rfb1-ohms = <10000>;
+            adi,vout-rfb2-ohms = <2000>;
         };
     };
 ...

--- a/Documentation/devicetree/bindings/hwmon/pmbus/adi,max20830.yaml
+++ b/Documentation/devicetree/bindings/hwmon/pmbus/adi,max20830.yaml
@@ -22,7 +22,13 @@ allOf:
 
 properties:
   compatible:
-    const: adi,max20830
+    oneOf:
+      - const: adi,max20830
+      - items:
+          - enum:
+              - adi,max20830c
+              - adi,max20840c
+          - const: adi,max20830
 
   reg:
     maxItems: 1

--- a/Documentation/devicetree/bindings/hwmon/pmbus/adi,max20830.yaml
+++ b/Documentation/devicetree/bindings/hwmon/pmbus/adi,max20830.yaml
@@ -26,6 +26,10 @@ properties:
       - const: adi,max20830
       - items:
           - enum:
+              - adi,ltm4739
+              - adi,ltm4740
+              - adi,max20810
+              - adi,max20815
               - adi,max20830c
               - adi,max20840c
           - const: adi,max20830

--- a/Documentation/hwmon/max20830.rst
+++ b/Documentation/hwmon/max20830.rst
@@ -13,6 +13,22 @@ Supported chips:
 
     Datasheet: https://www.analog.com/media/en/technical-documentation/data-sheets/max20830.pdf
 
+  * Analog Devices MAX20830C
+
+    Prefix: 'max20830c'
+
+    Addresses scanned: -
+
+    Datasheet:
+
+  * Analog Devices MAX20840C
+
+    Prefix: 'max20840c'
+
+    Addresses scanned: -
+
+    Datasheet:
+
 Author:
 
   - Alexis Czezar Torreno <alexisczezar.torreno@analog.com>
@@ -21,12 +37,13 @@ Author:
 Description
 -----------
 
-This driver supports hardware monitoring for Analog Devices MAX20830
-Step-Down Switching Regulator with PMBus Interface.
+This driver supports hardware monitoring for Analog Devices MAX20830, MAX20830C
+and MAX20840C. These are Step-Down Switching Regulator with PMBus Interface.
 
-The MAX20830 is a 2.7V to 16V, 30A fully integrated step-down DC-DC switching
-regulator. Through the PMBus interface, the device can monitor input/output
-voltages, output current and temperature.
+MAX20830, and MAX20830C are 2.7V to 16V, 30A fully integrated step-down DC-DC
+switching regulators. MAX20840C is similar but can reach 40A. Through the PMBus
+interface, these devices can monitor input/output voltages, output current and
+temperature.
 
 The driver is a client driver to the core PMBus driver. Please see
 Documentation/hwmon/pmbus.rst for details on PMBus client drivers.

--- a/Documentation/hwmon/max20830.rst
+++ b/Documentation/hwmon/max20830.rst
@@ -5,6 +5,38 @@ Kernel driver max20830
 
 Supported chips:
 
+  * Analog Devices LTM4739
+
+    Prefix: 'ltm4739'
+
+    Addresses scanned: -
+
+    Datasheet: https://www.analog.com/media/en/technical-documentation/data-sheets/ltm4739.pdf
+
+  * Analog Devices LTM4740
+
+    Prefix: 'ltm4740'
+
+    Addresses scanned: -
+
+    Datasheet: https://www.analog.com/media/en/technical-documentation/data-sheets/ltm4740.pdf
+
+  * Analog Devices MAX20810
+
+    Prefix: 'max20810'
+
+    Addresses scanned: -
+
+    Datasheet: https://www.analog.com/media/en/technical-documentation/data-sheets/max20810.pdf
+
+  * Analog Devices MAX20815
+
+    Prefix: 'max20815'
+
+    Addresses scanned: -
+
+    Datasheet: https://www.analog.com/media/en/technical-documentation/data-sheets/max20815.pdf
+
   * Analog Devices MAX20830
 
     Prefix: 'max20830'
@@ -37,13 +69,18 @@ Author:
 Description
 -----------
 
-This driver supports hardware monitoring for Analog Devices MAX20830, MAX20830C
-and MAX20840C. These are Step-Down Switching Regulator with PMBus Interface.
+This driver supports hardware monitoring for Analog Devices MAX20810, MAX20815,
+MAX20830, MAX20830C, MAX20840C, LTM4739, and LTM4740 Step-Down Switching Regulators
+with PMBus Interface.
 
-MAX20830, and MAX20830C are 2.7V to 16V, 30A fully integrated step-down DC-DC
-switching regulators. MAX20840C is similar but can reach 40A. Through the PMBus
-interface, these devices can monitor input/output voltages, output current and
-temperature.
+The MAX20810 and LTM4739 are 10A fully integrated step-down DC-DC switching
+regulators (2.7V–16V and 3V–15V input respectively). The MAX20815 and LTM4740
+provide up to 15A. The MAX20830 and MAX20830C provide up to 30A. The MAX20840C
+provides up to 40A. Through the PMBus interface, all devices can monitor
+input/output voltages, output current and temperature.
+
+LTM4739 and LTM4740 are the LTM-family equivalents of MAX20810 and MAX20815
+respectively, sharing an identical PMBus command set.
 
 The driver is a client driver to the core PMBus driver. Please see
 Documentation/hwmon/pmbus.rst for details on PMBus client drivers.

--- a/drivers/hwmon/pmbus/Kconfig
+++ b/drivers/hwmon/pmbus/Kconfig
@@ -332,7 +332,8 @@ config SENSORS_MAX20830
 	tristate "Analog Devices MAX20830 and compatibles"
 	help
 	  If you say yes here you get hardware monitoring support for Analog
-	  Devices MAX20830, MAX20830C, and MAX20840C.
+	  Devices MAX20810, MAX20815, MAX20830, MAX20830C, and MAX20840C.
+	  Other compatible are LTM4739 and LTM4740.
 
 	  This driver can also be built as a module. If so, the module will
 	  be called max20830.

--- a/drivers/hwmon/pmbus/Kconfig
+++ b/drivers/hwmon/pmbus/Kconfig
@@ -329,10 +329,10 @@ config SENSORS_MAX20751
 	  be called max20751.
 
 config SENSORS_MAX20830
-	tristate "Analog Devices MAX20830"
+	tristate "Analog Devices MAX20830 and compatibles"
 	help
 	  If you say yes here you get hardware monitoring support for Analog
-	  Devices MAX20830.
+	  Devices MAX20830, MAX20830C, and MAX20840C.
 
 	  This driver can also be built as a module. If so, the module will
 	  be called max20830.

--- a/drivers/hwmon/pmbus/max20830.c
+++ b/drivers/hwmon/pmbus/max20830.c
@@ -8,11 +8,62 @@
 #include <linux/errno.h>
 #include <linux/i2c.h>
 #include <linux/mod_devicetable.h>
+#include <linux/math64.h>
 #include <linux/module.h>
 #include <linux/string.h>
 #include "pmbus.h"
 
 #define MAX20830_IC_DEVICE_ID_LENGTH	9
+
+struct max20830_data {
+	struct pmbus_driver_info info;
+	u32 vout_rfb1;
+	u32 vout_rfb2;
+};
+
+/*
+ * MAX20830 only supports READ_VOUT for VOUT monitoring.
+ *
+ * Limit registers (VOUT_OV_WARN_LIMIT, VOUT_OV_FAULT_LIMIT, etc.) are not
+ * supported by this driver and return -ENODATA. This means sysfs attributes
+ * like in1_max, in1_crit, etc. will not be available. Only in1_input (the
+ * scaled output voltage) is supported.
+ *
+ * MAX20830 uses an external resistor divider for voltage sensing:
+ * - VOUT_COMMAND and VOUT_MAX set the reference voltage at the feedback pin
+ * - READ_VOUT reports the feedback voltage, which needs to be scaled for actual
+ *   output voltage
+ *
+ * Scaling formula: vout_actual = vout_fb × (1 + RFB1 / RFB2)
+ *
+ * If regulator support is added in the future, some adjustments are needed to
+ * ensure correct feedback voltages are set.
+ */
+static int max20830_read_word_data(struct i2c_client *client, int page,
+				   int phase, int reg)
+{
+	const struct pmbus_driver_info *info = pmbus_get_driver_info(client);
+	const struct max20830_data *data = container_of(info, struct max20830_data, info);
+	int ret;
+	u64 temp;
+
+	switch (reg) {
+	case PMBUS_READ_VOUT:
+		ret = pmbus_read_word_data(client, page, phase, reg);
+		if (ret < 0)
+			return ret;
+
+		/* Apply voltage divider scaling if resistors are non-zero */
+		if (data->vout_rfb1 && data->vout_rfb2) {
+			temp = (u64)data->vout_rfb1 + (u64)data->vout_rfb2;
+			temp = DIV_ROUND_CLOSEST_ULL((u64)ret * temp, data->vout_rfb2);
+			ret = clamp_val(temp, 0, 0xFFFF);
+		}
+		return ret;
+	default:
+		return -ENODATA;
+	}
+}
 
 static struct pmbus_driver_info max20830_info = {
 	.pages = 1,
@@ -24,12 +75,24 @@ static struct pmbus_driver_info max20830_info = {
 		PMBUS_HAVE_TEMP |
 		PMBUS_HAVE_STATUS_VOUT | PMBUS_HAVE_STATUS_IOUT |
 		PMBUS_HAVE_STATUS_INPUT | PMBUS_HAVE_STATUS_TEMP,
+	.read_word_data = max20830_read_word_data,
 };
 
 static int max20830_probe(struct i2c_client *client)
 {
 	u8 buf[I2C_SMBUS_BLOCK_MAX + 1] = {};
+	struct max20830_data *data;
 	int ret;
+
+	data = devm_kzalloc(&client->dev, sizeof(*data), GFP_KERNEL);
+	if (!data)
+		return -ENOMEM;
+
+	data->info = max20830_info;
+
+	/* Read optional voltage divider resistor values */
+	device_property_read_u32(&client->dev, "adi,vout-rfb1-ohms", &data->vout_rfb1);
+	device_property_read_u32(&client->dev, "adi,vout-rfb2-ohms", &data->vout_rfb2);
 
 	if (!i2c_check_functionality(client->adapter, I2C_FUNC_SMBUS_READ_BLOCK_DATA) &&
 	    !i2c_check_functionality(client->adapter, I2C_FUNC_SMBUS_READ_I2C_BLOCK))
@@ -78,7 +141,7 @@ static int max20830_probe(struct i2c_client *client)
 		return dev_err_probe(&client->dev, -ENODEV,
 				     "Unsupported device: '%s'\n", buf);
 
-	return pmbus_do_probe(client, &max20830_info);
+	return pmbus_do_probe(client, &data->info);
 }
 
 static const struct i2c_device_id max20830_id[] = {

--- a/drivers/hwmon/pmbus/max20830.c
+++ b/drivers/hwmon/pmbus/max20830.c
@@ -21,6 +21,12 @@ struct max20830_data {
 	u32 vout_rfb2;
 };
 
+static const char * const supported_chip_ids[] = {
+	"MAX20830",
+	"MAX20830C",
+	"MAX20840C",
+};
+
 /*
  * MAX20830 only supports READ_VOUT for VOUT monitoring.
  *
@@ -82,7 +88,7 @@ static int max20830_probe(struct i2c_client *client)
 {
 	u8 buf[I2C_SMBUS_BLOCK_MAX + 1] = {};
 	struct max20830_data *data;
-	int ret;
+	int i, ret;
 
 	data = devm_kzalloc(&client->dev, sizeof(*data), GFP_KERNEL);
 	if (!data)
@@ -104,13 +110,12 @@ static int max20830_probe(struct i2c_client *client)
 	 * which do not support SMBus block reads.
 	 */
 	if (i2c_check_functionality(client->adapter, I2C_FUNC_SMBUS_READ_BLOCK_DATA)) {
-		/* Reads 9 Data bytes from MAX20830 */
 		ret = i2c_smbus_read_block_data(client, PMBUS_IC_DEVICE_ID, buf);
 		if (ret < 0)
 			return dev_err_probe(&client->dev, ret,
 					     "Failed to read IC_DEVICE_ID\n");
 	} else {
-		/* Reads 1 length byte + 9 Data bytes from MAX20830 */
+		/* Reads 1 length byte + data bytes */
 		ret = i2c_smbus_read_i2c_block_data(client, PMBUS_IC_DEVICE_ID,
 						    MAX20830_IC_DEVICE_ID_LENGTH + 1,
 						    buf);
@@ -126,20 +131,25 @@ static int max20830_probe(struct i2c_client *client)
 		ret = ret - 1;
 	}
 
-	/*
-	 * MAX20830 IC_DEVICE_ID sends string data "MAX20830\0".
-	 * Return value should at least be 9 bytes of data.
-	 */
+	/* Verify we read the expected number of bytes */
 	if (ret < MAX20830_IC_DEVICE_ID_LENGTH)
 		return dev_err_probe(&client->dev, -ENODEV,
-				     "IC_DEVICE_ID too short: expected at least 9 bytes, got %d\n",
-				     ret);
+				     "IC_DEVICE_ID too short: expected %d bytes, got %d\n",
+				     MAX20830_IC_DEVICE_ID_LENGTH, ret);
 
-	/* 9 bytes of data, buf[0]-buf[7] = "MAX20830", buf[8] = '\0' */
-	buf[MAX20830_IC_DEVICE_ID_LENGTH - 1] = '\0';
-	if (strncmp(buf, "MAX20830", MAX20830_IC_DEVICE_ID_LENGTH - 1))
+	/* Null-terminate the string */
+	buf[ret] = '\0';
+
+	/* Verify the device ID matches what we expect */
+	for (i = 0; i < ARRAY_SIZE(supported_chip_ids); i++) {
+		if (!strcmp(buf, supported_chip_ids[i]))
+			break;
+	}
+
+	/* No match found - unsupported device */
+	if (i == ARRAY_SIZE(supported_chip_ids))
 		return dev_err_probe(&client->dev, -ENODEV,
-				     "Unsupported device: '%s'\n", buf);
+				     "Unsupported device: '%*pE'\n", ret, buf);
 
 	return pmbus_do_probe(client, &data->info);
 }

--- a/drivers/hwmon/pmbus/max20830.c
+++ b/drivers/hwmon/pmbus/max20830.c
@@ -22,6 +22,10 @@ struct max20830_data {
 };
 
 static const char * const supported_chip_ids[] = {
+	"MAX20810",
+	"MAX20810B",	/* also reported by the LTM4739 module */
+	"MAX20815",
+	"MAX20815B",	/* also reported by the LTM4740 module */
 	"MAX20830",
 	"MAX20830C",
 	"MAX20840C",
@@ -35,7 +39,7 @@ static const char * const supported_chip_ids[] = {
  * like in1_max, in1_crit, etc. will not be available. Only in1_input (the
  * scaled output voltage) is supported.
  *
- * MAX20830 uses an external resistor divider for voltage sensing:
+ * MAX20830 family uses an external resistor divider for voltage sensing:
  * - VOUT_COMMAND and VOUT_MAX set the reference voltage at the feedback pin
  * - READ_VOUT reports the feedback voltage, which needs to be scaled for actual
  *   output voltage
@@ -131,20 +135,21 @@ static int max20830_probe(struct i2c_client *client)
 		ret = ret - 1;
 	}
 
-	/* Verify we read the expected number of bytes */
-	if (ret < MAX20830_IC_DEVICE_ID_LENGTH)
+	/*
+	 * A valid read yields at least one byte to index and compare; a short
+	 * or garbled read then fails the strcmp() below, so no explicit ID
+	 * length check is needed to reject unsupported devices.
+	 */
+	if (ret <= 0)
 		return dev_err_probe(&client->dev, -ENODEV,
-				     "IC_DEVICE_ID too short: expected %d bytes, got %d\n",
-				     MAX20830_IC_DEVICE_ID_LENGTH, ret);
+				     "Failed to read IC_DEVICE_ID\n");
 
-	/* Null-terminate the string */
 	buf[ret] = '\0';
 
-	/* Verify the device ID matches what we expect */
-	for (i = 0; i < ARRAY_SIZE(supported_chip_ids); i++) {
+	/* Accept only known device IDs */
+	for (i = 0; i < ARRAY_SIZE(supported_chip_ids); i++)
 		if (!strcmp(buf, supported_chip_ids[i]))
 			break;
-	}
 
 	/* No match found - unsupported device */
 	if (i == ARRAY_SIZE(supported_chip_ids))


### PR DESCRIPTION
## PR Description

The MAX20810 (10A), MAX20815 (15A), LTM4739 (10A), and LTM4740 (15A) are members of the same device family as MAX20830 with an identical PMBus command set. LTM4739 and LTM4740 are the LTM-series equivalents of MAX20810 and MAX20815 respectively.

All five devices share:
- Same PMBus command set
- Same telemetry (VIN, VOUT, IOUT, TEMP)
- IC_DEVICE_ID based detection

Note: LTM4739/LTM4740 IC_DEVICE_ID responses are 8 bytes (7-char name + null) vs 9 bytes for MAX devices. The minimum length check is relaxed accordingly.

Datasheet (MAX20810): https://www.analog.com/MAX20810
Datasheet (MAX20815): https://www.analog.com/MAX20815
Datasheet (LTM4739):  https://www.analog.com/LTM4739
Datasheet (LTM4740):  https://www.analog.com/LTM4740

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [x] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore