### PR TITLE
iio: Kconfig.adi: imply ADI_AXI_ADC

### DIFF
--- a/drivers/iio/Kconfig.adi
+++ b/drivers/iio/Kconfig.adi
@@ -40,6 +40,7 @@ config IIO_ALL_ADI_DRIVERS
 	imply AD4000
 	imply AD4062 if I3C
 	imply AD4080
+	imply ADI_AXI_ADC
 	imply AD4170_4
 	imply AD4630
 	imply AD4691


### PR DESCRIPTION
## PR Description

Backend-based ADCs (e.g. AD4080) need the AXI ADC backend device, otherwise their probe defers forever waiting for it.

Add "imply ADI_AXI_ADC".

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
