### PR TITLE
Device Tree fixes for SC846

### DIFF
--- a/arch/arm64/boot/dts/adi/sc846-som-ezkit.dts
+++ b/arch/arm64/boot/dts/adi/sc846-som-ezkit.dts
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: GPL-2.0
+// SPDX-License-Identifier: GPL-2.0-only
 /*
- * Copyright (c) 2026 Analog Devices Incorporated
+ * Copyright (c) 2026 Analog Devices, Inc.
  */
 
 #include "sc846-som.dts"

--- a/arch/arm64/boot/dts/adi/sc846-som-ezkit.dts
+++ b/arch/arm64/boot/dts/adi/sc846-som-ezkit.dts
@@ -56,14 +56,14 @@
 			gpio-hog;
 			gpios = <1 GPIO_ACTIVE_LOW>;
 			output-high;
-			line-name = "spidif1-en";
+			line-name = "spdif1-en";
 		};
 
 		adau1966-reset-som-a {
 			gpio-hog;
 			gpios = <2 GPIO_ACTIVE_LOW>;
 			output-high;
-			line-name = "adsu1966-reset-som-a";
+			line-name = "adau1966-reset-som-a";
 		};
 
 		adau1979-a-reset-som-a {
@@ -77,13 +77,14 @@
 			gpio-hog;
 			gpios = <4 GPIO_ACTIVE_LOW>;
 			output-high;
+			line-name = "adau1979-b-reset-som-a";
 		};
 
 		pushbutton-b-en {
 			gpio-hog;
 			gpios = <5 GPIO_ACTIVE_LOW>;
 			output-high;
-			line-name = "ushbutton-b-en";
+			line-name = "pushbutton-b-en";
 		};
 
 		spdif1-opt-en {
@@ -153,7 +154,7 @@
 			gpio-hog;
 			gpios = <15 GPIO_ACTIVE_HIGH>;
 			output-low;
-			line-name = "a2b-io7";
+			line-name = "a2b1-io7";
 		};
 
 		a2b2-io1 {

--- a/arch/arm64/boot/dts/adi/sc846-som.dts
+++ b/arch/arm64/boot/dts/adi/sc846-som.dts
@@ -157,11 +157,11 @@
 	//bus-num = <2>;
 	status = "okay";
 
-	som_flash: is25lp02gg@0 {
-		compatible = "jedec,spi-nor", "is25lp02gg";
+	som_flash: flash@0 {
+		compatible = "jedec,spi-nor";
 		reg = <0>;
-		//spi-rx-bus-width = <4>;
-		//spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+		spi-tx-bus-width = <4>;
 		spi-max-frequency = <50000000>;
 
 		partitions {

--- a/arch/arm64/boot/dts/adi/sc846-som.dts
+++ b/arch/arm64/boot/dts/adi/sc846-som.dts
@@ -129,7 +129,7 @@
 
 		led-ds4 {
 			gpio-hog;
-			gpios = <17 GPIO_ACTIVE_LOW >;
+			gpios = <15 GPIO_ACTIVE_LOW >;
 			output-high;
 			line-name = "led-ds4";
 		};
@@ -143,7 +143,7 @@
 
 		led-ds2 {
 			gpio-hog;
-			gpios = <15 GPIO_ACTIVE_LOW>;
+			gpios = <17 GPIO_ACTIVE_LOW>;
 			output-high;
 			line-name = "led-ds2";
 		};

--- a/arch/arm64/boot/dts/adi/sc846-som.dts
+++ b/arch/arm64/boot/dts/adi/sc846-som.dts
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: GPL-2.0
+// SPDX-License-Identifier: GPL-2.0-only
 /*
- * Copyright (c) 2026 Analog Devices Incorporated
+ * Copyright (c) 2026 Analog Devices, Inc.
  */
 
 /dts-v1/;

--- a/arch/arm64/boot/dts/adi/sc846-som.dts
+++ b/arch/arm64/boot/dts/adi/sc846-som.dts
@@ -6,7 +6,6 @@
 /dts-v1/;
 
 #include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/net/ti-dp83867.h>
 #include <dt-bindings/pinctrl/adi-adsp.h>
 #include <dt-bindings/pinctrl/adi-adsp-sru.h>
 

--- a/arch/arm64/boot/dts/adi/sc846.dtsi
+++ b/arch/arm64/boot/dts/adi/sc846.dtsi
@@ -1,7 +1,6 @@
-// SPDX-License-Identifier: GPL-2.0
+// SPDX-License-Identifier: GPL-2.0-only
 /*
- * Copyright (c) 2021 Analog Devices Incorporated
- * Author: Nathan Barrett-Morrison <nathan.morrison@timesys.com>
+ * Copyright (c) 2026 Analog Devices, Inc.
  *
  * SoC level description for the ADSP-SC84x (SC846) family.
  */


### PR DESCRIPTION
https://www.analog.com/media/en/technical-documentation/eval-board-schematic/ev-sc846-som-schem.pdf

https://www.analog.com/media/en/technical-documentation/eval-board-schematic/ev-somcrr2-ezkit-schematic.pdf

Things I noticed when I compared device trees in Linux and U-Boot.
