### PR TITLE
Add adaq2387x support

### DIFF
--- a/Documentation/devicetree/bindings/iio/adc/lltc,ltc2387.yaml
+++ b/Documentation/devicetree/bindings/iio/adc/lltc,ltc2387.yaml
@@ -2,7 +2,7 @@
 # Copyright 2022 Analog Devices Inc.
 %YAML 1.2
 ---
-$id: http://devicetree.org/schemas/bindings/iio/adc/ltc2387.yaml#
+$id: http://devicetree.org/schemas/iio/adc/lltc,ltc2387.yaml#
 $schema: http://devicetree.org/meta-schemas/core.yaml#
 
 title: Linear Technology / Analog Devices LTC2387 ADC
@@ -50,9 +50,39 @@ properties:
       - const: cnv
       - const: clk_en
 
+  vref-supply:
+    description:
+      External voltage reference. When absent the device's internal 4.096 V
+      reference is assumed.
+
   adi,use-two-lanes:
     description: The device uses two lanes for data transfer
     type: boolean
+
+  adi,use-one-lane:
+    description: |
+      Configure the device for one-lane output mode. In one-lane mode a
+      single physical LVDS pair (DA) carries all 16/18 bits per conversion
+      via DDR, halving the achievable sample rate compared to two-lane
+      mode. Omit for the default two-lane behavior.
+    type: boolean
+
+  adi,gain-milli:
+    description: |
+      Front-end amplifier gain, expressed as gain * 1000. Only meaningful
+      for the ADAQ2387x modules, which integrate a fully-differential
+      amplifier ahead of the LTC2387 die; the value must match the board's
+      pin strapping.
+
+        ADAQ23875:           fixed gain = 2  (2000)
+        ADAQ23876/ADAQ23878: pin-selectable (370, 730, 870, 1380, 2250)
+
+      Used by the driver to compute in_voltage_scale referred to the SMA
+      input. When omitted the driver assumes a per-compatible default:
+      1000 (unity) for the bare ltc2387-* parts, which have no amplifier,
+      and 2000 for the adaq2387x parts.
+    $ref: /schemas/types.yaml#/definitions/uint32
+    enum: [370, 730, 870, 1000, 1380, 2000, 2250]
 
 required:
   - compatible
@@ -62,16 +92,16 @@ required:
   - pwms
   - pwm-names
 
+additionalProperties: false
+
 examples:
   - |
