### PR TITLE
Staging/fix init cal channel mask

### DIFF
--- a/drivers/iio/trx-rf/adrv903x/adrv903x.c
+++ b/drivers/iio/trx-rf/adrv903x/adrv903x.c
@@ -198,12 +198,15 @@ static ssize_t adrv903x_phy_store(struct device *dev,
 			static const u32 INIT_CALS_TIMEOUT_MS =
 				60000; /*60 seconds timeout*/
 
-			phy->cal_mask.orxChannelMask =
-				phy->adrv903xPostMcsInitInst.initCals.orxChannelMask;
-			phy->cal_mask.rxChannelMask =
-				phy->adrv903xPostMcsInitInst.initCals.rxChannelMask;
-			phy->cal_mask.txChannelMask =
-				phy->adrv903xPostMcsInitInst.initCals.txChannelMask;
+			if (!phy->cal_mask.orxChannelMask)
+				phy->cal_mask.orxChannelMask =
+					phy->adrv903xPostMcsInitInst.initCals.orxChannelMask;
+			if (!phy->cal_mask.rxChannelMask)
+				phy->cal_mask.rxChannelMask =
+					phy->adrv903xPostMcsInitInst.initCals.rxChannelMask;
+			if (!phy->cal_mask.txChannelMask)
+				phy->cal_mask.txChannelMask =
+					phy->adrv903xPostMcsInitInst.initCals.txChannelMask;
 
 			/* Run Init Cals */
 			ret = adrv903x_api_call(phy, adi_adrv903x_InitCalsRun,

--- a/drivers/iio/trx-rf/adrv904x/adrv904x.c
+++ b/drivers/iio/trx-rf/adrv904x/adrv904x.c
@@ -196,12 +196,15 @@ static ssize_t adrv904x_phy_store(struct device *dev,
 			else
 				phy->cal_mask.calMask &= ~val;
 		} else if (enable) {
-			phy->cal_mask.orxChannelMask =
-				phy->adrv904xPostMcsInitInst.initCals.orxChannelMask;
-			phy->cal_mask.rxChannelMask =
-				phy->adrv904xPostMcsInitInst.initCals.rxChannelMask;
-			phy->cal_mask.txChannelMask =
-				phy->adrv904xPostMcsInitInst.initCals.txChannelMask;
+			if (!phy->cal_mask.orxChannelMask)
+				phy->cal_mask.orxChannelMask =
+					phy->adrv904xPostMcsInitInst.initCals.orxChannelMask;
+			if (!phy->cal_mask.rxChannelMask)
+				phy->cal_mask.rxChannelMask =
+					phy->adrv904xPostMcsInitInst.initCals.rxChannelMask;
+			if (!phy->cal_mask.txChannelMask)
+				phy->cal_mask.txChannelMask =
+					phy->adrv904xPostMcsInitInst.initCals.txChannelMask;
 
 			/* Run Init Cals */
 			ret = adrv904x_api_call(phy, adi_adrv904x_InitCalsRun,


### PR DESCRIPTION
## PR Description

When triggering initial calibrations via the 'calibrate' sysfs attribute, the driver unconditionally overwrites the user-configured channel masks (rx, tx, orx) with the profile defaults. This prevents users from running calibrations on specific channels only.
For example, setting calibrate_tx_channel_mask to 0x01 (channel 0 only) would be overwritten to 0xFF (all channels) when writing 1 to calibrate.
Fix this by only applying the profile defaults when the user hasn't set a custom channel mask (i.e., when the mask is 0). This matches the behavior of the adrv9025 driver.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
