### PR TITLE
sc84x: platform fixes for adsp-6.18.31-y (interrupts, DT correctness, driver fixes)

### DIFF
--- a/arch/arm64/boot/dts/adi/sc59x-64.dtsi
+++ b/arch/arm64/boot/dts/adi/sc59x-64.dtsi
@@ -486,6 +486,8 @@
 			interrupts = <GIC_SPI 124 IRQ_TYPE_LEVEL_HIGH>;
 			dmas = <&spi_cluster 22>, <&spi_cluster 23>;
 			dma-names = "tx", "rx";
+			clocks = <&clk ADSP_SC598_CLK_SPI>;
+			clock-names = "spi";
 			status = "disabled";
 		};
 

--- a/arch/arm64/boot/dts/adi/sc846-som.dts
+++ b/arch/arm64/boot/dts/adi/sc846-som.dts
@@ -8,6 +8,7 @@
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/net/ti-dp83867.h>
 #include <dt-bindings/pinctrl/adi-adsp.h>
+#include <dt-bindings/soc/adi/sc5xx-tru.h>
 #include <dt-bindings/pinctrl/adi-adsp-sru.h>
 
 #include "sc846.dtsi"
@@ -78,7 +79,7 @@
 		adi,rsc-table = <&rsc_tbl0>;
 		adi,verify = <1>;
 		adi,tru = <&tru>;
-		adi,tru-master-id = <171>; /* trigger master SOFT4 */
+		adi,tru-master-id = <ADI_TRU_MST_SOFT(4)>;
 		status = "okay";
 	};
 };

--- a/arch/arm64/boot/dts/adi/sc846.dtsi
+++ b/arch/arm64/boot/dts/adi/sc846.dtsi
@@ -32,14 +32,12 @@
 		timer6 = &gptimer6;
 		timer7 = &gptimer7;
 		ethernet0 = &emac0;
-		ethernet1 = &emac1;
 		spi0   = &spi0;
 		spi1   = &spi1;
 		spi2   = &spi2;
 		spi5   = &spi5;
 		can0 = &can0;
 		can1 = &can1;
-		rtc0 = &rtc0;
 		i2s4 = &i2s4;
 		mmc0 = &mmc0;
 		sru0 = &sru_ctrl_dai0;
@@ -313,14 +311,6 @@
 			status = "okay";
 		};
 
-		rtc0: rtc@310C8000 {
-			compatible = "adi,rtc2";
-			reg = <0x310C8000 0x100>;
-			/*interrupts = <GIC_SPI 165 IRQ_TYPE_LEVEL_HIGH>;*/
-			calibration = /bits/ 8 <0>;
-			status = "disabled";
-		};
-
 		uart0: uart@31003000 {
 			compatible = "adi,uart4";
 			reg = <0x31003000 0x40>;
@@ -550,21 +540,6 @@
 			status = "disabled";
 		};
 
