### PR TITLE
zynqmp-ad9084-vpx: add PL clocks, reference select, and fix

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-ad9084-vpx.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-ad9084-vpx.dts
@@ -45,6 +45,45 @@
 		clock-frequency = <125000000>;
 	};
 
+	fclk0: fclk0 {
+		compatible = "xlnx,fclk";
+		clocks = <&zynqmp_clk 71>;
+		status = "okay";
+	};
+
+	fclk1: fclk1 {
+		compatible = "xlnx,fclk";
+		clocks = <&zynqmp_clk 72>;
+		status = "okay";
+	};
+
+	fclk2: fclk2 {
+		compatible = "xlnx,fclk";
+		clocks = <&zynqmp_clk 73>;
+		status = "okay";
+	};
+
+	fclk3: fclk3 {
+		compatible = "xlnx,fclk";
+		clocks = <&zynqmp_clk 74>;
+		status = "okay";
+	};
+
+	system_reference_select: system-reference-select {
+		compatible = "adi,one-bit-adc-dac";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		status = "okay";
+		label = "system_reference_select";
+
+		out-gpios = <&gpio 128 GPIO_ACTIVE_HIGH>; /* 1=REFCLK_P0, 0=REFCLK_P2 */
+
+		channel@0 {
+			reg = <0>;
+			label = "REFCLK_SELECT [1:P0 0:P2]";
+		};
+	};
+
 	vu11p_fpga_mgr: fpga-mgr@93000000 {
 		compatible = "adi,fpga-16-selectmap";
 		reg = <0x0 0x93000000 0x0 0x10000>;
@@ -181,7 +220,7 @@
 
 //TODO:PCW
 &gic {
-	num_cpus = <2>;
+	num_cpus = <4>;
 	num_interrupts = <96>;
 };
 


### PR DESCRIPTION
## PR Description
- Add fclk0-fclk3 nodes to keep PS-to-PL fabric clocks enabled,
  fixing AXI hangs when accessing the SelectMAP FPGA manager
- Add system reference clock select as IIO channel (gpio_o[50])
  for toggling between P0 and P2 REFCLK sources
- Fix GIC num_cpus to match ZU4EG (4 cores, not 2)

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
