### PR TITLE
arm64: dts: adi: sc846-som: expand kernel flash partition

### DIFF
--- a/arch/arm64/boot/dts/adi/sc846-som.dts
+++ b/arch/arm64/boot/dts/adi/sc846-som.dts
@@ -177,17 +177,17 @@
 
 			partition@40000 {
 				label = "u-boot proper";
-				reg = <0x00040000 0xC0000>;
+				reg = <0x00040000 0xc0000>;
 			};
 
-			partition@210000 {
+			partition@100000 {
 				label = "kernel";
-				reg = <0x00210000 0x1000000>;
+				reg = <0x00100000 0x2000000>;
 			};
 
-			partition@1210000 {
+			partition@2100000 {
 				label = "rootfs";
-				reg = <0x1210000 0xEDF0000>;
+				reg = <0x2100000 0xdf00000>;
 			};
 		};
 	};


### PR DESCRIPTION
- There is a 1088 KB region between the end of u-boot (0x100000) and the start of kernel (0x210000) that had no partition entry. Move the start of the kernel partition to match SC598
- Increase the kernel partition from 16 MB to 32 MB to match the allocation on the SC598-SOM
- Fix two pre-existing uppercase hex literals in partition regs to follow the lowercase convention

Fixes: 212bd6509cc0 ("arm64: dts: adi: add device trees for SC846 SoM and EZ-KIT")