### PR TITLE
WIP: sdhci-dwc: adsp-sc598: consume emmc_timer_cmq clock

### DIFF
--- a/arch/arm64/boot/dts/adi/sc59x-64.dtsi
+++ b/arch/arm64/boot/dts/adi/sc59x-64.dtsi
@@ -659,12 +659,13 @@
 
 
 		mmc0: mmc@310c7000 {
-			compatible = "snps,dwcmshc-sdhci";
+			compatible = "adi,adsp-sc598-dwcmshc", "snps,dwcmshc-sdhci";
 			reg = <0x310c7000 0x1000>;
 			interrupts = <GIC_SPI 237 IRQ_TYPE_LEVEL_HIGH>; /* Status */
 				     /*<GIC_SPI 239 IRQ_TYPE_LEVEL_HIGH>;*/ /* Wakeup */
-			clocks = <&clk ADSP_SC598_CLK_EMMC>;
-			clock-names = "core";
+			clocks = <&clk ADSP_SC598_CLK_EMMC>,
+				 <&clk ADSP_SC598_CLK_EMMC_TIMER_QMC>;
+			clock-names = "core", "timer";
 			bus-width = <8>;
 			status = "disabled";
 		};

--- a/drivers/mmc/host/sdhci-of-dwcmshc.c
+++ b/drivers/mmc/host/sdhci-of-dwcmshc.c
@@ -1120,6 +1120,15 @@ static int sg2042_init(struct device *dev, struct sdhci_host *host,
 					     ARRAY_SIZE(clk_ids), clk_ids);
 }
 
+static int dwcmshc_adsp_sc598_init(struct device *dev, struct sdhci_host *host,
+				   struct dwcmshc_priv *dwc_priv)
+{
+	static const char * const clk_ids[] = {"timer"};
+
+	return dwcmshc_get_enable_other_clks(mmc_dev(host->mmc), dwc_priv,
+					     ARRAY_SIZE(clk_ids), clk_ids);
+}
+
 static const struct sdhci_ops sdhci_dwcmshc_ops = {
 	.set_clock		= sdhci_set_clock,
 	.set_bus_width		= sdhci_set_bus_width,
@@ -1200,6 +1209,15 @@ static const struct dwcmshc_pltfm_data sdhci_dwcmshc_pdata = {
 		.quirks = SDHCI_QUIRK_CAP_CLOCK_BASE_BROKEN,
 		.quirks2 = SDHCI_QUIRK2_PRESET_VALUE_BROKEN,
 	},
+};
+
+static const struct dwcmshc_pltfm_data sdhci_dwcmshc_adsp_sc598_pdata = {
+	.pdata = {
+		.ops = &sdhci_dwcmshc_ops,
+		.quirks = SDHCI_QUIRK_CAP_CLOCK_BASE_BROKEN,
+		.quirks2 = SDHCI_QUIRK2_PRESET_VALUE_BROKEN,
+	},
+	.init = dwcmshc_adsp_sc598_init,
 };
 
 #ifdef CONFIG_ACPI
@@ -1342,6 +1360,10 @@ static const struct of_device_id sdhci_dwcmshc_dt_ids[] = {
 	{
 		.compatible = "rockchip,rk3568-dwcmshc",
 		.data = &sdhci_dwcmshc_rk35xx_pdata,
+	},
+	{
+		.compatible = "adi,adsp-sc598-dwcmshc",
+		.data = &sdhci_dwcmshc_adsp_sc598_pdata,
 	},
 	{
 		.compatible = "snps,dwcmshc-sdhci",


### PR DESCRIPTION
Fixes an odd race. Need to understand when/why this clock is needed.

To reproduce: build with CONFIG_MMC_SDHCI_OF_DWCMSHC=m and boot rootfs over NFS. Then mmc will probe much later than the disabling of unused clocks. emmc_timer_cmq is then disabled and you hit the error.

Another issue: the clock in the DT headers is mislabelled QMC. Also in the clock driver. To fix...

## PR Description

- Please replace this comment with a summary of your changes, and add any context
necessary to understand them. List any dependencies required for this change.
- To check the checkboxes below, insert a 'x' between square brackets (without
any space), or simply check them after publishing the PR.
- If you changes include a breaking change, please specify dependent PRs in the
description and try to push all related PRs simultaneously.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have compiled my changes, including the documentation
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
