### PR TITLE
microblaze: dts: vcu118_ad9084_204C_M4_L8_NP16_20p0_4x4: Update ASYNM_A_B_MODE to default

### DIFF
--- a/arch/microblaze/boot/dts/vcu118_ad9084_204C_M4_L8_NP16_20p0_4x4.dts
+++ b/arch/microblaze/boot/dts/vcu118_ad9084_204C_M4_L8_NP16_20p0_4x4.dts
@@ -38,7 +38,7 @@
 
 #define WITH_AION 1
 #define WITH_AXI_AION_TRIG 0
-#define ASYNM_A_B_MODE 1
+#define ASYNM_A_B_MODE 0
 
 #include "vcu118_ad9084.dts"
 


### PR DESCRIPTION
## PR Description

Update this devicetree to be the default use case and to match the working clocking on 4x4 decimation/interpolation and the single link(ASYNM_A_B_MODE = 0) default VCU118 + AD9084 HDL build

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
