### PR TITLE
Staging/fix orx channels madura

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9025-nls.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9025-nls.dts
@@ -17,6 +17,16 @@
 
 	adi,device-profile-name = "ActiveUseCase_NLS.profile";
 
+	/*
+	 * ORx_CTRL pins for dual-channel 4-pin mode (orxEnableMode=4).
+	 * HDL index + 78: A=54->132, B=53->131, C=52->130, D=51->129.
+	 * A/C = side-A/side-B enable, B/D = side-A/side-B channel select.
+	 */
+	orx-ctrl-a-gpios = <&gpio 132 0>;
+	orx-ctrl-b-gpios = <&gpio 131 0>;
+	orx-ctrl-c-gpios = <&gpio 130 0>;
+	orx-ctrl-d-gpios = <&gpio 129 0>;
+
 	jesd204-device;
 	#jesd204-cells = <2>;
 	jesd204-top-device = <0>; /* This is the TOP device */

--- a/drivers/iio/adc/adrv902x/adrv9025.c
+++ b/drivers/iio/adc/adrv902x/adrv9025.c
@@ -1081,15 +1081,15 @@ static ssize_t adrv9025_phy_tx_write(struct iio_dev *indio_dev,
 }
 
 static const char * const adrv9025_obs1_rx_port[] = {
-	"OFF", "ORX1_ON_ORX2_OFF", "ORX1_OFF_ORX2_ON",
+	"ORX1_ON_ORX2_OFF", "ORX1_OFF_ORX2_ON",
 };
 
 static const char * const adrv9025_obs2_rx_port[] = {
-	"OFF", "ORX3_ON_ORX4_OFF", "ORX3_OFF_ORX4_ON",
+	"ORX3_ON_ORX4_OFF", "ORX3_OFF_ORX4_ON",
 };
 
 static const u8 ad9371_obs_rx_port_lut[] = {
-	0x00, BIT(4), BIT(5)
+	BIT(4), BIT(5)
 };
 
 static int adrv9025_set_obs_rx_path(struct iio_dev *indio_dev,
@@ -1127,6 +1127,7 @@ static int adrv9025_get_obs_rx_path(struct iio_dev *indio_dev,
 	struct adrv9025_rf_phy *phy = iio_priv(indio_dev);
 	u32 rxchan = 0, txchan = 0;
 	int shift_right = CHAN_OBS_RX1;
+	int pair;
 	int ret;
 
 	ret = adi_adrv9025_RxTxEnableGet(phy->madDevice, &rxchan,
@@ -1137,7 +1138,16 @@ static int adrv9025_get_obs_rx_path(struct iio_dev *indio_dev,
 	if (chan->channel > CHAN_OBS_RX1)
 		shift_right = CHAN_OBS_RX3;
 
-	return rxchan >> shift_right & 0x3;
+	/*
+	 * Each ORx pair occupies two adjacent enable bits (lower/upper). The
+	 * rf_port_select enum is now SELECT-only with two items: index 0 =
+	 * lower ORx, index 1 = upper ORx. Map the upper enable bit to index 1
+	 * and everything else (lower-on or disabled) to index 0 so the read
+	 * always lands on a valid enum item.
+	 */
+	pair = rxchan >> shift_right & 0x3;
+
+	return (pair & 0x2) ? 1 : 0;
 }
 
 static const struct iio_enum adrv9025_rf_obs1_rx_port_available = {

--- a/drivers/iio/adc/adrv902x/adrv9025.c
+++ b/drivers/iio/adc/adrv902x/adrv9025.c
@@ -1092,6 +1092,58 @@ static const u8 ad9371_obs_rx_port_lut[] = {
 	BIT(4), BIT(5)
 };
 
+/*
+ * True when the device is configured for dual-channel 4-pin ORx mode
+ * (orxEnableMode=4) AND the ORX_CTRL pins are wired in the device tree. In
+ * this mode ORx enable/select is driven by the ORX_CTRL pins (A/C = side-A/
+ * side-B enable, B/D = side-A/side-B channel select), not the 0x106 SPI
+ * enable. The enable mode comes from the init profile cached at probe.
+ */
+static bool adrv9025_orx_dual_4pin(struct adrv9025_rf_phy *phy)
+{
+	return phy->orx_ctrl_a_gpio && phy->orx_ctrl_c_gpio &&
+	       phy->adrv9025PostMcsInitInst.radioCtrlInit.radioCtrlModeCfg
+		       .orxRadioCtrlModeCfg.orxEnableMode ==
+		       ADI_ADRV9025_ORX_EN_DUAL_CH_4PIN_MODE;
+}
+
+/*
+ * Re-assert the framer-1 ADC sample crossbar to split routing. The on-chip
+ * stream processor collapses it on every ORx enable edge, so this must run
+ * AFTER the enable change. conv0/1 = side-A I/Q, conv2/3 = side-B I/Q.
+ */
+static int adrv9025_orx_xbar_reassert(struct adrv9025_rf_phy *phy)
+{
+	int ret;
+
+	ret = adi_adrv9025_SpiFieldWrite(phy->madDevice, 0x7000,
+					 ADI_ADRV9025_ADC_ORX1_I, 0x7F, 0);
+	if (ret)
+		return ret;
+
+	ret = adi_adrv9025_SpiFieldWrite(phy->madDevice, 0x7001,
+					 ADI_ADRV9025_ADC_ORX1_Q, 0x7F, 0);
+	if (ret)
+		return ret;
+
+	ret = adi_adrv9025_SpiFieldWrite(phy->madDevice, 0x7002,
+					 ADI_ADRV9025_ADC_ORX2_I, 0x7F, 0);
+	if (ret)
+		return ret;
+
+	ret = adi_adrv9025_SpiFieldWrite(phy->madDevice, 0x7003,
+					 ADI_ADRV9025_ADC_ORX2_Q, 0x7F, 0);
+	return ret;
+}
+
+/*
+ * rf_port_select for the obs channels. In dual-channel 4-pin mode this is
+ * SELECT-ONLY: it drives the side's channel-select pin (B for side-A, D for
+ * side-B) to pick which ORx of the pair is observed. It does NOT enable the
+ * side - enable is owned by the _en attribute (write_raw). mode is the enum
+ * index: 0 = first ORx of the pair (sel low), 1 = second ORx (sel high).
+ * On boards without the ORX_CTRL pins it falls back to legacy SPI selection.
+ */
 static int adrv9025_set_obs_rx_path(struct iio_dev *indio_dev,
 				    const struct iio_chan_spec *chan, u32 mode)
 {
@@ -1101,6 +1153,24 @@ static int adrv9025_set_obs_rx_path(struct iio_dev *indio_dev,
 	u32 val = 0;
 	int ret;
 
+	if (adrv9025_orx_dual_4pin(phy)) {
+		struct gpio_desc *sel_gpio = (chan->channel > CHAN_OBS_RX1) ?
+					     phy->orx_ctrl_d_gpio :
+					     phy->orx_ctrl_b_gpio;
+
+		/* select line: mode 1 = second ORx of the pair => assert */
+		if (sel_gpio)
+			gpiod_set_value_cansleep(sel_gpio, mode ? 1 : 0);
+
+		/* selecting changes routing; re-assert the split crossbar */
+		ret = adrv9025_orx_xbar_reassert(phy);
+		if (ret)
+			return adrv9025_dev_err(phy);
+
+		return 0;
+	}
+
+	/* Legacy SPI-mode select+enable (boards without ORX_CTRL pins). */
 	ret = adi_adrv9025_RxTxEnableGet(phy->madDevice, &rxchan,
 					 &txchan);
 	if (ret)
@@ -1129,6 +1199,19 @@ static int adrv9025_get_obs_rx_path(struct iio_dev *indio_dev,
 	int shift_right = CHAN_OBS_RX1;
 	int pair;
 	int ret;
+
+	/*
+	 * In dual-4-pin mode selection is held by the channel-select pin, so
+	 * read it back directly. The output gpio returns the last value set.
+	 * 0 = first ORx of the pair, 1 = second ORx (matches the 2-item enum).
+	 */
+	if (adrv9025_orx_dual_4pin(phy)) {
+		struct gpio_desc *sel_gpio = (chan->channel > CHAN_OBS_RX1) ?
+					     phy->orx_ctrl_d_gpio :
+					     phy->orx_ctrl_b_gpio;
+
+		return (sel_gpio && gpiod_get_value_cansleep(sel_gpio)) ? 1 : 0;
+	}
 
 	ret = adi_adrv9025_RxTxEnableGet(phy->madDevice, &rxchan,
 					 &txchan);
@@ -1277,7 +1360,17 @@ static int adrv9025_phy_read_raw(struct iio_dev *indio_dev,
 		if (chan->output)
 			*val = !!(txchan & (ADI_ADRV9025_TX1 << chan->channel));
 		else
-			if (chan->channel >= CHAN_OBS_RX1) {
+			if (chan->channel >= CHAN_OBS_RX1 &&
+			    adrv9025_orx_dual_4pin(phy)) {
+				/* enable is held by the side ENABLE pin (A/C) */
+				struct gpio_desc *en_gpio =
+					(chan->channel > CHAN_OBS_RX1) ?
+					phy->orx_ctrl_c_gpio :
+					phy->orx_ctrl_a_gpio;
+
+				*val = en_gpio ?
+				       !!gpiod_get_value_cansleep(en_gpio) : 0;
+			} else if (chan->channel >= CHAN_OBS_RX1) {
 				chan_no = chan->channel;
 				if (chan_no == CHAN_OBS_RX2)
 					chan_no += 1;
@@ -1412,6 +1505,28 @@ static int adrv9025_phy_write_raw(struct iio_dev *indio_dev,
 				txchan |= (ADI_ADRV9025_TX1 << chan->channel);
 			else
 				txchan &= ~(ADI_ADRV9025_TX1 << chan->channel);
+		} else if (chan->channel >= CHAN_OBS_RX1 &&
+			   adrv9025_orx_dual_4pin(phy)) {
+			/*
+			 * Dual-channel 4-pin mode: the ORx side ENABLE is owned
+			 * by the ORX_CTRL pin (A for side-A/obs1, C for side-B/
+			 * obs2), not the 0x106 SPI enable. _en drives the pin;
+			 * which ORx of the pair is picked by rf_port_select (the
+			 * select pin). Re-assert the split crossbar after the
+			 * enable edge (the stream collapses it on that edge).
+			 */
+			struct gpio_desc *en_gpio =
+				(chan->channel > CHAN_OBS_RX1) ?
+				phy->orx_ctrl_c_gpio : phy->orx_ctrl_a_gpio;
+
+			gpiod_set_value_cansleep(en_gpio, val ? 1 : 0);
+
+			if (val) {
+				ret = adrv9025_orx_xbar_reassert(phy);
+				if (ret)
+					ret = adrv9025_dev_err(phy);
+			}
+			break;
 		} else {
 			chan_no = chan->channel;
 			if (chan_no == CHAN_OBS_RX2)
@@ -3653,6 +3768,19 @@ static int adrv9025_probe(struct spi_device *spi)
 
 	phy->linux_hal.reset_gpio =
 		devm_gpiod_get(&spi->dev, "reset", GPIOD_OUT_LOW);
+
+	/*
+	 * Optional ORx_CTRL pins for dual-channel 4-pin mode (orxEnableMode=4).
+	 * Absent on boards/profiles using SPI or single-channel ORx modes.
+	 */
+	phy->orx_ctrl_a_gpio =
+		devm_gpiod_get_optional(&spi->dev, "orx-ctrl-a", GPIOD_OUT_LOW);
+	phy->orx_ctrl_b_gpio =
+		devm_gpiod_get_optional(&spi->dev, "orx-ctrl-b", GPIOD_OUT_LOW);
+	phy->orx_ctrl_c_gpio =
+		devm_gpiod_get_optional(&spi->dev, "orx-ctrl-c", GPIOD_OUT_LOW);
+	phy->orx_ctrl_d_gpio =
+		devm_gpiod_get_optional(&spi->dev, "orx-ctrl-d", GPIOD_OUT_LOW);
 
 	ret = clk_prepare_enable(phy->dev_clk);
 	if (ret)

--- a/drivers/iio/adc/adrv902x/adrv9025.h
+++ b/drivers/iio/adc/adrv902x/adrv9025.h
@@ -166,6 +166,15 @@ struct adrv9025_rf_phy {
 
 	struct gpio_desc *sysref_req_gpio;
 
+	/*
+	 * ORx_CTRL pins for dual-channel 4-pin mode (orxEnableMode=4):
+	 * A/C = side-A/side-B enable, B/D = side-A/side-B channel select.
+	 */
+	struct gpio_desc *orx_ctrl_a_gpio;
+	struct gpio_desc *orx_ctrl_b_gpio;
+	struct gpio_desc *orx_ctrl_c_gpio;
+	struct gpio_desc *orx_ctrl_d_gpio;
+
 	u8 device_id;
 
 	u32 adrv9025_debugfs_entry_index;

--- a/firmware/ActiveUtilInit.profile
+++ b/firmware/ActiveUtilInit.profile
@@ -10,7 +10,7 @@
         "rxChannelMask": 255
       },
       "orxRadioCtrlModeCfg": {
-        "orxEnableMode": 0,
+        "orxEnableMode": 4,
         "orxPinSelectSettlingDelay_armClkCycles": 0,
         "singleChannel1PinModeOrxSel": 0,
         "singleChannel2PinModeLowOrxSel": 0,


### PR DESCRIPTION
## PR Description

There is a problem in IIO oscilloscope:
if i use 2 TXs using loopbacks to 2 ORXs and i enable them both,i can only
see on both ORXs only one TX.This usually happens when i enable the second 
digital chennel first,then the first one.After this sequence,it looks like the SPI
mode can only control 1 digital channel.This isn't addressed in the user guide,
so it could be only a guess.And at the same time,following the enables for 
the ORX channels in the 0x106 register,it looks like the stream processors
also modify the routing of the channels,so the write on the crossbar registers
is required.

The device tree change only selects the GPIO pins used for ORx control.
The profile switches the ORx enable mode from SPI mode to dual-channel
4-pin mode, where the ORx channels are controlled through GPIO pins
instead of the 0x106 SPI enable register.

In the driver, the enable functionality is removed from rf_port_select;
enable is now driven solely from in_voltage4_en (write_raw). So in
dual-channel 4-pin mode, enabling a channel just drives the GPIO pins
described in the user guide, based on the channel in use: CTRL_A enables
the first digital channel, CTRL_C the second.

On every ORx enable edge the on-chip stream processor alters the ADC
sample crossbar state, collapsing the dual-channel split. To keep the two
ORx channels routed to separate converters, the driver re-asserts the ADC
sample crossbar (with a mask) after the enable change. This crossbar
re-assert is a required part of the fix: without it, the stream processor
leaves both channels routed together. As described in the user guide:

  "A stream processor ... performs a series of configuration tasks based
   on some event. ... The stream processor executes streams ... for:
   ORx1/ORx2/ORx3/ORx4 enable/disable."

In set_obs_rx_path(), the driver only sets the select pin: CTRL_B for the
first digital channel or CTRL_D for the second. The 'mode' value comes
from rf_port_select (set via IIO oscilloscope): 0 selects ORx2/ORx4,
1 selects the other two. So selection is purely a GPIO set through IIO.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [x] I have provided links for the relevant upstream lore
