### PR TITLE
zynqmp-ad9084-vpx: fix GIC num_cpus to match ZU4EG

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-ad9084-vpx.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-ad9084-vpx.dts
@@ -181,7 +181,7 @@
 
 //TODO:PCW
 &gic {
-	num_cpus = <2>;
+	num_cpus = <4>;
 	num_interrupts = <96>;
 };
 


### PR DESCRIPTION
## PR Description

The ZU4EG has 4 Cortex-A53 cores. Update the GIC num_cpus property from 2 to 4 to match the actual hardware.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
