### PR TITLE
arm64: dts: zynqmp-zcu102-rev10-adrv904x: fix AD9528 reset GPIO polarity

### DIFF
--- a/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv904x.dts
+++ b/arch/arm64/boot/dts/xilinx/zynqmp-zcu102-rev10-adrv904x.dts
@@ -371,5 +371,5 @@
 };
 
 &clk0_ad9528 {
-	reset-gpios = <&gpio 147 0>;
+	reset-gpios = <&gpio 147 GPIO_ACTIVE_LOW>;
 };


### PR DESCRIPTION
## PR Description

The AD9528 driver was updated in commit 907be261ca15f ("iio: frequency: ad9528: Fix reset logic") to follow Linux GPIO convention where reset GPIOs are active-high from the driver's viewpoint, with active-low polarity communicated via devicetree properties.

Add GPIO_ACTIVE_LOW flag to the AD9528 reset-gpios to match the updated driver behavior. Without this fix, the AD9528 probe fails with error -5 (EIO) because the chip remains in reset.

Fixes: 907be261ca15f ("iio: frequency: ad9528: Fix reset logic")

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