-		ospi: spi@31027000 {
-			compatible = "adi,sc59x-ospi";
-			#address-cells = <1>;
-			#size-cells = <0>;
-			reg = <0x31027000 0x1000>,
-				  <0x60000000 0x20000000>;
-			interrupts = <GIC_SPI 151 IRQ_TYPE_LEVEL_HIGH>;
-			clocks = <&clk ADSP_SC846_CLK_XSPI0>;
-			cdns,is-decoded-cs;
-			cdns,fifo-depth = <128>;
-			cdns,fifo-width = <4>;
-			cdns,trigger-address = <0x00000000>;
-			status = "disabled";
-		};
-
 		emac0: ethernet@31040000 {
 			compatible = "adi,dwmac", "snps,dwmac-4.20a", "snps,dwmac-5.20a";
 			reg = <0x31040000 0x2000>;
@@ -584,21 +559,6 @@
 			snps,perfect-filter-entries = <32>;
 			snps,tso = <1>;
 			clocks = <&clk ADSP_SC846_CLK_GIGE>;
-			clock-names = "stmmaceth";
-			adi,pads-syscon = <&pads_syscon>;
-			status = "disabled";
-		};
-
-		emac1: ethernet@31042000 {
-			compatible = "adi,dwmac", "snps,dwmac-4.20a", "snps,dwmac-5.20a";
-			reg = <0x31042000 0x2000>;
-			interrupt-parent = <&gic>;
-			interrupts = <GIC_SPI 227 IRQ_TYPE_LEVEL_HIGH>;
-			interrupt-names = "macirq";
-			snps,fixed-burst;
-			snps,pbl = <1>;
-			snps,force_thresh_dma_mode;
-			clocks = <&emac1_clkin>;
 			clock-names = "stmmaceth";
 			adi,pads-syscon = <&pads_syscon>;
 			status = "disabled";
@@ -668,13 +628,6 @@
 			reg = <0x310CA000 0x224>;
 			adi,pads-syscon = <&pads_syscon>;
 			status = "disabled";
-		};
-
-		emac1_clkin: emac1-clkin@0 {
-			compatible = "fixed-clock";
-			#clock-cells = <0>;
-			clock-frequency = <50000000>;
-			clock-output-names = "emac1_clkin";
 		};
 
 		mmc0: mmc@31152000 {

--- a/arch/arm64/boot/dts/adi/sc846.dtsi
+++ b/arch/arm64/boot/dts/adi/sc846.dtsi
@@ -706,49 +706,65 @@
 		pint0: pint@31005000 {
 			compatible = "adi,adsp-pint";
 			reg = <0x31005000 0xFF>;
-			interrupts = <GIC_SPI 65 IRQ_TYPE_LEVEL_HIGH>;
+			interrupts = <GIC_SPI 217 IRQ_TYPE_LEVEL_HIGH>;
+			interrupt-controller;
+			#interrupt-cells = <1>;
 		};
 
 		pint1: pint@31005100 {
 			compatible = "adi,adsp-pint";
 			reg = <0x31005100 0xFF>;
-			interrupts = <GIC_SPI 66 IRQ_TYPE_LEVEL_HIGH>;
+			interrupts = <GIC_SPI 218 IRQ_TYPE_LEVEL_HIGH>;
+			interrupt-controller;
+			#interrupt-cells = <1>;
 		};
 
 		pint2: pint@31005200 {
 			compatible = "adi,adsp-pint";
 			reg = <0x31005200 0xFF>;
-			interrupts = <GIC_SPI 67 IRQ_TYPE_LEVEL_HIGH>;
+			interrupts = <GIC_SPI 219 IRQ_TYPE_LEVEL_HIGH>;
+			interrupt-controller;
+			#interrupt-cells = <1>;
 		};
 
 		pint3: pint@31005300 {
 			compatible = "adi,adsp-pint";
 			reg = <0x31005300 0xFF>;
-			interrupts = <GIC_SPI 68 IRQ_TYPE_LEVEL_HIGH>;
+			interrupts = <GIC_SPI 220 IRQ_TYPE_LEVEL_HIGH>;
+			interrupt-controller;
+			#interrupt-cells = <1>;
 		};
 
 		pint4: pint@31005400 {
 			compatible = "adi,adsp-pint";
 			reg = <0x31005400 0xFF>;
-			interrupts = <GIC_SPI 69 IRQ_TYPE_LEVEL_HIGH>;
+			interrupts = <GIC_SPI 221 IRQ_TYPE_LEVEL_HIGH>;
+			interrupt-controller;
+			#interrupt-cells = <1>;
 		};
 
 		pint5: pint@31005500 {
 			compatible = "adi,adsp-pint";
 			reg = <0x31005500 0xFF>;
-			interrupts = <GIC_SPI 70 IRQ_TYPE_LEVEL_HIGH>;
+			interrupts = <GIC_SPI 222 IRQ_TYPE_LEVEL_HIGH>;
+			interrupt-controller;
+			#interrupt-cells = <1>;
 		};
 
 		pint6: pint@31005600 {
 			compatible = "adi,adsp-pint";
 			reg = <0x31005600 0xFF>;
-			interrupts = <GIC_SPI 71 IRQ_TYPE_LEVEL_HIGH>;
+			interrupts = <GIC_SPI 223 IRQ_TYPE_LEVEL_HIGH>;
+			interrupt-controller;
+			#interrupt-cells = <1>;
 		};
 
 		pint7: pint@31005700 {
 			compatible = "adi,adsp-pint";
 			reg = <0x31005700 0xFF>;
-			interrupts = <GIC_SPI 72 IRQ_TYPE_LEVEL_HIGH>;
+			interrupts = <GIC_SPI 224 IRQ_TYPE_LEVEL_HIGH>;
+			interrupt-controller;
+			#interrupt-cells = <1>;
 		};
 
 		gpa: gport@31004000 {

--- a/arch/arm64/boot/dts/adi/sc846.dtsi
+++ b/arch/arm64/boot/dts/adi/sc846.dtsi
@@ -308,7 +308,7 @@
 			compatible = "adi,hadc";
 			reg = <0x31016000 0x100>;
 			interrupt-parent = <&gic>;
-			interrupts = <GIC_SPI 186 IRQ_TYPE_EDGE_RISING>;
+			interrupts = <GIC_SPI 118 IRQ_TYPE_EDGE_RISING>;
 			#iio-cells = <1>;
 			status = "okay";
 		};

--- a/arch/arm64/boot/dts/adi/sc846.dtsi
+++ b/arch/arm64/boot/dts/adi/sc846.dtsi
@@ -255,7 +255,7 @@
 			compatible = "adi,sram-controller";
 			reg = <0x31080000 0x100>;
 			/* adi,sram = <&sram0>, <&sram1>; */
-			interrupts = <GIC_SPI 10 IRQ_TYPE_LEVEL_HIGH>;
+			interrupts = <GIC_SPI 143 IRQ_TYPE_LEVEL_HIGH>;
 			status = "disabled";
 		};
 
