### PR TITLE
arm64: dts: xilinx: Update zynqmp daq3 devicetree

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-fmcdaq3.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-fmcdaq3.dts
@@ -46,7 +46,6 @@
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c400000 0x10000>;
 			#dma-cells = <1>;
-			dma-coherent;
 			interrupts = <0 109 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&zynqmp_clk 71>;
 		};
@@ -55,7 +54,6 @@
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x9c420000 0x10000>;
 			#dma-cells = <1>;
-			dma-coherent;
 			interrupts = <0 108 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&zynqmp_clk 71>;
 		};


### PR DESCRIPTION
## PR Description

Disable cache coherency in order to connect to HP ports which support maximum frequency.

Related to: https://github.com/analogdevicesinc/hdl/pull/2094

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
