### PR TITLE
iio: trx-rf: adrv903x: add Tx-ORx mapping control

### DIFF
--- a/drivers/iio/trx-rf/adrv903x/adrv903x.c
+++ b/drivers/iio/trx-rf/adrv903x/adrv903x.c
@@ -1109,16 +1109,8 @@ static ssize_t adrv903x_phy_tx_write(struct iio_dev *indio_dev,
 		mask = ADI_ADRV903X_TX0 << chan->channel;
 		calMask = ADI_ADRV903X_TC_TX_LOL_MASK;
 
-		adi_adrv903x_ChannelTrackingCals_t channelMask = { 0 };
-
-		channelMask.txChannel = mask;
-
-		ret = adrv903x_api_call(phy, adi_adrv903x_TxToOrxMappingSet, 0x50);
-		if (ret)
-			break;
-
-		ret = adrv903x_api_call(phy, adi_adrv903x_TrackingCalsEnableSet, calMask,
-					mask,
+		ret = adrv903x_api_call(phy, adi_adrv903x_TrackingCalsEnableSet,
+					calMask, mask,
 					enable ? ADI_ADRV903X_TRACKING_CAL_ENABLE :
 						ADI_ADRV903X_TRACKING_CAL_DISABLE);
 		break;

--- a/drivers/iio/trx-rf/adrv903x/adrv903x.h
+++ b/drivers/iio/trx-rf/adrv903x/adrv903x.h
@@ -74,6 +74,7 @@ enum debugfs_cmd {
 	DBGFS_RX7_ADC_STATUS,
 	DBGFS_ORX0_ADC_STATUS,
 	DBGFS_ORX1_ADC_STATUS,
+	DBGFS_TX_TO_ORX_MAPPING,
 };
 
 enum adrv903x_rx_ext_info {

--- a/drivers/iio/trx-rf/adrv903x/adrv903x_debugfs.c
+++ b/drivers/iio/trx-rf/adrv903x/adrv903x_debugfs.c
@@ -130,6 +130,25 @@ static ssize_t adrv903x_debugfs_read(struct file *file, char __user *userbuf,
 				return ret;
 			len = ret;
 			break;
+		case DBGFS_TX_TO_ORX_MAPPING: {
+			adi_adrv903x_TxChannels_e tx_orx0 = ADI_ADRV903X_TXOFF;
+			adi_adrv903x_TxChannels_e tx_orx1 = ADI_ADRV903X_TXOFF;
+
+			guard(mutex)(&phy->lock);
+
+			ret = adrv903x_api_call(phy, adi_adrv903x_TxToOrxMappingGet,
+						ADI_ADRV903X_ORX0, &tx_orx0);
+			if (ret)
+				return ret;
+
+			ret = adrv903x_api_call(phy, adi_adrv903x_TxToOrxMappingGet,
+						ADI_ADRV903X_ORX1, &tx_orx1);
+			if (ret)
+				return ret;
+			val = (ffs(tx_orx1) ? (ffs(tx_orx1) - 1) << 4 : 0) |
+			      (ffs(tx_orx0) ? (ffs(tx_orx0) - 1) : 0);
+			break;
+		}
 		default:
 			val = entry->val;
 		}
@@ -234,6 +253,20 @@ static ssize_t adrv903x_debugfs_write(struct file *file,
 		entry->val = val;
 		return count;
 
+	case DBGFS_TX_TO_ORX_MAPPING:
+		if (ret != 1)
+			return -EINVAL;
+
+		if (val < 0 || val > 0xff)
+			return -EINVAL;
+
+		ret = adrv903x_api_call(phy, adi_adrv903x_TxToOrxMappingSet,
+					(u8)val);
+		if (ret)
+			return ret;
+
+		return count;
+
 	default:
 		break;
 	}
@@ -320,6 +353,7 @@ void adrv903x_register_debugfs(struct iio_dev *indio_dev)
 	}
 	adrv903x_add_debugfs_entry(phy, "orx0_adc_status", DBGFS_ORX0_ADC_STATUS);
 	adrv903x_add_debugfs_entry(phy, "orx1_adc_status", DBGFS_ORX1_ADC_STATUS);
+	adrv903x_add_debugfs_entry(phy, "tx_to_orx_mapping", DBGFS_TX_TO_ORX_MAPPING);
 
 	for (i = 0; i < phy->adrv903x_debugfs_entry_index; i++) {
 		switch (phy->debugfs_entry[i].cmd) {
@@ -328,6 +362,7 @@ void adrv903x_register_debugfs(struct iio_dev *indio_dev)
 		case DBGFS_BIST_FRAMER_0_LOOPBACK:
 		case DBGFS_BIST_FRAMER_1_LOOPBACK:
 		case DBGFS_BIST_TONE:
+		case DBGFS_TX_TO_ORX_MAPPING:
 			mode = 0644;
 			break;
 		default:

--- a/drivers/iio/trx-rf/adrv903x/adrv903x_debugfs.c
+++ b/drivers/iio/trx-rf/adrv903x/adrv903x_debugfs.c
@@ -322,8 +322,18 @@ void adrv903x_register_debugfs(struct iio_dev *indio_dev)
 	adrv903x_add_debugfs_entry(phy, "orx1_adc_status", DBGFS_ORX1_ADC_STATUS);
 
 	for (i = 0; i < phy->adrv903x_debugfs_entry_index; i++) {
-		if (phy->adrv903x_debugfs_entry_index > DBGFS_BIST_TONE)
-			mode = 0400;
+		switch (phy->debugfs_entry[i].cmd) {
+		case DBGFS_BIST_FRAMER_0_PRBS:
+		case DBGFS_BIST_FRAMER_1_PRBS:
+		case DBGFS_BIST_FRAMER_0_LOOPBACK:
+		case DBGFS_BIST_FRAMER_1_LOOPBACK:
+		case DBGFS_BIST_TONE:
+			mode = 0644;
+			break;
+		default:
+			mode = 0444;
+			break;
+		}
 		debugfs_create_file(phy->debugfs_entry[i].propname, mode,
 				    iio_get_debugfs_dentry(indio_dev),
 				    &phy->debugfs_entry[i],


### PR DESCRIPTION
## PR Description

Add a tx_to_orx_mapping debugfs entry so the Tx-to-ORx routing can be configured before enabling TX LOL tracking calibration, and remove the hardcoded mapping from the TX LOL enable path.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
