### PR TITLE
iio: cdc: ad7746: fix VT channel delay using wrong filter table

### DIFF
--- a/drivers/iio/cdc/ad7746.c
+++ b/drivers/iio/cdc/ad7746.c
@@ -294,7 +294,7 @@ static int ad7746_select_channel(struct iio_dev *indio_dev,
 			FIELD_PREP(AD7746_VTSETUP_VTEN, 1);
 		cap_setup = chip->cap_setup & ~AD7746_CAPSETUP_CAPEN;
 		idx = FIELD_GET(AD7746_CONF_VTFS_MASK, chip->config);
-		delay = ad7746_cap_filter_rate_table[idx][1];
+		delay = ad7746_vt_filter_rate_table[idx][1];
 		break;
 	default:
 		return -EINVAL;


### PR DESCRIPTION
The voltage/temperature (VT) channel path in ad7746_select_channel() computes the conversion-ready delay from ad7746_cap_filter_rate_table[] but indexes it with the VT filter setup field (AD7746_CONF_VTFS_MASK). The two tables differ, so the delay applied for voltage and temperature conversions is wrong (too short) and the result can be read before the conversion has completed.

Use ad7746_vt_filter_rate_table[] for the VT channel.

Fixes: 83e416f458d5 ("staging: iio: adc: Replace, rewrite ad7745 from scratch.")

## PR Description

- Please replace this comment with a summary of your changes, and add any context
necessary to understand them. List any dependencies required for this change.
- To check the checkboxes below, insert a 'x' between square brackets (without
any space), or simply check them after publishing the PR.
- If you changes include a breaking change, please specify dependent PRs in the
description and try to push all related PRs simultaneously.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
