### PR TITLE
ADSY1100: Enable PRBS support

### DIFF
--- a/arch/arm64/boot/dts/xilinx/vu11p-ad9084-vpx-reva-204C_M4_L8_NP16_8p0_4x2.dtso
+++ b/arch/arm64/boot/dts/xilinx/vu11p-ad9084-vpx-reva-204C_M4_L8_NP16_8p0_4x2.dtso
@@ -62,7 +62,7 @@
 		interrupts = <0 104 4>;
 		reg = <0x0 0x88160000 0x0 0x1000>;
 		xlnx,kind-of-intr = <0xffe0385>;
-		xlnx,num-intr-inputs = <17>;
+		xlnx,num-intr-inputs = <32>;
 	};
 
 	adf4382_spi: spi@88000000 {

--- a/arch/arm64/boot/dts/xilinx/vu11p-ad9084-vpx-reva.dtso
+++ b/arch/arm64/boot/dts/xilinx/vu11p-ad9084-vpx-reva.dtso
@@ -63,7 +63,7 @@
 		interrupts = <0 104 4>;
 		reg = <0x0 0x88160000 0x0 0x1000>;
 		xlnx,kind-of-intr = <0xffe0385>;
-		xlnx,num-intr-inputs = <17>;
+		xlnx,num-intr-inputs = <32>;
 	};
 
 	adf4382_spi: spi@88000000 {

--- a/arch/arm64/boot/dts/xilinx/vu11p-ad9084-vpx-revb-204C_M4_L4_NP16_8p0_2x2.dtso
+++ b/arch/arm64/boot/dts/xilinx/vu11p-ad9084-vpx-revb-204C_M4_L4_NP16_8p0_2x2.dtso
@@ -64,7 +64,7 @@
 		interrupts = <0 104 4>;
 		reg = <0x0 0x88160000 0x0 0x1000>;
 		xlnx,kind-of-intr = <0xffe0385>;
-		xlnx,num-intr-inputs = <19>;
+		xlnx,num-intr-inputs = <32>;
 	};
 
 	ltc6952_spi: spi@881a0000 {

--- a/arch/arm64/boot/dts/xilinx/vu11p-ad9084-vpx-revb-204C_M4_L8_NP16_8p0_4x2.dtso
+++ b/arch/arm64/boot/dts/xilinx/vu11p-ad9084-vpx-revb-204C_M4_L8_NP16_8p0_4x2.dtso
@@ -79,7 +79,7 @@
 		interrupts = <0 104 4>;
 		reg = <0x0 0x88160000 0x0 0x1000>;
 		xlnx,kind-of-intr = <0xffe0385>;
-		xlnx,num-intr-inputs = <19>;
+		xlnx,num-intr-inputs = <32>;
 	};
 
 	adf4382_spi: spi@88000000 {

--- a/arch/arm64/boot/dts/xilinx/vu11p-ad9084-vpx-revb-eth-prbs.dtsi
+++ b/arch/arm64/boot/dts/xilinx/vu11p-ad9084-vpx-revb-eth-prbs.dtsi
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * PRBS test access for the QSFP transceivers. Included from inside the base
+ * overlay's fpga-region block: fpga_region rejects a second overlay fragment
+ * targeting the same region, so these nodes cannot live in a fragment of their
+ * own. Requires the HDL built with XCVR_ETH_PRBS=1, which drives the quad from
+ * util_adxcvr instead of an Ethernet MAC and so cannot coexist with CORUNDUM=1.
+ */
+
+	qsfp_gt_refclk: clock@5 {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-frequency = <156250000>;
+		clock-output-names = "qsfp_gt_refclk";
+	};
+
+	/*
+	 * No jesd204-device: these instances exist only to reach the GT PRBS
+	 * generator/checker and the per-channel DRP. sys-clk-select must stay off
+	 * XCVR_CPLL so adxcvr_enforce_settings() takes its early return: the lane
+	 * rate is the one baked into the bitstream, and xilinx_xcvr_calc_qpll_config()
+	 * would reject it anyway, since it checks refclk * N / m against the 16.375
+	 * GHz QPLL0 ceiling without the factor of two GTY applies to the line rate.
+	 *
+	 */
+	axi_eth_adxcvr_rx: axi-adxcvr-eth-rx@88390000 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "adi,axi-adxcvr-1.0";
+		reg = <0x0 0x88390000 0x0 0x1000>;
+
+		clocks = <&qsfp_gt_refclk>;
+		clock-names = "conv";
+
+		#clock-cells = <1>;
+		clock-output-names = "eth_rx_gt_clk", "eth_rx_out_clk";
+
+		adi,sys-clk-select = <XCVR_QPLL1>;
+		adi,out-clk-select = <XCVR_OUTCLK_PCS>;
+	};
+
+	axi_eth_adxcvr_tx: axi-adxcvr-eth-tx@883a0000 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "adi,axi-adxcvr-1.0";
+		reg = <0x0 0x883A0000 0x0 0x1000>;
+
+		clocks = <&qsfp_gt_refclk>;
+		clock-names = "conv";
+
+		#clock-cells = <1>;
+		clock-output-names = "eth_tx_gt_clk", "eth_tx_out_clk";
+
+		adi,sys-clk-select = <XCVR_QPLL1>;
+		adi,out-clk-select = <XCVR_OUTCLK_PCS>;
+	};
+
+	/*
+	 * Lines 0..11 are LOOPBACK[2:0] per lane, UG578 encoding. gtwizard brings the
+	 * port out, so no QSFP loopback module is needed for an internal test.
+	 */
+	axi_eth_xcvr_gpio: gpio@883b0000 {
+		compatible = "xlnx,axi-gpio-2.0", "xlnx,xps-gpio-1.00.a";
+		gpio-controller;
+		#gpio-cells = <2>;
+		reg = <0x0 0x883B0000 0x0 0x10000>;
+		xlnx,all-inputs = <0x0>;
+		xlnx,all-inputs-2 = <0x0>;
+		xlnx,all-outputs = <0x1>;
+		xlnx,all-outputs-2 = <0x0>;
+		xlnx,dout-default = <0x00000000>;
+		xlnx,dout-default-2 = <0x00000000>;
+		xlnx,gpio-width = <0xc>;
+		xlnx,gpio2-width = <0x20>;
+		xlnx,interrupt-present = <0x0>;
+		xlnx,is-dual = <0x0>;
+	};

