### PR TITLE
arm/arm64: dts: adi: remoteproc: use vendor firmware subdirectory

### DIFF
--- a/arch/arm/boot/dts/adi/sc573-ezlite.dts
+++ b/arch/arm/boot/dts/adi/sc573-ezlite.dts
@@ -58,7 +58,7 @@
 			reg = <0x28240000 0x2000>,
 			      <0x20000000 0x200000>;
 			core-id = <1>;
-			firmware-name = "adi_adsp_core1_fw.ldr";
+			firmware-name = "adi/rpmsg_echo_sharc_core1.ldr";
 			interrupts = <GIC_SPI 206 IRQ_TYPE_EDGE_RISING>;
 			adi,svect = <&rcu 0x24>;
 			resets = <&rcu 1 0>, <&rcu 1 1>;
@@ -76,7 +76,7 @@
 			reg = <0x28A40000 0x2000>,
 			      <0x20000000 0x200000>;
 			core-id = <2>;
-			firmware-name = "adi_adsp_core2_fw.ldr";
+			firmware-name = "adi/rpmsg_echo_sharc_core2.ldr";
 			interrupts = <GIC_SPI 206 IRQ_TYPE_EDGE_RISING>;
 			adi,svect = <&rcu 0x28>;
 			resets = <&rcu 2 0>, <&rcu 2 1>;

--- a/arch/arm/boot/dts/adi/sc589-mini.dts
+++ b/arch/arm/boot/dts/adi/sc589-mini.dts
@@ -69,7 +69,7 @@
 			reg = <0x28240000 0x160000>,
 					<0x20080000 0x40000>;
 			core-id = <1>;
-			firmware-name = "adi_adsp_core1_fw.ldr";
+			firmware-name = "adi/rpmsg_echo_sharc_core1.ldr";
 			interrupts = <GIC_SPI 251 IRQ_TYPE_EDGE_RISING>;
 			adi,svect = <&rcu 0x24>;
 			resets = <&rcu 1 0>, <&rcu 1 1>;
@@ -86,7 +86,7 @@
 			reg = <0x28a40000 0x160000>,
 					<0x20080000 0x40000>;
 			core-id = <2>;
-			firmware-name = "adi_adsp_core2_fw.ldr";
+			firmware-name = "adi/rpmsg_echo_sharc_core2.ldr";
 			interrupts = <GIC_SPI 251 IRQ_TYPE_EDGE_RISING>;
 			adi,svect = <&rcu 0x28>;
 			resets = <&rcu 2 0>, <&rcu 2 1>;

--- a/arch/arm/boot/dts/adi/sc594-som.dtsi
+++ b/arch/arm/boot/dts/adi/sc594-som.dtsi
@@ -61,7 +61,7 @@
 			reg = <0x28240000 0x160000>,
 					<0x20000000 0x200000>;
 			core-id = <1>;
-			firmware-name = "adi_adsp_core1_fw.ldr";
+			firmware-name = "adi/rpmsg_echo_sharc_core1.ldr";
 			interrupts = <GIC_SPI 165 IRQ_TYPE_EDGE_RISING>; /* TRU0_SLV3 */
 			adi,svect = <&rcu 0x30>;
 			resets = <&rcu 1 0>, <&rcu 1 1>;
@@ -80,7 +80,7 @@
 			reg = <0x28a40000 0x160000>,
 					<0x20000000 0x200000>;
 			core-id = <2>;
-			firmware-name = "adi_adsp_core2_fw.ldr";
+			firmware-name = "adi/rpmsg_echo_sharc_core2.ldr";
 			interrupts = <GIC_SPI 165 IRQ_TYPE_EDGE_RISING>; /* TRU0_SLV3 */
 			adi,svect = <&rcu 0x34>;
 			resets = <&rcu 2 0>, <&rcu 2 1>;

--- a/arch/arm64/boot/dts/adi/sc598-som.dtsi
+++ b/arch/arm64/boot/dts/adi/sc598-som.dtsi
@@ -95,7 +95,7 @@
 			reg = <0x28240000 0x160000>,
 					<0x20000000 0x200000>;
 			core-id = <1>;
-			firmware-name = "adi_adsp_core1_fw.ldr";
+			firmware-name = "adi/rpmsg_echo_sharc_core1.ldr";
 			interrupts = <GIC_SPI 337 IRQ_TYPE_EDGE_RISING>; /* TRU0_SLV3 */
 			adi,svect = <&rcu 0x30>;
 			resets = <&rcu 1 0>, <&rcu 1 1>;
@@ -114,7 +114,7 @@
 			reg = <0x28a40000 0x160000>,
 					<0x20000000 0x200000>;
 			core-id = <2>;
-			firmware-name = "adi_adsp_core2_fw.ldr";
+			firmware-name = "adi/rpmsg_echo_sharc_core2.ldr";
 			interrupts = <GIC_SPI 337 IRQ_TYPE_EDGE_RISING>; /* TRU0_SLV3 */
 			adi,svect = <&rcu 0x34>;
 			resets = <&rcu 2 0>, <&rcu 2 1>;

--- a/arch/arm64/boot/dts/adi/sc846-som.dts
+++ b/arch/arm64/boot/dts/adi/sc846-som.dts
@@ -70,7 +70,7 @@
 				<0x20000000 0x200000>;
 		core-id = <1>;
 		core-irq = <321>; /* SOFT1 */
-		firmware-name = "adi_adsp_core1_fw.ldr";
+		firmware-name = "adi/rpmsg_echo_sharc_core1.ldr";
 		interrupts = <GIC_SPI 352 IRQ_TYPE_EDGE_RISING>; /* TRU0_RCV3 */
 		adi,rcu = <&rcu>;
 		adi,l1-da = <0x240000 0x3a0000>;


### PR DESCRIPTION
Update firmware-name in ADI ADSP remoteproc DTS nodes (sc573, sc589, sc594, sc598, sc846) to place firmware under a vendor subdirectory (adi/) with a descriptive name, following the Linux firmware loading convention.

The companion rpmsg-examples PR [#10](https://github.com/analogdevicesinc/rpmsg-examples/pull/10) adds a Makefile install target that deploys the echo_example firmware under the new path. The buildroot packaging PR [#129](https://github.com/analogdevicesinc/buildroot/pull/129) will need to adopt that Makefile install target to align with the new naming.

The SC594 is the configured target in the rpmsg-examples echo_example so it should work. SC598 is referenced in the .cproject configuration but has not been verified. For SC573, SC589 and SC846 there are no existing firmware builds in rpmsg-examples — these will need dedicated builds, and it should be verified whether the existing SHARC firmware is compatible or needs to be rebuilt for each platform variant before these DTS entries are functional.
