### PR TITLE
Koror ram capture support

### DIFF
--- a/drivers/iio/trx-rf/Kconfig
+++ b/drivers/iio/trx-rf/Kconfig
@@ -30,6 +30,7 @@ config ADRV904X
 	tristate "Analog Devices ADRV904X/ADRV9040 RF Transceiver driver"
 	depends on SPI
 	select CF_AXI_ADC
+	select IIO_KFIFO_BUF
 	help
 	  Say yes here to build support for Analog Devices:
 	  ADRV904X/ADRV9040 RF Transceivers. Provides direct access

--- a/drivers/iio/trx-rf/adrv904x/Makefile
+++ b/drivers/iio/trx-rf/adrv904x/Makefile
@@ -72,7 +72,8 @@ adrv904x_drv-y = \
 	devices/adrv904x/private/src/initdata.o \
 	adrv904x.o \
 	adrv904x_conv.o \
-	adrv904x_debugfs.o
+	adrv904x_debugfs.o \
+	adrv904x_ramc.o
 
 ccflags-y += -I$(src)/devices/adrv904x/private/include/ \
 	-I$(src)/devices/adrv904x/private/src/ \

--- a/drivers/iio/trx-rf/adrv904x/adrv904x.c
+++ b/drivers/iio/trx-rf/adrv904x/adrv904x.c
@@ -2107,6 +2107,13 @@ static const struct jesd204_dev_data jesd204_adrv904x_init = {
 	.sizeof_priv = sizeof(struct adrv904x_jesd204_priv),
 };
 
