### PR TITLE
arm64: dts: zynqmp-zcu102: remove ad7291 from ad9172-fmc-ebz

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9172-fmc-ebz.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-ad9172-fmc-ebz.dts
@@ -21,11 +21,6 @@
 			#size-cells = <0>;
 			reg = <0>;
 			/* HPC0_IIC */
-			ad7291@2f {
-				compatible = "adi,ad7291";
-				reg = <0x2f>;
-			};
-
 			eeprom@50 {
 				compatible = "at24,24c02";
 				reg = <0x50>;


### PR DESCRIPTION
## PR Description

Created PR to add commit to release branch as well
The AD7291 temperature/voltage monitor is not populated on the AD9172-FMC-EBZ board, causing a probe failure with -EIO at boot. Remove the node to avoid the spurious error. 

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
