### PR TITLE
[backport] iio: adc: ad4080: allow debugfs register access to both channels

### DIFF
--- a/drivers/iio/adc/ad4080.c
+++ b/drivers/iio/adc/ad4080.c
@@ -146,6 +146,10 @@
 #define AD4080_MAX_SAMP_FREQ					40000000
 #define AD4080_MIN_SAMP_FREQ					1250000
 
+/* debugfs direct_reg_access channel windowing: 0x0RR = ch0, 0x1RR = ch1 */
+#define AD4080_DEBUGFS_REG_CH_MSK				GENMASK(15, 8)
+#define AD4080_DEBUGFS_REG_OFFSET_MSK				GENMASK(7, 0)
+
 enum ad4080_filter_type {
 	FILTER_NONE,
 	SINC_1,
@@ -211,11 +215,16 @@ static int ad4080_reg_access(struct iio_dev *indio_dev, unsigned int reg,
 			     unsigned int writeval, unsigned int *readval)
 {
 	struct ad4080_state *st = iio_priv(indio_dev);
+	unsigned int ch = FIELD_GET(AD4080_DEBUGFS_REG_CH_MSK, reg);
+	unsigned int offset = FIELD_GET(AD4080_DEBUGFS_REG_OFFSET_MSK, reg);
+
+	if (ch >= st->info->num_channels)
+		return -EINVAL;
 
 	if (readval)
-		return regmap_read(st->regmap[0], reg, readval);
+		return regmap_read(st->regmap[ch], offset, readval);
 
-	return regmap_write(st->regmap[0], reg, writeval);
+	return regmap_write(st->regmap[ch], offset, writeval);
 }
 
 static int ad4080_get_scale(struct ad4080_state *st, int *val, int *val2)


### PR DESCRIPTION
## PR Description

The dual-channel parts (AD4880/AD4883/AD4884) are built from two independent ADC dies, each with its own SPI chip select and register map. They are presented as a single IIO device because the FPGA interleaves both dies into one DMA stream, so only one direct_reg_access debugfs file is created and it can only reach channel A's regmap. Channel B's registers are therefore inaccessible, which blocks bring-up and debugging of the second die.

Select the target die through the debugfs register address: the low 8 bits are the register offset and the upper bits are the channel index (0x0nn selects channel A, 0x1nn channel B). A read returns the real register value of the selected die and each die is addressed independently; single-channel parts only accept channel 0.

Link: https://patch.msgid.link/20260826111613.14218-1-antoniu.miclaus@analog.com

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [x] I have provided links for the relevant upstream lore
