### PR TITLE
iio: frequency: ad9508: fix out-of-bounds write into mutex

### DIFF
--- a/drivers/iio/frequency/ad9508.c
+++ b/drivers/iio/frequency/ad9508.c
@@ -66,6 +66,8 @@
 
 #define AD9508_NUM_CHAN		4
 
+#define AD9508_NUM_REGS		45
+
 struct ad9508_outputs {
 	struct clk_hw hw;
 	struct iio_dev *indio_dev;
@@ -88,7 +90,7 @@ struct ad9508_state {
 	struct gpio_desc		*reset_gpio;
 	struct gpio_desc		*sync_gpio;
 	bool			write_mode_only;
-	unsigned long		regs_hw[44];
+	unsigned long		regs_hw[AD9508_NUM_REGS];
 	struct mutex		lock;
 
 	/*


### PR DESCRIPTION
## PR Description

regs_hw[] is indexed by register address, but its size (44) is one short of the highest address used, AD9508_CHANNEL_OUT_DRIVER_ALL(3) = 0x2C (44). ad9508_write() for channel 3 thus writes past the array into the adjacent mutex, corrupting its owner field and oopsing on the next mutex_lock().

Size the array to cover the full register map.

Fixes: 856b10df02a4 ("iio: frequency: ad9508: Support write only mode")

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