--- a/arch/arm64/boot/dts/xilinx/vu11p-ad9084-vpx-revb-eth-prbs.dtso
+++ b/arch/arm64/boot/dts/xilinx/vu11p-ad9084-vpx-revb-eth-prbs.dtso
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+#define XCVR_ETH_PRBS   1
+
+#include "vu11p-ad9084-vpx-revb.dtso"

--- a/arch/arm64/boot/dts/xilinx/vu11p-ad9084-vpx-revb-prbs.dtsi
+++ b/arch/arm64/boot/dts/xilinx/vu11p-ad9084-vpx-revb-prbs.dtsi
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * PRBS test access for the PCIe transceivers. Included from inside the base
+ * overlay's fpga-region block: fpga_region rejects a second overlay fragment
+ * targeting the same region, so these nodes cannot live in a fragment of their
+ * own. Requires the HDL built with XCVR_PRBS=1.
+ */
+
+	pcie_gt_refclk: clock@4 {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-frequency = <100000000>;
+		clock-output-names = "pcie_gt_refclk";
+	};
+
+	/*
+	 * No jesd204-device: these instances exist only to reach the GT PRBS
+	 * generator/checker and the per-channel DRP. sys-clk-select must stay
+	 * off XCVR_CPLL so adxcvr_enforce_settings() takes its early return and
+	 * never reprograms the quad the PCIe core owns.
+	 */
+	axi_pcie_adxcvr_rx: axi-adxcvr-pcie-rx@88360000 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "adi,axi-adxcvr-1.0";
+		reg = <0x0 0x88360000 0x0 0x1000>;
+
+		clocks = <&pcie_gt_refclk>;
+		clock-names = "conv";
+
+		#clock-cells = <1>;
+		clock-output-names = "pcie_rx_gt_clk", "pcie_rx_out_clk";
+
+		adi,sys-clk-select = <XCVR_QPLL1>;
+		adi,out-clk-select = <XCVR_OUTCLK_PCS>;
+	};
+
+	axi_pcie_adxcvr_tx: axi-adxcvr-pcie-tx@88370000 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "adi,axi-adxcvr-1.0";
+		reg = <0x0 0x88370000 0x0 0x1000>;
+
+		clocks = <&pcie_gt_refclk>;
+		clock-names = "conv";
+
+		#clock-cells = <1>;
+		clock-output-names = "pcie_tx_gt_clk", "pcie_tx_out_clk";
+
+		adi,sys-clk-select = <XCVR_QPLL1>;
+		adi,out-clk-select = <XCVR_OUTCLK_PCS>;
+	};
+
+	/*
+	 * Channel 1 lines 0..23 are LOOPBACK[2:0] per lane, channel 2 lines
+	 * 0..7 are TXINHIBIT per lane.
+	 */
+	axi_pcie_xcvr_gpio: gpio@88380000 {
+		compatible = "xlnx,axi-gpio-2.0", "xlnx,xps-gpio-1.00.a";
+		gpio-controller;
+		#gpio-cells = <2>;
+		reg = <0x0 0x88380000 0x0 0x10000>;
+		xlnx,all-inputs = <0x0>;
+		xlnx,all-inputs-2 = <0x0>;
+		xlnx,all-outputs = <0x1>;
+		xlnx,all-outputs-2 = <0x1>;
+		xlnx,dout-default = <0x00000000>;
+		xlnx,dout-default-2 = <0x00000000>;
+		xlnx,gpio-width = <0x18>;
+		xlnx,gpio2-width = <0x8>;
+		xlnx,interrupt-present = <0x0>;
+		xlnx,is-dual = <0x1>;
+	};