+static void adrv904x_free_capture_data(void *data)
+{
+	struct adrv904x_rf_phy *phy = data;
+
+	kfree(phy->rx_capture_data);
+}
+
 static int adrv904x_probe(struct spi_device *spi)
 {
 	adi_adrv904x_ExtractInitDataOutput_e checkExtractInitData =
@@ -2339,6 +2346,10 @@ static int adrv904x_probe(struct spi_device *spi)
 		return ret;
 
 	adrv904x_register_debugfs(indio_dev);
+
+	ret = devm_add_action_or_reset(&spi->dev, adrv904x_free_capture_data, phy);
+	if (ret)
+		return ret;
 
 	ret = adrv904x_ramc_probe(phy);
 	if (ret < 0)

--- a/drivers/iio/trx-rf/adrv904x/adrv904x.c
+++ b/drivers/iio/trx-rf/adrv904x/adrv904x.c
@@ -2340,6 +2340,10 @@ static int adrv904x_probe(struct spi_device *spi)
 
 	adrv904x_register_debugfs(indio_dev);
 
+	ret = adrv904x_ramc_probe(phy);
+	if (ret < 0)
+		return ret;
+
 	adi_adrv904x_HwClose(phy->kororDevice);
 
 	return devm_jesd204_fsm_start(&spi->dev, phy->jdev, JESD204_LINKS_ALL);

--- a/drivers/iio/trx-rf/adrv904x/adrv904x.h
+++ b/drivers/iio/trx-rf/adrv904x/adrv904x.h
@@ -36,6 +36,7 @@ enum debugfs_cmd {
 	DBGFS_BIST_FRAMER_0_PRBS,
 	DBGFS_BIST_FRAMER_LOOPBACK,
 	DBGFS_BIST_TONE,
+	DBGFS_RX_DATA_CAPTURE,
 };
 
 enum adrv904x_rx_ext_info {
@@ -136,6 +137,10 @@ struct adrv904x_rf_phy {
 	u32 tracking_cal_mask;
 
 	bool is_initialized;
+
+	/* RX/ORx data capture storage */
+	u32 *rx_capture_data;
+	u32 rx_capture_len;
 };
 
 int __adrv904x_dev_err(struct adrv904x_rf_phy *phy, const char *function, int line);

--- a/drivers/iio/trx-rf/adrv904x/adrv904x.h
+++ b/drivers/iio/trx-rf/adrv904x/adrv904x.h
@@ -158,4 +158,6 @@ void adrv904x_register_debugfs(struct iio_dev *indio_dev);
 static inline void adrv904x_register_debugfs(struct iio_dev *indio_dev) {}
 #endif
 
+int adrv904x_ramc_probe(struct adrv904x_rf_phy *phy);
+
 #endif

--- a/drivers/iio/trx-rf/adrv904x/adrv904x_debugfs.c
+++ b/drivers/iio/trx-rf/adrv904x/adrv904x_debugfs.c
@@ -14,14 +14,45 @@
 
 #include "adrv904x.h"
 #include "adi_adrv904x_datainterface.h"
+#include "adi_adrv904x_datainterface_types.h"
+
+static ssize_t adrv904x_debugfs_read_rx_capture(struct adrv904x_rf_phy *phy,
+						char __user *userbuf,
+						size_t count, loff_t *ppos)
+{
+	char *out_buf __free(kvfree) = NULL;
+	size_t buf_size, pos = 0;
+	u32 i;
+
+	guard(mutex)(&phy->lock);
+
+	if (!phy->rx_capture_data || !phy->rx_capture_len)
+		return -ENODATA;
+
+	/* Allocate buffer: up to 12 chars per value (including newline) */
+	buf_size = phy->rx_capture_len * 12 + 1;
+	out_buf = kvzalloc(buf_size, GFP_KERNEL);
+	if (!out_buf)
+		return -ENOMEM;
+
+	for (i = 0; i < phy->rx_capture_len && pos < buf_size - 12; i++)
+		pos += scnprintf(out_buf + pos, buf_size - pos, "%u\n",
+				 phy->rx_capture_data[i]);
+
+	return simple_read_from_buffer(userbuf, count, ppos, out_buf, pos);
+}
 
 static ssize_t adrv904x_debugfs_read(struct file *file, char __user *userbuf,
 				     size_t count, loff_t *ppos)
 {
 	struct adrv904x_debugfs_entry *entry = file->private_data;
+	struct adrv904x_rf_phy *phy = entry->phy;
 	char buf[700];
 	u64 val = 0;
 	ssize_t len = 0;
+
+	if (entry->cmd == DBGFS_RX_DATA_CAPTURE)
+		return adrv904x_debugfs_read_rx_capture(phy, userbuf, count, ppos);
 
 	if (entry->out_value) {
 		switch (entry->size) {
@@ -55,6 +86,52 @@ static ssize_t adrv904x_debugfs_read(struct file *file, char __user *userbuf,
 	return simple_read_from_buffer(userbuf, count, ppos, buf, len);
 }
 
+/*
+ * Parse and validate RX capture parameters. Returns 0 on success.
+ * Does NOT allocate memory or call hardware - that's done by caller.
+ */
+static int adrv904x_parse_rx_capture_params(const char *buf, s64 *channel,
+					    u32 *length,
+					    adi_adrv904x_RxChannels_e *chan_sel)
+{
+	if (sscanf(buf, "%lld %u", channel, length) < 2)
+		return -EINVAL;
+
+	/* Channel: 0-7 for RX0-RX7, 8-9 for ORX0-ORX1 */
+	if (*channel < 0 || *channel > 9)
+		return -EINVAL;
+
+	/* Validate capture length against hardware-supported sizes */
+	switch (*length) {
+	case ADI_ADRV904X_CAPTURE_SIZE_32:
+	case ADI_ADRV904X_CAPTURE_SIZE_64:
+	case ADI_ADRV904X_CAPTURE_SIZE_128:
+	case ADI_ADRV904X_CAPTURE_SIZE_256:
+	case ADI_ADRV904X_CAPTURE_SIZE_512:
+	case ADI_ADRV904X_CAPTURE_SIZE_1K:
+	case ADI_ADRV904X_CAPTURE_SIZE_2K:
+	case ADI_ADRV904X_CAPTURE_SIZE_4K:
+	case ADI_ADRV904X_CAPTURE_SIZE_8K:
+	case ADI_ADRV904X_CAPTURE_SIZE_12K:
+		break;
+	case ADI_ADRV904X_CAPTURE_SIZE_16K:
+	case ADI_ADRV904X_CAPTURE_SIZE_32K:
+		/* ORX channels limited to 12K max */
+		if (*channel >= 8)
+			return -EINVAL;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	if (*channel < 8)
+		*chan_sel = ADI_ADRV904X_RX0 << *channel;
+	else
+		*chan_sel = ADI_ADRV904X_ORX0 << (*channel - 8);
+
+	return 0;
+}
+
 static ssize_t adrv904x_debugfs_write(struct file *file,
 				      const char __user *userbuf, size_t count,
 				      loff_t *ppos)
@@ -73,6 +150,41 @@ static ssize_t adrv904x_debugfs_write(struct file *file,
 	if (ret < 0)
 		return ret;
 	buf[ret] = '\0';
+
+	/*
+	 * Handle RX_DATA_CAPTURE before taking the lock since it needs
+	 * to allocate memory with GFP_KERNEL which can sleep.
+	 */
+	if (entry->cmd == DBGFS_RX_DATA_CAPTURE) {
+		adi_adrv904x_RxChannels_e chan_sel;
+		u32 *capture_buf __free(kfree) = NULL;
+
+		ret = adrv904x_parse_rx_capture_params(buf, &val, &val2,
+						       &chan_sel);
+		if (ret)
+			return ret;
+
+		capture_buf = kcalloc(val2, sizeof(u32), GFP_KERNEL);
+		if (!capture_buf)
+			return -ENOMEM;
+
+		guard(mutex)(&phy->lock);
+
+		ret = adi_adrv904x_RxOrxDataCaptureStart(phy->kororDevice,
+							 chan_sel,
+							 ADI_ADRV904X_CAPTURE_LOC_DDC0,
+							 capture_buf, val2,
+							 0, 1000000);
+		if (ret)
+			return __adrv904x_dev_err(phy, __func__, __LINE__);
+
+		kfree(phy->rx_capture_data);
+		phy->rx_capture_data = no_free_ptr(capture_buf);
+		phy->rx_capture_len = val2;
+		entry->val = val;
+
+		return count;
+	}
 
 	ret = kstrtoll(strim(buf), 10, &val);
 	if (ret)
@@ -194,6 +306,7 @@ void adrv904x_register_debugfs(struct iio_dev *indio_dev)
 	adrv904x_add_debugfs_entry(phy, "bist_framer_loopback",
 				   DBGFS_BIST_FRAMER_LOOPBACK);
 	adrv904x_add_debugfs_entry(phy, "bist_tone", DBGFS_BIST_TONE);
+	adrv904x_add_debugfs_entry(phy, "rx_data_capture", DBGFS_RX_DATA_CAPTURE);
 
 	for (i = 0; i < phy->adrv904x_debugfs_entry_index; i++)
 		debugfs_create_file(phy->debugfs_entry[i].propname, 0644,

--- a/drivers/iio/trx-rf/adrv904x/adrv904x_ramc.c
+++ b/drivers/iio/trx-rf/adrv904x/adrv904x_ramc.c
@@ -1,0 +1,392 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Driver for ADRV904X RAMC (RAM Capture) interface
+ *
+ * Copyright 2020-2026 Analog Devices Inc.
+ *
+ * This driver provides access to the RX/ORX data capture RAM for debugging
+ * and signal analysis. The hardware can only capture from one channel at a
+ * time, so only one I/Q pair can be enabled simultaneously.
+ *
+ * Capture is single-shot: enabling the buffer triggers one capture, fills
+ * the buffer with samples, then stops. To capture again, disable and
+ * re-enable the buffer (or use iio_readdev which handles this automatically).
+ */
+
+#include <linux/bitops.h>
+#include <linux/cleanup.h>
+#include <linux/kernel.h>
+#include <linux/spi/spi.h>
+
+#include <linux/iio/buffer.h>
+#include <linux/iio/iio.h>
+#include <linux/iio/kfifo_buf.h>
+
+#include "adrv904x.h"
+#include "adi_adrv904x_datainterface.h"
+#include "adi_adrv904x_datainterface_types.h"
+
+/* Max capture is 32768 samples × 4 bytes = 128KB */
+#define ADRV904X_MAX_RAM_SIZE_BYTES	(32768 * sizeof(u32))
+#define ADRV904X_RAMC_TIMEOUT_US	1000000
+
+#define ADRV904X_RAMC_NUM_RX_CHANNELS	8
+#define ADRV904X_RAMC_NUM_ORX_CHANNELS	2
+#define ADRV904X_RAMC_NUM_CHANNELS \
+	(ADRV904X_RAMC_NUM_RX_CHANNELS + ADRV904X_RAMC_NUM_ORX_CHANNELS)
+
+/* Total IIO channels: (RX0-7 + ORX0-1) * 2 (I/Q) + timestamp */
+#define ADRV904X_RAMC_NUM_IIO_CHANNELS	(ADRV904X_RAMC_NUM_CHANNELS * 2 + 1)
+
+struct adrv904x_ramc_state {
+	struct device *dev;
+	struct mutex lock; /* Protects sample_count and active_channel* */
+	struct adrv904x_rf_phy *phy;
+	struct iio_dev *indio_dev;
+	u32 sample_count;
+	u32 *channel_buffer;
+	unsigned long active_channel;
+	int active_channel_idx;
+
+	IIO_DECLARE_DMA_BUFFER_WITH_TS(s32, scan_data, 2);
+};
+
+/* Map channel index to API channel mask */
+static const u32 adrv904x_ramc_channel_map[] = {
+	ADI_ADRV904X_RX0,	/* 0 */
+	ADI_ADRV904X_RX1,	/* 1 */
+	ADI_ADRV904X_RX2,	/* 2 */
+	ADI_ADRV904X_RX3,	/* 3 */
+	ADI_ADRV904X_RX4,	/* 4 */
+	ADI_ADRV904X_RX5,	/* 5 */
+	ADI_ADRV904X_RX6,	/* 6 */
+	ADI_ADRV904X_RX7,	/* 7 */
+	ADI_ADRV904X_ORX0,	/* 8 */
+	ADI_ADRV904X_ORX1,	/* 9 */
+};
+
+/*
+ * Valid scan masks - only one I/Q pair at a time.
+ * Each mask enables both I and Q channels for one RX/ORX channel.
+ * Channels are: RX0_I(0), RX0_Q(1), RX1_I(2), RX1_Q(3), ..., ORX1_Q(19)
+ */
+static const unsigned long adrv904x_ramc_scan_masks[] = {
+	BIT(0)  | BIT(1),	/* RX0 I+Q */
+	BIT(2)  | BIT(3),	/* RX1 I+Q */
+	BIT(4)  | BIT(5),	/* RX2 I+Q */
+	BIT(6)  | BIT(7),	/* RX3 I+Q */
+	BIT(8)  | BIT(9),	/* RX4 I+Q */
+	BIT(10) | BIT(11),	/* RX5 I+Q */
+	BIT(12) | BIT(13),	/* RX6 I+Q */
+	BIT(14) | BIT(15),	/* RX7 I+Q */
+	BIT(16) | BIT(17),	/* ORX0 I+Q */
+	BIT(18) | BIT(19),	/* ORX1 I+Q */
+	0
+};
+
+static inline s32 sign_extend_28bit(u32 val)
+{
+	return sign_extend32(val, 27);
+}
+
+static int adrv904x_ramc_capture_and_push(struct adrv904x_ramc_state *st)
+{
+	adi_adrv904x_Device_t *device = st->phy->kororDevice;
+	u32 i, word_count, num_samples;
+	unsigned long active_channel;
+	int active_channel_idx;
+	u32 *buf;
+	s32 *scan_s32;
+	int ret;
+	bool is_orx;
+
+	scoped_guard(mutex, &st->lock) {
+		word_count = st->sample_count;
+		active_channel = st->active_channel;
+		active_channel_idx = st->active_channel_idx;
+	}
+
+	is_orx = active_channel_idx >= ADRV904X_RAMC_NUM_RX_CHANNELS;
+
+	scoped_guard(mutex, &st->phy->lock) {
+		ret = adi_adrv904x_RxOrxDataCaptureStart(device,
+							 active_channel,
+							 ADI_ADRV904X_CAPTURE_LOC_DDC0,
+							 st->channel_buffer,
+							 word_count,
+							 0,
+							 ADRV904X_RAMC_TIMEOUT_US);
+		if (ret) {
+			dev_err(st->dev, "Failed to capture channel 0x%lx: %d\n",
+				active_channel, ret);
+			return -EIO;
+		}
+	}
+
+	buf = st->channel_buffer;
+	scan_s32 = (s32 *)st->scan_data;
+
+	if (is_orx) {
+		/*
+		 * ORx capture RAM: 3 banks of 4K words each, read sequentially.
+		 * Data format: Q at even indices, I at odd indices.
+		 * 28-bit two's complement data, Q needs negation.
+		 */
+		num_samples = word_count / 2;
+		for (i = 0; i < num_samples; i++) {
+			s32 i_val, q_val;
+
+			q_val = -sign_extend_28bit(buf[2 * i]);
+			i_val = sign_extend_28bit(buf[2 * i + 1]);
+			scan_s32[0] = i_val;
+			scan_s32[1] = q_val;
+			iio_push_to_buffers_with_ts(st->indio_dev, st->scan_data,
+							sizeof(st->scan_data),
+							iio_get_time_ns(st->indio_dev));
+		}
+	} else {
+		/*
+		 * RX/DPD capture RAM: 2 banks of 8K words each.
+		 * Each bank: Q at even indices, I at odd indices.
+		 * Samples interleaved: sample[2n] from Bank0, sample[2n+1] from Bank1.
+		 * 28-bit two's complement data, Q needs negation.
+		 */
+		u32 offset = word_count / 2;
+		u32 *bank0 = buf;
+		u32 *bank1 = buf + offset;
+		u32 bank_samples = offset / 2;
+
+		for (i = 0; i < bank_samples; i++) {
+			s32 i_val, q_val;
+
+			/* Bank 0 sample */
+			q_val = -sign_extend_28bit(bank0[2 * i]);
+			i_val = sign_extend_28bit(bank0[2 * i + 1]);
+			scan_s32[0] = i_val;
+			scan_s32[1] = q_val;
+			iio_push_to_buffers_with_ts(st->indio_dev, st->scan_data,
+							sizeof(st->scan_data),
+							iio_get_time_ns(st->indio_dev));
+
+			/* Bank 1 sample */
+			q_val = -sign_extend_28bit(bank1[2 * i]);
+			i_val = sign_extend_28bit(bank1[2 * i + 1]);
+			scan_s32[0] = i_val;
+			scan_s32[1] = q_val;
+			iio_push_to_buffers_with_ts(st->indio_dev, st->scan_data,
+							sizeof(st->scan_data),
+							iio_get_time_ns(st->indio_dev));
+		}
+	}
+
+	return 0;
+}
+
+static int adrv904x_ramc_read_raw(struct iio_dev *indio_dev,
+				  struct iio_chan_spec const *chan,
+				  int *val, int *val2, long mask)
+{
+	struct adrv904x_ramc_state *st = iio_priv(indio_dev);
+	u64 freq;
+
+	switch (mask) {
+	case IIO_CHAN_INFO_SAMP_FREQ: {
+		guard(mutex)(&st->phy->lock);
+		freq = st->phy->rx_iqRate_kHz * 1000ULL;
+		*val = lower_32_bits(freq);
+		*val2 = upper_32_bits(freq);
+		return IIO_VAL_INT_64;
+	}
+	default:
+		return -EINVAL;
+	}
+}
+
+static ssize_t adrv904x_ramc_sample_count_show(struct iio_dev *indio_dev,
+					       uintptr_t private,
+					       const struct iio_chan_spec *chan,
+					       char *buf)
+{
+	struct adrv904x_ramc_state *st = iio_priv(indio_dev);
+
+	guard(mutex)(&st->lock);
+
+	return sysfs_emit(buf, "%u\n", st->sample_count);
+}
+
+static ssize_t adrv904x_ramc_sample_count_store(struct iio_dev *indio_dev,
+						uintptr_t private,
+						const struct iio_chan_spec *chan,
+						const char *buf, size_t len)
+{
+	struct adrv904x_ramc_state *st = iio_priv(indio_dev);
+	unsigned long val;
+	int ret;
+
+	ret = kstrtoul(buf, 10, &val);
+	if (ret)
+		return ret;
+
+	/* Validate capture size against hardware-supported values */
+	switch (val) {
+	case ADI_ADRV904X_CAPTURE_SIZE_32:
+	case ADI_ADRV904X_CAPTURE_SIZE_64:
+	case ADI_ADRV904X_CAPTURE_SIZE_128:
+	case ADI_ADRV904X_CAPTURE_SIZE_256:
+	case ADI_ADRV904X_CAPTURE_SIZE_512:
+	case ADI_ADRV904X_CAPTURE_SIZE_1K:
+	case ADI_ADRV904X_CAPTURE_SIZE_2K:
+	case ADI_ADRV904X_CAPTURE_SIZE_4K:
+	case ADI_ADRV904X_CAPTURE_SIZE_8K:
+	case ADI_ADRV904X_CAPTURE_SIZE_12K:
+		break;
+	case ADI_ADRV904X_CAPTURE_SIZE_16K:
+	case ADI_ADRV904X_CAPTURE_SIZE_32K:
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	guard(mutex)(&st->lock);
+
+	/* ORx channels limited to 12K max (3 banks x 4K each) */
+	if (st->active_channel_idx >= ADRV904X_RAMC_NUM_RX_CHANNELS &&
+	    (val == ADI_ADRV904X_CAPTURE_SIZE_16K ||
+	     val == ADI_ADRV904X_CAPTURE_SIZE_32K))
+		return -EINVAL;
+
+	st->sample_count = val;
+
+	return len;
+}
+
+static const struct iio_chan_spec_ext_info adrv904x_ramc_ext_info[] = {
+	{
+		.name = "sample_count",
+		.read = adrv904x_ramc_sample_count_show,
+		.write = adrv904x_ramc_sample_count_store,
+		.shared = IIO_SHARED_BY_ALL,
+	},
+
+	{ }
+};
+
+static int adrv904x_ramc_update_scan_mode(struct iio_dev *indio_dev,
+					  const unsigned long *scan_mask)
+{
+	struct adrv904x_ramc_state *st = iio_priv(indio_dev);
+	int i;
+
+	for (i = 0; i < ADRV904X_RAMC_NUM_CHANNELS; i++) {
+		if (*scan_mask == adrv904x_ramc_scan_masks[i]) {
+			guard(mutex)(&st->lock);
+			st->active_channel_idx = i;
+			st->active_channel = adrv904x_ramc_channel_map[i];
+			return 0;
+		}
+	}
+
+	return -EINVAL;
+}
+
+static const struct iio_info adrv904x_ramc_info = {
+	.read_raw = &adrv904x_ramc_read_raw,
+	.update_scan_mode = &adrv904x_ramc_update_scan_mode,
+};
+
+static int adrv904x_ramc_buffer_postenable(struct iio_dev *indio_dev)
+{
+	struct adrv904x_ramc_state *st = iio_priv(indio_dev);
+
+	return adrv904x_ramc_capture_and_push(st);
+}
+
+static const struct iio_buffer_setup_ops adrv904x_ramc_buffer_ops = {
+	.postenable = adrv904x_ramc_buffer_postenable,
+};
+
+int adrv904x_ramc_probe(struct adrv904x_rf_phy *phy)
+{
+	struct iio_dev *indio_dev;
+	struct adrv904x_ramc_state *st;
+	struct device *dev = &phy->spi->dev;
+	struct iio_chan_spec *channels;
+	int i, ret;
+
+	indio_dev = devm_iio_device_alloc(dev, sizeof(*st));
+	if (!indio_dev)
+		return -ENOMEM;
+
+	st = iio_priv(indio_dev);
+	st->indio_dev = indio_dev;
+	st->dev = dev;
+	st->phy = phy;
+	st->sample_count = ADI_ADRV904X_CAPTURE_SIZE_2K;
+	st->active_channel = ADI_ADRV904X_RX0;
+	st->active_channel_idx = 0;
+
+	ret = devm_mutex_init(dev, &st->lock);
+	if (ret)
+		return ret;
+
+	st->channel_buffer = devm_kzalloc(dev, ADRV904X_MAX_RAM_SIZE_BYTES,
+					  GFP_KERNEL);
+	if (!st->channel_buffer)
+		return -ENOMEM;
+
+	channels = devm_kcalloc(dev, ADRV904X_RAMC_NUM_IIO_CHANNELS,
+				sizeof(*channels), GFP_KERNEL);
+	if (!channels)
+		return -ENOMEM;
+
+	/* Create I/Q channel pairs for RX0-7 and ORX0-1 */
+	for (i = 0; i < ADRV904X_RAMC_NUM_CHANNELS; i++) {
+		/* I channel */
+		channels[i * 2].type = IIO_VOLTAGE;
+		channels[i * 2].indexed = 1;
+		channels[i * 2].modified = 1;
+		channels[i * 2].channel = i;
+		channels[i * 2].channel2 = IIO_MOD_I;
+		channels[i * 2].scan_index = i * 2;
+		channels[i * 2].info_mask_shared_by_all =
+			BIT(IIO_CHAN_INFO_SAMP_FREQ);
+		channels[i * 2].ext_info = adrv904x_ramc_ext_info;
+		channels[i * 2].scan_type.sign = 's';
+		channels[i * 2].scan_type.realbits = 28;
+		channels[i * 2].scan_type.storagebits = 32;
+		channels[i * 2].scan_type.endianness = IIO_LE;
+
+		/* Q channel */
+		channels[i * 2 + 1].type = IIO_VOLTAGE;
+		channels[i * 2 + 1].indexed = 1;
+		channels[i * 2 + 1].modified = 1;
+		channels[i * 2 + 1].channel = i;
+		channels[i * 2 + 1].channel2 = IIO_MOD_Q;
+		channels[i * 2 + 1].scan_index = i * 2 + 1;
+		channels[i * 2 + 1].info_mask_shared_by_all =
+			BIT(IIO_CHAN_INFO_SAMP_FREQ);
+		channels[i * 2 + 1].ext_info = adrv904x_ramc_ext_info;
+		channels[i * 2 + 1].scan_type.sign = 's';
+		channels[i * 2 + 1].scan_type.realbits = 28;
+		channels[i * 2 + 1].scan_type.storagebits = 32;
+		channels[i * 2 + 1].scan_type.endianness = IIO_LE;
+	}
+
+	/* Timestamp channel */
+	channels[ADRV904X_RAMC_NUM_CHANNELS * 2] = (struct iio_chan_spec)
+		IIO_CHAN_SOFT_TIMESTAMP(ADRV904X_RAMC_NUM_CHANNELS * 2);
+
+	indio_dev->info = &adrv904x_ramc_info;
+	indio_dev->modes = INDIO_DIRECT_MODE | INDIO_BUFFER_SOFTWARE;
+	indio_dev->channels = channels;
+	indio_dev->num_channels = ADRV904X_RAMC_NUM_IIO_CHANNELS;
+	indio_dev->available_scan_masks = adrv904x_ramc_scan_masks;
+	indio_dev->name = "adrv904x-ramc";
+
+	ret = devm_iio_kfifo_buffer_setup_ext(dev, indio_dev,
+					      &adrv904x_ramc_buffer_ops, NULL);
+	if (ret)
+		return ret;
+
+	return devm_iio_device_register(dev, indio_dev);
+}


### PR DESCRIPTION
## PR Description

- Add debugfs interface for quick single-shot RX/ORx RAM captures
- Add full IIO device (adrv904x-ramc) with I/Q channel support and buffer infrastructure
-
## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [x] I have updated the documentation outside this repo accordingly
- [x] I have provided links for the relevant upstream lore
