### PR TITLE
arm64: dts: adi: fix all dtc W=1 warnings and DT convention violations

### DIFF
--- a/arch/arm64/boot/dts/adi/sc598-htol.dts
+++ b/arch/arm64/boot/dts/adi/sc598-htol.dts
@@ -96,8 +96,6 @@
 
 &spi2 {
 	flash@1 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "issi,is25lp01g", "jedec,spi-nor";
 		reg = <1>;
 		spi-tx-bus-width = <4>;

--- a/arch/arm64/boot/dts/adi/sc598-htol.dts
+++ b/arch/arm64/boot/dts/adi/sc598-htol.dts
@@ -109,22 +109,22 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 
-			qspi_0@0 {
+			partition@0 {
 				label = "u-boot-spl";
 				reg = <0x00000000 0x40000>;
 			};
 
-			qspi_1@40000 {
+			partition@40000 {
 				label = "u-boot";
 				reg = <0x00040000 0xC0000>;
 			};
 
-			qspi_2@100000 {
+			partition@100000 {
 				label = "kernel";
 				reg = <0x00100000 0x2000000>;
 			};
 
-			qspi_3@2100000 {
+			partition@2100000 {
 				label = "rootfs";
 				reg = <0x02100000 0x5ef0000>;
 			};

--- a/arch/arm64/boot/dts/adi/sc598-htol.dts
+++ b/arch/arm64/boot/dts/adi/sc598-htol.dts
@@ -82,7 +82,7 @@
 	pinctrl-0 = <&eth0_default>;
 	status = "okay";
 
-	mdio0 {
+	mdio {
 		compatible = "snps,dwmac-mdio";
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/arch/arm64/boot/dts/adi/sc598-som-ezkit.dtsi
+++ b/arch/arm64/boot/dts/adi/sc598-som-ezkit.dtsi
@@ -26,8 +26,6 @@
 	status = "disabled";
 
 	flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "mxicy,mx66lm1g45", "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <83333334>;

--- a/arch/arm64/boot/dts/adi/sc598-som-ezkit.dtsi
+++ b/arch/arm64/boot/dts/adi/sc598-som-ezkit.dtsi
@@ -12,12 +12,10 @@
 	model = "ADI 64-bit SC598 SOM EZ Kit";
 	compatible = "adi,sc598-som-ezkit", "adi,sc59x-64";
 
-	scb {
-		sound {
-			compatible = "adi,sc5xx-asoc-card";
-			adi,cpu-dai = <&i2s4>;
-			adi,codec = <&adau1962>, <&adau1979>;
-		};
+	sound {
+		compatible = "adi,sc5xx-asoc-card";
+		adi,cpu-dai = <&i2s4>;
+		adi,codec = <&adau1962>, <&adau1979>;
 	};
 };
 

--- a/arch/arm64/boot/dts/adi/sc598-som-ezkit.dtsi
+++ b/arch/arm64/boot/dts/adi/sc598-som-ezkit.dtsi
@@ -176,12 +176,12 @@
 		};
 	};
 
-	adau1979: adau1979@11 {
+	adau1979: audio-codec@11 {
 		compatible = "adi,adau1979";
 		reg = <0x11>;
 	};
 
-	adau1962: adau1962@4 {
+	adau1962: audio-codec@4 {
 		compatible = "adi,adau1962";
 		reg = <0x4>;
 		reset-gpios = <&crr_gpio_expander 5 GPIO_ACTIVE_LOW>;
@@ -231,7 +231,7 @@
 		};
 	};
 
-	mdio0 {
+	mdio {
 		compatible = "snps,dwmac-mdio";
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/arch/arm64/boot/dts/adi/sc598-som-ezkit.dtsi
+++ b/arch/arm64/boot/dts/adi/sc598-som-ezkit.dtsi
@@ -50,17 +50,17 @@
 				reg = <0x0 0x40000>;
 			};
 
-			ospi_1: partition@1 {
+			ospi_1: partition@40000 {
 				label = "u-boot";
 				reg = <0x40000 0xc0000>;
 			};
 
-			ospi_2: partition@2 {
+			ospi_2: partition@100000 {
 				label = "kernel";
 				reg = <0x100000 0xf00000>;
 			};
 
-			ospi_3: partition@3 {
+			ospi_3: partition@1000000 {
 				label = "rootfs";
 				reg = <0x1000000 0x1000000>;
 			};

--- a/arch/arm64/boot/dts/adi/sc598-som-ezlite.dts
+++ b/arch/arm64/boot/dts/adi/sc598-som-ezlite.dts
@@ -11,22 +11,17 @@
 	model = "ADI 64-bit SC598 SOM EZ Lite";
 	compatible = "adi,sc598-som-ezlite", "adi,sc59x-64";
 
-	clocks {
-		compatible = "simple-bus";
-		mclk: mclk {
-			compatible = "fixed-clock";
-			#clock-cells = <0>;
-			clock-frequency = <24576000>;
-			clock-output-names = "mclk";
-		};
+	mclk: clock-24576000 {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-frequency = <24576000>;
+		clock-output-names = "mclk";
 	};
 
-	scb {
-		sound {
-			compatible = "adi,sc5xx-asoc-card";
-			adi,cpu-dai = <&i2s0>;
-			adi,codec = <&adau1372>;
-		};
+	sound {
+		compatible = "adi,sc5xx-asoc-card";
+		adi,cpu-dai = <&i2s0>;
+		adi,codec = <&adau1372>;
 	};
 };
 

--- a/arch/arm64/boot/dts/adi/sc598-som-ezlite.dts
+++ b/arch/arm64/boot/dts/adi/sc598-som-ezlite.dts
@@ -48,7 +48,7 @@
 };
 
 &i2c2 {
-	crr_gpio_expander: adp5588@30 {
+	crr_gpio_expander: gpio@30 {
 		compatible = "adi,adp5588-gpio";
 		gpio-controller;
 		#gpio-cells = <2>;
@@ -119,7 +119,7 @@
 		};
 	};
 
-	adau1372: adau1372@3c {
+	adau1372: audio-codec@3c {
 		compatible = "adi,adau1372";
 		reg = <0x3c>;
 		clock-names = "mclk";
@@ -170,7 +170,7 @@
 		};
 	};
 
-	mdio0 {
+	mdio {
 		compatible = "snps,dwmac-mdio";
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/arch/arm64/boot/dts/adi/sc598-som-revD.dtsi
+++ b/arch/arm64/boot/dts/adi/sc598-som-revD.dtsi
@@ -101,22 +101,22 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 
-			qspi_0@0 {
+			partition@0 {
 				label = "u-boot-spl";
 				reg = <0x00000000 0x40000>;
 			};
 
-			qspi_1@40000 {
+			partition@40000 {
 				label = "u-boot";
 				reg = <0x00040000 0xc0000>;
 			};
 
-			qspi_2@100000 {
+			partition@100000 {
 				label = "kernel";
 				reg = <0x00100000 0xf00000>;
 			};
 
-			qspi_3@1000000 {
+			partition@1000000 {
 				label = "rootfs";
 				reg = <0x01000000 0x3000000>;
 			};

--- a/arch/arm64/boot/dts/adi/sc598-som-revD.dtsi
+++ b/arch/arm64/boot/dts/adi/sc598-som-revD.dtsi
@@ -8,7 +8,7 @@
 #include "sc598-som.dtsi"
 
 / {
-	mmc_muxctl: mmc-mux-controller {
+	mmc_muxctl: mux-controller {
 		compatible = "gpio-mux";
 		#mux-state-cells = <1>;
 		mux-gpios = <&som_gpio_expander 8 GPIO_ACTIVE_LOW>,
@@ -30,7 +30,7 @@
 };
 
 &i2c2 {
-	som_gpio_expander: mcp23018@20 {
+	som_gpio_expander: gpio@20 {
 		compatible = "microchip,mcp23018";
 		reg = <0x20>;
 		gpio-controller;

--- a/arch/arm64/boot/dts/adi/sc598-som-revE.dtsi
+++ b/arch/arm64/boot/dts/adi/sc598-som-revE.dtsi
@@ -8,7 +8,7 @@
 #include "sc598-som.dtsi"
 
 / {
-	mmc_muxctl: mmc-mux-controller {
+	mmc_muxctl: mux-controller {
 		compatible = "gpio-mux";
 		#mux-state-cells = <1>;
 		mux-gpios = <&som_gpio_expander 8 GPIO_ACTIVE_LOW>,
@@ -30,7 +30,7 @@
 };
 
 &i2c2 {
-	som_gpio_expander: adp5587@34 {
+	som_gpio_expander: gpio@34 {
 		compatible = "adi,adp5587";
 		reg = <0x34>;
 		gpio-controller;

--- a/arch/arm64/boot/dts/adi/sc598-som-revE.dtsi
+++ b/arch/arm64/boot/dts/adi/sc598-som-revE.dtsi
@@ -99,22 +99,22 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 
-			qspi_0@0 {
+			partition@0 {
 				label = "u-boot-spl";
 				reg = <0x00000000 0x40000>;
 			};
 
-			qspi_1@40000 {
+			partition@40000 {
 				label = "u-boot";
 				reg = <0x00040000 0xC0000>;
 			};
 
-			qspi_2@100000 {
+			partition@100000 {
 				label = "kernel";
 				reg = <0x00100000 0x2000000>;
 			};
 
-			qspi_3@2100000 {
+			partition@2100000 {
 				label = "rootfs";
 				reg = <0x02100000 0x5ef0000>;
 			};

--- a/arch/arm64/boot/dts/adi/sc598-som.dtsi
+++ b/arch/arm64/boot/dts/adi/sc598-som.dtsi
@@ -43,14 +43,14 @@
 			no-map;
 		};
 
-		vdev1vrings: vdev0vring0@200A4000 {
-			reg = <0x200A4000 0x4000>;
+		vdev1vrings: vdev1vring0@200a4000 {
+			reg = <0x200a4000 0x4000>;
 			no-map;
 		};
 
-		vdev1buffer: vdev0buffer@200A8000 {
+		vdev1buffer: vdev1buffer@200a8000 {
 			compatible = "shared-dma-pool";
-			reg = <0x200A8000 0x20000>;
+			reg = <0x200a8000 0x20000>;
 			no-map;
 		};
 	};

--- a/arch/arm64/boot/dts/adi/sc598-som.dtsi
+++ b/arch/arm64/boot/dts/adi/sc598-som.dtsi
@@ -55,7 +55,35 @@
 		};
 	};
 
-	sram1_mmap: sram-mmap@0 {
+	sharc0_rpmsg: core0-rpmsg {
+		status = "disabled";
+		compatible = "adi,rpmsg-sc598";
+		core-id = <1>;
+		adi,rcu = <&rcu>;
+		adi,check-idle;
+		adi,rsc-table = <&rsc_tbl0>;
+		interrupts = <GIC_SPI 337 IRQ_TYPE_EDGE_RISING>; /* TRU0_SLV3 */
+		adi,tru = <&tru>;
+		adi,tru-master-id = <135>; /* trigger master SOFT4 */
+		vdev-vring = <&vdev0vrings>;
+		memory-region = <&vdev0buffer>;
+	};
+
+	sharc1_rpmsg: core1-rpmsg {
+		status = "disabled";
+		compatible = "adi,rpmsg-sc598";
+		core-id = <2>;
+		adi,rcu = <&rcu>;
+		adi,check-idle;
+		adi,rsc-table = <&rsc_tbl1>;
+		interrupts = <GIC_SPI 337 IRQ_TYPE_EDGE_RISING>; /* TRU0_SLV3 */
+		adi,tru = <&tru>;
+		adi,tru-master-id = <136>; /* trigger master SOFT5 */
+		vdev-vring = <&vdev1vrings>;
+		memory-region = <&vdev1buffer>;
+	};
+
+	sram1_mmap: sram-mmap {
 		compatible = "adi,sram-mmap";
 		memory-region = <&sram1_res>;
 		status = "okay";
@@ -100,47 +128,21 @@
 			status = "okay";
 		};
 
-		sharc0_rpmsg: core0-rpmsg@28240000 {
-			status = "disabled";
-			compatible = "adi,rpmsg-sc598";
-			core-id = <1>;
-			adi,rcu = <&rcu>;
-			adi,check-idle;
-			adi,rsc-table = <&rsc_tbl0>;
-			interrupts = <GIC_SPI 337 IRQ_TYPE_EDGE_RISING>; /* TRU0_SLV3 */
-			adi,tru = <&tru>;
-			adi,tru-master-id = <135>; /* trigger master SOFT4 */
-			vdev-vring = <&vdev0vrings>;
-			memory-region = <&vdev0buffer>;
-		};
 
-		sharc1_rpmsg: core1-rpmsg@28a40000 {
-			status = "disabled";
-			compatible = "adi,rpmsg-sc598";
-			core-id = <2>;
-			adi,rcu = <&rcu>;
-			adi,check-idle;
-			adi,rsc-table = <&rsc_tbl1>;
-			interrupts = <GIC_SPI 337 IRQ_TYPE_EDGE_RISING>; /* TRU0_SLV3 */
-			adi,tru = <&tru>;
-			adi,tru-master-id = <136>; /* trigger master SOFT5 */
-			vdev-vring = <&vdev1vrings>;
-			memory-region = <&vdev1buffer>;
-		};
 	};
 
 };
 
 &tru {
-	rpmsg_to_a55: channel@0 {
+	rpmsg_to_a55: channel-0 {
 		adi,tru-master-id = <134>; /* trigger master SOFT3 */
 		adi,tru-slave-id = <160>; /* TRU0_IRQ3 */
 	};
-	rpmsg_to_sharc0: channel@1 {
+	rpmsg_to_sharc0: channel-1 {
 		adi,tru-master-id = <135>; /* trigger master SOFT4 */
 		adi,tru-slave-id = <164>; /* TRU0_IRQ7 */
 	};
-	rpmsg_to_sharc1: channel@2 {
+	rpmsg_to_sharc1: channel-2 {
 		adi,tru-master-id = <136>; /* trigger master SOFT5 */
 		adi,tru-slave-id = <168>; /* TRU0_IRQ11 */
 	};

--- a/arch/arm64/boot/dts/adi/sc59x-64.dtsi
+++ b/arch/arm64/boot/dts/adi/sc59x-64.dtsi
@@ -670,24 +670,6 @@
 			status = "disabled";
 		};
 
-		lp0: linkport@0 {
-			compatible = "linkport0";
-			interrupt-parent = <&gic>;
-			interrupts = <GIC_SPI 117 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 118 IRQ_TYPE_LEVEL_HIGH>;
-			clock-div = <1>;
-			status = "disabled";
-		};
-
-		lp1: linkport@1 {
-			compatible = "linkport1";
-			interrupt-parent = <&gic>;
-			interrupts = <GIC_SPI 119 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 120 IRQ_TYPE_LEVEL_HIGH>;
-			clock-div = <1>;
-			status = "disabled";
-		};
-
 		pint0: pint@31005000 {
 			compatible = "adi,adsp-pint";
 			reg = <0x31005000 0xFF>;

--- a/arch/arm64/boot/dts/adi/sc59x-64.dtsi
+++ b/arch/arm64/boot/dts/adi/sc59x-64.dtsi
@@ -1083,10 +1083,13 @@
 		sport0_dma_cluster: dma@31022000 {
 			compatible = "adi,dma-controller";
 			reg = <0x31022000 0x1000>;
+			#address-cells = <1>;
+			#size-cells = <0>;
 			status = "okay";
 			#dma-cells = <1>;
 
 			sport0a: channel@0 {
+				reg = <0>;
 				adi,id = <0>;
 				adi,src-offset = <0>;
 				adi,skip-interrupts = <0>;
@@ -1096,6 +1099,7 @@
 			};
 
 			sport0b: channel@1 {
+				reg = <1>;
 				adi,id = <1>;
 				adi,src-offset = <0x80>;
 				adi,skip-interrupts = <0>;
@@ -1108,10 +1112,13 @@
 		sport4_dma_cluster: dma@31023000 {
 			compatible = "adi,dma-controller";
 			reg = <0x31023000 0x1000>;
+			#address-cells = <1>;
+			#size-cells = <0>;
 			status = "okay";
 			#dma-cells = <1>;
 
-			sport4a: channel@10 {
+			sport4a: channel@a {
+				reg = <10>;
 				adi,id = <10>;
 				adi,src-offset = <0>;
 				adi,skip-interrupts = <0>;
@@ -1120,7 +1127,8 @@
 				interrupt-names = "complete", "error";
 			};
 
-			sport4b: channel@11 {
+			sport4b: channel@b {
+				reg = <11>;
 				adi,id = <11>;
 				adi,src-offset = <0x80>;
 				adi,skip-interrupts = <0>;
@@ -1133,10 +1141,13 @@
 		spi_cluster: dma@3102d000 {
 			compatible = "adi,dma-controller";
 			reg = <0x3102d000 0x1000>;
+			#address-cells = <1>;
+			#size-cells = <0>;
 			status = "okay";
 			#dma-cells = <1>;
 
-			spi0_tx: channel@22 {
+			spi0_tx: channel@16 {
+				reg = <22>;
 				adi,id = <22>;
 				interrupts = <GIC_SPI 121 IRQ_TYPE_LEVEL_HIGH>,
 					<GIC_SPI 261 IRQ_TYPE_LEVEL_HIGH>;
@@ -1144,7 +1155,8 @@
 				adi,src-offset = <0>;
 			};
 
-			spi0_rx: channel@23 {
+			spi0_rx: channel@17 {
+				reg = <23>;
 				adi,id = <23>;
 				interrupts = <GIC_SPI 122 IRQ_TYPE_LEVEL_HIGH>,
 					<GIC_SPI 262 IRQ_TYPE_LEVEL_HIGH>;
@@ -1152,7 +1164,8 @@
 				adi,src-offset = <0x80>;
 			};
 
-			spi1_tx: channel@24 {
+			spi1_tx: channel@18 {
+				reg = <24>;
 				adi,id = <24>;
 				interrupts = <GIC_SPI 125 IRQ_TYPE_LEVEL_HIGH>,
 					<GIC_SPI 263 IRQ_TYPE_LEVEL_HIGH>;
@@ -1160,7 +1173,8 @@
 				adi,src-offset = <0x100>;
 			};
 
-			spi1_rx: channel@25 {
+			spi1_rx: channel@19 {
+				reg = <25>;
 				adi,id = <25>;
 				interrupts = <GIC_SPI 126 IRQ_TYPE_LEVEL_HIGH>,
 					<GIC_SPI 264 IRQ_TYPE_LEVEL_HIGH>;
@@ -1168,7 +1182,8 @@
 				adi,src-offset = <0x180>;
 			};
 
-			spi2_tx: channel@26 {
+			spi2_tx: channel@1a {
+				reg = <26>;
 				adi,id = <26>;
 				interrupts = <GIC_SPI 129 IRQ_TYPE_LEVEL_HIGH>,
 					<GIC_SPI 265 IRQ_TYPE_LEVEL_HIGH>;
@@ -1176,7 +1191,8 @@
 				adi,src-offset = <0x200>;
 			};
 
-			spi2_rx: channel@27 {
+			spi2_rx: channel@1b {
+				reg = <27>;
 				adi,id = <27>;
 				interrupts = <GIC_SPI 130 IRQ_TYPE_LEVEL_HIGH>,
 					<GIC_SPI 266 IRQ_TYPE_LEVEL_HIGH>;
@@ -1184,7 +1200,8 @@
 				adi,src-offset = <0x280>;
 			};
 
-			spi3_tx: channel@55 {
+			spi3_tx: channel@37 {
+				reg = <55>;
 				adi,id = <55>;
 				interrupts = <GIC_SPI 133 IRQ_TYPE_LEVEL_HIGH>,
 					<GIC_SPI 267 IRQ_TYPE_LEVEL_HIGH>;
@@ -1192,7 +1209,8 @@
 				adi,src-offset = <0x300>;
 			};
 
-			spi3_rx: channel@56 {
+			spi3_rx: channel@38 {
+				reg = <56>;
 				adi,id = <56>;
 				interrupts = <GIC_SPI 134 IRQ_TYPE_LEVEL_HIGH>,
 					<GIC_SPI 268 IRQ_TYPE_LEVEL_HIGH>;
@@ -1205,10 +1223,13 @@
 		crc_cluster: dma@310a7000 {
 			compatible = "adi,dma-controller";
 			reg = <0x310a7000 0x1000>;
+			#address-cells = <1>;
+			#size-cells = <0>;
 			status = "okay";
 			#dma-cells = <1>;
 
 			crc0_dma: channel@8 { /* MDMA0_SRC */
+				reg = <8>;
 				adi,id = <8>;
 				interrupts = <GIC_SPI 192 IRQ_TYPE_LEVEL_HIGH>,
 					<GIC_SPI 281 IRQ_TYPE_LEVEL_HIGH>;
@@ -1216,7 +1237,8 @@
 				adi,src-offset = <0x0>;
 			};
 
-			crc1_dma: channel@18 { /* MDMA1_SRC */
+			crc1_dma: channel@12 { /* MDMA1_SRC */
+				reg = <18>;
 				adi,id = <18>;
 				interrupts = <GIC_SPI 194 IRQ_TYPE_LEVEL_HIGH>,
 					<GIC_SPI 283 IRQ_TYPE_LEVEL_HIGH>;
@@ -1224,7 +1246,8 @@
 				adi,src-offset = <0x100>;
 			};
 
-			crc2_dma: channel@45 { /* MDMA4_SRC */
+			crc2_dma: channel@2d { /* MDMA4_SRC */
+				reg = <45>;
 				adi,id = <45>;
 				interrupts = <GIC_SPI 200 IRQ_TYPE_LEVEL_HIGH>,
 					<GIC_SPI 289 IRQ_TYPE_LEVEL_HIGH>;
@@ -1232,7 +1255,8 @@
 				adi,src-offset = <0x200>;
 			};
 
-			crc3_dma: channel@47 { /* MDMA5_SRC */
+			crc3_dma: channel@2f { /* MDMA5_SRC */
+				reg = <47>;
 				adi,id = <47>;
 				interrupts = <GIC_SPI 202 IRQ_TYPE_LEVEL_HIGH>,
 					<GIC_SPI 291 IRQ_TYPE_LEVEL_HIGH>;
@@ -1244,10 +1268,13 @@
 		dma_cluster2: dma@31026000 {
 			compatible = "adi,dma-controller";
 			reg = <0x31026000 0x1000>;
+			#address-cells = <1>;
+			#size-cells = <0>;
 			status = "okay";
 			#dma-cells = <1>;
 
-			uart0_tx: channel@20 {
+			uart0_tx: channel@14 {
+				reg = <20>;
 				adi,id = <20>;
 				interrupts = <GIC_SPI 138 IRQ_TYPE_LEVEL_HIGH>,
 					<GIC_SPI 269 IRQ_TYPE_LEVEL_HIGH>;
@@ -1255,7 +1282,8 @@
 				adi,src-offset = <0x80>;
 			};
 
-			uart0_rx: channel@21 {
+			uart0_rx: channel@15 {
+				reg = <21>;
 				adi,id = <21>;
 				interrupts = <GIC_SPI 139 IRQ_TYPE_LEVEL_HIGH>,
 					<GIC_SPI 270 IRQ_TYPE_LEVEL_HIGH>;
@@ -1263,7 +1291,8 @@
 				adi,src-offset = <0>;
 			};
 
-			uart1_tx: channel@34 {
+			uart1_tx: channel@22 {
+				reg = <34>;
 				adi,id = <34>;
 				interrupts = <GIC_SPI 141 IRQ_TYPE_LEVEL_HIGH>,
 					<GIC_SPI 271 IRQ_TYPE_LEVEL_HIGH>;
@@ -1271,7 +1300,8 @@
 				adi,src-offset = <0x180>;
 			};
 
-			uart1_rx: channel@35 {
+			uart1_rx: channel@23 {
+				reg = <35>;
 				adi,id = <35>;
 				interrupts = <GIC_SPI 142 IRQ_TYPE_LEVEL_HIGH>,
 					<GIC_SPI 272 IRQ_TYPE_LEVEL_HIGH>;
@@ -1279,7 +1309,8 @@
 				adi,src-offset = <0x100>;
 			};
 
-			uart2_tx: channel@37 {
+			uart2_tx: channel@25 {
+				reg = <37>;
 				adi,id = <37>;
 				interrupts = <GIC_SPI 144 IRQ_TYPE_LEVEL_HIGH>,
 					<GIC_SPI 273 IRQ_TYPE_LEVEL_HIGH>;
@@ -1287,7 +1318,8 @@
 				adi,src-offset = <0x280>;
 			};
 
-			uart2_rx: channel@38 {
+			uart2_rx: channel@26 {
+				reg = <38>;
 				adi,id = <38>;
 				interrupts = <GIC_SPI 145 IRQ_TYPE_LEVEL_HIGH>,
 					<GIC_SPI 274 IRQ_TYPE_LEVEL_HIGH>;
@@ -1295,7 +1327,8 @@
 				adi,src-offset = <0x200>;
 			};
 
-			uart3_tx: channel@53 {
+			uart3_tx: channel@35 {
+				reg = <53>;
 				adi,id = <53>;
 				interrupts = <GIC_SPI 147 IRQ_TYPE_LEVEL_HIGH>,
 					<GIC_SPI 275 IRQ_TYPE_LEVEL_HIGH>;
@@ -1303,7 +1336,8 @@
 				adi,src-offset = <0x380>;
 			};
 
-			uart3_rx: channel@54 {
+			uart3_rx: channel@36 {
+				reg = <54>;
 				adi,id = <54>;
 				interrupts = <GIC_SPI 148 IRQ_TYPE_LEVEL_HIGH>,
 					<GIC_SPI 276 IRQ_TYPE_LEVEL_HIGH>;
@@ -1315,9 +1349,12 @@
 		mdma: dma@3109a000 {
 			compatible = "adi,mdma-controller";
 			reg = <0x3109a000 0x1000>;
+			#address-cells = <1>;
+			#size-cells = <0>;
 			status = "okay";
 
-			sdma2: channel@40 {
+			sdma2: channel@28 {
+				reg = <40>;
 				adi,id = <40>;
 				// The destination interrupts are used for primary complete detection
 				interrupts = <GIC_SPI 207 IRQ_TYPE_LEVEL_HIGH>,

--- a/arch/arm64/boot/dts/adi/sc59x-64.dtsi
+++ b/arch/arm64/boot/dts/adi/sc59x-64.dtsi
@@ -633,16 +633,12 @@
 
 		pinctrl0: pinctrl@31004600 {
 			compatible = "adi,adsp-pinctrl";
-			#address-cells = <1>;
-			#size-cells = <1>;
 			reg = <0x31004600 0x400>;
 			adi,port-sizes = <16 16 16 16 16 16 16 16 7>;
 		};
 
 		sru_ctrl_dai0: sru-ctrl-dai0@310c9000 {
 			compatible = "adi,adsp-sru-ctrl";
-			#address-cells = <1>;
-			#size-cells = <1>;
 			reg = <0x310c9000 0x224>;
 			adi,pads-syscon = <&pads_syscon>;
 			status = "disabled";
@@ -650,8 +646,6 @@
 
 		sru_ctrl_dai1: sru-ctrl-dai1@310ca000 {
 			compatible = "adi,adsp-sru-ctrl";
-			#address-cells = <1>;
-			#size-cells = <1>;
 			reg = <0x310ca000 0x224>;
 			adi,pads-syscon = <&pads_syscon>;
 			status = "disabled";
@@ -673,8 +667,6 @@
 			compatible = "adi,gp_counter";
 			reg = <0x3100b000 0xff>;
 			interrupts = <GIC_SPI 126 IRQ_TYPE_LEVEL_HIGH>;
-			#address-cells = <1>;
-			#size-cells = <0>;
 			status = "disabled";
 		};
 

--- a/arch/arm64/boot/dts/adi/sc59x-64.dtsi
+++ b/arch/arm64/boot/dts/adi/sc59x-64.dtsi
@@ -98,7 +98,7 @@
 		clock-output-names = "sys_clkin1";
 	};
 
-	clk: clocks@3108d000 {
+	clk: clock-controller@3108d000 {
 		compatible = "adi,sc598-clocks";
 		reg = <0x3108d000 0x1000>,
 			<0x3108e000 0x1000>,
@@ -264,7 +264,7 @@
 			status = "okay";
 		};
 
-		tru: tru@3108a000 {
+		tru: mailbox@3108a000 {
 			compatible = "adi,trigger-routing-unit";
 			reg = <0x3108a000 0x1000>;
 			#mbox-cells = <1>;
@@ -273,7 +273,7 @@
 			status = "okay";
 		};
 
-		thermal: thermal@31016800 {
+		thermal: thermal-sensor@31016800 {
 			compatible = "adi,sc59x-thermal";
 			reg = <0x31016800 0x100>;
 			#thermal-sensor-cells = <0>;
@@ -285,7 +285,7 @@
 			status = "disabled";
 		};
 
-		hadc: hadc@31016000 {
+		hadc: adc@31016000 {
 			compatible = "adi,hadc";
 			reg = <0x31016000 0x100>;
 			interrupt-parent = <&gic>;
@@ -302,7 +302,7 @@
 			status = "disabled";
 		};
 
-		uart0: uart@31003000 {
+		uart0: serial@31003000 {
 			compatible = "adi,uart4";
 			reg = <0x31003000 0x40>;
 			dmas = <&dma_cluster2 20>, <&dma_cluster2 21>;
@@ -318,7 +318,7 @@
 			status = "disabled";
 		};
 
-		uart1: uart@31003400 {
+		uart1: serial@31003400 {
 			compatible = "adi,uart4";
 			reg = <0x31003400 0x40>;
 			dmas = <&dma_cluster2 34>, <&dma_cluster2 35>;
@@ -334,7 +334,7 @@
 			status = "disabled";
 		};
 
-		uart2: uart@31003800 {
+		uart2: serial@31003800 {
 			compatible = "adi,uart4";
 			reg = <0x31003800 0x40>;
 			dmas = <&dma_cluster2 37>, <&dma_cluster2 38>;
@@ -350,7 +350,7 @@
 			status = "disabled";
 		};
 
-		uart3: uart@31003c00 {
+		uart3: serial@31003c00 {
 			compatible = "adi,uart4";
 			reg = <0x31003c00 0x40>;
 			dmas = <&dma_cluster2 53>, <&dma_cluster2 54>;
@@ -386,7 +386,7 @@
 			status = "disabled";
 		};
 
-		i2c0: twi@31001400 {
+		i2c0: i2c@31001400 {
 			#address-cells = <1>;
 			#size-cells = <0>;
 			compatible = "adi,twi";
@@ -398,7 +398,7 @@
 			status = "disabled";
 		};
 
-		i2c1: twi@31001500 {
+		i2c1: i2c@31001500 {
 			#address-cells = <1>;
 			#size-cells = <0>;
 			compatible = "adi,twi";
@@ -410,7 +410,7 @@
 			status = "disabled";
 		};
 
-		i2c2: twi@31001600 {
+		i2c2: i2c@31001600 {
 			#address-cells = <1>;
 			#size-cells = <0>;
 			compatible = "adi,twi";
@@ -422,7 +422,7 @@
 			status = "disabled";
 		};
 
-		i2c3: twi@31001000 {
+		i2c3: i2c@31001000 {
 			#address-cells = <1>;
 			#size-cells = <0>;
 			compatible = "adi,twi";
@@ -434,7 +434,7 @@
 			status = "disabled";
 		};
 
-		i2c4: twi@31001100 {
+		i2c4: i2c@31001100 {
 			#address-cells = <1>;
 			#size-cells = <0>;
 			compatible = "adi,twi";
@@ -446,7 +446,7 @@
 			status = "disabled";
 		};
 
-		i2c5: twi@31001200 {
+		i2c5: i2c@31001200 {
 			#address-cells = <1>;
 			#size-cells = <0>;
 			compatible = "adi,twi";
@@ -569,7 +569,7 @@
 			snps,pbl = <8>;
 			snps,force_sf_dma_mode;
 			snps,perfect-filter-entries = <32>;
-			snps,tso = <1>;
+			snps,tso;
 			clocks = <&clk ADSP_SC598_CLK_GIGE>;
 			clock-names = "stmmaceth";
 			adi,pads-syscon = <&pads_syscon>;
@@ -663,7 +663,7 @@
 			status = "disabled";
 		};
 
-		gp_counter: cnt@3100b000 {
+		gp_counter: counter@3100b000 {
 			compatible = "adi,gp_counter";
 			reg = <0x3100b000 0xff>;
 			interrupts = <GIC_SPI 126 IRQ_TYPE_LEVEL_HIGH>;
@@ -718,7 +718,7 @@
 			interrupts = <GIC_SPI 72 IRQ_TYPE_LEVEL_HIGH>;
 		};
 
-		gpa: gport@31004000 {
+		gpa: gpio@31004000 {
 			compatible = "adi,adsp-port-gpio";
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -728,7 +728,7 @@
 			status = "okay";
 		};
 
-		gpb: gport@31004080 {
+		gpb: gpio@31004080 {
 			compatible = "adi,adsp-port-gpio";
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -738,7 +738,7 @@
 			status = "okay";
 		};
 
-		gpc: gport@31004100 {
+		gpc: gpio@31004100 {
 			compatible = "adi,adsp-port-gpio";
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -748,7 +748,7 @@
 			status = "okay";
 		};
 
-		gpd: gport@31004180 {
+		gpd: gpio@31004180 {
 			compatible = "adi,adsp-port-gpio";
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -757,7 +757,7 @@
 			adi,pint = <&pint2 0>;
 		};
 
-		gpe: gport@31004200 {
+		gpe: gpio@31004200 {
 			compatible = "adi,adsp-port-gpio";
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -766,7 +766,7 @@
 			adi,pint = <&pint4 1>;
 		};
 
-		gpf: gport@31004280 {
+		gpf: gpio@31004280 {
 			compatible = "adi,adsp-port-gpio";
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -775,7 +775,7 @@
 			adi,pint = <&pint4 0>;
 		};
 
-		gpg: gport@31004300 {
+		gpg: gpio@31004300 {
 			compatible = "adi,adsp-port-gpio";
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -784,7 +784,7 @@
 			adi,pint = <&pint6 1>;
 		};
 
-		gph: gport@31004380 {
+		gph: gpio@31004380 {
 			compatible = "adi,adsp-port-gpio";
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -793,7 +793,7 @@
 			adi,pint = <&pint6 0>;
 		};
 
-		gpi: gport@31004400 {
+		gpi: gpio@31004400 {
 			compatible = "adi,adsp-port-gpio";
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -812,7 +812,7 @@
 			status = "disabled";
 		};
 
-		pkte1: pkte@310cd000 {
+		pkte1: crypto@310cd000 {
 			compatible = "adi,pkte";
 			reg = <0x310cd000 0x400>;
 			interrupts = <GIC_SPI 161 IRQ_TYPE_LEVEL_HIGH>;

--- a/arch/arm64/boot/dts/adi/sc59x-64.dtsi
+++ b/arch/arm64/boot/dts/adi/sc59x-64.dtsi
@@ -53,7 +53,7 @@
 		cpu0: cpu@0 {
 			device_type = "cpu";
 			compatible = "arm,cortex-a55";
-			reg = <0x0 0x0>;
+			reg = <0x0>;
 			enable-method = "spin-table";
 			cpu-release-addr = <0x0 0xdeadbeef>;
 			clocks = <&clk ADSP_SC598_CLK_ARM>, <&clk ADSP_SC598_CLK_DDR>;
@@ -84,14 +84,14 @@
 			     <GIC_PPI 10 IRQ_TYPE_LEVEL_LOW>; /* Hypervisor */
 	};
 
-	sys_clkin0: oscillator@1 {
+	sys_clkin0: clock-sys-clkin0 {
 		compatible = "fixed-clock";
 		#clock-cells = <0>;
 		clock-frequency = <25000000>;
 		clock-output-names = "sys_clkin0";
 	};
 
-	sys_clkin1: oscillator@2 {
+	sys_clkin1: clock-sys-clkin1 {
 		compatible = "fixed-clock";
 		#clock-cells = <0>;
 		clock-frequency = <25000000>;
@@ -184,17 +184,17 @@
 		#size-cells = <1>;
 		ranges;
 
-		rsc_tbl0: rsc_tbl0@20000000 {
+		rsc_tbl0: rsc-table@20000000 {
 			reg = <0x20000000 0x400>; /*1KiB*/
 			no-map;
 		};
 
-		rsc_tbl1: rsc_tbl0@20000400 {
+		rsc_tbl1: rsc-table@20000400 {
 			reg = <0x20000400 0x400>; /*1KiB*/
 			no-map;
 		};
 
-		sharc_internal_icc@20005000 {
+		sharc-internal-icc@20005000 {
 			reg = <0x20005000 0x20000>; /*128KiB*/
 			no-map;
 		};
@@ -294,9 +294,9 @@
 			status = "okay";
 		};
 
-		rtc0: rtc@310C8000 {
+		rtc0: rtc@310c8000 {
 			compatible = "adi,rtc2";
-			reg = <0x310C8000 0x100>;
+			reg = <0x310c8000 0x100>;
 			/*interrupts = <GIC_SPI 165 IRQ_TYPE_LEVEL_HIGH>;*/
 			calibration = /bits/ 8 <0>;
 			status = "disabled";
@@ -350,9 +350,9 @@
 			status = "disabled";
 		};
 
-		uart3: uart@31003C00 {
+		uart3: uart@31003c00 {
 			compatible = "adi,uart4";
-			reg = <0x31003C00 0x40>;
+			reg = <0x31003c00 0x40>;
 			dmas = <&dma_cluster2 53>, <&dma_cluster2 54>;
 			dma-names = "tx", "rx";
 			clocks = <&clk ADSP_SC598_CLK_CGU0_SCLK0>;
@@ -458,7 +458,7 @@
 			status = "disabled";
 		};
 
-		i2s4: i2s@4 {
+		i2s4: i2s@31002400 {
 			compatible = "adi,sc5xx-i2s-dai";
 			status = "disabled";
 			reg = <0x31002400 0x80>, <0x31002480 0x80>;
@@ -471,7 +471,7 @@
 			clock-names = "sclk";
 		};
 
-		i2s0: i2s0@0 {
+		i2s0: i2s@31002000 {
 			compatible = "adi,sc5xx-i2s-dai";
 			status = "disabled";
 			reg = <0x31002000 0x80>, <0x31002080 0x80>;
@@ -639,28 +639,28 @@
 			adi,port-sizes = <16 16 16 16 16 16 16 16 7>;
 		};
 
-		sru_ctrl_dai0: sru-ctrl-dai0@310C9000 {
+		sru_ctrl_dai0: sru-ctrl-dai0@310c9000 {
 			compatible = "adi,adsp-sru-ctrl";
 			#address-cells = <1>;
 			#size-cells = <1>;
-			reg = <0x310C9000 0x224>;
+			reg = <0x310c9000 0x224>;
 			adi,pads-syscon = <&pads_syscon>;
 			status = "disabled";
 		};
 
-		sru_ctrl_dai1: sru-ctrl-dai1@310CA000 {
+		sru_ctrl_dai1: sru-ctrl-dai1@310ca000 {
 			compatible = "adi,adsp-sru-ctrl";
 			#address-cells = <1>;
 			#size-cells = <1>;
-			reg = <0x310CA000 0x224>;
+			reg = <0x310ca000 0x224>;
 			adi,pads-syscon = <&pads_syscon>;
 			status = "disabled";
 		};
 
 
-		mmc0: mmc@310C7000 {
+		mmc0: mmc@310c7000 {
 			compatible = "snps,dwcmshc-sdhci";
-			reg = <0x310C7000 0x1000>;
+			reg = <0x310c7000 0x1000>;
 			interrupts = <GIC_SPI 237 IRQ_TYPE_LEVEL_HIGH>; /* Status */
 				     /*<GIC_SPI 239 IRQ_TYPE_LEVEL_HIGH>;*/ /* Wakeup */
 			clocks = <&clk ADSP_SC598_CLK_EMMC>;
@@ -669,9 +669,9 @@
 			status = "disabled";
 		};
 
-		gp_counter: cnt@3100B000 {
+		gp_counter: cnt@3100b000 {
 			compatible = "adi,gp_counter";
-			reg = <0x3100B000 0xFF>;
+			reg = <0x3100b000 0xff>;
 			interrupts = <GIC_SPI 126 IRQ_TYPE_LEVEL_HIGH>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -820,9 +820,9 @@
 			status = "disabled";
 		};
 
-		pkte1: pkte@310CD000 {
+		pkte1: pkte@310cd000 {
 			compatible = "adi,pkte";
-			reg = <0x310CD000 0x400>;
+			reg = <0x310cd000 0x400>;
 			interrupts = <GIC_SPI 161 IRQ_TYPE_LEVEL_HIGH>;
 			status = "disabled";
 		};
@@ -1352,9 +1352,9 @@
 			};
 		};
 
-		trng: rng@310D0000 {
+		trng: rng@310d0000 {
 			compatible = "adi,sc5xx-trng";
-			reg = <0x310D0000 0x74>, <0x310D8000 0x14>;
+			reg = <0x310d0000 0x74>, <0x310d8000 0x14>;
 			interrupts = <GIC_SPI 160 IRQ_TYPE_LEVEL_HIGH>;
 			interrupt-names = "pkic0_irq";
 			startup-cycles = <0xff>;

--- a/arch/arm64/boot/dts/adi/sc59x-64.dtsi
+++ b/arch/arm64/boot/dts/adi/sc59x-64.dtsi
@@ -200,6 +200,24 @@
 		};
 	};
 
+	gptimer_counter: gptimer-counter {
+		compatible = "adi,gptimer-counter";
+		status = "okay";
+	};
+
+	emac1_clkin: clock-emac1-clkin {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-frequency = <50000000>;
+		clock-output-names = "emac1_clkin";
+	};
+
+	usb0_phy: usb-phy {
+		compatible = "usb-nop-xceiv";
+		#phy-cells = <0>;
+		status = "disabled";
+	};
+
 	scb {
 		compatible = "simple-bus";
 		#address-cells = <1>;
@@ -226,10 +244,6 @@
 			status = "disabled";
 		};
 
-		gptimer_counter: gptimer-counters@0 {
-			compatible = "adi,gptimer-counter";
-			status = "okay";
-		};
 
 		rcu: rcu@3108c000 {
 			compatible = "syscon", "adi,reset-controller";
@@ -643,12 +657,6 @@
 			status = "disabled";
 		};
 
-		emac1_clkin: emac1-clkin@0 {
-			compatible = "fixed-clock";
-			#clock-cells = <0>;
-			clock-frequency = <50000000>;
-			clock-output-names = "emac1_clkin";
-		};
 
 		mmc0: mmc@310C7000 {
 			compatible = "snps,dwcmshc-sdhci";
@@ -802,11 +810,6 @@
 			adi,pint = <&pint7 1>;
 		};
 
-		usb0_phy: usbphy {
-			compatible = "usb-nop-xceiv";
-			#phy-cells = <0>;
-			status = "disabled";
-		};
 
 		usb0: usb@310c5000 {
 			compatible = "snps,dwc2";

--- a/arch/arm64/boot/dts/adi/sc59x-64.dtsi
+++ b/arch/arm64/boot/dts/adi/sc59x-64.dtsi
@@ -224,6 +224,12 @@
 		#size-cells = <1>;
 		ranges;
 
+		/*
+		 * Deliberately at the same address as the pinctrl node: both
+		 * describe the PADS0 block. The pinctrl driver programs the
+		 * pads registers directly, while the emac glue and sru-ctrl
+		 * reach them through this syscon regmap (adi,pads-syscon).
+		 */
 		pads_syscon: syscon@31004600 {
 			compatible = "adi,sc5xx-pads-syscon", "syscon";
 			reg = <0x31004600 0x200>;

--- a/arch/arm64/boot/dts/adi/sc846-som-ezkit.dts
+++ b/arch/arm64/boot/dts/adi/sc846-som-ezkit.dts
@@ -181,7 +181,7 @@
 	pinctrl-0 = <&eth0_default>;
 	status = "okay";
 
-	mdio0 {
+	mdio {
 		compatible = "snps,dwmac-mdio";
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/arch/arm64/boot/dts/adi/sc846-som.dts
+++ b/arch/arm64/boot/dts/adi/sc846-som.dts
@@ -44,14 +44,14 @@
 			no-map;
 		};
 
-		vdev1vrings: vdev0vring0@200A4000 {
-			reg = <0x200A4000 0x4000>;
+		vdev1vrings: vdev1vring0@200a4000 {
+			reg = <0x200a4000 0x4000>;
 			no-map;
 		};
 
-		vdev1buffer: vdev0buffer@200A8000 {
+		vdev1buffer: vdev1buffer@200a8000 {
 			compatible = "shared-dma-pool";
-			reg = <0x200A8000 0x20000>;
+			reg = <0x200a8000 0x20000>;
 			no-map;
 		};
 	};
@@ -170,22 +170,22 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 
-			qspi_0@0 {
+			partition@0 {
 				label = "u-boot spl";
 				reg = <0x00000000 0x40000>;
 			};
 
-			qspi_1@40000 {
+			partition@40000 {
 				label = "u-boot proper";
 				reg = <0x00040000 0xC0000>;
 			};
 
-			qspi_2@210000 {
+			partition@210000 {
 				label = "kernel";
 				reg = <0x00210000 0x1000000>;
 			};
 
-			qspi_3@2000000 {
+			partition@1210000 {
 				label = "rootfs";
 				reg = <0x1210000 0xEDF0000>;
 			};

--- a/arch/arm64/boot/dts/adi/sc846-som.dts
+++ b/arch/arm64/boot/dts/adi/sc846-som.dts
@@ -56,7 +56,7 @@
 		};
 	};
 
-	sram1_mmap: sram-mmap@0 {
+	sram1_mmap: sram-mmap {
 		compatible = "adi,sram-mmap";
 		memory-region = <&sram1_res>;
 		status = "okay";

--- a/arch/arm64/boot/dts/adi/sc846.dtsi
+++ b/arch/arm64/boot/dts/adi/sc846.dtsi
@@ -827,10 +827,13 @@
 		sport0_dma_cluster: dma@31022000 {
 			compatible = "adi,dma-controller";
 			reg = <0x31022000 0x1000>;
+			#address-cells = <1>;
+			#size-cells = <0>;
 			status = "okay";
 			#dma-cells = <1>;
 
 			sport0a: channel@0 {
+				reg = <0>;
 				adi,id = <0>;
 				adi,src-offset = <0>;
 				adi,skip-interrupts = <0>;
@@ -840,6 +843,7 @@
 			};
 
 			sport0b: channel@1 {
+				reg = <1>;
 				adi,id = <1>;
 				adi,src-offset = <0x80>;
 				adi,skip-interrupts = <0>;
@@ -852,10 +856,13 @@
 		sport4_dma_cluster: dma@31023000 {
 			compatible = "adi,dma-controller";
 			reg = <0x31023000 0x1000>;
+			#address-cells = <1>;
+			#size-cells = <0>;
 			status = "okay";
 			#dma-cells = <1>;
 
-			sport4a: channel@10 {
+			sport4a: channel@a {
+				reg = <10>;
 				adi,id = <10>;
 				adi,src-offset = <0>;
 				adi,skip-interrupts = <0>;
@@ -864,7 +871,8 @@
 				interrupt-names = "complete", "error";
 			};
 
-			sport4b: channel@11 {
+			sport4b: channel@b {
+				reg = <11>;
 				adi,id = <11>;
 				adi,src-offset = <0x80>;
 				adi,skip-interrupts = <0>;
@@ -877,10 +885,13 @@
 		spi_cluster: dma@3102d000 {
 			compatible = "adi,dma-controller";
 			reg = <0x3102d000 0x1000>;
+			#address-cells = <1>;
+			#size-cells = <0>;
 			status = "okay";
 			#dma-cells = <1>;
 
-			spi0_tx: channel@22 {
+			spi0_tx: channel@16 {
+				reg = <22>;
 				adi,id = <22>;
 				interrupts = <GIC_SPI 230 IRQ_TYPE_LEVEL_HIGH>,
 					<GIC_SPI 246 IRQ_TYPE_LEVEL_HIGH>;
@@ -888,7 +899,8 @@
 				adi,src-offset = <0>;
 			};
 
-			spi0_rx: channel@23 {
+			spi0_rx: channel@17 {
+				reg = <23>;
 				adi,id = <23>;
 				interrupts = <GIC_SPI 231 IRQ_TYPE_LEVEL_HIGH>,
 					<GIC_SPI 247 IRQ_TYPE_LEVEL_HIGH>;
@@ -896,7 +908,8 @@
 				adi,src-offset = <0x80>;
 			};
 
-			spi1_tx: channel@24 {
+			spi1_tx: channel@18 {
+				reg = <24>;
 				adi,id = <24>;
 				interrupts = <GIC_SPI 234 IRQ_TYPE_LEVEL_HIGH>,
 					<GIC_SPI 248 IRQ_TYPE_LEVEL_HIGH>;
@@ -904,7 +917,8 @@
 				adi,src-offset = <0x100>;
 			};
 
-			spi1_rx: channel@25 {
+			spi1_rx: channel@19 {
+				reg = <25>;
 				adi,id = <25>;
 				interrupts = <GIC_SPI 235 IRQ_TYPE_LEVEL_HIGH>,
 					<GIC_SPI 249 IRQ_TYPE_LEVEL_HIGH>;
@@ -912,7 +926,8 @@
 				adi,src-offset = <0x180>;
 			};
 
-			spi2_tx: channel@26 {
+			spi2_tx: channel@1a {
+				reg = <26>;
 				adi,id = <26>;
 				interrupts = <GIC_SPI 238 IRQ_TYPE_LEVEL_HIGH>,
 					<GIC_SPI 250 IRQ_TYPE_LEVEL_HIGH>;
@@ -920,7 +935,8 @@
 				adi,src-offset = <0x200>;
 			};
 
-			spi2_rx: channel@27 {
+			spi2_rx: channel@1b {
+				reg = <27>;
 				adi,id = <27>;
 				interrupts = <GIC_SPI 239 IRQ_TYPE_LEVEL_HIGH>,
 					<GIC_SPI 251 IRQ_TYPE_LEVEL_HIGH>;
@@ -928,7 +944,8 @@
 				adi,src-offset = <0x280>;
 			};
 
-			spi5_tx: channel@59 {
+			spi5_tx: channel@3b {
+				reg = <59>;
 				adi,id = <59>;
 				interrupts = <GIC_SPI 242 IRQ_TYPE_LEVEL_HIGH>,
 					<GIC_SPI 252 IRQ_TYPE_LEVEL_HIGH>;
@@ -936,7 +953,8 @@
 				adi,src-offset = <0x500>;
 			};
 
-			spi5_rx: channel@60 {
+			spi5_rx: channel@3c {
+				reg = <60>;
 				adi,id = <60>;
 				interrupts = <GIC_SPI 243 IRQ_TYPE_LEVEL_HIGH>,
 					<GIC_SPI 253 IRQ_TYPE_LEVEL_HIGH>;
@@ -949,10 +967,13 @@
 		crc_cluster: dma@310a7000 {
 			compatible = "adi,dma-controller";
 			reg = <0x310a7000 0x1000>;
+			#address-cells = <1>;
+			#size-cells = <0>;
 			status = "okay";
 			#dma-cells = <1>;
 
 			crc0_dma: channel@8 { /* MDMA0_SRC */
+				reg = <8>;
 				adi,id = <8>;
 				interrupts = <GIC_SPI 36 IRQ_TYPE_LEVEL_HIGH>,
 					<GIC_SPI 50 IRQ_TYPE_LEVEL_HIGH>;
@@ -960,7 +981,8 @@
 				adi,src-offset = <0x0>;
 			};
 
-			crc1_dma: channel@18 { /* MDMA1_SRC */
+			crc1_dma: channel@12 { /* MDMA1_SRC */
+				reg = <18>;
 				adi,id = <18>;
 				interrupts = <GIC_SPI 38 IRQ_TYPE_LEVEL_HIGH>,
 					<GIC_SPI 52 IRQ_TYPE_LEVEL_HIGH>;
@@ -968,7 +990,8 @@
 				adi,src-offset = <0x100>;
 			};
 
-			crc2_dma: channel@45 { /* MDMA4_SRC */
+			crc2_dma: channel@2d { /* MDMA4_SRC */
+				reg = <45>;
 				adi,id = <45>;
 				interrupts = <GIC_SPI 44 IRQ_TYPE_LEVEL_HIGH>,
 					<GIC_SPI 54 IRQ_TYPE_LEVEL_HIGH>;
@@ -976,7 +999,8 @@
 				adi,src-offset = <0x200>;
 			};
 
-			crc3_dma: channel@47 { /* MDMA5_SRC */
+			crc3_dma: channel@2f { /* MDMA5_SRC */
+				reg = <47>;
 				adi,id = <47>;
 				interrupts = <GIC_SPI 46 IRQ_TYPE_LEVEL_HIGH>,
 					<GIC_SPI 56 IRQ_TYPE_LEVEL_HIGH>;
@@ -988,10 +1012,13 @@
 		dma_cluster2: dma@31026000 {
 			compatible = "adi,dma-controller";
 			reg = <0x31026000 0x1000>;
+			#address-cells = <1>;
+			#size-cells = <0>;
 			status = "okay";
 			#dma-cells = <1>;
 
-			uart0_tx: channel@20 {
+			uart0_tx: channel@14 {
+				reg = <20>;
 				adi,id = <20>;
 				interrupts = <GIC_SPI 367 IRQ_TYPE_LEVEL_HIGH>,
 					<GIC_SPI 376 IRQ_TYPE_LEVEL_HIGH>;
@@ -999,7 +1026,8 @@
 				adi,src-offset = <0x80>;
 			};
 
-			uart0_rx: channel@21 {
+			uart0_rx: channel@15 {
+				reg = <21>;
 				adi,id = <21>;
 				interrupts = <GIC_SPI 368 IRQ_TYPE_LEVEL_HIGH>,
 					<GIC_SPI 377 IRQ_TYPE_LEVEL_HIGH>;
@@ -1007,7 +1035,8 @@
 				adi,src-offset = <0>;
 			};
 
-			uart1_tx: channel@34 {
+			uart1_tx: channel@22 {
+				reg = <34>;
 				adi,id = <34>;
 				interrupts = <GIC_SPI 370 IRQ_TYPE_LEVEL_HIGH>,
 					<GIC_SPI 378 IRQ_TYPE_LEVEL_HIGH>;
@@ -1015,7 +1044,8 @@
 				adi,src-offset = <0x180>;
 			};
 
-			uart1_rx: channel@35 {
+			uart1_rx: channel@23 {
+				reg = <35>;
 				adi,id = <35>;
 				interrupts = <GIC_SPI 371 IRQ_TYPE_LEVEL_HIGH>,
 					<GIC_SPI 379 IRQ_TYPE_LEVEL_HIGH>;
@@ -1023,7 +1053,8 @@
 				adi,src-offset = <0x100>;
 			};
 
-			uart2_tx: channel@37 {
+			uart2_tx: channel@25 {
+				reg = <37>;
 				adi,id = <37>;
 				interrupts = <GIC_SPI 373 IRQ_TYPE_LEVEL_HIGH>,
 					<GIC_SPI 380 IRQ_TYPE_LEVEL_HIGH>;
@@ -1031,7 +1062,8 @@
 				adi,src-offset = <0x280>;
 			};
 
-			uart2_rx: channel@38 {
+			uart2_rx: channel@26 {
+				reg = <38>;
 				adi,id = <38>;
 				interrupts = <GIC_SPI 374 IRQ_TYPE_LEVEL_HIGH>,
 					<GIC_SPI 381 IRQ_TYPE_LEVEL_HIGH>;
@@ -1043,9 +1075,12 @@
 		mdma: dma@3109a000 {
 			compatible = "adi,mdma-controller";
 			reg = <0x3109a000 0x1000>;
+			#address-cells = <1>;
+			#size-cells = <0>;
 			status = "okay";
 
-			sdma2: channel@40 {
+			sdma2: channel@28 {
+				reg = <40>;
 				adi,id = <40>;
 				// The destination interrupts are used for primary complete detection
 				interrupts = <GIC_SPI 168 IRQ_TYPE_LEVEL_HIGH>,

--- a/arch/arm64/boot/dts/adi/sc846.dtsi
+++ b/arch/arm64/boot/dts/adi/sc846.dtsi
@@ -50,7 +50,7 @@
 		cpu0: cpu@0 {
 			device_type = "cpu";
 			compatible = "arm,cortex-a55";
-			reg = <0x0 0x0>;
+			reg = <0x0>;
 			enable-method = "spin-table";
 			cpu-release-addr = <0x0 0xdeadbeef>;
 			clocks = <&clk ADSP_SC846_CLK_ARM0>;
@@ -87,17 +87,17 @@
 		#size-cells = <1>;
 		ranges;
 
-		rsc_tbl0: rsc_tbl0@20000000 {
+		rsc_tbl0: rsc-table@20000000 {
 			reg = <0x20000000 0x400>; /*1KiB*/
 			no-map;
 		};
 
-		rsc_tbl1: rsc_tbl0@20000400 {
+		rsc_tbl1: rsc-table@20000400 {
 			reg = <0x20000400 0x400>; /*1KiB*/
 			no-map;
 		};
 
-		sharc_internal_icc@20005000 {
+		sharc-internal-icc@20005000 {
 			reg = <0x20005000 0x20000>; /*128KiB*/
 			no-map;
 		};
@@ -134,14 +134,14 @@
 					  IRQ_TYPE_LEVEL_LOW)>; /* Hypervisor */
 	};
 
-	sys_clkin0: oscillator@1 {
+	sys_clkin0: clock-sys-clkin0 {
 		compatible = "fixed-clock";
 		#clock-cells = <0>;
 		clock-frequency = <25000000>;
 		clock-output-names = "sys_clkin0";
 	};
 
-	sys_clkin1: oscillator@2 {
+	sys_clkin1: clock-sys-clkin1 {
 		compatible = "fixed-clock";
 		#clock-cells = <0>;
 		clock-frequency = <25000000>;
@@ -456,7 +456,7 @@
 			status = "disabled";
 		};
 
-		i2s4: i2s@4 {
+		i2s4: i2s@31002400 {
 			compatible = "adi,sc5xx-i2s-dai";
 			status = "disabled";
 			reg = <0x31002400 0x80>, <0x31002480 0x80>;
@@ -469,7 +469,7 @@
 			clock-names = "sclk";
 		};
 
-		i2s0: i2s0@0 {
+		i2s0: i2s@31002000 {
 			compatible = "adi,sc5xx-i2s-dai";
 			status = "disabled";
 			reg = <0x31002000 0x80>, <0x31002080 0x80>;
@@ -614,20 +614,20 @@
 			adi,port-sizes = <16 16 16 16 16 16 16 16 7>;
 		};
 
-		sru_ctrl_dai0: sru-ctrl-dai0@310C9000 {
+		sru_ctrl_dai0: sru-ctrl-dai0@310c9000 {
 			compatible = "adi,adsp-sru-ctrl";
 			#address-cells = <1>;
 			#size-cells = <1>;
-			reg = <0x310C9000 0x224>;
+			reg = <0x310c9000 0x224>;
 			adi,pads-syscon = <&pads_syscon>;
 			status = "disabled";
 		};
 
-		sru_ctrl_dai1: sru-ctrl-dai1@310CA000 {
+		sru_ctrl_dai1: sru-ctrl-dai1@310ca000 {
 			compatible = "adi,adsp-sru-ctrl";
 			#address-cells = <1>;
 			#size-cells = <1>;
-			reg = <0x310CA000 0x224>;
+			reg = <0x310ca000 0x224>;
 			adi,pads-syscon = <&pads_syscon>;
 			status = "disabled";
 		};
@@ -643,9 +643,9 @@
 			status = "disabled";
 		};
 
-		gp_counter: cnt@3100B000 {
+		gp_counter: cnt@3100b000 {
 			compatible = "adi,gp_counter";
-			reg = <0x3100B000 0xFF>;
+			reg = <0x3100b000 0xff>;
 			interrupts = <GIC_SPI 9 IRQ_TYPE_LEVEL_HIGH>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -800,9 +800,9 @@
 			adi,pint = <&pint7 1>;
 		};
 
-		pkte1: pkte@310CD000 {
+		pkte1: pkte@310cd000 {
 			compatible = "adi,pkte";
-			reg = <0x310CD000 0x400>;
+			reg = <0x310cd000 0x400>;
 			interrupts = <GIC_SPI 226 IRQ_TYPE_LEVEL_HIGH>;
 			status = "disabled";
 		};
@@ -1076,9 +1076,9 @@
 			};
 		};
 
-		trng: rng@310D0000 {
+		trng: rng@310d0000 {
 			compatible = "adi,sc5xx-trng";
-			reg = <0x310D0000 0x74>, <0x310D8000 0x14>;
+			reg = <0x310d0000 0x74>, <0x310d8000 0x14>;
 			interrupts = <GIC_SPI 225 IRQ_TYPE_LEVEL_HIGH>;
 			interrupt-names = "pkic0_irq";
 			startup-cycles = <0xff>;

--- a/arch/arm64/boot/dts/adi/sc846.dtsi
+++ b/arch/arm64/boot/dts/adi/sc846.dtsi
@@ -651,24 +651,6 @@
 			status = "disabled";
 		};
 
-		lp0: linkport@0 {
-			compatible = "linkport0";
-			interrupt-parent = <&gic>;
-			interrupts = <GIC_SPI 152 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 153 IRQ_TYPE_LEVEL_HIGH>;
-			clock-div = <1>;
-			status = "disabled";
-		};
-
-		lp1: linkport@1 {
-			compatible = "linkport1";
-			interrupt-parent = <&gic>;
-			interrupts = <GIC_SPI 154 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 155 IRQ_TYPE_LEVEL_HIGH>;
-			clock-div = <1>;
-			status = "disabled";
-		};
-
 		pint0: pint@31005000 {
 			compatible = "adi,adsp-pint";
 			reg = <0x31005000 0xFF>;

--- a/arch/arm64/boot/dts/adi/sc846.dtsi
+++ b/arch/arm64/boot/dts/adi/sc846.dtsi
@@ -241,6 +241,12 @@
 		#size-cells = <1>;
 		ranges;
 
+		/*
+		 * Deliberately at the same address as the pinctrl node: both
+		 * describe the PADS0 block. The pinctrl driver programs the
+		 * pads registers directly, while the emac glue and sru-ctrl
+		 * reach them through this syscon regmap (adi,pads-syscon).
+		 */
 		pads_syscon: syscon@31004600 {
 			compatible = "adi,sc5xx-pads-syscon", "syscon";
 			reg = <0x31004600 0x200>;

--- a/arch/arm64/boot/dts/adi/sc846.dtsi
+++ b/arch/arm64/boot/dts/adi/sc846.dtsi
@@ -608,16 +608,12 @@
 
 		pinctrl0: pinctrl@31004600 {
 			compatible = "adi,adsp-pinctrl";
-			#address-cells = <1>;
-			#size-cells = <1>;
 			reg = <0x31004600 0x400>;
 			adi,port-sizes = <16 16 16 16 16 16 16 16 7>;
 		};
 
 		sru_ctrl_dai0: sru-ctrl-dai0@310c9000 {
 			compatible = "adi,adsp-sru-ctrl";
-			#address-cells = <1>;
-			#size-cells = <1>;
 			reg = <0x310c9000 0x224>;
 			adi,pads-syscon = <&pads_syscon>;
 			status = "disabled";
@@ -625,8 +621,6 @@
 
 		sru_ctrl_dai1: sru-ctrl-dai1@310ca000 {
 			compatible = "adi,adsp-sru-ctrl";
-			#address-cells = <1>;
-			#size-cells = <1>;
 			reg = <0x310ca000 0x224>;
 			adi,pads-syscon = <&pads_syscon>;
 			status = "disabled";
@@ -647,8 +641,6 @@
 			compatible = "adi,gp_counter";
 			reg = <0x3100b000 0xff>;
 			interrupts = <GIC_SPI 9 IRQ_TYPE_LEVEL_HIGH>;
-			#address-cells = <1>;
-			#size-cells = <0>;
 			status = "disabled";
 		};
 

--- a/arch/arm64/boot/dts/adi/sc846.dtsi
+++ b/arch/arm64/boot/dts/adi/sc846.dtsi
@@ -148,7 +148,7 @@
 		clock-output-names = "sys_clkin1";
 	};
 
-	clk: clocks@3108d000 {
+	clk: clock-controller@3108d000 {
 		compatible = "adi,sc846-clocks";
 		reg = <0x3108d000 0x1000>,
 			<0x3108e000 0x1000>,
@@ -281,7 +281,7 @@
 			status = "okay";
 		};
 
-		tru: tru@3108a000 {
+		tru: mailbox@3108a000 {
 			compatible = "adi,trigger-routing-unit";
 			reg = <0x3108a000 0x1000>;
 			#mbox-cells = <1>;
@@ -290,7 +290,7 @@
 			status = "okay";
 		};
 
-		thermal: thermal@31016800 {
+		thermal: thermal-sensor@31016800 {
 			compatible = "adi,sc59x-thermal";
 			reg = <0x31016800 0x100>;
 			#thermal-sensor-cells = <0>;
@@ -302,7 +302,7 @@
 			status = "disabled";
 		};
 
-		hadc: hadc@31016000 {
+		hadc: adc@31016000 {
 			compatible = "adi,hadc";
 			reg = <0x31016000 0x100>;
 			interrupt-parent = <&gic>;
@@ -311,7 +311,7 @@
 			status = "okay";
 		};
 
-		uart0: uart@31003000 {
+		uart0: serial@31003000 {
 			compatible = "adi,uart4";
 			reg = <0x31003000 0x40>;
 			dmas = <&dma_cluster2 20>, <&dma_cluster2 21>;
@@ -327,7 +327,7 @@
 			status = "disabled";
 		};
 
-		uart1: uart@31003400 {
+		uart1: serial@31003400 {
 			compatible = "adi,uart4";
 			reg = <0x31003400 0x40>;
 			dmas = <&dma_cluster2 34>, <&dma_cluster2 35>;
@@ -343,7 +343,7 @@
 			status = "disabled";
 		};
 
-		uart2: uart@31003800 {
+		uart2: serial@31003800 {
 			compatible = "adi,uart4";
 			reg = <0x31003800 0x40>;
 			dmas = <&dma_cluster2 37>, <&dma_cluster2 38>;
@@ -384,7 +384,7 @@
 			status = "disabled";
 		};
 
-		i2c0: twi@31001400 {
+		i2c0: i2c@31001400 {
 			#address-cells = <1>;
 			#size-cells = <0>;
 			compatible = "adi,twi";
@@ -396,7 +396,7 @@
 			status = "disabled";
 		};
 
-		i2c1: twi@31001500 {
+		i2c1: i2c@31001500 {
 			#address-cells = <1>;
 			#size-cells = <0>;
 			compatible = "adi,twi";
@@ -408,7 +408,7 @@
 			status = "disabled";
 		};
 
-		i2c2: twi@31001600 {
+		i2c2: i2c@31001600 {
 			#address-cells = <1>;
 			#size-cells = <0>;
 			compatible = "adi,twi";
@@ -420,7 +420,7 @@
 			status = "disabled";
 		};
 
-		i2c3: twi@31001000 {
+		i2c3: i2c@31001000 {
 			#address-cells = <1>;
 			#size-cells = <0>;
 			compatible = "adi,twi";
@@ -432,7 +432,7 @@
 			status = "disabled";
 		};
 
-		i2c4: twi@31001100 {
+		i2c4: i2c@31001100 {
 			#address-cells = <1>;
 			#size-cells = <0>;
 			compatible = "adi,twi";
@@ -444,7 +444,7 @@
 			status = "disabled";
 		};
 
-		i2c5: twi@31001200 {
+		i2c5: i2c@31001200 {
 			#address-cells = <1>;
 			#size-cells = <0>;
 			compatible = "adi,twi";
@@ -559,7 +559,7 @@
 			snps,pbl = <8>;
 			snps,force_sf_dma_mode;
 			snps,perfect-filter-entries = <32>;
-			snps,tso = <1>;
+			snps,tso;
 			clocks = <&clk ADSP_SC846_CLK_GIGE>;
 			clock-names = "stmmaceth";
 			adi,pads-syscon = <&pads_syscon>;
@@ -637,7 +637,7 @@
 			status = "disabled";
 		};
 
-		gp_counter: cnt@3100b000 {
+		gp_counter: counter@3100b000 {
 			compatible = "adi,gp_counter";
 			reg = <0x3100b000 0xff>;
 			interrupts = <GIC_SPI 9 IRQ_TYPE_LEVEL_HIGH>;
@@ -708,7 +708,7 @@
 			#interrupt-cells = <1>;
 		};
 
-		gpa: gport@31004000 {
+		gpa: gpio@31004000 {
 			compatible = "adi,adsp-port-gpio";
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -718,7 +718,7 @@
 			status = "okay";
 		};
 
-		gpb: gport@31004080 {
+		gpb: gpio@31004080 {
 			compatible = "adi,adsp-port-gpio";
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -728,7 +728,7 @@
 			status = "okay";
 		};
 
-		gpc: gport@31004100 {
+		gpc: gpio@31004100 {
 			compatible = "adi,adsp-port-gpio";
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -738,7 +738,7 @@
 			status = "okay";
 		};
 
-		gpd: gport@31004180 {
+		gpd: gpio@31004180 {
 			compatible = "adi,adsp-port-gpio";
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -747,7 +747,7 @@
 			adi,pint = <&pint2 0>;
 		};
 
-		gpe: gport@31004200 {
+		gpe: gpio@31004200 {
 			compatible = "adi,adsp-port-gpio";
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -756,7 +756,7 @@
 			adi,pint = <&pint4 1>;
 		};
 
-		gpf: gport@31004280 {
+		gpf: gpio@31004280 {
 			compatible = "adi,adsp-port-gpio";
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -765,7 +765,7 @@
 			adi,pint = <&pint4 0>;
 		};
 
-		gpg: gport@31004300 {
+		gpg: gpio@31004300 {
 			compatible = "adi,adsp-port-gpio";
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -774,7 +774,7 @@
 			adi,pint = <&pint6 1>;
 		};
 
-		gph: gport@31004380 {
+		gph: gpio@31004380 {
 			compatible = "adi,adsp-port-gpio";
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -783,7 +783,7 @@
 			adi,pint = <&pint6 0>;
 		};
 
-		gpi: gport@31004400 {
+		gpi: gpio@31004400 {
 			compatible = "adi,adsp-port-gpio";
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -792,7 +792,7 @@
 			adi,pint = <&pint7 1>;
 		};
 
-		pkte1: pkte@310cd000 {
+		pkte1: crypto@310cd000 {
 			compatible = "adi,pkte";
 			reg = <0x310cd000 0x400>;
 			interrupts = <GIC_SPI 226 IRQ_TYPE_LEVEL_HIGH>;

--- a/arch/arm64/boot/dts/adi/sc846.dtsi
+++ b/arch/arm64/boot/dts/adi/sc846.dtsi
@@ -76,7 +76,7 @@
 		reg = <0x20040000 0x40000>;
 	};
 
-	sram1_mmap: sram-mmap@0 {
+	sram1_mmap: sram-mmap {
 		compatible = "adi,sram-mmap";
 		memory-region = <&sram1_res>;
 		status = "okay";
@@ -230,6 +230,11 @@
 		};
 	};
 
+	gptimer_counter: gptimer-counter {
+		compatible = "adi,gptimer-counter";
+		status = "okay";
+	};
+
 	scb: scb {
 		compatible = "simple-bus";
 		#address-cells = <1>;
@@ -256,10 +261,6 @@
 			status = "disabled";
 		};
 
-		gptimer_counter: gptimer-counters@0 {
-			compatible = "adi,gptimer-counter";
-			status = "okay";
-		};
 
 		rcu: rcu@3108c000 {
 			compatible = "syscon", "adi,reset-controller";


### PR DESCRIPTION
Cleans up all remaining dtc W=1 warnings and devicetree-convention
violations across arch/arm64/boot/dts/adi: 322 warnings -> 6 on all six
buildable boards (sc598-som-ezkit/-sd/ezlite/htol, sc846-som,
sc846-som-ezkit).

Stacked on #3480 (base staging/sc84x-platform-fixes); retarget to
adsp-6.18.31-y once that merges. Independent of #3481 — the same
commits cherry-pick cleanly on top of it.

### Commits

1. **DMA channel subnodes get a reg property** matching adi,id, with
   lowercase-hex unit addresses and #address-cells/#size-cells on the
   controllers (was ~200 unit_address_vs_reg warnings). adi,id is kept;
   the driver is unchanged.
2. **linkport nodes removed**: no driver or binding in the tree,
   invalid compatibles ("linkport0"), no reg.
3. **reg-less virtual devices moved off the scb simple-bus** to the
   root node (sound cards, usb phy, fixed clocks, gptimer-counter,
   rpmsg) — of_platform_default_populate picks them up identically.
4. **Unit-address/style fixes**: lowercase hex, real unit addresses for
   the i2s nodes, cpu@0's stray two-cell reg, reserved-memory
   copy-paste names, fixed-partitions children renamed
   partition@<offset> — two had unit addresses that did not match
   their actual offset.
5. **Unnecessary #address-cells/#size-cells dropped** (pinctrl,
   sru-ctrl, cnt, flash nodes).
6. **Generic node names** per DT spec / binding schemas: uart->serial,
   twi->i2c, gport->gpio, tru->mailbox, hadc->adc, pkte->crypto,
   clocks->clock-controller, codecs->audio-codec@, expanders->gpio@,
   mdio0->mdio, snps,tso as a flag, vendor-prefixed spi-nor compatible.
7. **Document the intentional pads/pinctrl address overlap** at
   0x31004600 (the one remaining W=1 warning, once per board): the
   syscon binding pins the compatible list so the nodes cannot be
   merged today, and the sru-ctrl syscon usage is expected to be
   revisited with the pinctrl rework.

### Validation

- All six DTBs build with a single dtc W=1 warning each (the
  documented pads/pinctrl duplicate unit address), down from 322
  warnings in total.
- Hardware A/B on the SC846 SOM EZ-kit (same kernel Image, DTB with and
  without this series, on top of the #3481 driver stack): dmesg
  warn/error scan identical, clk_summary line-for-line identical, every
  renamed platform device re-binds to the same driver, Ethernet (the
  adi,pads-syscon consumer) unaffected, ADEMA127 SPI-offload streaming
  captures with the expected interrupt-per-watermark cadence.

### Known follow-ups (out of scope here)

- dtbs_check still reports pre-existing issues that need binding-side
  work: adi,trigger-routing-unit.yaml expects channel@N children with
  no reg,
  gpio-hog node names lack the -hog suffix, the scb bus name, and a
  number of undocumented legacy adi,* compatibles.

