### PR TITLE
ARM: dts: adi: sc59x: remove mmc

### DIFF
--- a/arch/arm/boot/dts/adi/sc594-som.dtsi
+++ b/arch/arm/boot/dts/adi/sc594-som.dtsi
@@ -308,15 +308,6 @@
 	status = "okay";
 };
 
-&mmc0 {
-	/* wp-en-pin = <&som_gpio_expander ? GPIO_ACTIVE_LOW>;	 SD_WP_EN */
-	bus-width = <4>;
-	pinctrl-names = "default";
-	pinctrl-0 = <&mmc0_8bgrp>;
-	cap-sd-highspeed;
-	status = "disabled";
-};
-
 &sram_mmap {
 	status = "okay";
 };
@@ -410,21 +401,6 @@
 				 <ADI_ADSP_PINMUX('F', 1, ADI_ADSP_PINFUNC_ALT0)>,
 				 <ADI_ADSP_PINMUX('F', 2, ADI_ADSP_PINFUNC_ALT0)>,
 				 <ADI_ADSP_PINMUX('F', 3, ADI_ADSP_PINFUNC_ALT0)>;
-		};
-	};
-	mmc0_8bgrp: mmc0_8bgrp_pins {
-		pins {
-			pinmux = <ADI_ADSP_PINMUX('F', 2, ADI_ADSP_PINFUNC_ALT0)>,
-				 <ADI_ADSP_PINMUX('F', 3, ADI_ADSP_PINFUNC_ALT0)>,
-				 <ADI_ADSP_PINMUX('F', 4, ADI_ADSP_PINFUNC_ALT0)>,
-				 <ADI_ADSP_PINMUX('F', 5, ADI_ADSP_PINFUNC_ALT0)>,
-				 <ADI_ADSP_PINMUX('F', 6, ADI_ADSP_PINFUNC_ALT0)>,
-				 <ADI_ADSP_PINMUX('F', 7, ADI_ADSP_PINFUNC_ALT0)>,
-				 <ADI_ADSP_PINMUX('F', 8, ADI_ADSP_PINFUNC_ALT0)>,
-				 <ADI_ADSP_PINMUX('F', 9, ADI_ADSP_PINFUNC_ALT0)>,
-				 <ADI_ADSP_PINMUX('F', 10, ADI_ADSP_PINFUNC_ALT0)>,
-				 <ADI_ADSP_PINMUX('F', 11, ADI_ADSP_PINFUNC_ALT0)>,
-				 <ADI_ADSP_PINMUX('F', 12, ADI_ADSP_PINFUNC_ALT0)>;
 		};
 	};
 	usbc0_default: usbc0_default_pins {

--- a/arch/arm/boot/dts/adi/sc59x.dtsi
+++ b/arch/arm/boot/dts/adi/sc59x.dtsi
@@ -48,7 +48,6 @@
 		i2c4 = &i2c4;
 		i2c5 = &i2c5;
 		i2s4 = &i2s4;
-		mmc0 = &mmc0;
 		sru0 = &sru_ctrl_dai0;
 		sru1 = &sru_ctrl_dai1;
 	};
@@ -601,17 +600,6 @@
 			#size-cells = <1>;
 			reg = <0x310CA000 0x224>;
 			adi,pads-syscon = <&pads_syscon>;
-			status = "disabled";
-		};
-
-		mmc0: mmc@31010000 {
-			compatible = "snps,dw-mshc";
-			reg = <0x31010000 0xFFF>;
-			interrupts = <GIC_SPI 131 IRQ_TYPE_LEVEL_HIGH>;
-			spu_securep_id = <58>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			fifo-depth = <1024>;
 			status = "disabled";
 		};
 


### PR DESCRIPTION
These SoCs don't have an MMC controller. Remove.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
