### PR TITLE
ci: Fix download source for buildroot artifacts

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,7 +42,8 @@ stages:
             buildType: 'specific'
             project: 'OpenSource'
             definition: 56  # The ID of the buildroot pipeline to download microblaze rootfs
-            buildVersionToDownload: 'latest'
+            buildVersionToDownload: 'latestFromBranch'
+            branchName: 'refs/heads/master'
             artifactName: 'mb_rootfs'
             targetPath: '$(Agent.BuildDirectory)/s'
         - script: ./ci/travis/run-build.sh


### PR DESCRIPTION
## PR Description

Specify strict branch name for buildroot artifacts download to fix binaries being taken from PR builds.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have compiled my changes, including the documentation
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