--- a/arch/arm64/boot/dts/xilinx/vu11p-ad9084-vpx-revb-prbs.dtso
+++ b/arch/arm64/boot/dts/xilinx/vu11p-ad9084-vpx-revb-prbs.dtso
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+#define XCVR_PCIE_PRBS  1
+#define XCVR_ETH_PRBS   1
+#define WITH_AION 1
+
+#include "vu11p-ad9084-vpx-revb.dtso"

--- a/arch/arm64/boot/dts/xilinx/vu11p-ad9084-vpx-revb.dtso
+++ b/arch/arm64/boot/dts/xilinx/vu11p-ad9084-vpx-revb.dtso
@@ -80,7 +80,7 @@
 		interrupts = <0 104 4>;
 		reg = <0x0 0x88160000 0x0 0x1000>;
 		xlnx,kind-of-intr = <0xffe0385>;
-		xlnx,num-intr-inputs = <19>;
+		xlnx,num-intr-inputs = <32>;
 	};
 
 	adf4382_spi: spi@88000000 {

--- a/arch/arm64/boot/dts/xilinx/vu11p-ad9084-vpx-revb.dtso
+++ b/arch/arm64/boot/dts/xilinx/vu11p-ad9084-vpx-revb.dtso
@@ -25,6 +25,14 @@
 #define WITH_AION		1
 #endif
 
+#ifndef XCVR_PCIE_PRBS
+#define XCVR_PCIE_PRBS	0
+#endif
+
+#ifndef XCVR_ETH_PRBS
+#define XCVR_ETH_PRBS	0
+#endif
+
 #ifndef VU11_FIRMWARE_NAME
 #define VU11_FIRMWARE_NAME	"vu11p.bin"
 #endif
@@ -780,4 +788,12 @@
 		#size-cells = <0>;
 		status = "disabled";
 	};
+
+#if XCVR_PCIE_PRBS
+#include "vu11p-ad9084-vpx-revb-prbs.dtsi"
+#endif
+
+#if XCVR_ETH_PRBS
+#include "vu11p-ad9084-vpx-revb-eth-prbs.dtsi"
+#endif
 };


### PR DESCRIPTION
## PR Description

This PR adds the necessary xcvr nodes that are required for PRBS testing on the Ethernet and PCIe lanes.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have compiled my changes, including the documentation
- [ ] I have tested the changes on the relevant hardware
- [ ] I have updated the documentation outside this repo accordingly
- [ ] I have provided links for the relevant upstream lore
