### PR TITLE
Input: adp5588-keys - cache GPIO state before registering the gpiochip

### DIFF
--- a/drivers/input/keyboard/adp5588-keys.c
+++ b/drivers/input/keyboard/adp5588-keys.c
@@ -447,17 +447,17 @@ static int adp5588_gpio_add(struct adp5588_kpad *kpad)
 
 	mutex_init(&kpad->gpio_lock);
 
-	error = devm_gpiochip_add_data(dev, &kpad->gc, kpad);
-	if (error) {
-		dev_err(dev, "gpiochip_add failed: %d\n", error);
-		return error;
-	}
-
 	for (i = 0; i <= ADP5588_BANK(ADP5588_MAXGPIO); i++) {
 		kpad->dat_out[i] = adp5588_read(kpad->client,
 						GPIO_DAT_OUT1 + i);
 		kpad->dir[i] = adp5588_read(kpad->client, GPIO_DIR1 + i);
 		kpad->pull_dis[i] = adp5588_read(kpad->client, GPIO_PULL1 + i);
+	}
+
+	error = devm_gpiochip_add_data(dev, &kpad->gc, kpad);
+	if (error) {
+		dev_err(dev, "gpiochip_add failed: %d\n", error);
+		return error;
 	}
 
 	return 0;


### PR DESCRIPTION
This is actually borne from yet more MMC issues I encountered.

submitted upstream: https://lore.kernel.org/all/20260818-adp5588-gpio-cache-v1-1-650a2674fc0d@analog.com/T/#u

Basically I was getting these errors shortly after booting:

```
[   25.483303] mmc0: Timeout waiting for hardware interrupt.
[   25.488556] mmc0: sdhci: ============ SDHCI REGISTER DUMP ===========
[   25.494976] mmc0: sdhci: Sys addr:  0x00000000 | Version:  0x00000005
[   25.501398] mmc0: sdhci: Blk size:  0x00007200 | Blk cnt:  0x00000000
[   25.507821] mmc0: sdhci: Argument:  0x03b30001 | Trn mode: 0x00000033
[   25.514244] mmc0: sdhci: Present:   0x020f0001 | Host ctl: 0x00000035
[   25.520668] mmc0: sdhci: Power:     0x0000000e | Blk gap:  0x00000000
[   25.527091] mmc0: sdhci: Wake-up:   0x00000000 | Clock:    0x00000007
[   25.533514] mmc0: sdhci: Timeout:   0x00000009 | Int stat: 0x00000000
[   25.539937] mmc0: sdhci: Int enab:  0x03ff000b | Sig enab: 0x03ff000b
[   25.546360] mmc0: sdhci: ACmd stat: 0x00000000 | Slot int: 0x00000000
[   25.552784] mmc0: sdhci: Caps:      0x216d328a | Caps_1:   0x08000007
[   25.559207] mmc0: sdhci: Cmd:       0x0000061b | Max curr: 0x00000000
[   25.565630] mmc0: sdhci: Resp[0]:   0x00000900 | Resp[1]:  0xffffffff
[   25.572053] mmc0: sdhci: Resp[2]:   0x320f5903 | Resp[3]:  0x00000900
[   25.578476] mmc0: sdhci: Host ctl2: 0x00000001
[   25.582903] mmc0: sdhci: ADMA Err:  0x00000000 | ADMA Ptr: 0x90e79208
[   25.589327] mmc0: sdhci: ============================================
```

Thinking I fixed this, I reapplied the patch that I reverted the other day in https://github.com/analogdevicesinc/linux/pull/3493, hoping it would fix the issue. And it did. But in the process I looked again at the schematics and realized that the gpio-hogs for the eMMC case should actually be NO-OPs, i.e. u-boot should have already configured them that way, and before that, the pull resistors should have configured the logic gpio8=LOW gpio9=HIGH, thus connecting eMMC and gating SD card. So although I still think the fix is semantically correct, it should only actually have an effect when using an SD card. The only other thing the change does, in practice, is delay the probing of MMC. So why does that help?

I got tired of this problem so I just cracked out the oscilloscope to see if I was mad, and apparently I'm not. This is the trace of gpio9 (controlling the SD card gate switch), which should always be HIGH, about 2 seconds into kernel boot, exactly when the adp5588-keys driver is probing:

<img width="960" height="1280" alt="photo_2026-08-18_17-11-34" src="https://github.com/user-attachments/assets/fbd0f170-7bcc-4337-9213-fc24ca8a36ab" />

Those 320 us is the period between the two register writes in `adp5588_gpio_direction_output()`, which led me to make this change, which fixed the errors I was seeing even with the revert from yesterday. And in case you don't believe me, I put an fsleep(1000) inbetween the two writes and captured this afterwards:

<img width="1280" height="960" alt="photo_2026-08-18_17-11-35" src="https://github.com/user-attachments/assets/38b52726-729a-421d-b673-b3101ed3f49e" />

Actual commit message follows.


---

So as not to clobber any pre-programmed GPIO state in the execution of its gpiochip ops, the driver caches things during probe time. However, since those ops can be called both during and immediately after the call to devm_gpiochip_add_data(), it is imperative that things are cached before that. That's not the case right now, so reorder the two steps to prevent any clobbering.

In a conrete example which motivated this change, a bootloader was preconfiguring an important GPIO output to HIGH before booting the kernel. Linux would then inadvertently set that output to LOW while configuring a GPIO hog on a discrete GPIO line within the same 8-bit bank (because the cached value was 0=LOW).

Fixes: ba9f507a1bea ("Input: adp5588-keys - export unused GPIO pins")

## PR Description

- Please replace this comment with a summary of your changes, and add any context
necessary to understand them. List any dependencies required for this change.
- To check the checkboxes below, insert a 'x' between square brackets (without
any space), or simply check them after publishing the PR.
- If you changes include a breaking change, please specify dependent PRs in the
description and try to push all related PRs simultaneously.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [x] I have provided links for the relevant upstream lore
