### PR TITLE
remoteproc: Call mbox_client_txdone() after mbox_send_message()

### DIFF
--- a/drivers/remoteproc/adi_remoteproc.c
+++ b/drivers/remoteproc/adi_remoteproc.c
@@ -732,8 +732,10 @@ static void adi_rproc_kick(struct rproc *rproc, int vqid)
 		}
 	}
 
-	if (rproc_data->rpmsg_state == ADI_RP_RPMSG_SYNCED)
+	if (rproc_data->rpmsg_state == ADI_RP_RPMSG_SYNCED) {
 		mbox_send_message(rproc_data->kick_chan, NULL);
+		mbox_client_txdone(rproc_data->kick_chan, 0);
+	}
 }
 
 static int adi_rproc_sanity_check(struct rproc *rproc, const struct firmware *fw)


### PR DESCRIPTION
It's necessary to call one of the txdone functions to get the mailbox state machine moving.

Currently it still works by some luck: The message being sent is NULL. The framework code thus sets chan->active_req = NULL to signal that this message is currently sending out. On the next call to mbox_send_message() chan->active_req == NULL is interpreted differently though, that is as not busy and the next message is processed.

The inner workings of the mailbox subsystem will change in commit c58e9456e30c ("mailbox: Fix NULL message support in mbox_send_message()") that is part of v7.1-rc2 where this inconsistency is somewhat fixed. (Then -1 is the value that cannot be properly sent instead of (the more usual) NULL. The upside is that this -1 is properly catched as bogous.)

To prepare updating the code to after v7.1-rc2 add a call to mbox_client_txdone() which is already now required conceptually, but deviating doesn't hurt while only sending NULL.

## PR Type
- [x] Bug fix (a change that fixes an issue, well somewhat)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
