### PR TITLE
arm64: dts: adi: sc598-som-ezkit: expand OSPI flash partitions

### DIFF
--- a/arch/arm64/boot/dts/adi/sc598-som-ezkit.dtsi
+++ b/arch/arm64/boot/dts/adi/sc598-som-ezkit.dtsi
@@ -61,12 +61,12 @@
 
 			ospi_2: partition@100000 {
 				label = "kernel";
-				reg = <0x100000 0xf00000>;
+				reg = <0x100000 0x2000000>;
 			};
 
-			ospi_3: partition@1000000 {
+			ospi_3: partition@2100000 {
 				label = "rootfs";
-				reg = <0x1000000 0x1000000>;
+				reg = <0x2100000 0x5f00000>;
 			};
 		};
 	};


### PR DESCRIPTION
The OSPI kernel and rootfs partitions on the MX66LM1G45G (128 MB) were not updated when the SoM SPI flash partitions were resized in commit 4e662b50bb87 ("arm64: dts: adi: sc598-som-revE: extend rootfs to fill flash"). This left the kernel allocation at 15 MB and the rootfs at 16 MB, wasting 96 MB of the 128 MB device.

Align the OSPI layout with the IS25LP01G on the SoM revE:

  kernel: 0x100000 + 0x2000000  (15 MB -> 32 MB)
  rootfs: 0x2100000 + 0x5f00000 (16 MB -> 95 MB, fills device)

Fixes: dfc678d524ab ("arch: arm64: dts: Add SD card dts for the sc598 EZKIT")