### PR TITLE
rpmsg: adi: use lowercase compatible string for adi,rpmsg-sc598

### DIFF
--- a/Documentation/devicetree/bindings/soc/adi/adi,rpmsg-sc598.yaml
+++ b/Documentation/devicetree/bindings/soc/adi/adi,rpmsg-sc598.yaml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
 %YAML 1.2
 ---
-$id: http://devicetree.org/schemas/soc/adi/adi,rpmsg-SC598.yaml#
+$id: http://devicetree.org/schemas/soc/adi/adi,rpmsg-sc598.yaml#
 $schema: http://devicetree.org/meta-schemas/core.yaml#
 
 title: Analog Devices RPMSG Driver for SC5XX processor family
@@ -18,7 +18,7 @@ description: |
 properties:
   compatible:
     enum:
-      - adi,rpmsg-SC598
+      - adi,rpmsg-sc598
 
   reg:
     maxItems: 1
@@ -112,7 +112,7 @@ examples:
     };
 
     core0-rpmsg@28240000 {
-      compatible = "adi,rpmsg-SC598";
+      compatible = "adi,rpmsg-sc598";
       reg = <0x28240000 0x1000>;
       core-id = <1>;
       adi,rcu = <&rcu>;

--- a/arch/arm64/boot/dts/adi/sc598-som.dtsi
+++ b/arch/arm64/boot/dts/adi/sc598-som.dtsi
@@ -102,7 +102,7 @@
 
 		sharc0_rpmsg: core0-rpmsg@28240000 {
 				status = "disabled";
-				compatible = "adi,rpmsg-SC598";
+				compatible = "adi,rpmsg-sc598";
 				core-id = <1>;
 				adi,rcu = <&rcu>;
 				adi,check-idle;
@@ -116,7 +116,7 @@
 
 		sharc1_rpmsg: core1-rpmsg@28a40000 {
 				status = "disabled";
-				compatible = "adi,rpmsg-SC598";
+				compatible = "adi,rpmsg-sc598";
 				core-id = <2>;
 				adi,rcu = <&rcu>;
 				adi,check-idle;

--- a/drivers/rpmsg/Kconfig
+++ b/drivers/rpmsg/Kconfig
@@ -87,5 +87,6 @@ config RPMSG_ADI
 	depends on HAS_DMA
 	select ADI_MACH_SC5XX
 	select RPMSG
+	select RPMSG_VIRTIO
 
 endmenu

--- a/drivers/rpmsg/adi_rpmsg.c
+++ b/drivers/rpmsg/adi_rpmsg.c
@@ -576,7 +576,7 @@ static void adi_rpmsg_remove(struct platform_device *pdev)
 }
 
 static const struct of_device_id adi_rpmsg_dt_ids[] = {
-	{ .compatible = "adi,rpmsg-SC598", .data = (void *)SC598, },
+	{ .compatible = "adi,rpmsg-sc598", .data = (void *)SC598, },
 	{ /* sentinel */ }
 };
 MODULE_DEVICE_TABLE(of, adi_rpmsg_dt_ids);


### PR DESCRIPTION
## PR Description

change compatibility string for adi_rpmsg from upper case to lower case

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
