### PR TITLE
Support for max9295d and continous clock for ov5640 and imx708

### DIFF
--- a/Documentation/devicetree/bindings/media/i2c/maxim,max96717.yaml
+++ b/Documentation/devicetree/bindings/media/i2c/maxim,max96717.yaml
@@ -37,6 +37,7 @@ properties:
     oneOf:
       - enum:
           - maxim,max9295a
+          - maxim,max9295d
           - maxim,max96717f
       - items:
           - enum:

--- a/arch/arm/boot/dts/overlays/gen_gmsl_dts/README.md
+++ b/arch/arm/boot/dts/overlays/gen_gmsl_dts/README.md
@@ -8,6 +8,7 @@
 - [Example Configuration](#example-configuration)
 - [Usage](#usage)
 - [Applying the Overlay](#applying-the-overlay)
+- [Capturing from Multiple Cameras on a Single GMSL Link](#capturing-from-multiple-cameras-on-a-single-gmsl-link)
 - [Troubleshooting](#troubleshooting)
 - [References](#references)
 
@@ -223,6 +224,36 @@ The JSON configuration file defines the GMSL setup. Below are the primary parame
    ```bash
    sudo reboot
    ```
+
+## Capturing from Multiple Cameras on a Single GMSL Link
+
+Some serializers (e.g. `max9295d`) carry more than one camera over a single GMSL link. In that case the deserializer only sets up a route for the *first* camera automatically. The other camera streams arrive on the same deserializer sink pad, told apart by their stream number, and have to be routed to userspace by hand with `media-ctl` before they can be captured.
+
+First, find the correct media device (there may be several `/dev/media*`):
+
+```bash
+media-ctl -p
+```
+
+Pick the device that lists your GMSL parts (for example `/dev/media0`) and use it with `-d` below. Read the entity names and pad numbers from that same output — the names used below are placeholders.
+
+Then route both camera streams through the graph. Send the routing commands **before** setting any formats: `-R` resets every pad format, so running it later would undo formats you have already applied.
+
+```bash
+# Deserializer: send link streams 0 and 1 to two separate source pads
+media-ctl -d /dev/media0 -R '"deserializer":0/0->1/0[1],0/1->2/0[1]'
+```
+
+```bash
+# CSI-2 receiver: send the two streams to two capture channels
+media-ctl -d /dev/media0 -R '"csi2":0/0->3/0[1],0/1->3/1[1]'
+```
+
+After routing, set matching formats along both chains (sensor -> serializer -> deserializer -> CSI-2), enable the CSI-2 links, and each camera will appear on its own `/dev/videoN`.
+
+### Ordering multi-camera serializers
+
+The deserializer hands its pipes to the enabled links in turn, and the lowest-numbered link collects any extra pipes. A serializer that carries several cameras over one link needs more than one pipe, so it must land on a link that receives the extras. In a mixed setup, list the multi-camera serializer **first** in the `links` array (so it takes the lowest-numbered link) — otherwise a deserializer with only as many pipes as cameras (e.g. `max96724`, four pipes) can run out of pipes for it and the extra streams fail to route. With a single serializer, or when every camera has its own link, ordering does not matter.
 
 ## Troubleshooting
 

--- a/arch/arm/boot/dts/overlays/gen_gmsl_dts/imx708.dtsi.in
+++ b/arch/arm/boot/dts/overlays/gen_gmsl_dts/imx708.dtsi.in
@@ -18,8 +18,12 @@
 	{{reg_label}}: {{reg_label}} {
 		compatible = "regulator-fixed";
 		regulator-name = "{{reg_label}}";
+		{% if cam_cfg.enable_gpio | d(true) %}
 		enable-active-high;
 		gpio = <&{{ser_label}} {{reset_pin}} 0>;
+		{% else %}
+		regulator-always-on;
+		{% endif %}
 	};
 };
 
@@ -36,35 +40,43 @@
 		rotation = <180>;
 		orientation = <2>;
 
+		{% if cam_cfg.enable_vcm | d(true) %}
 		lens-focus = <&{{vcm_label}}>;
+		{% endif %}
 
 		port {
 			{{cam_out_label}}: endpoint {
 				clock-lanes = <0>;
 				data-lanes = <1 2>;
+				{% if not cam_cfg.clock_continuous | d(false) %}
 				clock-noncontinuous;
+				{% endif %}
 				link-frequencies = /bits/ 64 <450000000>;
 				remote-endpoint = <&{{cam_out_remote_label}}>;
 			};
 		};
 	};
 
+	{% if cam_cfg.enable_vcm | d(true) %}
 	{{vcm_label}}: dw9817@0c {
 		compatible = "dongwoon,dw9817-vcm";
 		reg = <0x0c>;
 		VDD-supply = <&{{reg_label}}>;
 	};
+	{% endif %}
 };
 
 &{{ser_label}} {
 	ports {
 		port@{{cam_idx}} {
-			reg = <0>;
+			reg = <{{cam_idx}}>;
 
 			{{cam_out_remote_label}}: endpoint {
 				clock-lanes = <0>;
 				data-lanes = <1 2>;
+				{% if not cam_cfg.clock_continuous | d(false) %}
 				clock-noncontinuous;
+				{% endif %}
 				link-frequencies = /bits/ 64 <450000000>;
 				remote-endpoint = <&{{cam_out_label}}>;
 			};

--- a/arch/arm/boot/dts/overlays/gen_gmsl_dts/max9295d.dtsi.in
+++ b/arch/arm/boot/dts/overlays/gen_gmsl_dts/max9295d.dtsi.in
@@ -1,0 +1,3 @@
+{% set default_address = '0x40' %}
+{% set default_compatible = 'maxim,max9295d' %}
+{% include 'ser.dtsi.in' %}

--- a/arch/arm/boot/dts/overlays/gen_gmsl_dts/max96716_1_max9295d_ov5640_imx708_rpi5.json
+++ b/arch/arm/boot/dts/overlays/gen_gmsl_dts/max96716_1_max9295d_ov5640_imx708_rpi5.json
@@ -1,0 +1,39 @@
+[
+    {
+        "name": "max96716a",
+        "i2c_bus": "i2c_csi_dsi0",
+        "platform_cfg": {
+            "name": "rpi-5-b",
+            "csi_idx": 0,
+            "phy_idx": 1
+        },
+        "phys": [
+            {
+                "phy_idx": 1,
+                "num_lanes": 4,
+                "link_frequencies": [750000000],
+                "clock_lanes": [0],
+                "data_lanes": [1, 2, 3, 4]
+            }
+        ],
+        "links": [
+            {
+                "name": "max9295d",
+                "cameras": [
+                    {
+                        "name": "ov5640",
+                        "clock_continuous": true,
+                        "enable_gpio": false
+                    },
+                    {
+                        "name": "imx708",
+                        "clock_continuous": true,
+                        "enable_gpio": false,
+                        "enable_vcm": false
+                    }
+                ],
+                "pool_addrs": ["0x50", "0x51", "0x52", "0x53"]
+            }
+        ]
+    }
+]

--- a/arch/arm/boot/dts/overlays/gen_gmsl_dts/ov5640.dtsi.in
+++ b/arch/arm/boot/dts/overlays/gen_gmsl_dts/ov5640.dtsi.in
@@ -17,7 +17,9 @@
 		compatible = "ovti,ov5640";
 		reg = <0x3c>;
 
+		{% if cam_cfg.enable_gpio | d(true) %}
 		reset-gpios = <&{{ser_label}} {{reset_pin}} 0>;
+		{% endif %}
 
 		clocks = <&{{xclk_label}}>;
 		clock-names = "xclk";
@@ -26,7 +28,9 @@
 			{{cam_out_label}}: endpoint {
 				clock-lanes = <0>;
 				data-lanes = <1 2>;
+				{% if not cam_cfg.clock_continuous | d(false) %}
 				clock-noncontinuous;
+				{% endif %}
 				link-frequencies = /bits/ 64 <456000000>;
 				remote-endpoint = <&{{cam_out_remote_label}}>;
 			};
@@ -37,12 +41,14 @@
 &{{ser_label}} {
 	ports {
 		port@{{cam_idx}} {
-			reg = <0>;
+			reg = <{{cam_idx}}>;
 
 			{{cam_out_remote_label}}: endpoint {
 				clock-lanes = <0>;
 				data-lanes = <1 2>;
+				{% if not cam_cfg.clock_continuous | d(false) %}
 				clock-noncontinuous;
+				{% endif %}
 				link-frequencies = /bits/ 64 <456000000>;
 				remote-endpoint = <&{{cam_out_label}}>;
 			};

--- a/arch/arm/boot/dts/overlays/gen_gmsl_dts/ser.dtsi.in
+++ b/arch/arm/boot/dts/overlays/gen_gmsl_dts/ser.dtsi.in
@@ -5,6 +5,7 @@
 {% set ser_out_label = ser_label ~ '_out' %}
 {% set ser_out_remote_label = des_in_label_x(ser_idx) %}
 {% set i2c_label = des_i2c_label_x(ser_idx) %}
+{% set ser_out_port = ser_cfg.cameras | length %}
 {% macro ser_in_label_x(x) -%}
 	{{ ser_label ~ '_in_' ~ x }}
 {%- endmacro %}
@@ -47,8 +48,8 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 
-		port@1 {
-			reg = <1>;
+		port@{{ser_out_port}} {
+			reg = <{{ser_out_port}}>;
 
 			{{ser_out_label}}: endpoint {
 				remote-endpoint = <&{{ser_out_remote_label}}>;

--- a/drivers/media/i2c/imx708.c
+++ b/drivers/media/i2c/imx708.c
@@ -113,6 +113,10 @@ MODULE_PARM_DESC(qbc_adjust, "Quad Bayer broken line correction strength [0,2-5]
 #define IMX708_REG_MID_ANALOG_GAIN	0x3118
 #define IMX708_REG_SHT_ANALOG_GAIN	0x0216
 
+/* MIPI clock lane mode: continuous vs non-continuous */
+#define IMX708_REG_CLKLANE_BLANK	0x3220
+#define IMX708_CLKLANE_BLANK_NONCONT	BIT(0)
+
 /* QBC Re-mosaic broken line correction registers */
 #define IMX708_LPF_INTENSITY_EN		0xC428
 #define IMX708_LPF_INTENSITY_ENABLED	0x00
@@ -877,6 +881,9 @@ struct imx708 {
 	unsigned int long_exp_shift;
 
 	unsigned int link_freq_idx;
+
+	/* CSI-2 bus flags parsed from the endpoint (e.g. non-continuous clock) */
+	unsigned int csi_flags;
 };
 
 static inline struct imx708 *to_imx708(struct v4l2_subdev *_sd)
@@ -1502,6 +1509,16 @@ static int imx708_start_streaming(struct imx708 *imx708)
 			return ret;
 		}
 
+		ret = imx708_write_reg(imx708, IMX708_REG_CLKLANE_BLANK,
+				       IMX708_REG_VALUE_08BIT,
+				       imx708->csi_flags & V4L2_MBUS_CSI2_NONCONTINUOUS_CLOCK ?
+				       IMX708_CLKLANE_BLANK_NONCONT : 0);
+		if (ret) {
+			dev_err(&client->dev, "%s failed to set clock lane mode\n",
+				__func__);
+			return ret;
+		}
+
 		ret = imx708_read_reg(imx708, IMX708_REG_BASE_SPC_GAINS_L,
 				      IMX708_REG_VALUE_08BIT, &val);
 		if (ret == 0 && val == 0x40) {
@@ -1998,6 +2015,8 @@ static int imx708_check_hwcfg(struct device *dev, struct imx708 *imx708)
 			ret = -EINVAL;
 			goto error_out;
 	}
+
+	imx708->csi_flags = ep_cfg.bus.mipi_csi2.flags;
 
 	ret = 0;
 

--- a/drivers/media/i2c/maxim-serdes/max9296a.c
+++ b/drivers/media/i2c/maxim-serdes/max9296a.c
@@ -1123,6 +1123,7 @@ static int max9296a_probe(struct i2c_client *client)
 	ops->phys_configs = priv->info->ops->phys_configs;
 	ops->set_pipe_enable = priv->info->ops->set_pipe_enable;
 	ops->set_pipe_stream_id = priv->info->ops->set_pipe_stream_id;
+	ops->set_pipe_link = priv->info->ops->set_pipe_link;
 	ops->set_pipe_tunnel_phy = priv->info->ops->set_pipe_tunnel_phy;
 	ops->set_pipe_tunnel_enable = priv->info->ops->set_pipe_tunnel_enable;
 	ops->use_atr = priv->info->ops->use_atr;
@@ -1263,6 +1264,7 @@ static const struct max_des_ops max96716a_ops = {
 	.set_pipe_enable = max96714_set_pipe_enable,
 	.set_pipe_tunnel_phy = max96716a_set_pipe_tunnel_phy,
 	.set_pipe_tunnel_enable = max96714_set_pipe_tunnel_enable,
+	.needs_unique_stream_id = true,
 	.use_atr = true,
 	.phys_configs = {
 		.num_configs = ARRAY_SIZE(max9296a_phys_configs),

--- a/drivers/media/i2c/maxim-serdes/max96717.c
+++ b/drivers/media/i2c/maxim-serdes/max96717.c
@@ -141,22 +141,30 @@
 
 #define MAX96717_MIPI_RX0			0x330
 #define MAX96717_MIPI_RX0_NONCONTCLK_EN		BIT(6)
+#define MAX96717_MIPI_RX0_PHY_CONFIG		GENMASK(2, 0)
+#define MAX9295D_MIPI_RX0_PHY_CONFIG_2X4_AB	0b110
 
 #define MAX96717_MIPI_RX1			0x331
-#define MAX96717_MIPI_RX1_CTRL_NUM_LANES	GENMASK(5, 4)
+#define MAX96717_MIPI_RX1_NUM_LANES		GENMASK(1, 0)
 
 #define MAX96717_MIPI_RX2			0x332
 #define MAX96717_MIPI_RX2_PHY1_LANE_MAP		GENMASK(7, 4)
+#define MAX9295D_MIPI_RX2_PHY1_LANE_MAP		GENMASK(7, 4)
+#define MAX9295D_MIPI_RX2_PHY0_LANE_MAP		GENMASK(3, 0)
 
 #define MAX96717_MIPI_RX3			0x333
 #define MAX96717_MIPI_RX3_PHY2_LANE_MAP		GENMASK(3, 0)
+#define MAX9295D_MIPI_RX3_PHY3_LANE_MAP		GENMASK(7, 4)
+#define MAX9295D_MIPI_RX3_PHY2_LANE_MAP		GENMASK(3, 0)
 
 #define MAX96717_MIPI_RX4			0x334
 #define MAX96717_MIPI_RX4_PHY1_POL_MAP		GENMASK(5, 4)
+#define MAX9295D_MIPI_RX4_PHY0_POL_MAP		GENMASK(2, 0)
 
 #define MAX96717_MIPI_RX5			0x335
 #define MAX96717_MIPI_RX5_PHY2_POL_MAP		GENMASK(1, 0)
 #define MAX96717_MIPI_RX5_PHY2_POL_MAP_CLK	BIT(2)
+#define MAX9295D_MIPI_RX5_PHY3_POL_MAP		GENMASK(6, 4)
 
 #define MAX96717_EXTA(x)			(0x3dc + (x))
 
@@ -229,6 +237,8 @@ struct max96717_chip_info {
 	unsigned int pipe_hw_ids[MAX96717_PIPES_NUM];
 	unsigned int num_phys;
 	unsigned int phy_hw_ids[MAX96717_PHYS_NUM];
+	struct max_serdes_phys_configs phys_configs;
+	bool max9295d_port_layout;
 };
 
 #define ser_to_priv(_ser) \
@@ -934,6 +944,7 @@ static int max96717_init_phy(struct max_ser *ser,
 {
 	struct max96717_priv *priv = ser_to_priv(ser);
 	unsigned int num_data_lanes = phy->mipi.num_data_lanes;
+	unsigned int phy_id = max96717_phy_id(priv, phy);
 	unsigned int used_data_lanes = 0;
 	unsigned int val;
 	unsigned int i;
@@ -952,9 +963,8 @@ static int max96717_init_phy(struct max_ser *ser,
 
 	/* Configure a lane count. */
 	ret = regmap_update_bits(priv->regmap, MAX96717_MIPI_RX1,
-				 MAX96717_MIPI_RX1_CTRL_NUM_LANES,
-				 FIELD_PREP(MAX96717_MIPI_RX1_CTRL_NUM_LANES,
-					    num_data_lanes - 1));
+				 MAX96717_MIPI_RX1_NUM_LANES << (phy_id * 4),
+				 (num_data_lanes - 1) << (phy_id * 4));
 	if (ret)
 		return ret;
 
@@ -972,40 +982,88 @@ static int max96717_init_phy(struct max_ser *ser,
 		used_data_lanes |= BIT(map);
 	}
 
-	ret = regmap_update_bits(priv->regmap, MAX96717_MIPI_RX3,
-				 MAX96717_MIPI_RX3_PHY2_LANE_MAP,
-				 FIELD_PREP(MAX96717_MIPI_RX3_PHY2_LANE_MAP, val));
-	if (ret)
-		return ret;
+	if (priv->info->max9295d_port_layout && phy_id == 0) {
+		ret = regmap_update_bits(priv->regmap, MAX96717_MIPI_RX2,
+					 MAX9295D_MIPI_RX2_PHY1_LANE_MAP |
+					 MAX9295D_MIPI_RX2_PHY0_LANE_MAP,
+					 FIELD_PREP(MAX9295D_MIPI_RX2_PHY1_LANE_MAP,
+						    val & 0xf) |
+					 FIELD_PREP(MAX9295D_MIPI_RX2_PHY0_LANE_MAP,
+						    val >> 4));
+		if (ret)
+			return ret;
+	} else if (priv->info->max9295d_port_layout && phy_id == 1) {
+		ret = regmap_update_bits(priv->regmap, MAX96717_MIPI_RX3,
+					 MAX9295D_MIPI_RX3_PHY3_LANE_MAP |
+					 MAX9295D_MIPI_RX3_PHY2_LANE_MAP,
+					 FIELD_PREP(MAX9295D_MIPI_RX3_PHY3_LANE_MAP,
+						    val >> 4) |
+					 FIELD_PREP(MAX9295D_MIPI_RX3_PHY2_LANE_MAP,
+						    val & 0xf));
+		if (ret)
+			return ret;
+	} else {
+		ret = regmap_update_bits(priv->regmap, MAX96717_MIPI_RX3,
+					 MAX96717_MIPI_RX3_PHY2_LANE_MAP,
+					 FIELD_PREP(MAX96717_MIPI_RX3_PHY2_LANE_MAP, val));
+		if (ret)
+			return ret;
 
-	ret = regmap_update_bits(priv->regmap, MAX96717_MIPI_RX2,
-				 MAX96717_MIPI_RX2_PHY1_LANE_MAP,
-				 FIELD_PREP(MAX96717_MIPI_RX2_PHY1_LANE_MAP, val >> 4));
-	if (ret)
-		return ret;
+		ret = regmap_update_bits(priv->regmap, MAX96717_MIPI_RX2,
+					 MAX96717_MIPI_RX2_PHY1_LANE_MAP,
+					 FIELD_PREP(MAX96717_MIPI_RX2_PHY1_LANE_MAP, val >> 4));
+		if (ret)
+			return ret;
+	}
 
 	/* Configure lane polarity. */
 	for (i = 0, val = 0; i < num_data_lanes; i++)
 		if (phy->mipi.lane_polarities[i + 1])
 			val |= BIT(i);
 
-	ret = regmap_update_bits(priv->regmap, MAX96717_MIPI_RX5,
-				 MAX96717_MIPI_RX5_PHY2_POL_MAP,
-				 FIELD_PREP(MAX96717_MIPI_RX5_PHY2_POL_MAP, val));
-	if (ret)
-		return ret;
+	if (priv->info->max9295d_port_layout && phy_id == 0) {
+		ret = regmap_update_bits(priv->regmap, MAX96717_MIPI_RX4,
+					 MAX96717_MIPI_RX4_PHY1_POL_MAP |
+					 MAX9295D_MIPI_RX4_PHY0_POL_MAP,
+					 FIELD_PREP(MAX96717_MIPI_RX4_PHY1_POL_MAP,
+						    val & 0x3) |
+					 FIELD_PREP(MAX9295D_MIPI_RX4_PHY0_POL_MAP,
+						    ((val >> 2) & 0x3) |
+						    (phy->mipi.lane_polarities[0] << 2)));
+		if (ret)
+			return ret;
+	} else if (priv->info->max9295d_port_layout && phy_id == 1) {
+		ret = regmap_update_bits(priv->regmap, MAX96717_MIPI_RX5,
+					 MAX9295D_MIPI_RX5_PHY3_POL_MAP |
+					 MAX96717_MIPI_RX5_PHY2_POL_MAP |
+					 MAX96717_MIPI_RX5_PHY2_POL_MAP_CLK,
+					 FIELD_PREP(MAX9295D_MIPI_RX5_PHY3_POL_MAP,
+						    (val >> 2) & 0x3) |
+					 FIELD_PREP(MAX96717_MIPI_RX5_PHY2_POL_MAP |
+						    MAX96717_MIPI_RX5_PHY2_POL_MAP_CLK,
+						    (val & 0x3) |
+						    (phy->mipi.lane_polarities[0] << 2)));
+		if (ret)
+			return ret;
+	} else {
+		ret = regmap_update_bits(priv->regmap, MAX96717_MIPI_RX5,
+					 MAX96717_MIPI_RX5_PHY2_POL_MAP,
+					 FIELD_PREP(MAX96717_MIPI_RX5_PHY2_POL_MAP, val));
+		if (ret)
+			return ret;
 
-	ret = regmap_update_bits(priv->regmap, MAX96717_MIPI_RX4,
-				 MAX96717_MIPI_RX4_PHY1_POL_MAP,
-				 FIELD_PREP(MAX96717_MIPI_RX4_PHY1_POL_MAP, val >> 2));
-	if (ret)
-		return ret;
+		ret = regmap_update_bits(priv->regmap, MAX96717_MIPI_RX4,
+					 MAX96717_MIPI_RX4_PHY1_POL_MAP,
+					 FIELD_PREP(MAX96717_MIPI_RX4_PHY1_POL_MAP, val >> 2));
+		if (ret)
+			return ret;
 
-	ret = regmap_assign_bits(priv->regmap, MAX96717_MIPI_RX5,
-				 MAX96717_MIPI_RX5_PHY2_POL_MAP_CLK,
-				 phy->mipi.lane_polarities[0]);
-	if (ret)
-		return ret;
+		ret = regmap_assign_bits(priv->regmap, MAX96717_MIPI_RX5,
+					 MAX96717_MIPI_RX5_PHY2_POL_MAP_CLK,
+					 phy->mipi.lane_polarities[0]);
+		if (ret)
+			return ret;
+	}
 
 	if (priv->info->supports_noncontinuous_clock) {
 		ret = regmap_assign_bits(priv->regmap, MAX96717_MIPI_RX0,
@@ -1260,6 +1318,10 @@ static const struct max_serdes_phys_config max96717_phys_configs[] = {
 	{ { 4 } },
 };
 
+static const struct max_serdes_phys_config max9295d_phys_configs[] = {
+	{ { 4, 4 } },
+};
+
 static int max96717_init_tpg(struct max_ser *ser)
 {
 	struct max96717_priv *priv = ser_to_priv(ser);
@@ -1298,6 +1360,15 @@ static int max96717_init(struct max_ser *ser)
 					    MAX96717_CMU2_PFDDIV_RSHORT_1_1V));
 	if (ret)
 		return ret;
+
+	if (priv->info->max9295d_port_layout) {
+		ret = regmap_update_bits(priv->regmap, MAX96717_MIPI_RX0,
+					 MAX96717_MIPI_RX0_PHY_CONFIG,
+					 FIELD_PREP(MAX96717_MIPI_RX0_PHY_CONFIG,
+						    MAX9295D_MIPI_RX0_PHY_CONFIG_2X4_AB));
+		if (ret)
+			return ret;
+	}
 
 	if (ser->ops->set_tunnel_enable) {
 		ret = ser->ops->set_tunnel_enable(ser, false);
@@ -1617,6 +1688,10 @@ static int max96717_probe(struct i2c_client *client)
 	ops->num_pipes = priv->info->num_pipes;
 	ops->num_dts_per_pipe = priv->info->num_dts_per_pipe;
 	ops->num_phys = priv->info->num_phys;
+
+	if (priv->info->phys_configs.num_configs)
+		ops->phys_configs = priv->info->phys_configs;
+
 	priv->ser.ops = ops;
 
 	ret = max96717_wait_for_device(priv);
@@ -1650,6 +1725,18 @@ static const struct max96717_chip_info max9295a_info = {
 	.phy_hw_ids = { 1 },
 };
 
+static const struct max96717_chip_info max9295d_info = {
+	.modes = BIT(MAX_SERDES_GMSL_PIXEL_MODE),
+	.num_pipes = 2,
+	.num_dts_per_pipe = 2,
+	.pipe_hw_ids = { 1, 0 },
+	.num_phys = 2,
+	.phy_hw_ids = { 0, 1 },
+	.phys_configs = { .configs = max9295d_phys_configs,
+			  .num_configs = ARRAY_SIZE(max9295d_phys_configs) },
+	.max9295d_port_layout = true,
+};
+
 static const struct max96717_chip_info max96717_info = {
 	.modes = BIT(MAX_SERDES_GMSL_PIXEL_MODE) |
 		 BIT(MAX_SERDES_GMSL_TUNNEL_MODE),
@@ -1665,6 +1752,7 @@ static const struct max96717_chip_info max96717_info = {
 
 static const struct of_device_id max96717_of_ids[] = {
 	{ .compatible = "maxim,max9295a", .data = &max9295a_info },
+	{ .compatible = "maxim,max9295d", .data = &max9295d_info },
 	{ .compatible = "maxim,max96717", .data = &max96717_info },
 	{ .compatible = "maxim,max96717f", .data = &max96717_info },
 	{ .compatible = "maxim,max96793", .data = &max96717_info },

--- a/drivers/media/i2c/maxim-serdes/max_des.c
+++ b/drivers/media/i2c/maxim-serdes/max_des.c
@@ -168,6 +168,27 @@ max_des_find_link_pipe(struct max_des *des, struct max_des_link *link)
 	return NULL;
 }
 
+static struct max_des_pipe *
+max_des_find_link_pipe_by_index(struct max_des *des, struct max_des_link *link,
+				unsigned int pipe_index)
+{
+	unsigned int i, count = 0;
+
+	for (i = 0; i < des->ops->num_pipes; i++) {
+		struct max_des_pipe *pipe = &des->pipes[i];
+
+		if (pipe->link_id != link->index)
+			continue;
+
+		if (count == pipe_index)
+			return pipe;
+
+		count++;
+	}
+
+	return NULL;
+}
+
 static struct max_serdes_source *
 max_des_get_link_source(struct max_des_priv *priv, struct max_des_link *link)
 {
@@ -288,7 +309,7 @@ static int max_des_route_to_hw(struct max_des_priv *priv,
 	if (!hw->phy)
 		return -ENOENT;
 
-	hw->pipe = max_des_find_link_pipe(des, link);
+	hw->pipe = max_des_find_link_pipe_by_index(des, link, route->sink_stream);
 	if (!hw->pipe)
 		return -ENOENT;
 
@@ -322,14 +343,29 @@ static int max_des_link_to_hw(struct max_des_priv *priv,
 	memset(hw, 0, sizeof(*hw));
 
 	hw->link = link;
+	hw->source = max_des_get_link_source(priv, hw->link);
+	if (!link->enabled)
+		return 0;
 
 	hw->pipe = max_des_find_link_pipe(des, hw->link);
 	if (!hw->pipe)
 		return -ENOENT;
 
-	hw->source = max_des_get_link_source(priv, hw->link);
-
 	return 0;
+}
+
+static bool max_des_link_pipes_in_use(struct max_des *des,
+				      struct max_des_remap_context *context,
+				      struct max_des_link *link)
+{
+	unsigned int i;
+
+	for (i = 0; i < des->ops->num_pipes; i++)
+		if (des->pipes[i].link_id == link->index &&
+		    context->pipe_in_use[i])
+			return true;
+
+	return false;
 }
 
 static int max_des_link_index_to_hw(struct max_des_priv *priv, unsigned int i,
@@ -476,7 +512,7 @@ static int max_des_get_supported_modes(struct max_des_priv *priv,
 		if (!hw.source->sd)
 			continue;
 
-		if (!context->pipe_in_use[hw.pipe->index])
+		if (!max_des_link_pipes_in_use(des, context, hw.link))
 			continue;
 
 		*modes &= max_ser_get_supported_modes(hw.source->sd);
@@ -511,6 +547,7 @@ static int max_des_populate_remap_context_mode(struct max_des_priv *priv,
 
 	for (i = 0; i < des->ops->num_links; i++) {
 		struct max_des_link_hw hw;
+		unsigned int j;
 
 		ret = max_des_link_index_to_hw(priv, i, &hw);
 		if (ret)
@@ -522,16 +559,23 @@ static int max_des_populate_remap_context_mode(struct max_des_priv *priv,
 		if (!hw.source->sd)
 			continue;
 
-		if (!context->pipe_in_use[hw.pipe->index])
-			continue;
+		for (j = 0; j < des->ops->num_pipes; j++) {
+			struct max_des_pipe *pipe = &des->pipes[j];
 
-		if (hweight_long(context->pipe_phy_masks[hw.pipe->index]) == 1 &&
-		    (!context->vc_ids_remapped[hw.pipe->index] ||
-		     max_ser_supports_vc_remap(hw.source->sd) ||
-		     des->ops->set_pipe_vc_remap))
-			continue;
+			if (pipe->link_id != hw.link->index)
+				continue;
 
-		return 0;
+			if (!context->pipe_in_use[pipe->index])
+				continue;
+
+			if (hweight_long(context->pipe_phy_masks[pipe->index]) == 1 &&
+			    (!context->vc_ids_remapped[pipe->index] ||
+			     max_ser_supports_vc_remap(hw.source->sd) ||
+			     des->ops->set_pipe_vc_remap))
+				continue;
+
+			return 0;
+		}
 	}
 
 	context->mode = MAX_SERDES_GMSL_TUNNEL_MODE;
@@ -879,6 +923,7 @@ static int max_des_set_modes(struct max_des_priv *priv,
 	for (i = 0; i < des->ops->num_links; i++) {
 		struct max_des_link_hw hw;
 		u32 pipe_double_bpps = 0;
+		unsigned int j;
 
 		ret = max_des_link_index_to_hw(priv, i, &hw);
 		if (ret)
@@ -890,7 +935,10 @@ static int max_des_set_modes(struct max_des_priv *priv,
 		if (!hw.source->sd)
 			continue;
 
-		pipe_double_bpps = context->pipes_double_bpps[hw.pipe->index];
+		for (j = 0; j < des->ops->num_pipes; j++)
+			if (des->pipes[j].link_id == hw.link->index)
+				pipe_double_bpps |=
+					context->pipes_double_bpps[j];
 
 		ret = max_ser_set_double_bpps(hw.source->sd, pipe_double_bpps);
 		if (ret)
@@ -931,7 +979,7 @@ static int max_des_set_tunnel(struct max_des_priv *priv,
 		if (!hw.source->sd)
 			continue;
 
-		if (!context->pipe_in_use[hw.pipe->index])
+		if (!max_des_link_pipes_in_use(des, context, hw.link))
 			continue;
 
 		ret = max_ser_set_mode(hw.source->sd, context->mode);
@@ -2198,16 +2246,22 @@ static int max_des_update_link(struct max_des_priv *priv,
 			       u64 *streams_masks)
 {
 	struct max_des *des = priv->des;
-	struct max_des_pipe *pipe;
+	unsigned int i;
 	int ret;
 
-	pipe = max_des_find_link_pipe(des, link);
-	if (!pipe)
-		return -ENOENT;
+	if (!link->enabled)
+		return 0;
 
-	ret = max_des_update_pipe(priv, context, pipe, state, streams_masks);
-	if (ret)
-		return ret;
+	for (i = 0; i < des->ops->num_pipes; i++) {
+		struct max_des_pipe *pipe = &des->pipes[i];
+
+		if (pipe->link_id != link->index)
+			continue;
+
+		ret = max_des_update_pipe(priv, context, pipe, state, streams_masks);
+		if (ret)
+			return ret;
+	}
 
 	return 0;
 }
@@ -2449,7 +2503,7 @@ static int max_des_disable_streams(struct v4l2_subdev *sd,
 static int max_des_init_state(struct v4l2_subdev *sd,
 			      struct v4l2_subdev_state *state)
 {
-	struct v4l2_subdev_route routes[MAX_DES_NUM_LINKS] = { 0 };
+	struct v4l2_subdev_route routes[MAX_DES_NUM_PIPES] = { 0 };
 	struct v4l2_subdev_krouting routing = {
 		.routes = routes,
 	};
@@ -2972,6 +3026,7 @@ static int max_des_parse_dt(struct max_des_priv *priv)
 	struct max_des_link *link;
 	struct max_des_pipe *pipe;
 	struct max_des_phy *phy;
+	unsigned int num_enabled_links;
 	unsigned int i;
 	int ret;
 
@@ -3039,6 +3094,46 @@ static int max_des_parse_dt(struct max_des_priv *priv)
 		ret = max_des_parse_sink_dt_endpoint(priv, link, source, fwnode);
 		if (ret)
 			return ret;
+	}
+
+	/*
+	 * The mapping above points pipe[i] at link[i]. A serializer that sends
+	 * more than one stream over a single link (e.g. the max9295d driving
+	 * two cameras) needs every pipe for that link pointed at the one link
+	 * it uses, which the per-index mapping cannot express when some links
+	 * are disabled.
+	 *
+	 * Deserializers that can route a pipe to any link implement
+	 * set_pipe_link; for those, hand the pipes to the enabled links in
+	 * turn. For each pipe, walk the links, skip the disabled ones, and
+	 * bind the pipe to the (i % num_enabled_links)-th enabled link. With
+	 * every link enabled this is the pipe[i] <- link[i] default; with only
+	 * some enabled the pipes pack onto those, the lowest-numbered link
+	 * getting any extras. A serializer that puts several streams on one
+	 * link should therefore be wired to the lowest-numbered link in use,
+	 * so it is given the extra pipes it needs. Chips without set_pipe_link
+	 * are wired to pipe[i] <- link[i] and keep the default above.
+	 */
+	num_enabled_links = 0;
+	for (i = 0; i < des->ops->num_links; i++)
+		if (des->links[i].enabled)
+			num_enabled_links++;
+
+	if (des->ops->set_pipe_link && num_enabled_links) {
+		for (i = 0; i < des->ops->num_pipes; i++) {
+			unsigned int nth = i % num_enabled_links;
+			unsigned int link_idx, seen = 0;
+
+			for (link_idx = 0; link_idx < des->ops->num_links;
+			     link_idx++) {
+				if (!des->links[link_idx].enabled)
+					continue;
+				if (seen++ == nth)
+					break;
+			}
+
+			des->pipes[i].link_id = link_idx;
+		}
 	}
 
 	return 0;

--- a/drivers/media/i2c/maxim-serdes/max_ser.c
+++ b/drivers/media/i2c/maxim-serdes/max_ser.c
@@ -19,7 +19,7 @@
 #include "max_serdes.h"
 
 #define MAX_SER_NUM_LINKS	1
-#define MAX_SER_NUM_PHYS	1
+#define MAX_SER_NUM_PHYS	2
 
 struct max_ser_priv {
 	struct max_ser *ser;
@@ -1324,14 +1324,6 @@ static int max_ser_init_state(struct v4l2_subdev *sd,
 			.flags = V4L2_SUBDEV_ROUTE_FL_ACTIVE,
 		};
 		stream++;
-
-		/*
-		 * The Streams API is an experimental feature.
-		 * If multiple routes are provided here, userspace will not be
-		 * able to configure them unless the Streams API is enabled.
-		 * Provide a single route until it is enabled.
-		 */
-		break;
 	}
 
 	return __max_ser_set_routing(sd, state, &routing);

--- a/drivers/media/i2c/ov5640.c
+++ b/drivers/media/i2c/ov5640.c
@@ -1748,10 +1748,9 @@ static void ov5640_load_regs(struct ov5640_dev *sensor,
 		val = regs->val;
 		mask = regs->mask;
 
-		/* remain in power down mode for DVP */
+		/* remain in power down mode until stream on */
 		if (regs->reg_addr == OV5640_REG_SYS_CTRL0 &&
-		    val == OV5640_REG_SYS_CTRL0_SW_PWUP &&
-		    !ov5640_is_csi2(sensor))
+		    val == OV5640_REG_SYS_CTRL0_SW_PWUP)
 			continue;
 
 		if (mask)
@@ -1873,8 +1872,22 @@ static int ov5640_set_stream_mipi(struct ov5640_dev *sensor, bool on)
 	if (ret)
 		return ret;
 
-	return ov5640_write_reg(sensor, OV5640_REG_FRAME_CTRL01,
-				on ? 0x00 : 0x0f);
+	ret = ov5640_write_reg(sensor, OV5640_REG_FRAME_CTRL01,
+			       on ? 0x00 : 0x0f);
+	if (ret)
+		return ret;
+
+	/*
+	 * MIPI CSI-2 start-of-transmission requires each lane to enter
+	 * high-speed mode out of the LP-11 state (LP11 -> HS). The sensor is
+	 * kept in software standby (SW_PWDN) through configuration (the PWUP
+	 * in ov5640_init_setting is skipped in ov5640_load_regs), so powering
+	 * it up here, once the interface is configured, lets the lanes settle
+	 * in LP-11 first and then perform a proper LP11 -> HS transition.
+	 */
+	return ov5640_write_reg(sensor, OV5640_REG_SYS_CTRL0, on ?
+				OV5640_REG_SYS_CTRL0_SW_PWUP :
+				OV5640_REG_SYS_CTRL0_SW_PWDN);
 }
 
 static int ov5640_get_sysclk(struct ov5640_dev *sensor)
@@ -2545,6 +2558,7 @@ static void ov5640_set_power_off(struct ov5640_dev *sensor)
 static int ov5640_set_power_mipi(struct ov5640_dev *sensor, bool on)
 {
 	int ret;
+	u8 mipi_ctrl00 = 0x04;
 
 	if (!on) {
 		/* Reset MIPI bus settings to their default values. */
@@ -2569,13 +2583,19 @@ static int ov5640_set_power_mipi(struct ov5640_dev *sensor, bool on)
 		return ret;
 
 	/*
-	 * Gate clock and set LP11 in 'no packets mode' (idle)
+	 * Set LP11 in 'no packets mode' (idle) and, unless the endpoint
+	 * requests a non-continuous clock, keep the MIPI clock running
+	 * continuously.
 	 *
-	 * 0x4800 = 0x24
-	 * [5] = 1	: Gate clock when 'no packets'
+	 * 0x4800 = 0x04
+	 * [5] = 0	: Continuous clock (do not gate when 'no packets')
 	 * [2] = 1	: MIPI bus in LP11 when 'no packets'
 	 */
-	ret = ov5640_write_reg(sensor, OV5640_REG_MIPI_CTRL00, 0x24);
+
+	if (sensor->ep.bus.mipi_csi2.flags & V4L2_MBUS_CSI2_NONCONTINUOUS_CLOCK)
+		mipi_ctrl00 |= BIT(5);
+
+	ret = ov5640_write_reg(sensor, OV5640_REG_MIPI_CTRL00, mipi_ctrl00);
 	if (ret)
 		return ret;
 


### PR DESCRIPTION
* Added support for max9295d
* Added support for continous clock for imx708 and ov5640
* Added deserializer support for multiple cameras over a single GMSL link

## PR Description

**Serializer (max96717.c, max_ser.c)**

* New max9295d compatible / max9295d_info. 
* max_ser now emits one route per enabled PHY (MAX_SER_NUM_PHYS 1→2). Other serializers serializers report num_phys=1, so their init routing is unchanged.

**Deserializer (max_des.c, max9296a.c)**

* Multiple video pipes can share one GMSL link
* needs_unique_stream_id + set_pipe_link wired for max96716a so each camera gets a unique stream ID and is demuxed correctly.

**Sensors (imx708.c, ov5640.c)**

* Continuous clock support 

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
