### PR TITLE
arm64: dts: adi: sc846: fix DRAM size and drop SRAM memory nodes

### DIFF
--- a/arch/arm64/boot/dts/adi/sc846-som.dts
+++ b/arch/arm64/boot/dts/adi/sc846-som.dts
@@ -17,49 +17,20 @@
 		stdout-path = &uart0;
 	};
 
-	memory@80000000 {
-		device_type = "memory";
-		reg = <0x80000000 0x20000000>;
-	};
-
-	memory@20040000 {
-		device_type = "memory";
-		reg = <0x20040000 0x40000>;
-	};
-
 	reserved-memory {
-		sram1_res: sram1-reserved@20040000 {
-			compatible = "adi,sram-access";
-			reg = <0x20040000 0x40000>;
-		};
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
 
-		vdev0vrings: vdev0vring0@20080000 {
-			reg = <0x20080000 0x4000>;
+		vdev0vrings: vdev0vring0@20400000 {
+			reg = <0x20400000 0x4000>;
 			no-map;
 		};
 
-		vdev0buffer: vdev0buffer@20084000 {
-			compatible = "shared-dma-pool";
-			reg = <0x20084000 0x20000>;
+		rsc_tbl0: rsc_tbl0@20404000 {
+			reg = <0x20404000 0x400>;
 			no-map;
 		};
-
-		vdev1vrings: vdev1vring0@200a4000 {
-			reg = <0x200a4000 0x4000>;
-			no-map;
-		};
-
-		vdev1buffer: vdev1buffer@200a8000 {
-			compatible = "shared-dma-pool";
-			reg = <0x200a8000 0x20000>;
-			no-map;
-		};
-	};
-
-	sram1_mmap: sram-mmap {
-		compatible = "adi,sram-mmap";
-		memory-region = <&sram1_res>;
-		status = "okay";
 	};
 };
 

--- a/arch/arm64/boot/dts/adi/sc846.dtsi
+++ b/arch/arm64/boot/dts/adi/sc846.dtsi
@@ -68,39 +68,7 @@
 
 	memory@80000000 {
 		device_type = "memory";
-		reg = <0x80000000 0x20000000>;
-	};
-
-	memory@20040000 {
-		device_type = "memory";
-		reg = <0x20040000 0x40000>;
-	};
-
-	sram1_mmap: sram-mmap {
-		compatible = "adi,sram-mmap";
-		memory-region = <&sram1_res>;
-		status = "okay";
-	};
-
-	reserved-memory {
-		#address-cells = <1>;
-		#size-cells = <1>;
-		ranges;
-
-		rsc_tbl0: rsc-table@20000000 {
-			reg = <0x20000000 0x400>; /*1KiB*/
-			no-map;
-		};
-
-		rsc_tbl1: rsc-table@20000400 {
-			reg = <0x20000400 0x400>; /*1KiB*/
-			no-map;
-		};
-
-		sharc-internal-icc@20005000 {
-			reg = <0x20005000 0x20000>; /*128KiB*/
-			no-map;
-		};
+		reg = <0x80000000 0x40000000>;
 	};
 
 	pmu {


### PR DESCRIPTION
## PR Description

Set DDR memroy region to max memory. 
Remove unused and untested L2 SRAM node
Set rpmsg node to match L2 memory region

Tested with:
stress --vm 2 --vm-bytes 64M --timeout 60s

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