@@ -297,8 +297,8 @@
 			reg = <0x31016800 0x100>;
 			#thermal-sensor-cells = <0>;
 			interrupt-parent = <&gic>;
-			interrupts = <GIC_SPI 7 IRQ_TYPE_EDGE_RISING>,
-						 <GIC_SPI 8 IRQ_TYPE_EDGE_RISING>;
+			interrupts = <GIC_SPI 347 IRQ_TYPE_EDGE_RISING>,
+						 <GIC_SPI 348 IRQ_TYPE_EDGE_RISING>;
 			adi,gain = <0x4>; /* 10-bit two's complement */
 			adi,offset = <0x7D40>; /* Q9.7 fixed point */
 			status = "disabled";
@@ -370,12 +370,17 @@
 		};
 
 		can0: can@31000200 {
+			/*
+			 * The SC846 controllers are CAN FD (HRM ch.19); the
+			 * legacy adi,can binding/driver predates CAN FD and
+			 * needs updating before these nodes can be enabled.
+			 */
 			compatible = "adi,can";
 			reg = <0x31000200 0x5FF>;
 			interrupt-parent = <&gic>;
-			interrupts = <GIC_SPI 84 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 85 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 86 IRQ_TYPE_LEVEL_HIGH>;
+			interrupts = <GIC_SPI 1 IRQ_TYPE_LEVEL_HIGH>,
+				     <GIC_SPI 2 IRQ_TYPE_LEVEL_HIGH>,
+				     <GIC_SPI 3 IRQ_TYPE_LEVEL_HIGH>;
 			status = "disabled";
 		};
 
@@ -383,9 +388,9 @@
 			compatible = "adi,can";
 			reg = <0x31000a00 0x5FF>;
 			interrupt-parent = <&gic>;
-			interrupts = <GIC_SPI 87 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 88 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 89 IRQ_TYPE_LEVEL_HIGH>;
+			interrupts = <GIC_SPI 4 IRQ_TYPE_LEVEL_HIGH>,
+				     <GIC_SPI 5 IRQ_TYPE_LEVEL_HIGH>,
+				     <GIC_SPI 6 IRQ_TYPE_LEVEL_HIGH>;
 			status = "disabled";
 		};
 
