### PR TITLE
arm64: dts: adi: sc598-som-revE: extend rootfs to fill flash

### DIFF
--- a/arch/arm64/boot/dts/adi/sc598-som-revE.dtsi
+++ b/arch/arm64/boot/dts/adi/sc598-som-revE.dtsi
@@ -84,7 +84,7 @@
 
 			partition@40000 {
 				label = "u-boot";
-				reg = <0x00040000 0xC0000>;
+				reg = <0x00040000 0xc0000>;
 			};
 
 			partition@100000 {
@@ -94,7 +94,7 @@
 
 			partition@2100000 {
 				label = "rootfs";
-				reg = <0x02100000 0x5ef0000>;
+				reg = <0x02100000 0x5f00000>;
 			};
 		};
 	};


### PR DESCRIPTION
The rootfs partition on the IS25LP01G (128 MB) ended at 0x7ff0000, leaving one erase block (64 KB) unallocated at the end of flash. Extend the partition by 0x10000 so it runs to the end of the device.