### PR TITLE
.github/top-level: Don't run on push to staging

### DIFF
--- a/.github/workflows/top-level.yml
+++ b/.github/workflows/top-level.yml
@@ -4,9 +4,8 @@ on:
   push:
     branches:
       - 'main'
-      - 'next_stable'
-      - 'staging/*'
       - 'xlnx/release/*'
+      - 'rpi/release/*'
   pull_request:
 
 concurrency:


### PR DESCRIPTION
## PR Description

Save CI/CD resources by running only on our 'release' branches, avoiding duplicated runs for staging branches with pull requests.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have compiled my changes, including the documentation
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
