### PR TITLE
ASoC: adi: Add porting note about .pcm_construct()

### DIFF
--- a/sound/soc/adi/sc5xx-pcm.c
+++ b/sound/soc/adi/sc5xx-pcm.c
@@ -172,6 +172,11 @@ static const struct snd_soc_component_driver sc5xx_pcm_component = {
 	.prepare	= sc5xx_pcm_prepare,
 	.trigger	= sc5xx_pcm_trigger,
 	.pointer	= sc5xx_pcm_pointer,
+	/*
+	 * Needs s/pcm_construct/pcm_new/ when rebased to v7.1-rc1 or later. See
+	 * commit tags/v7.1-rc1~166^2~5^2~86^2 ("ASoC: soc-component: remove
+	 * pcm_construct()/pcm_destruct()")
+	 */
 	.pcm_construct	= sc5xx_pcm_new,
 };
 

--- a/sound/soc/adi/sharc-alsa-asoc-card.c
+++ b/sound/soc/adi/sharc-alsa-asoc-card.c
@@ -502,6 +502,11 @@ static void sa_delayed_probe(struct work_struct *work)
 		sa_comp.component_driver.prepare = sa_pcm_prepare;
 		sa_comp.component_driver.trigger = sa_pcm_trigger;
 		sa_comp.component_driver.pointer = sa_pcm_pointer;
+		/*
+		 * Needs s/pcm_construct/pcm_new/ when rebased to v7.1-rc1 or later. See
+		 * commit tags/v7.1-rc1~166^2~5^2~86^2 ("ASoC: soc-component: remove
+		 * pcm_construct()/pcm_destruct()")
+		 */
 		sa_comp.component_driver.pcm_construct = sa_pcm_new;
 
 		sa->asoc_platform_devs[sa->platform_num] = platform_device_register_data(


### PR DESCRIPTION
## PR Description

`.pcm_construct()` went away in v7.1-rc1 and thus needs some adaption to the driver code. Now that I worked out what to do when porting to a newer upstream version, document the findings to help the next person stumbling over that issue.


## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
