### PR TITLE
zynqmp-ad9084-vpx: add system reference clock select IIO node

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-ad9084-vpx.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-ad9084-vpx.dts
@@ -45,6 +45,21 @@
 		clock-frequency = <125000000>;
 	};
 
+	system_reference_select: system-reference-select {
+		compatible = "adi,one-bit-adc-dac";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		status = "okay";
+		label = "system_reference_select";
+
+		out-gpios = <&gpio 128 GPIO_ACTIVE_HIGH>; /* 1=REFCLK_P0, 0=REFCLK_P2 */
+
+		channel@0 {
+			reg = <0>;
+			label = "REFCLK_SELECT [1:P0 0:P2]";
+		};
+	};
+
 	vu11p_fpga_mgr: fpga-mgr@93000000 {
 		compatible = "adi,fpga-16-selectmap";
 		reg = <0x0 0x93000000 0x0 0x10000>;


### PR DESCRIPTION


## PR Description

Add a one-bit-adc-dac node to expose EMIO gpio_o[50] as an IIO output channel for selecting the system reference clock source. Setting the channel high selects REFCLK_P0, low selects REFCLK_P2.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
