### PR TITLE
iio: adc: ad7768: Handle ad7768_set_power_mode()

### DIFF
--- a/drivers/iio/adc/Kconfig
+++ b/drivers/iio/adc/Kconfig
@@ -402,6 +402,7 @@ config AD7768
 	tristate "Analog Devices AD7768 ADC driver"
 	depends on SPI
 	depends on GPIOLIB
+	select CF_AXI_ADC
 	select IIO_BUFFER
 	select IIO_BUFFER_DMA
 	select IIO_BUFFER_DMAENGINE

--- a/drivers/iio/adc/ad7768.c
+++ b/drivers/iio/adc/ad7768.c
@@ -342,11 +342,7 @@ static int ad7768_set_power_mode(struct iio_dev *dev,
 	if (ret < 0)
 		return ret;
 
-	ret = ad7768_sync(st);
-	if (ret < 0)
-		return ret;
-
-	return ret;
+	return ad7768_sync(st);
 }
 
 static int ad7768_get_power_mode(struct iio_dev *dev,
@@ -829,7 +825,7 @@ static int ad7768_probe(struct spi_device *spi)
 
 	ad7768_set_available_sampl_freq(st);
 
-	ad7768_set_power_mode(indio_dev, NULL, AD7768_FAST_MODE);
+	ret = ad7768_set_power_mode(indio_dev, NULL, AD7768_FAST_MODE);
 	if (ret < 0)
 		return ret;
 


### PR DESCRIPTION

## PR Description

At ad7768_probe(), ad7768_set_power_mode() was discarted. Capture it instead. At the ad7768_set_power_mode(), return from ad7768_sync(), since the call chain is:

  ad7768_sync <- ad7768_spi_write_mask <- ad7768_spi_reg_write
  <- spi_write (zero on success, else a negative error code.)

Therefore, the "if (ret < 0)" is redundant and unnecessary.

While at it, fixes the symbol dependency.

closes https://github.com/analogdevicesinc/linux/issues/3437

Not an upstream driver, fixing directly to xlnx/main

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have compiled my changes, including the documentation
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
