### PR TITLE
Remove exclusion of '-devel' artifacts in workflow

### DIFF
--- a/.github/workflows/top-level.yml
+++ b/.github/workflows/top-level.yml
@@ -237,7 +237,5 @@ jobs:
       artifacts: >
         adi_bcm*_defconfig-*
         dtb-*
-      exclude-artifacts: >
-        *-devel
       pr-number: ${{ github.event.pull_request.number }}
       pr-target-branch: ${{ github.event.pull_request.base.ref }}


### PR DESCRIPTION
## PR Description

This PR enable the possibility to prepare the RPI kernel headers which was done in this PR https://github.com/analogdevicesinc/linux/pull/3395

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have compiled my changes, including the documentation
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
