### PR TITLE
arm64: dts: adi: sc598-som: use pwrseq for the enable signal

### DIFF
--- a/arch/arm64/boot/dts/adi/sc598-som-revD.dtsi
+++ b/arch/arm64/boot/dts/adi/sc598-som-revD.dtsi
@@ -7,6 +7,17 @@
 
 #include "sc598-som.dtsi"
 
+/ {
+	mmc0_pwrseq: mmc0-pwrseq {
+		compatible = "mmc-pwrseq-simple";
+		reset-gpios = <&som_gpio_expander 8 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&mmc0 {
+	mmc-pwrseq = <&mmc0_pwrseq>;
+};
+
 &i2c2 {
 	som_gpio_expander: mcp23018@20 {
 		compatible = "microchip,mcp23018";
@@ -62,13 +73,6 @@
 			gpios = <6 GPIO_ACTIVE_LOW>;
 			output-low;
 			line-name = "uart0-flow-en";
-		};
-
-		som-emmc {
-			gpio-hog;
-			gpios = <8 GPIO_ACTIVE_LOW>;
-			output-high;
-			line-name = "som-emmc-en";
 		};
 
 		crr-sdcard {

--- a/arch/arm64/boot/dts/adi/sc598-som-revE.dtsi
+++ b/arch/arm64/boot/dts/adi/sc598-som-revE.dtsi
@@ -7,6 +7,17 @@
 
 #include "sc598-som.dtsi"
 
+/ {
+	mmc0_pwrseq: mmc0-pwrseq {
+		compatible = "mmc-pwrseq-simple";
+		reset-gpios = <&som_gpio_expander 8 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&mmc0 {
+	mmc-pwrseq = <&mmc0_pwrseq>;
+};
+
 &i2c2 {
 	som_gpio_expander: adp5587@34 {
 		compatible = "adi,adp5587";
@@ -40,13 +51,6 @@
 			gpios = <3 GPIO_ACTIVE_LOW>;
 			output-high;
 			line-name = "som-flash-cs-en";
-		};
-
-		som-emmc {
-			gpio-hog;
-			gpios = <8 GPIO_ACTIVE_LOW>;
-			output-high;
-			line-name = "som-emmc-en";
 		};
 
 		crr-sdcard {


### PR DESCRIPTION
There is an obvious race between the probing of eMMC and the probing of the I2C GPIO expander which controls the eMMC enable signal. If eMMC is probed too early, the hog might be inactive, and probing can fail. Use the simple MMC power sequence provider to ensure proper synchronization.

## PR Description

I encountered spooky eMMC errors while doing unrelated modifications to the pinctrl subsystem. After chasing ghosts for a while, I noticed that it could be that the hog was not getting applied in time. Indeed, the order of probing had changed. With this change, the errors went away.

The driver is already enabled by default:

```
config PWRSEQ_SIMPLE
	tristate "Simple HW reset support for MMC"
	default y
...
```

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
