### PR TITLE
.github: add hardware-test and compile_devicetrees

### DIFF
--- a/.github/workflows/top-level.yml
+++ b/.github/workflows/top-level.yml
@@ -211,3 +211,23 @@ jobs:
       dts_files: >
         arch/arm64/boot/dts/adi/*.dts
         arch/arm/boot/dts/adi/*.dts
+
+  hardware-test:
+    needs: [build_gcc_aarch64_sc598-som-ezkit_defconfig, build_gcc_aarch64_sc598-som-ezlite_defconfig, build_gcc_aarch64_sc846-som-ezkit_defconfig, compile_devicetrees]
+    if: ${{ vars.RUNNER_HW_TEST != '' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - needs: '["sc598", "ezkit"]'
+          - needs: '["sc598", "ezlite"]'
+          - needs: '["sc846", "ezkit"]'
+    uses: analogdevicesinc/linux/.github/workflows/hw-test.yml@ci
+    with:
+      test-set: 'adsp/initramfs-boot'
+      needs: ${{ matrix.needs }}
+    secrets: inherit
+    permissions:
+      actions: read
+      contents: read
+      id-token: write

--- a/.github/workflows/top-level.yml
+++ b/.github/workflows/top-level.yml
@@ -200,3 +200,14 @@ jobs:
         sc594-som-ezlite_defconfig-*
         sc598-som-ezkit_defconfig-*
         sc598-som-ezlite_defconfig-*
+
+  compile_devicetrees:
+    needs: [assert_checks]
+    uses: analogdevicesinc/linux/.github/workflows/compile-devicetrees.yml@ci
+    secrets: inherit
+    with:
+      compiler: "gcc"
+      archs: "arm arm64"
+      dts_files: >
+        arch/arm64/boot/dts/adi/*.dts
+        arch/arm/boot/dts/adi/*.dts


### PR DESCRIPTION
After the sc598-som-ezkit kernel build, run the adsp/initramfs-boot hw-test.

The kernel and device tree just built are booted to a shell entirely from RAM, on a stable boot chain (SPL/U-Boot and initramfs sourced from other repos' runs).

## PR Description

- Please replace this comment with a summary of your changes, and add any context
necessary to understand them. List any dependencies required for this change.
- To check the checkboxes below, insert a 'x' between square brackets (without
any space), or simply check them after publishing the PR.
- If you changes include a breaking change, please specify dependent PRs in the
description and try to push all related PRs simultaneously.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