-    ltc2387@0{
+    adc {
             compatible = "ltc2387-16";
             clocks = <&clk 0>;
             dmas = <&dma 0>;
             dma-names = "rx";
-            pwms = <&pwm 0 0
-                    &pwm 1 0>;
+            pwms = <&pwm 0 0>, <&pwm 1 0>;
             pwm-names = "cnv", "clk_en";
-
-            adi,use-two-lanes;
+            vref-supply = <&vref>;
     };

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq23875-1lane.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq23875-1lane.dts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices ADAQ23875 (LTC2387-16 inside, 16-bit, one-lane mode).
+ *
+ * Pair with the matching one-lane HDL bitstream (TWOLANES=0, ADC_RES=16).
+ *
+ * hdl_project: <adaq2387x/zed with ADC_RES=16, TWOLANES=0>
+ * board_revision: <A>
+ *
+ * Copyright (C) 2026 Analog Devices Inc.
+ */
+/dts-v1/;
+
+#include "zynq-zed-adv7511-adaq23875.dtsi"
+
+&adaq23875 {
+	adi,use-one-lane;
+};

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq23875.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq23875.dts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices ADAQ23875 (LTC2387-16 inside, 16-bit, two-lane mode).
+ *
+ * hdl_project: <adaq2387x/zed with ADC_RES=16, TWOLANES=1>
+ * board_revision: <A>
+ *
+ * Copyright (C) 2026 Analog Devices Inc.
+ */
+/dts-v1/;
+
+#include "zynq-zed-adv7511-adaq23875.dtsi"

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq23875.dtsi
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq23875.dtsi
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * ADAQ23875 (LTC2387-16) on Zedboard.
+ *
+ * Copyright (C) 2026 Analog Devices Inc.
+ */
+
+#include "zynq-zed-adv7511-adaq2387x.dtsi"
+
+&rx_dma {
+	adi,channels {
+		#size-cells = <0>;
+		#address-cells = <1>;
+
+		dma-channel@0 {
+			reg = <0>;
+			adi,source-bus-width = <16>;
+			adi,source-bus-type = <2>;
+			adi,destination-bus-width = <64>;
+			adi,destination-bus-type = <0>;
+		};
+	};
+};
+
+&fpga_axi {
+	adaq23875: adc@0 {
+		compatible = "adaq23875";
+		clocks = <&ext_clk>;
+		dmas = <&rx_dma 0>;
+		dma-names = "rx";
+		pwms = <&axi_pwm_gen 0 0>, <&axi_pwm_gen 1 0>;
+		pwm-names = "cnv", "clk_en";
+		vref-supply = <&vref>;
+
+		/* Fixed FDA gain = 2, +/-2.048 V input range. */
+		adi,gain-milli = <2000>;
+	};
+};

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq23876-1lane.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq23876-1lane.dts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices ADAQ23876 (LTC2387-16 inside, 16-bit, one-lane mode).
+ *
+ * Pair with the matching one-lane HDL bitstream (TWOLANES=0, ADC_RES=16).
+ *
+ * hdl_project: <adaq2387x/zed with ADC_RES=16, TWOLANES=0>
+ * board_revision: <A>
+ *
+ * Copyright (C) 2026 Analog Devices Inc.
+ */
+/dts-v1/;
+
+#include "zynq-zed-adv7511-adaq23876.dtsi"
+
+&adaq23876 {
+	adi,use-one-lane;
+};

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq23876.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq23876.dts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices ADAQ23876 (LTC2387-16 inside, 16-bit, two-lane mode).
+ *
+ * hdl_project: <adaq2387x/zed with ADC_RES=16, TWOLANES=1>
+ * board_revision: <A>
+ *
+ * Copyright (C) 2026 Analog Devices Inc.
+ */
+/dts-v1/;
+
+#include "zynq-zed-adv7511-adaq23876.dtsi"

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq23876.dtsi
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq23876.dtsi
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * ADAQ23876 (LTC2387-16) on Zedboard.
+ *
+ * Copyright (C) 2026 Analog Devices Inc.
+ */
+
+#include "zynq-zed-adv7511-adaq2387x.dtsi"
+
+&rx_dma {
+	adi,channels {
+		#size-cells = <0>;
+		#address-cells = <1>;
+
+		dma-channel@0 {
+			reg = <0>;
+			adi,source-bus-width = <16>;
+			adi,source-bus-type = <2>;
+			adi,destination-bus-width = <64>;
+			adi,destination-bus-type = <0>;
+		};
+	};
+};
+
+&fpga_axi {
+	adaq23876: adc@0 {
+		compatible = "adaq23876";
+		clocks = <&ext_clk>;
+		dmas = <&rx_dma 0>;
+		dma-names = "rx";
+		pwms = <&axi_pwm_gen 0 0>, <&axi_pwm_gen 1 0>;
+		pwm-names = "cnv", "clk_en";
+		vref-supply = <&vref>;
+
+		/* Pin-strapped: 370, 730, 870, 1380 or 2250. */
+		adi,gain-milli = <870>;
+	};
+};

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq23878-1lane.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq23878-1lane.dts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices ADAQ23878 (LTC2387-18 inside, 18-bit, one-lane mode).
+ *
+ * Pair with the matching one-lane HDL bitstream (TWOLANES=0, ADC_RES=18).
+ *
+ * hdl_project: <adaq2387x/zed with ADC_RES=18, TWOLANES=0>
+ * board_revision: <A>
+ *
+ * Copyright (C) 2026 Analog Devices Inc.
+ */
+/dts-v1/;
+
+#include "zynq-zed-adv7511-adaq23878.dtsi"
+
+&adaq23878 {
+	adi,use-one-lane;
+};

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq23878.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq23878.dts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Analog Devices ADAQ23878 (LTC2387-18 inside, 18-bit, two-lane mode).
+ *
+ * hdl_project: <adaq2387x/zed with ADC_RES=18, TWOLANES=1>
+ * board_revision: <A>
+ *
+ * Copyright (C) 2026 Analog Devices Inc.
+ */
+/dts-v1/;
+
+#include "zynq-zed-adv7511-adaq23878.dtsi"

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq23878.dtsi
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq23878.dtsi
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * ADAQ23878 (LTC2387-18) on Zedboard.
+ *
+ * Copyright (C) 2026 Analog Devices Inc.
+ */
+
+#include "zynq-zed-adv7511-adaq2387x.dtsi"
+
+&rx_dma {
+	adi,channels {
+		#size-cells = <0>;
+		#address-cells = <1>;
+
+		dma-channel@0 {
+			reg = <0>;
+			adi,source-bus-width = <32>;
+			adi,source-bus-type = <2>;
+			adi,destination-bus-width = <64>;
+			adi,destination-bus-type = <0>;
+		};
+	};
+};
+
+&fpga_axi {
+	adaq23878: adc@0 {
+		compatible = "adaq23878";
+		clocks = <&ext_clk>;
+		dmas = <&rx_dma 0>;
+		dma-names = "rx";
+		pwms = <&axi_pwm_gen 0 0>, <&axi_pwm_gen 1 0>;
+		pwm-names = "cnv", "clk_en";
+		vref-supply = <&vref>;
+
+		/* Pin-strapped: 370, 730, 870, 1380 or 2250. */
+		adi,gain-milli = <870>;
+	};
+};

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq2387x.dtsi
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-adaq2387x.dtsi
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Shared carrier pieces for the ADAQ2387x modules on Zedboard.
+ *
+ * ext_clk must match the reference clock the HDL bitstream produces.
+ *
+ * Copyright (C) 2026 Analog Devices Inc.
+ */
+
+#include "zynq-zed.dtsi"
+#include "zynq-zed-adv7511.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/pwm/pwm.h>
+
+/ {
+	vref: regulator-vref {
+		compatible = "regulator-fixed";
+		regulator-name = "vref-4v096";
+		regulator-min-microvolt = <4096000>;
+		regulator-max-microvolt = <4096000>;
+		regulator-always-on;
+	};
+
+	clocks {
+		ext_clk: clock@0 {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <120000000>;
+			clock-output-names = "ref_clk_120m";
+		};
+	};
+
+	gpio-control@0 {
+		compatible = "adi,one-bit-adc-dac";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		out-gpios = <&gpio0 86 GPIO_ACTIVE_HIGH>,
+			    <&gpio0 87 GPIO_ACTIVE_HIGH>;
+		channel@0 {
+			reg = <0>;
+			label = "adaq2387x_testpat";
+		};
+		channel@1 {
+			reg = <1>;
+			label = "adaq2387x_pd";
+		};
+	};
+};
+
+&fpga_axi {
+	rx_dma: dma-controller@44a30000 {
+		compatible = "adi,axi-dmac-1.00.a";
+		reg = <0x44a30000 0x1000>;
+		#dma-cells = <1>;
+		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&clkc 15>;
+	};
+
+	axi_pwm_gen: pwm@44a60000 {
+		compatible = "adi,axi-pwmgen-2.00.a";
+		reg = <0x44a60000 0x1000>;
+		label = "adaq2387x_if";
+		#pwm-cells = <2>;
+		clocks = <&clkc 15>, <&ext_clk>;
+		clock-names = "axi", "ext";
+	};
+};
+
+/* The FMC FRU EEPROM on this card is a 24AA32A, not the carrier's default. */
+&eeprom1 {
+	compatible = "atmel,24c32";
+};

--- a/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-cn0577.dts
+++ b/arch/arm/boot/dts/xilinx/zynq-zed-adv7511-cn0577.dts
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: GPL-2.0
 /*
- * Analog Devices LTC2387
+ * Analog Devices LTC2387-18
  *
  * hdl_project: <cn0577/zed>
+ * for all config modes, please check the README of the HDL project
  * board_revision: <A>
  *
- * Copyright (C) 2022 Analog Devices Inc.
+ * Copyright (C) 2022 - 2026 Analog Devices Inc.
  */
 /dts-v1/;
 
@@ -54,6 +55,19 @@
 		#dma-cells = <1>;
 		interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&clkc 15>;
+
+		adi,channels {
+			#size-cells = <0>;
+			#address-cells = <1>;
+
+			dma-channel@0 {
+				reg = <0>;
+				adi,source-bus-width = <32>;
+				adi,source-bus-type = <2>;
+				adi,destination-bus-width = <64>;
+				adi,destination-bus-type = <0>;
+			};
+		};
 	};
 
 	axi_pwm_gen: pwm@44a60000 {
@@ -75,6 +89,7 @@
 		pwm-names = "cnv", "clk_en";
 		vref-supply = <&vref>;
 
-		adi,use-two-lanes;
+		// uncomment the below command to use in one lane mode
+		// adi,use-one-lane;
 	};
 };

