### PR TITLE
spi: adi-spi3: Round baud divisor up to not exceed requested speed

### DIFF
--- a/drivers/spi/spi-adi.c
+++ b/drivers/spi/spi-adi.c
@@ -20,6 +20,7 @@
 #include <linux/interrupt.h>
 #include <linux/irqdomain.h>
 #include <linux/io.h>
+#include <linux/math.h>
 #include <linux/module.h>
 #include <linux/of.h>
 #include <linux/platform_device.h>
@@ -295,7 +296,7 @@ static void adi_spi_dma_terminate(struct adi_spi_controller *drv_data)
 /* Calculate the SPI_CLOCK register value based on input HZ */
 static u32 hz_to_spi_clock(u32 sclk, u32 speed_hz)
 {
-	u32 spi_clock = sclk / speed_hz;
+	u32 spi_clock = DIV_ROUND_UP(sclk, speed_hz);
 
 	if (spi_clock)
 		spi_clock--;


### PR DESCRIPTION
## PR Description

The SPI clock divisor was computed with a truncating division (sclk / speed_hz) before subtracting one for the SPI_CLK.BAUD register. Since the hardware generates SCK = sclk / (BAUD + 1), rounding the divisor down produces a BAUD that is too small, yielding an actual SCK *higher* than the requested speed.

spi-max-frequency is a ceiling, not a target, so overshooting it is a spec violation. For example, with a 125 MHz source clock a request for 45-50 MHz resolves to BAUD=1 and clocks the bus at 62.5 MHz.

Use DIV_ROUND_UP() so the divisor is rounded up (frequency rounded down), guaranteeing SCK never exceeds the requested maximum. When speed_hz divides sclk evenly the result is unchanged.

Fixes: 5c802e0680ca ("spi: Add v3 SPI controller support for ADSP-SC5xx")


## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have compiled my changes, including the documentation
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
