### PR TITLE
[backport] dt-bindings: iio: adc: add ad408x axi variant

### DIFF
--- a/Documentation/devicetree/bindings/iio/adc/adi,axi-adc.yaml
+++ b/Documentation/devicetree/bindings/iio/adc/adi,axi-adc.yaml
@@ -19,11 +19,13 @@ description: |
   memory via DMA.
 
   https://wiki.analog.com/resources/fpga/docs/axi_adc_ip
+  https://analogdevicesinc.github.io/hdl/library/axi_ad408x/index.html
 
 properties:
   compatible:
     enum:
       - adi,axi-adc-10.0.a
+      - adi,axi-ad408x
 
   reg:
     maxItems: 1


### PR DESCRIPTION
## PR Description

Add a new compatible and related bindings for the fpga-based AD408x AXI IP core, a variant of the generic AXI ADC IP.

The AXI AD408x IP is a very similar HDL (fpga) variant of the generic AXI ADC IP, intended to control ad408x familiy.

Although there are some particularities added for extended control of the ad408x devices such as the filter configuration.

Wildcard naming is used to match the naming of the published firmware.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have compiled my changes, including the documentation
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
