### PR TITLE
iio: frequency: ad9162: use -EOPNOTSUPP for uncalibrated temp read

### DIFF
--- a/drivers/iio/frequency/ad9162.c
+++ b/drivers/iio/frequency/ad9162.c
@@ -636,7 +636,7 @@ static int ad9162_read_raw(struct iio_dev *indio_dev,
 		return IIO_VAL_INT;
 	case IIO_CHAN_INFO_PROCESSED:
 		if (!conv->temp_calib_code)
-			return -ENOTSUPP;
+			return -EOPNOTSUPP;
 
 		ret = ad9162_get_temperature_code(st, &code);
 		if (ret < 0)


### PR DESCRIPTION
ENOTSUPP is kernel-internal and must not reach userspace; use the standard -EOPNOTSUPP instead.

Fixes: ef0c4348f906 ("iio: ad9162: Support die temperature reading")

## PR Description

- Please replace this comment with a summary of your changes, and add any context
necessary to understand them. List any dependencies required for this change.
- To check the checkboxes below, insert a 'x' between square brackets (without
any space), or simply check them after publishing the PR.
- If you changes include a breaking change, please specify dependent PRs in the
description and try to push all related PRs simultaneously.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
