### PR TITLE
clocksource: adi-adsp-sc5xx: don't trace when sampling hardware timer

### DIFF
--- a/drivers/clocksource/timer-adi-adsp-sc5xx.c
+++ b/drivers/clocksource/timer-adi-adsp-sc5xx.c
@@ -150,7 +150,7 @@ static void set_gptimer_config(struct sc5xx_gptimer *timer,
 	writew(config, timer->io_base + GPTIMER_CFG_OFF);
 }
 
-static uint32_t get_gptimer_count(struct sc5xx_gptimer *timer)
+static uint32_t notrace get_gptimer_count(struct sc5xx_gptimer *timer)
 {
 	return readl(timer->io_base + GPTIMER_CNT_OFF);
 }


### PR DESCRIPTION
Unsurprisingly, the sched_clock gets sampled very frequently while tracing. Unfortunately, it litters the trace buffer in a very annoying way:

    root@adsp-sc598-som-ezkit:/sys/kernel/tracing# cat trace
    # tracer: function_graph
    #
    # CPU  DURATION                  FUNCTION CALLS
    # |     |   |                     |   |   |   |
     0) + 13.864 us   |    get_gptimer_count.isra.0();
     0)   1.664 us    |    get_gptimer_count.isra.0();
     0)               |  audio_graph2_link_normal [snd_soc_audio_graph_card2]() {
     0)   1.920 us    |    get_gptimer_count.isra.0();
     0)   4.320 us    |    of_graph_get_next_port_endpoint();
     0)   7.848 us    |    of_graph_get_remote_endpoint();
     0) ! 201.248 us  |    graph_parse_node [snd_soc_audio_graph_card2]();
     0)   2.248 us    |    snd_soc_ret();
     0)   1.584 us    |    get_gptimer_count.isra.0();
     0) ! 241.528 us  |  }

get_gptimer_count() is just a wrapper around readl(), called either by the sched_clock read callback, or by the general clocksource read callback. While the former ought not to be traced (and is correctly annotated notrace), the latter might reasonably be traced (and is correctly NOT annotated notrace). Either way, the internal call to get_gptimer_count() is decidedly uninteresting and should never be traced. Mark it notrace, rendering a much cleaner trace buffer:

    root@adsp-sc598-som-ezkit:/sys/kernel/tracing# cat trace
    # tracer: function_graph
    #
    # CPU  DURATION                  FUNCTION CALLS
    # |     |   |                     |   |   |   |
     0)               |  audio_graph2_link_normal [snd_soc_audio_graph_card2]() {
     0)   4.688 us    |    of_graph_get_next_port_endpoint();
     0)   7.304 us    |    of_graph_get_remote_endpoint();
     0) ! 198.312 us  |    graph_parse_node [snd_soc_audio_graph_card2]();
     0)   1.360 us    |    snd_soc_ret();
     0) ! 232.688 us  |  }

Fixes: 60af3db157d8 ("clocksource: Add support for ADSP-SC5xx generic timer")

## PR Description

- Please replace this comment with a summary of your changes, and add any context
necessary to understand them. List any dependencies required for this change.
- To check the checkboxes below, insert a 'x' between square brackets (without
any space), or simply check them after publishing the PR.
- If you changes include a breaking change, please specify dependent PRs in the
description and try to push all related PRs simultaneously.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have compiled my changes, including the documentation
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
