### PR TITLE
arm64: dts: sc598-ezkit: Add boot-trace label to gpio

### DIFF
--- a/arch/arm64/boot/dts/adi/sc598-som-ezkit.dts
+++ b/arch/arm64/boot/dts/adi/sc598-som-ezkit.dts
@@ -20,6 +20,12 @@
 	};
 };
 
+&gpa {
+	gpio-line-names =
+		"", "", "", "", "", "", "", "",
+		"", "", "", "", "", "boot-trace";
+};
+
 &ospi {
 	pinctrl-names = "default";
 	pinctrl-0 = <&ospi_default>;

--- a/arch/arm64/boot/dts/adi/sc598-som-ezkit.dtsi
+++ b/arch/arm64/boot/dts/adi/sc598-som-ezkit.dtsi
@@ -19,6 +19,12 @@
 	};
 };
 
+&gpa {
+	gpio-line-names =
+		"", "", "", "", "", "", "", "",
+		"", "", "", "", "", "boot-trace";
+};
+
 &ospi {
 	pinctrl-names = "default";
 	pinctrl-0 = <&ospi_default>;


### PR DESCRIPTION
## PR Description

Add a label to the gpio on pin 13 of port A so that scripts can use the label instead of hardcoding port + pin.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
