### PR TITLE
iio: frequency: ad9528: Fix reset logic

### DIFF
--- a/arch/arm/boot/dts/intel/socfpga/socfpga_arria10_socdk_adrv9009.dts
+++ b/arch/arm/boot/dts/intel/socfpga/socfpga_arria10_socdk_adrv9009.dts
@@ -273,7 +273,7 @@
 };
 
 &clk0_ad9528 {
-	reset-gpios = <&sys_gpio_out 27 0>;
+	reset-gpios = <&sys_gpio_out 27 1>;
 };
 
 &axi_adrv9009_core_tx {

--- a/arch/arm/boot/dts/intel/socfpga/socfpga_arria10_socdk_adrv9025.dts
+++ b/arch/arm/boot/dts/intel/socfpga/socfpga_arria10_socdk_adrv9025.dts
@@ -81,7 +81,7 @@
 					spi-max-frequency = <1000000>;
 					//adi,spi-3wire-enable;
 
-					reset-gpios = <&sys_gpio_out 27 0>;
+					reset-gpios = <&sys_gpio_out 27 1>;
 
 					clock-output-names = "ad9528-1_out0", "ad9528-1_out1", "ad9528-1_out2",
 						"ad9528-1_out3", "ad9528-1_out4", "ad9528-1_out5", "ad9528-1_out6",

--- a/arch/arm/boot/dts/intel/socfpga/socfpga_arria10_socdk_adrv9371.dts
+++ b/arch/arm/boot/dts/intel/socfpga/socfpga_arria10_socdk_adrv9371.dts
@@ -267,7 +267,7 @@
 
 &clk0_ad9528 {
 	reg = <0>;
-	reset-gpios = <&sys_gpio_out 27 0>;
+	reset-gpios = <&sys_gpio_out 27 1>;
 };
 
 &trx0_ad9371 {

--- a/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-adrv9008-1.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-adrv9008-1.dts
@@ -149,5 +149,5 @@
 };
 
 &clk0_ad9528 {
-	reset-gpios = <&gpio0 113 0>;
+	reset-gpios = <&gpio0 113 1>;
 };

--- a/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-adrv9008-2.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-adrv9008-2.dts
@@ -215,7 +215,7 @@
 };
 
 &clk0_ad9528 {
-	reset-gpios = <&gpio0 113 0>;
+	reset-gpios = <&gpio0 113 1>;
 };
 
 &axi_adrv9009_core_tx {

--- a/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-adrv9009.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-adrv9009.dts
@@ -277,7 +277,7 @@
 };
 
 &clk0_ad9528 {
-	reset-gpios = <&gpio0 113 0>;
+	reset-gpios = <&gpio0 113 1>;
 };
 
 &axi_adrv9009_core_tx {

--- a/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-adrv9371.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-adrv9371.dts
@@ -272,7 +272,7 @@
 };
 
 &clk0_ad9528 {
-	reset-gpios = <&gpio0 113 0>;
+	reset-gpios = <&gpio0 113 1>;
 };
 
 &axi_ad9371_core_tx {

--- a/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-fmcadc4.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zc706-adv7511-fmcadc4.dts
@@ -76,6 +76,6 @@
 #include "adi-fmcadc4.dtsi"
 
 &clk0_ad9528 {
-	reset-gpios = <&gpio0 86 0>;
+	reset-gpios = <&gpio0 86 1>;
 	status0-gpios = <&gpio0 87 0>;
 };

--- a/arch/arm64/boot/dts/xilinx/versal-vck190-reva-adrv9025.dts
+++ b/arch/arm64/boot/dts/xilinx/versal-vck190-reva-adrv9025.dts
@@ -314,7 +314,7 @@
 
 		spi-max-frequency = <1000000>;
 
-		reset-gpios = <&axi_gpio 35 0>;
+		reset-gpios = <&axi_gpio 35 1>;
 
 		clock-output-names = "ad9528-1_out0", "ad9528-1_out1", "ad9528-1_out2",
 			"ad9528-1_out3", "ad9528-1_out4", "ad9528-1_out5", "ad9528-1_out6",

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9008-1.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9008-1.dts
@@ -165,5 +165,5 @@
 };
 
 &clk0_ad9528 {
-	reset-gpios = <&gpio 137 0>;
+	reset-gpios = <&gpio 137 1>;
 };

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9008-2.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9008-2.dts
@@ -234,7 +234,7 @@
 };
 
 &clk0_ad9528 {
-	reset-gpios = <&gpio 137 0>;
+	reset-gpios = <&gpio 137 1>;
 };
 
 &axi_adrv9009_core_tx {

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9009.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9009.dts
@@ -313,7 +313,7 @@
 };
 
 &clk0_ad9528 {
-	reset-gpios = <&gpio 137 0>;
+	reset-gpios = <&gpio 137 1>;
 };
 
 &axi_adrv9009_core_tx {

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9025.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9025.dts
@@ -439,5 +439,5 @@
 };
 
 &clk0_ad9528 {
-	reset-gpios = <&gpio 146 0>;
+	reset-gpios = <&gpio 146 1>;
 };

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9032r-nls.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9032r-nls.dts
@@ -432,5 +432,5 @@
 };
 
 &clk0_ad9528 {
-	reset-gpios = <&gpio 147 0>;
+	reset-gpios = <&gpio 147 1>;
 };

