### PR TITLE
irqchip: adi-adsp: Switch to irq_domain_create_linear()

### DIFF
--- a/drivers/irqchip/irq-adi-adsp.c
+++ b/drivers/irqchip/irq-adi-adsp.c
@@ -242,7 +242,6 @@ static int adsp_pint_irq_set_type(struct irq_data *d, unsigned int type)
 static int adsp_pint_probe(struct platform_device *pdev)
 {
 	struct device *dev = &pdev->dev;
-	struct device_node *np = dev->of_node;
 	struct adsp_pint *pint;
 	struct resource *res;
 
@@ -266,8 +265,8 @@ static int adsp_pint_probe(struct platform_device *pdev)
 
 	// @todo determine if we actually need a raw spinlock
 
-	pint->domain = irq_domain_add_linear(np, ADSP_PINT_IRQS,
-		&adsp_irq_domain_ops, pint);
+	pint->domain = irq_domain_create_linear(dev_fwnode(&pdev->dev), ADSP_PINT_IRQS,
+						&adsp_irq_domain_ops, pint);
 	if (!pint->domain) {
 		dev_err(dev, "Could not create irq domain\n");
 		return -EINVAL;


### PR DESCRIPTION
irq_domain_add_linear() was deprecated by irq_domain_create_linear() in commit v6.16-rc1\~187^2\~16 ("irqdomain: Drop irq_domain_add_*() functions").
The latter was introduced in v4.4-rc1\~161^2\~17 ("irqdomain: Introduce irq_domain_create_{linear, tree}"), the former is removed upstream since commit v7.3-rc2\~6^2\~2 ("irqdomain: Delete irq_domain_add_linear()")

So switch to use irq_domain_create_linear().

Fixes: 72b5a2165202 ("irqchip: Add PINT PORT driver for ADSP-SC5xx SoCs")

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [x] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
