### PR TITLE
iio: frequency: ad9508: use sync gpio to synchronize outputs

### DIFF
--- a/drivers/iio/frequency/ad9508.c
+++ b/drivers/iio/frequency/ad9508.c
@@ -198,7 +198,19 @@ static int ad9508_get_channel_div_enable(struct iio_dev *indio_dev, unsigned cha
 
 static int ad9508_sync(struct iio_dev *indio_dev)
 {
-	int ret = ad9508_write(indio_dev,
+	struct ad9508_state *st = iio_priv(indio_dev);
+	int ret;
+
+	if (st->sync_gpio) {
+		/* SYNC_BAR is active low: assert then deassert to pulse */
+		gpiod_set_value_cansleep(st->sync_gpio, 0);
+		fsleep(1);
+		gpiod_set_value_cansleep(st->sync_gpio, 1);
+
+		return 0;
+	}
+
+	ret = ad9508_write(indio_dev,
 			AD9508_SYNC_BAR, 0);
 	if (ret < 0)
 		return ret;


### PR DESCRIPTION
## PR Description

The sync gpio was requested at probe but never used, so hardware output synchronization was never actually performed. Pulse the sync line in ad9508_sync() when present, falling back to the SYNC_BAR register write otherwise.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
