### PR TITLE
arch/arm64/boot/dts/xilinx/zynqmp-ad9084-vpx: add fclk0-3 to keep

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-ad9084-vpx.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-ad9084-vpx.dts
@@ -45,6 +45,30 @@
 		clock-frequency = <125000000>;
 	};
 
+	fclk0: fclk0 {
+		compatible = "xlnx,fclk";
+		clocks = <&zynqmp_clk 71>;
+		status = "okay";
+	};
+
+	fclk1: fclk1 {
+		compatible = "xlnx,fclk";
+		clocks = <&zynqmp_clk 72>;
+		status = "okay";
+	};
+
+	fclk2: fclk2 {
+		compatible = "xlnx,fclk";
+		clocks = <&zynqmp_clk 73>;
+		status = "okay";
+	};
+
+	fclk3: fclk3 {
+		compatible = "xlnx,fclk";
+		clocks = <&zynqmp_clk 74>;
+		status = "okay";
+	};
+
 	vu11p_fpga_mgr: fpga-mgr@93000000 {
 		compatible = "adi,fpga-16-selectmap";
 		reg = <0x0 0x93000000 0x0 0x10000>;


### PR DESCRIPTION
## PR Description

Add fclk0-fclk3 nodes using the xlnx,fclk driver to explicitly hold PS-to-PL fabric clocks enabled. Without these, the Linux clock framework can gate the PL clocks, causing AXI accesses to PL peripherals (such as the SelectMAP FPGA manager at 0x93000000) to hang the CPU.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
