### PR TITLE
Revert "arm64: dts: adi: sc598-som: describe the MMC muxes faithfully"

### DIFF
--- a/arch/arm64/boot/dts/adi/sc598-som-ezkit-sd.dts
+++ b/arch/arm64/boot/dts/adi/sc598-som-ezkit-sd.dts
@@ -7,8 +7,23 @@
 
 #include "sc598-som-ezkit.dtsi"
 
+&som_gpio_expander {
+	som-emmc {
+		gpio-hog;
+		gpios = <8 GPIO_ACTIVE_LOW>;
+		output-low;
+		line-name = "som-emmc-en";
+	};
+
+	crr-sdcard {
+		gpio-hog;
+		gpios = <9 GPIO_ACTIVE_LOW>;
+		output-high;
+		line-name = "crr-sdcard-en";
+	};
+};
+
 &mmc0 {
-	pinctrl-0 = <&mmc0_8bgrp>, <&mmc_carrier_grp>;
 	max-frequency = <44000000>;
 	no-1-8-v;
 	bus-width = <4>;

--- a/arch/arm64/boot/dts/adi/sc598-som-ezkit.dts
+++ b/arch/arm64/boot/dts/adi/sc598-som-ezkit.dts
@@ -7,8 +7,23 @@
 
 #include "sc598-som-ezkit.dtsi"
 
+&som_gpio_expander {
+	som-emmc {
+		gpio-hog;
+		gpios = <8 GPIO_ACTIVE_LOW>;
+		output-high;
+		line-name = "som-emmc-en";
+	};
+
+	crr-sdcard {
+		gpio-hog;
+		gpios = <9 GPIO_ACTIVE_LOW>;
+		output-low;
+		line-name = "crr-sdcard-en";
+	};
+};
+
 &mmc0 {
-	pinctrl-0 = <&mmc0_8bgrp>, <&mmc_som_grp>;
 	non-removable;
 
 	status = "okay";

--- a/arch/arm64/boot/dts/adi/sc598-som-revD.dtsi
+++ b/arch/arm64/boot/dts/adi/sc598-som-revD.dtsi
@@ -7,28 +7,6 @@
 
 #include "sc598-som.dtsi"
 
-/ {
-	mmc_muxctl: mux-controller {
-		compatible = "gpio-mux";
-		#mux-state-cells = <1>;
-		mux-gpios = <&som_gpio_expander 8 GPIO_ACTIVE_LOW>,
-			    <&som_gpio_expander 9 GPIO_ACTIVE_LOW>;
-		idle-state = <0>;
-	};
-
-	pinctrl-mmc-mux {
-		compatible = "pinctrl-multiplexer";
-
-		mmc_som_grp: som-grp {
-			mux-states = <&mmc_muxctl 1>;
-		};
-
-		mmc_carrier_grp: carrier-grp {
-			mux-states = <&mmc_muxctl 2>;
-		};
-	};
-};
-
 &i2c2 {
 	som_gpio_expander: gpio@20 {
 		compatible = "microchip,mcp23018";

--- a/arch/arm64/boot/dts/adi/sc598-som-revE.dtsi
+++ b/arch/arm64/boot/dts/adi/sc598-som-revE.dtsi
@@ -7,28 +7,6 @@
 
 #include "sc598-som.dtsi"
 
-/ {
-	mmc_muxctl: mux-controller {
-		compatible = "gpio-mux";
-		#mux-state-cells = <1>;
-		mux-gpios = <&som_gpio_expander 8 GPIO_ACTIVE_LOW>,
-			    <&som_gpio_expander 9 GPIO_ACTIVE_LOW>;
-		idle-state = <0>;
-	};
-
-	pinctrl-mmc-mux {
-		compatible = "pinctrl-multiplexer";
-
-		mmc_som_grp: som-grp {
-			mux-states = <&mmc_muxctl 1>;
-		};
-
-		mmc_carrier_grp: carrier-grp {
-			mux-states = <&mmc_muxctl 2>;
-		};
-	};
-};
-
 &i2c2 {
 	som_gpio_expander: gpio@34 {
 		compatible = "adi,adp5587";


### PR DESCRIPTION
This reverts commit 2ddfda5c62325dd56e8399bd6d8c36b3ccf9cc04.

Introducing this mux means that sometimes the MMC probe is deferred until after the late_initcall that disables all unused clocks. This exposes another bug where MMC fails to lock its internal clock and the driver fails to probe - presumably because the MMC_TIMER_CMQ clock is unavailable.

The correct fix is to solve that other bug, but until there's better clairty on the clocking requirements, maybe it's better to revert to the older behavior.

## PR Description

- Please replace this comment with a summary of your changes, and add any context
necessary to understand them. List any dependencies required for this change.
- To check the checkboxes below, insert a 'x' between square brackets (without
any space), or simply check them after publishing the PR.
- If you changes include a breaking change, please specify dependent PRs in the
description and try to push all related PRs simultaneously.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have compiled my changes, including the documentation
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