--- a/drivers/iio/adc/ltc2387.c
+++ b/drivers/iio/adc/ltc2387.c
@@ -75,33 +75,41 @@ enum ltc2387_id {
 	ID_LTC2387_16_X4,
 	ID_LTC2387_18,
 	ID_LTC2387_18_X4,
+	ID_ADAQ23875,
+	ID_ADAQ23876,
+	ID_ADAQ23878,
 };
 
 struct ltc2387_info {
+	const char *name;
 	struct iio_chan_spec channels[4];
 	unsigned int test_pattern[2];
 	int num_channels;
 	int resolution;
 };
 
+#define LTC2387_TEST_PATTERN_16 {					\
+	[ONE_LANE]  = 0b1010000001111111,				\
+	[TWO_LANES] = 0b1100110000111111,				\
+}
+
+#define LTC2387_TEST_PATTERN_18 {					\
+	[ONE_LANE]  = 0b101000000111111100,				\
+	[TWO_LANES] = 0b110011000011111100,				\
+}
+
 static const struct ltc2387_info ltc2387_infos[] = {
 	[ID_LTC2387_16] = {
+		.name = "ltc2387-16",
 		.resolution = 16,
-		.test_pattern = {
-			[ONE_LANE] = 0b1010000001111111,
-			[TWO_LANES] = 0b1100110000111111
-		},
-		.channels = {
-			LTC2378_CHAN(16, 16),
-		},
+		.test_pattern = LTC2387_TEST_PATTERN_16,
+		.channels = { LTC2378_CHAN(16, 16) },
 		.num_channels = 1,
 	},
 	[ID_LTC2387_16_X4] = {
+		.name = "ltc2387-16-x4",
 		.resolution = 16,
-		.test_pattern = {
-			[ONE_LANE] = 0b1010000001111111,
-			[TWO_LANES] = 0b1100110000111111
-		},
+		.test_pattern = LTC2387_TEST_PATTERN_16,
 		.channels = {
 			LTC2378_MULTIPLE_CHAN(0, 64, 16, 0),
 			LTC2378_MULTIPLE_CHAN(1, 64, 16, 16),
@@ -111,22 +119,16 @@ static const struct ltc2387_info ltc2387_infos[] = {
 		.num_channels = 4,
 	},
 	[ID_LTC2387_18] = {
+		.name = "ltc2387-18",
 		.resolution = 18,
-		.test_pattern = {
-			[ONE_LANE] = 0b101000000111111100,
-			[TWO_LANES] = 0b110011000011111100
-		},
-		.channels = {
-			LTC2378_CHAN(18, 32),
-		},
+		.test_pattern = LTC2387_TEST_PATTERN_18,
+		.channels = { LTC2378_CHAN(18, 32) },
 		.num_channels = 1,
 	},
 	[ID_LTC2387_18_X4] = {
+		.name = "ltc2387-18-x4",
 		.resolution = 18,
-		.test_pattern = {
-			[ONE_LANE] = 0b101000000111111100,
-			[TWO_LANES] = 0b110011000011111100
-		},
+		.test_pattern = LTC2387_TEST_PATTERN_18,
 		.channels = {
 			LTC2378_MULTIPLE_CHAN(0, 128, 32, 0),
 			LTC2378_MULTIPLE_CHAN(1, 128, 32, 32),
@@ -135,22 +137,40 @@ static const struct ltc2387_info ltc2387_infos[] = {
 		},
 		.num_channels = 4,
 	},
+	[ID_ADAQ23875] = {
+		.name = "adaq23875",
+		.resolution = 16,
+		.test_pattern = LTC2387_TEST_PATTERN_16,
+		.channels = { LTC2378_CHAN(16, 16) },
+		.num_channels = 1,
+	},
+	[ID_ADAQ23876] = {
+		.name = "adaq23876",
+		.resolution = 16,
+		.test_pattern = LTC2387_TEST_PATTERN_16,
+		.channels = { LTC2378_CHAN(16, 16) },
+		.num_channels = 1,
+	},
+	[ID_ADAQ23878] = {
+		.name = "adaq23878",
+		.resolution = 18,
+		.test_pattern = LTC2387_TEST_PATTERN_18,
+		.channels = { LTC2378_CHAN(18, 32) },
+		.num_channels = 1,
+	},
 };
 
 struct ltc2387_dev {
 	const struct ltc2387_info *device_info;
 	enum ltc2387_lane_modes lane_mode;
-	struct gpio_desc *gpio_testpat;
 	unsigned long ref_clk_rate;
 	struct pwm_device *clk_en;
 	struct regulator *vref;
 	struct pwm_device *cnv;
-	struct pwm_waveform clk_gate_wf;
-	struct pwm_waveform cnv_wf;
 	struct clk *ref_clk;
 
 	unsigned int vref_mv;
-	int sampling_freq;
+	u32 sampling_freq;
 };
 
 static int ltc2387_set_sampling_freq(struct ltc2387_dev *ltc, int freq)
@@ -190,23 +210,27 @@ static int ltc2387_set_sampling_freq(struct ltc2387_dev *ltc, int freq)
 	if (rem)
 		cnv_wf.period_length_ns += 1;
 
-	ret = pwm_set_waveform_might_sleep(ltc->cnv, &cnv_wf, false);
-	if (ret < 0)
-		return ret;
-
 	/* Gate the active period of the clock (see page 10-13 for both LTC's) */
 	if (ltc->lane_mode == TWO_LANES)
 		clk_en_time = DIV_ROUND_UP_ULL(ltc->device_info->resolution, 4);
 	else
 		clk_en_time = DIV_ROUND_UP_ULL(ltc->device_info->resolution, 2);
 
-	clk_gate_wf.period_length_ns = cnv_wf.period_length_ns;
 	clk_gate_wf.duty_length_ns = ref_clk_period_ns * clk_en_time;
 	clk_gate_wf.duty_offset_ns = LTC2387_T_FIRSTCLK_NS;
+
+	if (cnv_wf.period_length_ns < clk_gate_wf.duty_length_ns)
+		cnv_wf.period_length_ns = clk_gate_wf.duty_length_ns + ref_clk_period_ns;
+
+	clk_gate_wf.period_length_ns = cnv_wf.period_length_ns;
 
 	if (clk_gate_wf.duty_offset_ns >= clk_gate_wf.period_length_ns)
 		div64_u64_rem(clk_gate_wf.duty_offset_ns, clk_gate_wf.period_length_ns,
 				&clk_gate_wf.duty_offset_ns);
+
+	ret = pwm_set_waveform_might_sleep(ltc->cnv, &cnv_wf, false);
+	if (ret < 0)
+		return ret;
 
 	ret = pwm_set_waveform_might_sleep(ltc->clk_en, &clk_gate_wf, false);
 	if (ret < 0)
@@ -222,12 +246,9 @@ static int ltc2387_setup(struct iio_dev *indio_dev)
 	struct ltc2387_dev *ltc = iio_priv(indio_dev);
 	struct device *dev = indio_dev->dev.parent;
 
-	if (device_property_present(dev, "adi,use-one-lane")) {
-		ltc->lane_mode = ONE_LANE;
-		return ltc2387_set_sampling_freq(ltc, 15 * MHz);
-	}
+	ltc->lane_mode = device_property_present(dev, "adi,use-one-lane")
+			 ? ONE_LANE : TWO_LANES;
 
-	ltc->lane_mode = TWO_LANES;
 	return ltc2387_set_sampling_freq(ltc, 15 * MHz);
 }
 
@@ -236,21 +257,14 @@ static int ltc2387_read_raw(struct iio_dev *indio_dev,
 			    int *val, int *val2, long info)
 {
 	struct ltc2387_dev *ltc = iio_priv(indio_dev);
-	unsigned int temp;
 
 	switch (info) {
 	case IIO_CHAN_INFO_SAMP_FREQ:
 		*val = ltc->sampling_freq;
-
 		return IIO_VAL_INT;
 	case IIO_CHAN_INFO_SCALE:
-		temp = regulator_get_voltage(ltc->vref);
-		if (temp < 0)
-			return temp;
-
-		*val = (temp * 2) / 1000;
+		*val = ltc->vref_mv * 2;
 		*val2 = chan->scan_type.realbits;
-
 		return IIO_VAL_FRACTIONAL_LOG2;
 	default:
 		return -EINVAL;
@@ -272,7 +286,7 @@ static int ltc2387_write_raw(struct iio_dev *indio_dev,
 	}
 }
 
-static void ltc2387_pwm_diasble(void *data)
+static void ltc2387_pwm_disable(void *data)
 {
 	pwm_disable(data);
 }
@@ -307,13 +321,13 @@ static const struct of_device_id ltc2387_of_match[] = {
 		.data = &ltc2387_infos[ID_LTC2387_18_X4]
 	}, {
 		.compatible = "adaq23875",
-		.data = &ltc2387_infos[ID_LTC2387_16]
+		.data = &ltc2387_infos[ID_ADAQ23875]
 	}, {
 		.compatible = "adaq23876",
-		.data = &ltc2387_infos[ID_LTC2387_16]
+		.data = &ltc2387_infos[ID_ADAQ23876]
 	}, {
 		.compatible = "adaq23878",
-		.data = &ltc2387_infos[ID_LTC2387_18]
+		.data = &ltc2387_infos[ID_ADAQ23878]
 	},
 	{}
 };
@@ -335,7 +349,7 @@ static int ltc2387_probe(struct platform_device *pdev)
 	if (!IS_ERR(ltc->vref)) {
 		ret = regulator_enable(ltc->vref);
 		if (ret) {
-			dev_err(&pdev->dev, "Can't to enable vref regulator\n");
+			dev_err(&pdev->dev, "Can't enable vref regulator\n");
 			return ret;
 		}
 		ret = regulator_get_voltage(ltc->vref);
@@ -373,7 +387,7 @@ static int ltc2387_probe(struct platform_device *pdev)
 	if (IS_ERR(ltc->clk_en))
 		return PTR_ERR(ltc->clk_en);
 
-	ret = devm_add_action_or_reset(&pdev->dev, ltc2387_pwm_diasble,
+	ret = devm_add_action_or_reset(&pdev->dev, ltc2387_pwm_disable,
 				       ltc->clk_en);
 	if (ret)
 		return ret;
@@ -382,7 +396,7 @@ static int ltc2387_probe(struct platform_device *pdev)
 	if (IS_ERR(ltc->cnv))
 		return PTR_ERR(ltc->cnv);
 
-	ret = devm_add_action_or_reset(&pdev->dev, ltc2387_pwm_diasble,
+	ret = devm_add_action_or_reset(&pdev->dev, ltc2387_pwm_disable,
 				       ltc->cnv);
 
 	if (ret)
@@ -391,10 +405,11 @@ static int ltc2387_probe(struct platform_device *pdev)
 	ltc->device_info = device_get_match_data(&pdev->dev);
 	if (!ltc->device_info)
 		return -EINVAL;
+
 	indio_dev->channels = ltc->device_info->channels;
 	indio_dev->num_channels = ltc->device_info->num_channels;
 	indio_dev->dev.parent = &pdev->dev;
-	indio_dev->name = pdev->dev.of_node->name;
+	indio_dev->name = ltc->device_info->name;
 	indio_dev->info = &ltc2387_info;
 	indio_dev->modes = INDIO_BUFFER_HARDWARE;
 	ret = devm_iio_dmaengine_buffer_setup(indio_dev->dev.parent,

--- a/drivers/iio/adc/ltc2387.c
+++ b/drivers/iio/adc/ltc2387.c
@@ -2,7 +2,7 @@
 /*
  * Linear Technology LTC2387 ADC driver
  *
- * Copyright 2022 Analog Devices Inc.
+ * Copyright 2022 - 2026 Analog Devices Inc.
  */
 
 #include <linux/clk.h>
@@ -204,7 +204,7 @@ static int ltc2387_set_sampling_freq(struct ltc2387_dev *ltc, int freq)
 	clk_gate_wf.duty_length_ns = ref_clk_period_ns * clk_en_time;
 	clk_gate_wf.duty_offset_ns = LTC2387_T_FIRSTCLK_NS;
 
-	if (clk_gate_wf.duty_offset_ns > clk_gate_wf.period_length_ns)
+	if (clk_gate_wf.duty_offset_ns >= clk_gate_wf.period_length_ns)
 		div64_u64_rem(clk_gate_wf.duty_offset_ns, clk_gate_wf.period_length_ns,
 				&clk_gate_wf.duty_offset_ns);
 
@@ -212,7 +212,7 @@ static int ltc2387_set_sampling_freq(struct ltc2387_dev *ltc, int freq)
 	if (ret < 0)
 		return ret;
 
-	ltc->sampling_freq = freq;
+	ltc->sampling_freq = (u64)DIV_ROUND_UP(NSEC_PER_SEC, (u32)clk_gate_wf.period_length_ns);
 
 	return 0;
 }
@@ -222,9 +222,12 @@ static int ltc2387_setup(struct iio_dev *indio_dev)
 	struct ltc2387_dev *ltc = iio_priv(indio_dev);
 	struct device *dev = indio_dev->dev.parent;
 
-	if (device_property_present(dev, "adi,use-two-lanes"))
-		ltc->lane_mode = TWO_LANES;
+	if (device_property_present(dev, "adi,use-one-lane")) {
+		ltc->lane_mode = ONE_LANE;
+		return ltc2387_set_sampling_freq(ltc, 15 * MHz);
+	}
 
+	ltc->lane_mode = TWO_LANES;
 	return ltc2387_set_sampling_freq(ltc, 15 * MHz);
 }
 

--- a/drivers/iio/adc/ltc2387.c
+++ b/drivers/iio/adc/ltc2387.c
@@ -17,6 +17,7 @@
 #include <linux/iio/iio.h>
 #include <linux/iio/sysfs.h>
 #include <linux/kernel.h>
+#include <linux/math64.h>
 #include <linux/module.h>
 #include <linux/platform_device.h>
 #include <linux/property.h>
@@ -187,6 +188,7 @@ static int ltc2387_set_sampling_freq(struct ltc2387_dev *ltc, int freq)
 {
 	unsigned long long ref_clk_period_ns;
 	struct pwm_waveform clk_gate_wf = { }, cnv_wf = { };
+	unsigned long long period_cycles;
 	int ret, clk_en_time;
 	u32 rem;
 
@@ -246,7 +248,13 @@ static int ltc2387_set_sampling_freq(struct ltc2387_dev *ltc, int freq)
 	if (ret < 0)
 		return ret;
 
-	ltc->sampling_freq = (u64)DIV_ROUND_UP(NSEC_PER_SEC, (u32)clk_gate_wf.period_length_ns);
+	period_cycles = mul_u64_u32_div(cnv_wf.period_length_ns,
+					ltc->ref_clk_rate, NSEC_PER_SEC);
+	if (!period_cycles)
+		return -EINVAL;
+
+	ltc->sampling_freq = DIV_ROUND_CLOSEST_ULL(ltc->ref_clk_rate,
+						   period_cycles);
 
 	return 0;
 }

--- a/drivers/iio/adc/ltc2387.c
+++ b/drivers/iio/adc/ltc2387.c
@@ -86,6 +86,8 @@ struct ltc2387_info {
 	unsigned int test_pattern[2];
 	int num_channels;
 	int resolution;
+	/* Gain * 1000 when adi,gain-milli is absent; unity for the bare parts. */
+	u32 default_gain_milli;
 };
 
 #define LTC2387_TEST_PATTERN_16 {					\
@@ -101,6 +103,7 @@ struct ltc2387_info {
 static const struct ltc2387_info ltc2387_infos[] = {
 	[ID_LTC2387_16] = {
 		.name = "ltc2387-16",
+		.default_gain_milli = 1000,
 		.resolution = 16,
 		.test_pattern = LTC2387_TEST_PATTERN_16,
 		.channels = { LTC2378_CHAN(16, 16) },
@@ -108,6 +111,7 @@ static const struct ltc2387_info ltc2387_infos[] = {
 	},
 	[ID_LTC2387_16_X4] = {
 		.name = "ltc2387-16-x4",
+		.default_gain_milli = 1000,
 		.resolution = 16,
 		.test_pattern = LTC2387_TEST_PATTERN_16,
 		.channels = {
@@ -120,6 +124,7 @@ static const struct ltc2387_info ltc2387_infos[] = {
 	},
 	[ID_LTC2387_18] = {
 		.name = "ltc2387-18",
+		.default_gain_milli = 1000,
 		.resolution = 18,
 		.test_pattern = LTC2387_TEST_PATTERN_18,
 		.channels = { LTC2378_CHAN(18, 32) },
@@ -127,6 +132,7 @@ static const struct ltc2387_info ltc2387_infos[] = {
 	},
 	[ID_LTC2387_18_X4] = {
 		.name = "ltc2387-18-x4",
+		.default_gain_milli = 1000,
 		.resolution = 18,
 		.test_pattern = LTC2387_TEST_PATTERN_18,
 		.channels = {
@@ -139,6 +145,7 @@ static const struct ltc2387_info ltc2387_infos[] = {
 	},
 	[ID_ADAQ23875] = {
 		.name = "adaq23875",
+		.default_gain_milli = 2000,
 		.resolution = 16,
 		.test_pattern = LTC2387_TEST_PATTERN_16,
 		.channels = { LTC2378_CHAN(16, 16) },
@@ -146,6 +153,7 @@ static const struct ltc2387_info ltc2387_infos[] = {
 	},
 	[ID_ADAQ23876] = {
 		.name = "adaq23876",
+		.default_gain_milli = 2000,
 		.resolution = 16,
 		.test_pattern = LTC2387_TEST_PATTERN_16,
 		.channels = { LTC2378_CHAN(16, 16) },
@@ -153,6 +161,7 @@ static const struct ltc2387_info ltc2387_infos[] = {
 	},
 	[ID_ADAQ23878] = {
 		.name = "adaq23878",
+		.default_gain_milli = 2000,
 		.resolution = 18,
 		.test_pattern = LTC2387_TEST_PATTERN_18,
 		.channels = { LTC2378_CHAN(18, 32) },
@@ -171,6 +180,7 @@ struct ltc2387_dev {
 
 	unsigned int vref_mv;
 	u32 sampling_freq;
+	u32 gain_milli;
 };
 
 static int ltc2387_set_sampling_freq(struct ltc2387_dev *ltc, int freq)
@@ -263,9 +273,10 @@ static int ltc2387_read_raw(struct iio_dev *indio_dev,
 		*val = ltc->sampling_freq;
 		return IIO_VAL_INT;
 	case IIO_CHAN_INFO_SCALE:
-		*val = ltc->vref_mv * 2;
-		*val2 = chan->scan_type.realbits;
-		return IIO_VAL_FRACTIONAL_LOG2;
+		/* Referred to the SMA input, so divided by the front-end gain. */
+		*val = ltc->vref_mv * 2 * 1000;
+		*val2 = ltc->gain_milli << chan->scan_type.realbits;
+		return IIO_VAL_FRACTIONAL;
 	default:
 		return -EINVAL;
 	}
@@ -405,6 +416,12 @@ static int ltc2387_probe(struct platform_device *pdev)
 	ltc->device_info = device_get_match_data(&pdev->dev);
 	if (!ltc->device_info)
 		return -EINVAL;
+
+	ltc->gain_milli = ltc->device_info->default_gain_milli;
+	device_property_read_u32(&pdev->dev, "adi,gain-milli", &ltc->gain_milli);
+	if (!ltc->gain_milli)
+		return dev_err_probe(&pdev->dev, -EINVAL,
+				     "adi,gain-milli must be nonzero\n");
 
 	indio_dev->channels = ltc->device_info->channels;
 	indio_dev->num_channels = ltc->device_info->num_channels;

--- a/drivers/iio/adc/ltc2387.c
+++ b/drivers/iio/adc/ltc2387.c
@@ -44,6 +44,7 @@
 	{								\
 		.type = IIO_VOLTAGE,					\
 		.info_mask_shared_by_all = BIT(IIO_CHAN_INFO_SAMP_FREQ),\
+		.info_mask_shared_by_type = BIT(IIO_CHAN_INFO_SCALE),\
 		.indexed = 1,						\
 		.channel = _idx,					\
 		.scan_index = _idx,					\
@@ -59,6 +60,7 @@
 	{								\
 		.type = IIO_VOLTAGE,					\
 		.info_mask_shared_by_all = BIT(IIO_CHAN_INFO_SAMP_FREQ),\
+		.info_mask_shared_by_type = BIT(IIO_CHAN_INFO_SCALE),\
 		.scan_type = {						\
 			.sign = 's',					\
 			.storagebits = _storagebits,			\


### PR DESCRIPTION
## PR Description

Add Linux support for the ADAQ23875, ADAQ23876, and ADAQ23878 ADCs on the Xilinx Zedboard. All three parts wrap the LTC2387 behind an integrated fully-differential amplifier. The 23875 has fixed FDA gain of 2; the 23876 and 23878 have a board-strapped gain (0.37, 0.73, 0.87, 1.38, or 2.25) that the driver needs to reflect in in_voltage_scale.

Changes:
- Extend the LTC2387 driver: distinct info entries per compatible, new adi,gain-milli DT property, and adi,use-one-lane boolean to select the one lane bitstream.
- Update the LTC2387 DT binding with adi,gain-milli (enum) and adi,use-one-lane (boolean).
- Refactor the existing ADAQ23875/23878 device trees onto a shareddtsi (zynq-zed-adv7511-adaq2387x.dtsi) and add per-part dtsis + dts for the one lane versions
- Add new ADAQ23876 board files (dtsi + two-lane .dts + one-lane .dts).

Tested on ADAQ23875 + Zedboard with one and two lane bitstreams

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