@@ -622,7 +627,7 @@
 		crc2: crc@310aa000 {
 			compatible = "adi,hmac-crc";
 			reg = <0x310aa000 0x100>;
-			interrupts = <GIC_SPI 204 IRQ_TYPE_LEVEL_HIGH>;
+			interrupts = <GIC_SPI 48 IRQ_TYPE_LEVEL_HIGH>;
 			dmas = <&crc_cluster 45>;
 			dma-names = "mdma_chan";
 			crypto_crc_poly = <0x04c11db7>;
@@ -632,7 +637,7 @@
 		crc3: crc@310ab000 {
 			compatible = "adi,hmac-crc";
 			reg = <0x310ab000 0x100>;
-			interrupts = <GIC_SPI 205 IRQ_TYPE_LEVEL_HIGH>;
+			interrupts = <GIC_SPI 49 IRQ_TYPE_LEVEL_HIGH>;
 			dmas = <&crc_cluster 47>;
 			dma-names = "mdma_chan";
 			crypto_crc_poly = <0x04c11db7>;
@@ -672,11 +677,11 @@
 			clock-output-names = "emac1_clkin";
 		};
 
-		mmc0: mmc@310C7000 {
+		mmc0: mmc@31152000 {
 			compatible = "snps,dwcmshc-sdhci";
-			reg = <0x310C7000 0x1000>;
-			interrupts = <GIC_SPI 237 IRQ_TYPE_LEVEL_HIGH>; /* Status */
-				     /*<GIC_SPI 239 IRQ_TYPE_LEVEL_HIGH>;*/ /* Wakeup */
+			reg = <0x31152000 0x1000>;
+			interrupts = <GIC_SPI 214 IRQ_TYPE_LEVEL_HIGH>; /* Status */
+				     /*<GIC_SPI 215 IRQ_TYPE_LEVEL_HIGH>;*/ /* Wakeup */
 			clocks = <&clk ADSP_SC846_CLK_MSHC>;
 			clock-names = "core";
 			bus-width = <8>;
@@ -695,8 +700,8 @@
 		lp0: linkport@0 {
 			compatible = "linkport0";
 			interrupt-parent = <&gic>;
-			interrupts = <GIC_SPI 117 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 118 IRQ_TYPE_LEVEL_HIGH>;
+			interrupts = <GIC_SPI 152 IRQ_TYPE_LEVEL_HIGH>,
+				     <GIC_SPI 153 IRQ_TYPE_LEVEL_HIGH>;
 			clock-div = <1>;
 			status = "disabled";
 		};
@@ -704,8 +709,8 @@
 		lp1: linkport@1 {
 			compatible = "linkport1";
 			interrupt-parent = <&gic>;
-			interrupts = <GIC_SPI 119 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 120 IRQ_TYPE_LEVEL_HIGH>;
+			interrupts = <GIC_SPI 154 IRQ_TYPE_LEVEL_HIGH>,
+				     <GIC_SPI 155 IRQ_TYPE_LEVEL_HIGH>;
 			clock-div = <1>;
 			status = "disabled";
 		};
@@ -861,7 +866,7 @@
 		pkte1: pkte@310CD000 {
 			compatible = "adi,pkte";
 			reg = <0x310CD000 0x400>;
-			interrupts = <GIC_SPI 161 IRQ_TYPE_LEVEL_HIGH>;
+			interrupts = <GIC_SPI 226 IRQ_TYPE_LEVEL_HIGH>;
 			status = "disabled";
 		};
 
@@ -1011,16 +1016,16 @@
 
 			crc2_dma: channel@45 { /* MDMA4_SRC */
 				adi,id = <45>;
-				interrupts = <GIC_SPI 200 IRQ_TYPE_LEVEL_HIGH>,
-					<GIC_SPI 289 IRQ_TYPE_LEVEL_HIGH>;
+				interrupts = <GIC_SPI 44 IRQ_TYPE_LEVEL_HIGH>,
+					<GIC_SPI 54 IRQ_TYPE_LEVEL_HIGH>;
 				interrupt-names = "complete", "error";
 				adi,src-offset = <0x200>;
 			};
 
 			crc3_dma: channel@47 { /* MDMA5_SRC */
 				adi,id = <47>;
-				interrupts = <GIC_SPI 202 IRQ_TYPE_LEVEL_HIGH>,
-					<GIC_SPI 291 IRQ_TYPE_LEVEL_HIGH>;
+				interrupts = <GIC_SPI 46 IRQ_TYPE_LEVEL_HIGH>,
+					<GIC_SPI 56 IRQ_TYPE_LEVEL_HIGH>;
 				interrupt-names = "complete", "error";
 				adi,src-offset = <0x300>;
 			};

--- a/arch/arm64/boot/dts/adi/sc846.dtsi
+++ b/arch/arm64/boot/dts/adi/sc846.dtsi
@@ -566,7 +566,14 @@
 			interrupt-parent = <&gic>;
 			interrupts = <GIC_SPI 94 IRQ_TYPE_LEVEL_HIGH>;
 			interrupt-names = "macirq";
-			snps,mixed-burst;
+			/*
+			 * REVISIT: Workaround: mixed-burst MAC DMA can hang
+			 * the SoC fabric under sustained traffic, fixed bursts
+			 * are stable. The hang may be related to the Rev B SOM
+			 * LPDDR4 signal-margin issue (fixed in Rev C); revisit
+			 * once the root cause is confirmed.
+			 */
+			snps,fixed-burst;
 			snps,pbl = <8>;
 			snps,force_sf_dma_mode;
 			snps,perfect-filter-entries = <32>;

--- a/arch/arm64/boot/dts/adi/sc846.dtsi
+++ b/arch/arm64/boot/dts/adi/sc846.dtsi
@@ -498,6 +498,8 @@
 			interrupts = <GIC_SPI 233 IRQ_TYPE_LEVEL_HIGH>;
 			dmas = <&spi_cluster 22>, <&spi_cluster 23>;
 			dma-names = "tx", "rx";
+			clocks = <&clk ADSP_SC846_CLK_SPI>;
+			clock-names = "spi";
 			status = "disabled";
 		};
 

--- a/drivers/dma/adi-dma.c
+++ b/drivers/dma/adi-dma.c
@@ -137,8 +137,19 @@ static void __process_descriptor(struct adi_dma_descriptor *desc);
 static int init_channel_interrupts(struct adi_dma *dma, struct device_node *node,
 	struct adi_dma_channel *channel)
 {
+	const char *label;
 	int irq;
 	int ret;
+
+	/*
+	 * The channel <-> peripheral assignment is fixed in silicon (HRM
+	 * "DMA Channel List"), so the controller address plus channel id
+	 * uniquely identify the serviced peripheral in /proc/interrupts.
+	 */
+	label = devm_kasprintf(dma->dev, GFP_KERNEL, "%s ch%u",
+			       dev_name(dma->dev), channel->id);
+	if (!label)
+		return -ENOMEM;
 
 	irq = of_irq_get_byname(node, "complete");
 	if (irq <= 0) {
@@ -149,7 +160,7 @@ static int init_channel_interrupts(struct adi_dma *dma, struct device_node *node
 	channel->src_irq = irq;
 
 	ret = devm_request_threaded_irq(dma->dev, irq, adi_dma_handler,
-		adi_dma_thread_handler, 0, "dma controller irq", channel);
+		adi_dma_thread_handler, 0, label, channel);
 	if (ret) {
 		dev_err(dma->dev, "Failed to request IRQ %d\n", ret);
 		return ret;
@@ -164,7 +175,9 @@ static int init_channel_interrupts(struct adi_dma *dma, struct device_node *node
 	channel->src_err_irq = irq;
 
 	ret = devm_request_threaded_irq(dma->dev, irq, adi_dma_error_handler,
-		adi_dma_thread_handler, 0, "dma controller error irq", channel);
+		adi_dma_thread_handler, 0,
+		devm_kasprintf(dma->dev, GFP_KERNEL, "%s err", label),
+		channel);
 	if (ret) {
 		dev_err(dma->dev, "Failed to request IRQ %d\n", ret);
 		return ret;
@@ -181,7 +194,9 @@ static int init_channel_interrupts(struct adi_dma *dma, struct device_node *node
 		channel->dest_irq = irq;
 
 		ret = devm_request_threaded_irq(dma->dev, irq, adi_dma_handler,
-			adi_dma_thread_handler, 0, "dma controller irq", channel);
+			adi_dma_thread_handler, 0,
+			devm_kasprintf(dma->dev, GFP_KERNEL, "%s dst", label),
+			channel);
 		if (ret) {
 			dev_err(dma->dev, "Failed to request IRQ %d\n", ret);
 			return ret;
@@ -196,7 +211,9 @@ static int init_channel_interrupts(struct adi_dma *dma, struct device_node *node
 		channel->dest_err_irq = irq;
 
 		ret = devm_request_threaded_irq(dma->dev, irq, adi_dma_error_handler,
-			adi_dma_thread_handler, 0, "dma controller error irq", channel);
+			adi_dma_thread_handler, 0,
+			devm_kasprintf(dma->dev, GFP_KERNEL, "%s dst err", label),
+			channel);
 		if (ret) {
 			dev_err(dma->dev, "Failed to request IRQ %d\n", ret);
 			return ret;

--- a/drivers/pinctrl/adi/pinctrl-adsp.c
+++ b/drivers/pinctrl/adi/pinctrl-adsp.c
@@ -179,6 +179,14 @@ static void adsp_portmux_setup(struct adsp_gpio_port *port, unsigned int offset,
 		spin_unlock_irqrestore(&port->lock, flags);
 
 		adsp_set_pin_gpio(port, offset, false);
+
+		/*
+		 * PORT_INEN gates the pad's input buffer: peripheral input
+		 * functions read a constant 0 while it is clear, and it is
+		 * harmless for output-only pins, so enable it on every
+		 * peripheral-muxed pin.
+		 */
+		__adsp_gpio_writew(port, BIT(offset), ADSP_PORT_REG_INEN_SET);
 	}
 }
 

--- a/drivers/pinctrl/adi/pinctrl-adsp.c
+++ b/drivers/pinctrl/adi/pinctrl-adsp.c
@@ -647,6 +647,22 @@ static int adsp_pinconf_set(struct pinctrl_dev *pctldev, unsigned int pin,
 
 			spin_unlock(&port->lock);
 			break;
+		case PIN_CONFIG_INPUT_ENABLE:
+			/*
+			 * Control PORT_INEN directly so a board can enable a
+			 * pad's input buffer (e.g. for a PINT edge source)
+			 * without claiming the pin as a GPIO.
+			 */
+			range = pinctrl_find_gpio_range_from_pin(pctldev, pin);
+			offset = pin - range->pin_base;
+			port = to_adsp_gpio_port(range->gc);
+
+			spin_lock(&port->lock);
+			__adsp_gpio_writew(port, BIT(offset),
+					   arg ? ADSP_PORT_REG_INEN_SET
+					       : ADSP_PORT_REG_INEN_CLEAR);
+			spin_unlock(&port->lock);
+			break;
 		case ADSP_PIN_CONFIG_TRU_TOGGLE:
 			range = pinctrl_find_gpio_range_from_pin(pctldev, pin);
 			offset = pin - range->pin_base;

--- a/drivers/soc/adi/mach-sc5xx/icc.c
+++ b/drivers/soc/adi/mach-sc5xx/icc.c
@@ -153,8 +153,8 @@ int adi_tru_set_trigger_by_id(struct adi_tru *tru, u32 master, u32 slave)
 	}
 
 	if (!tru->use_smc) {
-		dev_info(tru->dev, "Connecting master %d to slave %d\n",
-			 master, slave);
+		dev_dbg(tru->dev, "Connecting master %d to slave %d\n",
+			master, slave);
 		writel(master, tru->ioaddr + (slave * 4));
 	} else {
 		dev_err(tru->dev,

--- a/drivers/spi/spi-adi.c
+++ b/drivers/spi/spi-adi.c
@@ -783,7 +783,6 @@ static int adi_spi_probe(struct platform_device *pdev)
 	drv_data = spi_controller_get_devdata(controller);
 	drv_data->controller = controller;
 	drv_data->sclk = sclk;
-	drv_data->sclk_rate = clk_get_rate(sclk);
 	drv_data->dev = dev;
 
 	mem = platform_get_resource(pdev, IORESOURCE_MEM, 0);
@@ -826,6 +825,13 @@ static int adi_spi_probe(struct platform_device *pdev)
 	ret = clk_prepare_enable(drv_data->sclk);
 	if (ret) {
 		dev_err(dev, "Could not enable SPI clock\n");
+		goto err_free_rx_dma;
+	}
+
+	drv_data->sclk_rate = clk_get_rate(drv_data->sclk);
+	if (!drv_data->sclk_rate) {
+		dev_err(dev, "Invalid SPI clock rate: %lu Hz\n", drv_data->sclk_rate);
+		ret = -EINVAL;
 		goto err_free_rx_dma;
 	}
 

--- a/drivers/tty/serial/adi_uart4.c
+++ b/drivers/tty/serial/adi_uart4.c
@@ -262,9 +262,11 @@ static void adi_uart4_serial_stop_tx(struct uart_port *port)
 		UART_PUT_LSR(uart, TFI);
 		UART_CLEAR_IER(uart, ETBEI);
 	} else {
-		if (!uart->tx_done)
-			dma_unmap_sg(uart->dev, &uart->tx_sgl, 1, DMA_TO_DEVICE);
-
+		/*
+		 * tx_sgl is only a view into the long-lived xmit_buf mapping
+		 * created with dma_map_single() in startup — there is nothing
+		 * to unmap per transfer; the mapping is released in shutdown.
+		 */
 		dmaengine_terminate_sync(uart->tx_dma_channel);
 		uart->port.icount.tx += uart->tx_count;
 		uart->tx_count = 0;
@@ -445,10 +447,8 @@ static void adi_uart4_serial_dma_tx_chars(struct adi_uart4_serial_port *uart)
 
 	desc = dmaengine_prep_slave_sg(uart->tx_dma_channel, &uart->tx_sgl, 1,
 			DMA_MEM_TO_DEV, 0);
-	if (!desc) {
-		dma_unmap_sg(uart->dev, &uart->tx_sgl, 1, DMA_TO_DEVICE);
+	if (!desc)
 		return;
-	}
 
 	uart->tx_count = sg_dma_len(&uart->tx_sgl);
 
@@ -549,8 +549,6 @@ static void adi_uart4_serial_dma_tx(void *data)
 	struct adi_uart4_serial_port *uart = data;
 	struct tty_port *tport = &uart->port.state->port;
 	unsigned long flags;
-
-	dma_unmap_sg(uart->dev, &uart->tx_sgl, 1, DMA_TO_DEVICE);
 
 	spin_lock_irqsave(&uart->port.lock, flags);
 	/* Anomaly notes:

--- a/include/dt-bindings/soc/adi/sc5xx-tru.h
+++ b/include/dt-bindings/soc/adi/sc5xx-tru.h
@@ -1,0 +1,37 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/*
+ * Trigger Routing Unit (TRU) master (generator) and slave (receiver) IDs
+ * for the ADI ADSP-SC84x.
+ *
+ * IDs verified against the ADSP-SC84x HRM trigger lists (TRU chapter
+ * "Trigger List Masters", SPI chapter Table "SPI Trigger List Receivers",
+ * TIMER chapter Table "TIMER Trigger List Generators"). Trigger IDs are
+ * assigned per die and differ between family members (including between
+ * the SC59x variants), so these values must not be reused for other SoCs.
+ *
+ * Copyright 2026 Analog Devices Inc.
+ */
+
+#ifndef _DT_BINDINGS_SOC_ADI_SC5XX_TRU_H
+#define _DT_BINDINGS_SOC_ADI_SC5XX_TRU_H
+
+/* Master ID 0 is reserved as the null source: routing it disconnects. */
+#define ADI_TRU_MST_NULL		0
+
+/* Software-driven trigger masters SOFT0..SOFT5 */
+#define ADI_TRU_MST_SOFT(n)		(167 + (n))
+
+/* GP timer trigger generators TIMER0_TMR00_GEN..TMR15_GEN */
+#define ADI_TRU_MST_TIMER0_TMR(n)	(173 + (n))
+
+/* SPI TX/RX DMA channel trigger receivers */
+#define ADI_TRU_RCV_SPI0_TXDMA		149
+#define ADI_TRU_RCV_SPI0_RXDMA		150
+#define ADI_TRU_RCV_SPI1_TXDMA		151
+#define ADI_TRU_RCV_SPI1_RXDMA		152
+#define ADI_TRU_RCV_SPI5_TXDMA		153
+#define ADI_TRU_RCV_SPI5_RXDMA		154
+#define ADI_TRU_RCV_SPI2_TXDMA		155
+#define ADI_TRU_RCV_SPI2_RXDMA		156
+
+#endif /* _DT_BINDINGS_SOC_ADI_SC5XX_TRU_H */


### PR DESCRIPTION
Platform-level fixes for SC846/SC84x on adsp-6.18.31-y, independent of
any new peripheral drivers. All hardware-validated on the SC846 SOM
EZ-kit (MUN lab) unless noted.

## Interrupt and device-tree correctness (sc846.dtsi)

- **PINT interrupt numbers**: the pint nodes carried the SC59x GIC
  SPIs (65..72); on SC846 they are 217..224 (SVD + HRM, verified on
  hardware — with the old numbers every pint consumer silently gets
  zero interrupts). Also adds the standard `interrupt-controller`
  binding to each PINT so consumer nodes can take PINT-domain
  interrupts directly.
- **HADC interrupt**: 186 (SC59x) -> 118 (HADC0_EVT per HRM).
- **Remaining SC59x-inherited interrupts** in (mostly disabled) nodes
  corrected against the SC846 HRM interrupt list/SVD: TMU thermal,
  CAN FD 0/1, link ports, PKTE, CRC2/3 + their MDMA channels,
  L2CTL0/sram-controller, and the eMMC host (EMSI0 is at 0x31152000,
  IRQs 214/215 — the node pointed at the SC59x MSHC address).
- **Remove nodes for hardware SC846 does not have**: emac1 (SC84x has
  one EMAC), rtc0, and the SC59x OSPI node at an unmapped address
  (flash on SC84x is served by the quad-capable SPI1/SPI2 and the two
  xSPI octal/HyperBus controllers, which need their own support).

## Stability fixes

- **emac0: fixed-burst DMA**: with `snps,mixed-burst`, sustained MAC
  DMA traffic hard-hangs the SoC silently (no exception, no watchdog;
  reproducible within a few hundred MB of streaming). Fixed bursts run
  the same workloads indefinitely; pbl/TSO unchanged. Validated with
  multi-GB streams and long iiod captures.
- **serial: adi_uart4**: remove three bogus `dma_unmap_sg` calls on
  the TX scatterlist (DMA-API debug flagged map/unmap size mismatch).
- **spi: adi**: read the SPI functional clock rate after enabling the
  clock, and fail probe loudly if it reads 0.

## Usability / enablement

- **dmaengine: adi-dma + DT labels**: name each DMA channel's IRQs
  after its peripheral (`adi-dma uart0-tx` etc. in /proc/interrupts),
  with `label` properties added for all SC846 and SC59x channels.
- **pinctrl: adi-adsp**: enable the pad input buffer on
  peripheral-muxed pins (peripheral inputs don't see the pin without
  INEN) and support `PIN_CONFIG_INPUT_ENABLE`.
- **soc: adi: icc**: demote the per-route TRU message to dev_dbg.
- **dt-bindings**: add the SC5xx TRU trigger ID header and use it in
  the SC846 SOM device tree instead of magic numbers.

## Validation

Boot-tested on SC846 SOM EZ-kit (base sc846-som-ezkit.dtb): clean
boot, Ethernet stable under multi-GB streaming, named DMA IRQs
visible, no DMA-API warnings. DTBs for all SC59x/SC84x boards build
cleanly.