--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9371.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv9371.dts
@@ -295,7 +295,7 @@
 };
 
 &clk0_ad9528 {
-	reset-gpios = <&gpio 137 0>;
+	reset-gpios = <&gpio 137 1>;
 };
 
 &axi_ad9371_core_tx {

--- a/arch/microblaze/boot/dts/kcu105_adrv9009.dts
+++ b/arch/microblaze/boot/dts/kcu105_adrv9009.dts
@@ -298,7 +298,7 @@
 };
 
 &clk0_ad9528 {
-	reset-gpios = <&axi_gpio 59 0>;
+	reset-gpios = <&axi_gpio 59 1>;
 };
 
 &fmc_i2c {

--- a/arch/microblaze/boot/dts/kcu105_adrv9371x.dts
+++ b/arch/microblaze/boot/dts/kcu105_adrv9371x.dts
@@ -226,7 +226,7 @@
 };
 
 &clk0_ad9528 {
-	reset-gpios = <&axi_gpio 59 0>;
+	reset-gpios = <&axi_gpio 59 1>;
 };
 
 &axi_ad9371_core_tx {

--- a/arch/microblaze/boot/dts/vcu118_adrv9025.dts
+++ b/arch/microblaze/boot/dts/vcu118_adrv9025.dts
@@ -195,7 +195,7 @@
 		#size-cells = <0>;
 
 		spi-max-frequency = <1000000>;
-		reset-gpios = <&axi_gpio 62 0>;
+		reset-gpios = <&axi_gpio 62 1>;
 
 		clock-output-names = "ad9528-1_out0", "ad9528-1_out1", "ad9528-1_out2",
 			"ad9528-1_out3", "ad9528-1_out4", "ad9528-1_out5", "ad9528-1_out6",

--- a/arch/nios2/boot/dts/a10gx_adrv9009.dts
+++ b/arch/nios2/boot/dts/a10gx_adrv9009.dts
@@ -215,7 +215,7 @@
 				//adi,spi-3wire-enable;
 				reg = <0>;
 
-				reset-gpios = <&sys_gpio_out 27 0>;
+				reset-gpios = <&sys_gpio_out 27 1>;
 
 				clock-output-names = "ad9528-1_out0", "ad9528-1_out1", "ad9528-1_out2",
 					"ad9528-1_out3", "ad9528-1_out4", "ad9528-1_out5", "ad9528-1_out6",

--- a/arch/nios2/boot/dts/a10gx_adrv9371.dts
+++ b/arch/nios2/boot/dts/a10gx_adrv9371.dts
@@ -208,7 +208,7 @@
 				#clock-cells = <1>;
 				compatible = "ad9528";
 
-				reset-gpios = <&sys_gpio_out 27 0>;
+				reset-gpios = <&sys_gpio_out 27 1>;
 
 				//spi-cpol;
 				//spi-cpha;

--- a/drivers/iio/frequency/ad9528.c
+++ b/drivers/iio/frequency/ad9528.c
@@ -273,7 +273,6 @@ struct ad9528_state {
 	struct iio_chan_spec		ad9528_channels[AD9528_NUM_CHAN];
 	struct clk_onecell_data		clk_data;
 	struct clk			*clks[AD9528_NUM_CHAN];
-	struct gpio_desc			*reset_gpio;
 	struct gpio_desc		*sysref_req_gpio;
 	struct jesd204_dev 		*jdev;
 	u32				jdev_lmfc_lemc_rate;
@@ -1674,6 +1673,7 @@ static int ad9528_probe(struct spi_device *spi)
 	struct ad9528_platform_data *pdata;
 	struct iio_dev *indio_dev;
 	struct ad9528_state *st;
+	struct gpio_desc *reset_gpio;
 	struct gpio_desc *status0_gpio;
 	struct gpio_desc *status1_gpio;
 	struct clk *clk;
@@ -1682,6 +1682,11 @@ static int ad9528_probe(struct spi_device *spi)
 	clk = devm_clk_get(&spi->dev, NULL);
 	if (PTR_ERR(clk) == -EPROBE_DEFER)
 		return -EPROBE_DEFER;
+
+	reset_gpio = devm_gpiod_get_optional(&spi->dev, "reset", GPIOD_OUT_HIGH);
+	if (IS_ERR(reset_gpio))
+		return dev_err_probe(&spi->dev, PTR_ERR(reset_gpio),
+				     "Failed to get reset gpio\n");
 
 	ret = devm_regulator_get_enable(&spi->dev, "vcc");
 	if (ret)
@@ -1721,10 +1726,12 @@ static int ad9528_probe(struct spi_device *spi)
 	status1_gpio = devm_gpiod_get_optional(&spi->dev,
 					"status1", GPIOD_OUT_LOW);
 
-	st->reset_gpio = devm_gpiod_get(&spi->dev, "reset", GPIOD_OUT_LOW);
-	if (!IS_ERR(st->reset_gpio)) {
+	if (reset_gpio) {
 		udelay(1);
-		ret = gpiod_direction_output(st->reset_gpio, 1);
+		ret = gpiod_direction_output(reset_gpio, 0);
+		if (ret)
+			return dev_err_probe(&spi->dev, ret,
+					     "Failed to release reset gpio\n");
 	}
 
 	mdelay(10);


### PR DESCRIPTION
Per Linux convention, a reset GPIO must be active high from the driver's viewpoint. Active low is communicated through devicetree properies.

First acquire the reset and activate it, then turn on power, and only then release the reset. This prevents a POR "spike" at startup.

There's no need to keep the reset pointer in the state struct.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
